### PR TITLE
feat: TMDB API key validation endpoint and UI

### DIFF
--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import requests
 from fastapi import APIRouter
 from pydantic import BaseModel
 
@@ -18,6 +19,12 @@ class ValidationRequest(BaseModel):
     """Request model for validation endpoints."""
 
     path: str
+
+
+class TmdbValidationRequest(BaseModel):
+    """Request model for TMDB API key validation."""
+
+    api_key: str
 
 
 class ValidationResponse(BaseModel):
@@ -243,3 +250,37 @@ async def validate_ffmpeg(request: ValidationRequest) -> ValidationResponse:
         return ValidationResponse(valid=False, error="FFmpeg command timeout (10s)")
     except Exception as e:
         return ValidationResponse(valid=False, error=f"Execution failed: {str(e)}")
+
+
+@router.post("/validate/tmdb", response_model=ValidationResponse)
+async def validate_tmdb(request: TmdbValidationRequest) -> ValidationResponse:
+    """Validate a TMDB API key by making a lightweight configuration request."""
+    api_key = request.api_key.strip()
+    if not api_key:
+        return ValidationResponse(valid=False, error="API key is empty")
+
+    from app.core.tmdb_classifier import _build_auth
+
+    headers, params = _build_auth(api_key)
+
+    try:
+        response = requests.get(
+            "https://api.themoviedb.org/3/configuration",
+            headers=headers,
+            params=params,
+            timeout=5,
+        )
+        if response.status_code == 200:
+            return ValidationResponse(valid=True, version="TMDB API v3")
+        elif response.status_code in (401, 403):
+            return ValidationResponse(valid=False, error="Invalid API key or token")
+        else:
+            return ValidationResponse(
+                valid=False, error=f"TMDB returned status {response.status_code}"
+            )
+    except requests.exceptions.Timeout:
+        return ValidationResponse(valid=False, error="TMDB API timeout (5s)")
+    except requests.exceptions.ConnectionError:
+        return ValidationResponse(valid=False, error="Cannot reach TMDB API — check internet connection")
+    except Exception as e:
+        return ValidationResponse(valid=False, error=f"Validation failed: {str(e)}")

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -4,6 +4,7 @@ Tests path validation, configuration validation, and input sanitization.
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from pydantic import ValidationError
 
@@ -315,3 +316,65 @@ class TestConfigurationEdgeCases:
             assert len(config.staging_path) <= 4096
         except ValidationError:
             pass  # Validation error is acceptable
+
+
+class TestTmdbValidation:
+    """Test TMDB API key validation endpoint logic."""
+
+    @patch("app.api.validation.requests.get")
+    def test_valid_tmdb_key(self, mock_get):
+        """Valid TMDB key returns valid=True."""
+        from app.api.validation import validate_tmdb, TmdbValidationRequest
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        import asyncio
+
+        req = TmdbValidationRequest(api_key="eyJhbGciOiJIUzI1NiJ9.test.sig")
+        result = asyncio.run(validate_tmdb(req))
+        assert result.valid is True
+
+    @patch("app.api.validation.requests.get")
+    def test_invalid_tmdb_key(self, mock_get):
+        """Invalid TMDB key returns valid=False with error."""
+        from app.api.validation import validate_tmdb, TmdbValidationRequest
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_get.return_value = mock_response
+
+        import asyncio
+
+        req = TmdbValidationRequest(api_key="bad_key")
+        result = asyncio.run(validate_tmdb(req))
+        assert result.valid is False
+        assert "Invalid" in result.error
+
+    def test_empty_tmdb_key(self):
+        """Empty TMDB key returns valid=False."""
+        from app.api.validation import validate_tmdb, TmdbValidationRequest
+
+        import asyncio
+
+        req = TmdbValidationRequest(api_key="")
+        result = asyncio.run(validate_tmdb(req))
+        assert result.valid is False
+        assert "empty" in result.error.lower()
+
+    @patch("app.api.validation.requests.get")
+    def test_tmdb_network_error(self, mock_get):
+        """Network error returns valid=False with connection error."""
+        import requests as req_lib
+
+        from app.api.validation import validate_tmdb, TmdbValidationRequest
+
+        mock_get.side_effect = req_lib.exceptions.ConnectionError("DNS failed")
+
+        import asyncio
+
+        req = TmdbValidationRequest(api_key="some_key")
+        result = asyncio.run(validate_tmdb(req))
+        assert result.valid is False
+        assert "connection" in result.error.lower()

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -54,6 +54,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [showMakemkvOverride, setShowMakemkvOverride] = useState(false);
     const [showFfmpegOverride, setShowFfmpegOverride] = useState(false);
     const [savedKeys, setSavedKeys] = useState<{makemkv: boolean, tmdb: boolean}>({makemkv: false, tmdb: false});
