### PR TITLE
feat: disc scan metadata logging and snapshot capture

### DIFF
--- a/backend/app/core/snapshot.py
+++ b/backend/app/core/snapshot.py
@@ -1,0 +1,75 @@
+"""Disc scan snapshot capture for debugging and test fixture generation."""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.core.analyst import DiscAnalysisResult
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOTS_DIR = Path.home() / ".engram" / "snapshots"
+
+
+def _safe_filename(label: str) -> str:
+    """Convert a volume label to a safe filename."""
+    return re.sub(r"[^\w]", "_", label).strip("_").lower()
+
+
+def save_snapshot(volume_label: str, analysis: DiscAnalysisResult) -> Path | None:
+    """Save a JSON snapshot of disc analysis results.
+
+    Args:
+        volume_label: The disc's volume label
+        analysis: Classification results from DiscAnalyst
+
+    Returns:
+        Path to the saved snapshot file, or None on failure
+    """
+    try:
+        SNAPSHOTS_DIR.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        safe_label = _safe_filename(volume_label) or "unknown"
+        filename = f"{safe_label}_{timestamp}.json"
+
+        snapshot = {
+            "volume_label": volume_label,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "classification": {
+                "content_type": analysis.content_type.value,
+                "confidence": analysis.confidence,
+                "source": analysis.classification_source,
+                "detected_name": analysis.detected_name,
+                "detected_season": analysis.detected_season,
+                "needs_review": analysis.needs_review,
+                "review_reason": analysis.review_reason,
+                "is_ambiguous_movie": analysis.is_ambiguous_movie,
+            },
+            "tmdb": {
+                "id": analysis.tmdb_id,
+                "name": analysis.tmdb_name,
+            },
+            "tracks": [
+                {
+                    "index": t.index,
+                    "duration_seconds": t.duration_seconds,
+                    "size_bytes": t.size_bytes,
+                    "chapter_count": t.chapter_count,
+                    "video_resolution": t.video_resolution,
+                }
+                for t in analysis.titles
+            ],
+            "play_all_indices": analysis.play_all_title_indices,
+        }
+
+        path = SNAPSHOTS_DIR / filename
+        path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+        logger.info(f"Saved disc snapshot: {path}")
+        return path
+
+    except Exception:
+        logger.warning("Failed to save disc snapshot", exc_info=True)
+        return None

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -54,6 +54,16 @@ class DiscJob(SQLModel, table=True):
     detected_season: int | None = None
     is_transcoding_enabled: bool = False
 
+    # Classification metadata (persisted from DiscAnalysisResult)
+    classification_confidence: float = Field(default=0.0, sa_column_kwargs={"server_default": "0.0"})
+    classification_source: str = Field(
+        default="heuristic", sa_column_kwargs={"server_default": "'heuristic'"}
+    )
+    tmdb_id: int | None = Field(default=None)
+    tmdb_name: str | None = Field(default=None)
+    play_all_indices_json: str | None = Field(default=None)
+    is_ambiguous_movie: bool = Field(default=False, sa_column_kwargs={"server_default": "0"})
+
     # Paths
     staging_path: str | None = None
     final_path: str | None = None

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -299,12 +299,28 @@ class JobManager:
                 analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
                 logger.info(f"Job {job_id} Analysis Result: {analysis}")
 
+                # Save snapshot for debugging and test fixture generation
+                from app.core.snapshot import save_snapshot
+
+                save_snapshot(job.volume_label, analysis)
+
                 # Update job with analysis results
                 job.content_type = analysis.content_type
                 job.detected_title = analysis.detected_name
                 job.detected_season = analysis.detected_season
                 job.total_titles = len(titles)
                 job.updated_at = datetime.utcnow()
+
+                # Persist classification metadata
+                job.classification_confidence = analysis.confidence
+                job.classification_source = analysis.classification_source
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.is_ambiguous_movie = analysis.is_ambiguous_movie
+                if analysis.play_all_title_indices:
+                    import json
+
+                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
 
                 # Extract disc number from volume label (e.g., "SHOW_S01D2" -> 2)
                 import re

