### PR TITLE
feat: processing visibility and match scores on cards

### DIFF
--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -10,7 +10,7 @@ import { DiscMetadata } from "./DiscCard/DiscMetadata";
 import { ActionButtons } from "./DiscCard/ActionButtons";
 
 export type MediaType = "movie" | "tv" | "unknown";
-export type DiscState = "idle" | "scanning" | "archiving_iso" | "ripping" | "processing" | "completed" | "error";
+export type DiscState = "idle" | "scanning" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
 export type TrackState = "pending" | "ripping" | "matching" | "matched" | "failed";
 
 export interface MatchCandidate {
@@ -89,7 +89,9 @@ const stateColors = {
   scanning: { from: "#06b6d4", to: "#22d3ee" }, // cyan
   archiving_iso: { from: "#8b5cf6", to: "#a78bfa" },
   ripping: { from: "#ec4899", to: "#f472b6" }, // magenta
-  processing: { from: "#f59e0b", to: "#fbbf24" }, // amber — matching/organizing
+  matching: { from: "#f59e0b", to: "#fbbf24" }, // amber
+  organizing: { from: "#8b5cf6", to: "#a78bfa" }, // violet
+  processing: { from: "#f59e0b", to: "#fbbf24" }, // amber — legacy fallback
   completed: { from: "#10b981", to: "#34d399" },
   error: { from: "#ef4444", to: "#f87171" },
 };
@@ -208,7 +210,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                 />
 
                 {/* State overlay icon */}
-                {["scanning", "archiving_iso", "ripping", "processing"].includes(disc.state) && (
+                {["scanning", "archiving_iso", "ripping", "matching", "organizing", "processing"].includes(disc.state) && (
                   <div className="absolute inset-0 flex items-center justify-center bg-black/30">
                     <motion.div
                       animate={{ rotate: 360 }}
@@ -323,22 +325,25 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                 </>
               )}
 
-              {/* Processing state (matching/organizing) - show track grid with status */}
-              {disc.state === "processing" && disc.tracks && (
+              {/* Matching state - show track grid with match progress */}
+              {disc.state === "matching" && disc.tracks && (
                 <>
                   <div className="flex items-center gap-3 text-sm text-amber-400 font-mono mb-3">
                     <motion.div
                       animate={{ opacity: [0.4, 1, 0.4] }}
                       transition={{ duration: 1.5, repeat: Infinity }}
                     >
-                      &gt; {disc.mediaType === "tv" ? "MATCHING EPISODES..." : "ORGANIZING FILES..."}
+                      &gt; MATCHING EPISODES...
                     </motion.div>
+                    {disc.subtitleStatus === 'downloading' && (
+                      <span className="text-xs text-cyan-400">(downloading subtitles)</span>
+                    )}
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4 font-mono">
+                  <div className="grid grid-cols-3 gap-4 font-mono">
                     <div className="flex flex-col">
                       <span className="text-xs text-slate-400 uppercase tracking-wider mb-1 font-bold" style={{ textShadow: "0 0 4px rgba(148, 163, 184, 0.5)" }}>
-                        &gt; COMPLETED
+                        &gt; MATCHED
                       </span>
                       <span className="text-sm font-bold text-green-400" style={{ textShadow: "0 0 8px rgba(16, 185, 129, 0.8)" }}>
                         {disc.tracks.filter(t => t.state === "matched").length}/{disc.tracks.length}
@@ -352,9 +357,68 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                         {disc.tracks.filter(t => t.state === "matching").length}
                       </span>
                     </div>
+                    <div className="flex flex-col">
+                      <span className="text-xs text-slate-400 uppercase tracking-wider mb-1 font-bold" style={{ textShadow: "0 0 4px rgba(148, 163, 184, 0.5)" }}>
+                        &gt; PENDING
+                      </span>
+                      <span className="text-sm font-bold text-slate-400" style={{ textShadow: "0 0 4px rgba(148, 163, 184, 0.5)" }}>
+                        {disc.tracks.filter(t => t.state === "pending").length}
+                      </span>
+                    </div>
                   </div>
 
                   {/* Track Grid */}
+                  <TrackGrid tracks={disc.tracks} />
+                </>
+              )}
+
+              {/* Organizing state - show file organization progress */}
+              {disc.state === "organizing" && disc.tracks && (
+                <>
+                  <div className="flex items-center gap-3 text-sm text-violet-400 font-mono mb-3">
+                    <motion.div
+                      animate={{ opacity: [0.4, 1, 0.4] }}
+                      transition={{ duration: 1.5, repeat: Infinity }}
+                    >
+                      &gt; ORGANIZING TO LIBRARY...
+                    </motion.div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-4 font-mono">
+                    <div className="flex flex-col">
+                      <span className="text-xs text-slate-400 uppercase tracking-wider mb-1 font-bold" style={{ textShadow: "0 0 4px rgba(148, 163, 184, 0.5)" }}>
+                        &gt; ORGANIZED
+                      </span>
+                      <span className="text-sm font-bold text-green-400" style={{ textShadow: "0 0 8px rgba(16, 185, 129, 0.8)" }}>
+                        {disc.tracks.filter(t => t.organizedTo).length}/{disc.tracks.length}
+                      </span>
+                    </div>
+                    <div className="flex flex-col">
+                      <span className="text-xs text-slate-400 uppercase tracking-wider mb-1 font-bold" style={{ textShadow: "0 0 4px rgba(148, 163, 184, 0.5)" }}>
+                        &gt; REMAINING
+                      </span>
+                      <span className="text-sm font-bold text-violet-400" style={{ textShadow: "0 0 8px rgba(139, 92, 246, 0.8)" }}>
+                        {disc.tracks.filter(t => !t.organizedTo).length}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Track Grid */}
+                  <TrackGrid tracks={disc.tracks} />
+                </>
+              )}
+
+              {/* Legacy processing state fallback */}
+              {disc.state === "processing" && disc.tracks && (
+                <>
+                  <div className="flex items-center gap-3 text-sm text-amber-400 font-mono mb-3">
+                    <motion.div
+                      animate={{ opacity: [0.4, 1, 0.4] }}
+                      transition={{ duration: 1.5, repeat: Infinity }}
+                    >
+                      &gt; PROCESSING...
+                    </motion.div>
+                  </div>
                   <TrackGrid tracks={disc.tracks} />
                 </>
               )}

--- a/frontend/src/app/components/StateIndicator.tsx
+++ b/frontend/src/app/components/StateIndicator.tsx
@@ -10,6 +10,8 @@ const stateConfig: Record<DiscState, { label: string; color: string; glow: strin
   scanning: { label: "SCANNING", color: "text-cyan-400", glow: "rgba(6, 182, 212, 0.8)" },
   archiving_iso: { label: "ARCHIVING", color: "text-purple-400", glow: "rgba(139, 92, 246, 0.8)" },
   ripping: { label: "RIPPING", color: "text-magenta-400", glow: "rgba(236, 72, 153, 0.8)" },
+  matching: { label: "MATCHING", color: "text-amber-400", glow: "rgba(245, 158, 11, 0.8)" },
+  organizing: { label: "ORGANIZING", color: "text-violet-400", glow: "rgba(139, 92, 246, 0.8)" },
   processing: { label: "PROCESSING", color: "text-amber-400", glow: "rgba(245, 158, 11, 0.8)" },
   completed: { label: "COMPLETE", color: "text-green-400", glow: "rgba(16, 185, 129, 0.8)" },
   error: { label: "ERROR", color: "text-red-400", glow: "rgba(239, 68, 68, 0.8)" },

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -225,11 +225,18 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks }: TrackGridProp
                       <span className="text-green-400 font-mono border-l-2 border-green-400 pl-2 flex-1">
                         → {track.finalMatch}
                       </span>
-                      {track.finalMatchVotes !== undefined && (
-                        <span className="text-green-300 font-mono font-bold shrink-0">
-                          {Math.min(track.finalMatchVotes, track.finalMatchTargetVotes || 4)}/{track.finalMatchTargetVotes || 4}
-                        </span>
-                      )}
+                      <span className="flex items-center gap-2 shrink-0">
+                        {track.finalMatchConfidence !== undefined && (
+                          <span className={`font-mono font-bold ${track.finalMatchConfidence >= 0.7 ? 'text-green-300' : track.finalMatchConfidence >= 0.4 ? 'text-yellow-300' : 'text-red-300'}`}>
+                            {(track.finalMatchConfidence * 100).toFixed(0)}%
+                          </span>
+                        )}
+                        {track.finalMatchVotes !== undefined && (
+                          <span className="text-green-300 font-mono font-bold">
+                            {Math.min(track.finalMatchVotes, track.finalMatchTargetVotes || 4)}/{track.finalMatchTargetVotes || 4}
+                          </span>
+                        )}
+                      </span>
                     </div>
 
                     {/* Runner-ups */}

--- a/frontend/src/types/__tests__/adapters.test.ts
+++ b/frontend/src/types/__tests__/adapters.test.ts
@@ -16,8 +16,8 @@ describe("mapJobStateToDiscState", () => {
     ["identifying", "scanning"],
     ["review_needed", "scanning"],
     ["ripping", "ripping"],
-    ["matching", "processing"],
-    ["organizing", "processing"],
+    ["matching", "matching"],
+    ["organizing", "organizing"],
     ["completed", "completed"],
     ["failed", "error"],
   ];

--- a/frontend/src/types/__tests__/discstate-mapping.test.ts
+++ b/frontend/src/types/__tests__/discstate-mapping.test.ts
@@ -11,14 +11,14 @@ import { mapJobStateToDiscState, mapTitleStateToTrackState } from '../adapters';
 
 describe('Issue #16: Processing state visibility', () => {
   describe('mapJobStateToDiscState', () => {
-    it('should map "matching" to "processing" state', () => {
+    it('should map "matching" to "matching" state', () => {
       const result = mapJobStateToDiscState('matching');
-      expect(result).toBe('processing');
+      expect(result).toBe('matching');
     });
 
-    it('should map "organizing" to "processing" state', () => {
+    it('should map "organizing" to "organizing" state', () => {
       const result = mapJobStateToDiscState('organizing');
-      expect(result).toBe('processing');
+      expect(result).toBe('organizing');
     });
 
     it('should still map "ripping" to "ripping"', () => {

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -11,8 +11,8 @@ export function mapJobStateToDiscState(jobState: Job['state']): DiscState {
     'identifying': 'scanning',
     'review_needed': 'scanning',
     'ripping': 'ripping',
-    'matching': 'processing',
-    'organizing': 'processing',
+    'matching': 'matching',
+    'organizing': 'organizing',
     'completed': 'completed',
     'failed': 'error'
   };


### PR DESCRIPTION
## Summary

### Issue #16 — Processing visibility
- Split the single `processing` DiscState into distinct `matching` and `organizing` states
- **Matching state**: amber theme, shows matched/in-progress/pending track counts, subtitle download indicator
- **Organizing state**: violet theme, shows organized/remaining counts
- Each state has a distinct `StateIndicator` label and pulsing animation
- Users can now clearly tell whether the app is fingerprinting audio or moving files to the library

### Issue #30 — Match scores on cards
- Added color-coded confidence percentage (green ≥70%, yellow ≥40%, red <40%) next to vote counts on matched tracks in TrackGrid
- `match_details` was already being broadcast via WebSocket and consumed by the frontend — no backend changes needed

Closes #16, Closes #30

## Test plan
- [x] Frontend builds clean (`npm run build`)
- [x] All 357 backend tests pass
- [x] Adapter tests updated for new state mappings
- [ ] Manual: simulate TV disc, verify matching state shows track counts and subtitle indicator
- [ ] Manual: simulate movie disc, verify organizing state shows violet theme

Generated with [Claude Code](https://claude.com/claude-code)