+    const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid', error?: string}>({status: 'idle'});
 
     const totalSteps = 4;
 
@@ -178,6 +179,30 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
             alert(`Failed to save configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
         } finally {
             setIsSaving(false);
+        }
+    };
+
+    const handleTestTmdb = async () => {
+        const key = config.tmdbApiKey.trim();
+        if (!key) {
+            setTmdbValidation({status: 'invalid', error: 'Please enter a token first'});
+            return;
+        }
+        setTmdbValidation({status: 'testing'});
+        try {
+            const response = await fetch('/api/validate/tmdb', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ api_key: key }),
+            });
+            const result = await response.json();
+            if (result.valid) {
+                setTmdbValidation({status: 'valid'});
+            } else {
+                setTmdbValidation({status: 'invalid', error: result.error || 'Invalid token'});
+            }
+        } catch {
+            setTmdbValidation({status: 'invalid', error: 'Failed to reach validation endpoint'});
         }
     };
 
@@ -403,9 +428,29 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 id="tmdbApiKey"
                                 type="text"
                                 value={config.tmdbApiKey}
-                                onChange={(e) => handleInputChange('tmdbApiKey', e.target.value)}
+                                onChange={(e) => {
+                                    handleInputChange('tmdbApiKey', e.target.value);
+                                    setTmdbValidation({status: 'idle'});
+                                }}
                                 placeholder={savedKeys.tmdb ? "Enter new token to replace existing" : "eyJhbGciOiJIUzI1NiJ9..."}
                             />
+                            <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem'}}>
+                                <button
+                                    type="button"
+                                    onClick={handleTestTmdb}
+                                    disabled={tmdbValidation.status === 'testing' || (!config.tmdbApiKey && !savedKeys.tmdb)}
+                                    className="btn-secondary"
+                                    style={{padding: '0.25rem 0.75rem', fontSize: '0.85rem'}}
+                                >
+                                    {tmdbValidation.status === 'testing' ? 'Testing...' : 'Test Token'}
+                                </button>
+                                {tmdbValidation.status === 'valid' && (
+                                    <span style={{color: '#22c55e', fontSize: '0.85rem'}}>Valid token</span>
+                                )}
+                                {tmdbValidation.status === 'invalid' && (
+                                    <span style={{color: '#ef4444', fontSize: '0.85rem'}}>{tmdbValidation.error}</span>
+                                )}
+                            </div>
                             <span className="form-hint">
                                 The Read Access Token is a long JWT string starting with "eyJ...".
                                 Find it under API &rarr; Read Access Token in your TMDB account settings.


### PR DESCRIPTION
## Summary
- Add `POST /api/validate/tmdb` endpoint that tests the key against TMDB's `/3/configuration` endpoint
- Add "Test Token" button to ConfigWizard TMDB step with valid/invalid/testing feedback states
- Reset validation state when user edits the token field
- Handles network errors, timeouts, and invalid keys gracefully

Closes #22

## Test plan
- [x] Unit tests for TMDB validation endpoint (4 tests: valid key, invalid key, empty key, network error)
- [x] Frontend builds clean (`npm run build`)
- [x] All 27 validation tests pass

Generated with [Claude Code](https://claude.com/claude-code)