--- a/backend/tests/unit/test_snapshot.py
+++ b/backend/tests/unit/test_snapshot.py
@@ -1,0 +1,92 @@
+"""Tests for disc scan snapshot capture."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.analyst import DiscAnalysisResult, TitleInfo
+from app.core.snapshot import save_snapshot
+from app.models.disc_job import ContentType
+
+
+class TestSaveSnapshot:
+    """Test snapshot file generation."""
+
+    def test_saves_json_file(self, tmp_path):
+        """Snapshot creates a valid JSON file in the snapshots directory."""
+        analysis = DiscAnalysisResult(
+            content_type=ContentType.TV,
+            confidence=0.95,
+            classification_source="tmdb+heuristic",
+            detected_name="Arrested Development",
+            detected_season=1,
+            tmdb_id=4589,
+            tmdb_name="Arrested Development",
+            titles=[
+                TitleInfo(index=0, duration_seconds=1320, size_bytes=500_000_000, chapter_count=5),
+                TitleInfo(index=1, duration_seconds=1380, size_bytes=520_000_000, chapter_count=5),
+            ],
+            play_all_title_indices=[2],
+        )
+
+        with patch("app.core.snapshot.SNAPSHOTS_DIR", tmp_path):
+            result = save_snapshot("ARRESTED_DEVELOPMENT_S1D1", analysis)
+
+        assert result is not None
+        assert result.exists()
+
+        data = json.loads(result.read_text())
+        assert data["volume_label"] == "ARRESTED_DEVELOPMENT_S1D1"
+        assert data["classification"]["content_type"] == "tv"
+        assert data["classification"]["confidence"] == 0.95
+        assert data["classification"]["source"] == "tmdb+heuristic"
+        assert data["classification"]["detected_name"] == "Arrested Development"
+        assert data["tmdb"]["id"] == 4589
+        assert len(data["tracks"]) == 2
+        assert data["tracks"][0]["duration_seconds"] == 1320
+        assert data["play_all_indices"] == [2]
+
+    def test_filename_from_volume_label(self, tmp_path):
+        """Snapshot filename is derived from volume label."""
+        analysis = DiscAnalysisResult(content_type=ContentType.MOVIE, confidence=0.9)
+
+        with patch("app.core.snapshot.SNAPSHOTS_DIR", tmp_path):
+            result = save_snapshot("THE_GRANDMASTER_2013", analysis)
+
+        assert result is not None
+        assert result.name.startswith("the_grandmaster_2013_")
+        assert result.suffix == ".json"
+
+    def test_handles_write_failure_gracefully(self, tmp_path):
+        """Snapshot failure returns None without raising."""
+        analysis = DiscAnalysisResult(content_type=ContentType.MOVIE, confidence=0.9)
+
+        # Point to a file (not directory) so mkdir fails
+        bad_path = tmp_path / "blocker.txt"
+        bad_path.write_text("not a dir")
+        nested = bad_path / "snapshots"
+
+        with patch("app.core.snapshot.SNAPSHOTS_DIR", nested):
+            result = save_snapshot("TEST", analysis)
+
+        # Should return None, not raise
+        assert result is None
+
+    def test_movie_snapshot_fields(self, tmp_path):
+        """Movie snapshots include ambiguous_movie flag."""
+        analysis = DiscAnalysisResult(
+            content_type=ContentType.MOVIE,
+            confidence=0.6,
+            classification_source="tmdb",
+            is_ambiguous_movie=True,
+            needs_review=True,
+            review_reason="Ambiguous movie detection",
+        )
+
+        with patch("app.core.snapshot.SNAPSHOTS_DIR", tmp_path):
+            result = save_snapshot("SOME_DISC", analysis)
+
+        data = json.loads(result.read_text())
+        assert data["classification"]["is_ambiguous_movie"] is True
+        assert data["classification"]["needs_review"] is True
+        assert data["classification"]["review_reason"] == "Ambiguous movie detection"


### PR DESCRIPTION
## Summary
- Add 6 classification metadata fields to `DiscJob` model (`classification_confidence`, `classification_source`, `tmdb_id`, `tmdb_name`, `play_all_indices_json`, `is_ambiguous_movie`)
- Persist `DiscAnalysisResult` fields to database after disc analysis
- Auto-save JSON snapshots to `~/.engram/snapshots/` for debugging and test fixture generation
- New `snapshot.py` module with `save_snapshot()` utility

Closes #34

## Test plan
- [x] Unit tests for snapshot generation (4 tests)
- [x] Existing migration tests pass with new schema fields
- [x] All 361 unit + pipeline tests pass

Generated with [Claude Code](https://claude.com/claude-code)