### PR TITLE
feat: configurable staging file cleanup policies

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -67,6 +67,9 @@ class ConfigResponse(BaseModel):
     ripping_file_ready_timeout: float
     # Sentinel monitoring
     sentinel_poll_interval: float
+    # Staging cleanup
+    staging_cleanup_policy: str
+    staging_cleanup_days: int
     # Onboarding
     setup_complete: bool
 
@@ -97,6 +100,9 @@ class ConfigUpdate(BaseModel):
     ripping_file_ready_timeout: float | None = None
     # Sentinel monitoring
     sentinel_poll_interval: float | None = None
+    # Staging cleanup
+    staging_cleanup_policy: str | None = None
+    staging_cleanup_days: int | None = None
     # Onboarding
     setup_complete: bool | None = None
 
@@ -328,6 +334,9 @@ async def get_config() -> ConfigResponse:
         ripping_file_ready_timeout=config.ripping_file_ready_timeout,
         # Sentinel monitoring
         sentinel_poll_interval=config.sentinel_poll_interval,
+        # Staging cleanup
+        staging_cleanup_policy=config.staging_cleanup_policy,
+        staging_cleanup_days=config.staging_cleanup_days,
         # Onboarding
         setup_complete=config.setup_complete,
     )
@@ -685,3 +694,71 @@ async def cleanup_orphaned_staging(session: AsyncSession = Depends(get_session))
             logger.error(f"Failed to delete {item['path']}: {e}")
 
     return {"deleted_count": deleted_count, "reclaimed_bytes": orphaned_info["total_size"]}
+
+
+@router.get("/staging/size")
+async def get_staging_size(session: AsyncSession = Depends(get_session)) -> dict:
+    """Get total staging directory size and per-job breakdown."""
+    from pathlib import Path
+
+    from app.services.config_service import get_config
+
+    config = await get_config()
+    staging_root = Path(config.staging_path)
+
+    if not staging_root.exists():
+        return {"total_size": 0, "jobs": [], "policy": config.staging_cleanup_policy}
+
+    jobs = []
+    total_size = 0
+
+    for d in staging_root.iterdir():
+        if not d.is_dir():
+            continue
+        size = sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
+        jobs.append({"path": str(d), "name": d.name, "size_bytes": size})
+        total_size += size
+
+    return {
+        "total_size": total_size,
+        "jobs": jobs,
+        "policy": config.staging_cleanup_policy,
+        "cleanup_days": config.staging_cleanup_days,
+    }
+
+
+@router.delete("/staging/job/{job_id}")
+async def cleanup_job_staging(
+    job_id: int, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Delete staging files for a specific job."""
+    import shutil
+
+    job = await session.get(DiscJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Safety: only allow cleanup for terminal jobs
+    if job.state not in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot clean staging for active job (state: {job.state.value})",
+        )
+
+    if not job.staging_path:
+        return {"deleted": False, "reason": "No staging path set"}
+
+    from pathlib import Path
+
+    staging_path = Path(job.staging_path)
+    if not staging_path.exists():
+        return {"deleted": False, "reason": "Staging directory already removed"}
+
+    size = sum(f.stat().st_size for f in staging_path.rglob("*") if f.is_file())
+
+    try:
+        shutil.rmtree(staging_path)
+        logger.info(f"Manually cleaned staging for job {job_id}: {staging_path}")
+        return {"deleted": True, "reclaimed_bytes": size}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to delete staging: {e}") from e

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -58,5 +58,9 @@ class AppConfig(SQLModel, table=True):
     # Sentinel Drive Monitoring
     sentinel_poll_interval: float = 2.0  # Seconds between drive polls
 
+    # Staging Cleanup
+    staging_cleanup_policy: str = "on_success"  # "on_success" | "on_completion" | "manual" | "after_days"
+    staging_cleanup_days: int = 7  # Only used when policy is "after_days"
+
     # Onboarding
     setup_complete: bool = False  # Set True after user completes setup wizard

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -96,6 +96,10 @@ class JobManager:
         self._episode_runtimes: dict[int, list[int]] = {}  # job_id → episode runtimes in minutes
         self._loop: asyncio.AbstractEventLoop | None = None
         self._match_semaphore: asyncio.Semaphore | None = None
+        self._timed_cleanup_task: asyncio.Task | None = None
+
+        # Register staging cleanup on terminal job states
+        state_machine.on_terminal_state(self._on_job_terminal)
 
     async def start(self) -> None:
         """Start the job manager and begin monitoring drives."""
@@ -127,6 +131,13 @@ class JobManager:
                 f"in config, using {concurrency}"
             )
         self._match_semaphore = asyncio.Semaphore(concurrency)
+
+        # Start timed staging cleanup if policy is "after_days"
+        if config.staging_cleanup_policy == "after_days":
+            self._timed_cleanup_task = asyncio.create_task(
+                self._run_timed_cleanup(config.staging_path, config.staging_cleanup_days)
+            )
+
         logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
 
     async def _cleanup_stale_jobs(self) -> None:
@@ -878,9 +889,7 @@ class JobManager:
                 job.progress_percent = 100.0
                 await state_machine.transition_to_completed(job, session)
 
-            # Clean up staging directory if job completed successfully
-            if job.state == JobState.COMPLETED:
-                await self._cleanup_staging(job_id)
+            # Staging cleanup is now handled by the state machine's terminal-state callback
 
     def _on_task_done(self, task: asyncio.Task, job_id: int) -> None:
         """Callback for background tasks to log any unhandled exceptions."""
@@ -889,8 +898,25 @@ class JobManager:
         elif exc := task.exception():
             logger.error(f"Job {job_id} task failed with exception: {exc}", exc_info=exc)
 
-    async def _cleanup_staging(self, job_id: int) -> None:
-        """Clean up staging directory after successful job completion."""
+    async def _on_job_terminal(self, job_id: int, state: JobState) -> None:
+        """Called by state machine when a job reaches COMPLETED or FAILED."""
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        policy = config.staging_cleanup_policy
+
+        if policy == "manual":
+            return
+        if policy == "after_days":
+            # Timed cleanup handled by background task, not here
+            return
+        if policy == "on_success" and state == JobState.COMPLETED:
+            await self._delete_staging(job_id)
+        elif policy == "on_completion":
+            await self._delete_staging(job_id)
+
+    async def _delete_staging(self, job_id: int) -> None:
+        """Delete the staging directory for a job."""
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
             if not job or not job.staging_path:
@@ -901,13 +927,45 @@ class JobManager:
                 return
 
             try:
-                # Remove all files and directory
                 import shutil
 
                 shutil.rmtree(staging_path)
                 logger.info(f"Cleaned up staging directory: {staging_path}")
             except Exception as e:
                 logger.warning(f"Failed to clean staging for job {job_id}: {e}")
+
+    async def _run_timed_cleanup(self, staging_root: str, max_age_days: int) -> None:
+        """Background task: periodically delete staging dirs older than max_age_days."""
+        import shutil
+
+        interval = 3600  # Check every hour
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                root = Path(staging_root)
+                if not root.exists():
+                    continue
+
+                now = time.time()
+                cutoff = now - (max_age_days * 86400)
+
+                for d in root.iterdir():
+                    if not d.is_dir() or not d.name.startswith("job_"):
+                        continue
+                    try:
+                        mtime = d.stat().st_mtime
+                        if mtime < cutoff:
+                            shutil.rmtree(d)
+                            logger.info(
+                                f"Timed cleanup: deleted staging dir {d.name} "
+                                f"(age: {(now - mtime) / 86400:.1f} days)"
+                            )
+                    except Exception as e:
+                        logger.warning(f"Timed cleanup: failed to delete {d}: {e}")
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Timed cleanup error: {e}", exc_info=True)
 
     async def _run_ripping(self, job_id: int) -> None:
         """Execute the ripping process."""

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -54,6 +54,14 @@ class JobStateMachine:
 
     def __init__(self, event_broadcaster: EventBroadcaster):
         self._broadcaster = event_broadcaster
+        self._on_terminal_callbacks: list = []
+
+    def on_terminal_state(self, callback) -> None:
+        """Register a callback invoked when a job reaches a terminal state (COMPLETED/FAILED).
+
+        Callback signature: async def callback(job_id: int, state: JobState) -> None
+        """
+        self._on_terminal_callbacks.append(callback)
 
     def can_transition(self, from_state: JobState, to_state: JobState) -> bool:
         """Validate if state transition is allowed.
@@ -134,6 +142,16 @@ class JobStateMachine:
                     f"Job {job.id}: broadcast failed after committing {to_state.value}: {e}",
                     exc_info=True,
                 )
+
+        # Fire terminal-state callbacks (COMPLETED or FAILED)
+        if to_state in (JobState.COMPLETED, JobState.FAILED):
+            for cb in self._on_terminal_callbacks:
+                try:
+                    await cb(job.id, to_state)
+                except Exception as e:
+                    logger.error(
+                        f"Job {job.id}: terminal-state callback failed: {e}", exc_info=True
+                    )
 
         return True
 

--- a/backend/tests/unit/test_staging_cleanup.py
+++ b/backend/tests/unit/test_staging_cleanup.py
@@ -1,0 +1,236 @@
+"""Tests for staged file cleanup policies (#28)."""
+
+import asyncio
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models import JobState
+from app.services.job_state_machine import JobStateMachine
+
+# ---------------------------------------------------------------------------
+# State machine terminal callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def state_machine():
+    broadcaster = MagicMock()
+    broadcaster.broadcast_job_completed = AsyncMock()
+    broadcaster.broadcast_job_failed = AsyncMock()
+    broadcaster.broadcast_job_state_changed = AsyncMock()
+    return JobStateMachine(broadcaster)
+
+
+class TestTerminalCallback:
+    """Verify that the state machine fires callbacks on COMPLETED/FAILED."""
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_on_completed(self, state_machine):
+        callback = AsyncMock()
+        state_machine.on_terminal_state(callback)
+
+        job = MagicMock()
+        job.id = 1
+        job.state = JobState.ORGANIZING
+
+        session = AsyncMock()
+
+        await state_machine.transition(job, JobState.COMPLETED, session)
+        callback.assert_awaited_once_with(1, JobState.COMPLETED)
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_on_failed(self, state_machine):
+        callback = AsyncMock()
+        state_machine.on_terminal_state(callback)
+
+        job = MagicMock()
+        job.id = 2
+        job.state = JobState.RIPPING
+
+        session = AsyncMock()
+
+        await state_machine.transition(
+            job, JobState.FAILED, session, error_message="test error"
+        )
+        callback.assert_awaited_once_with(2, JobState.FAILED)
+
+    @pytest.mark.asyncio
+    async def test_callback_not_fired_on_non_terminal(self, state_machine):
+        callback = AsyncMock()
+        state_machine.on_terminal_state(callback)
+
+        job = MagicMock()
+        job.id = 3
+        job.state = JobState.IDENTIFYING
+
+        session = AsyncMock()
+
+        await state_machine.transition(job, JobState.RIPPING, session)
+        callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_callback_error_does_not_prevent_transition(self, state_machine):
+        callback = AsyncMock(side_effect=RuntimeError("boom"))
+        state_machine.on_terminal_state(callback)
+
+        job = MagicMock()
+        job.id = 4
+        job.state = JobState.ORGANIZING
+
+        session = AsyncMock()
+
+        result = await state_machine.transition(job, JobState.COMPLETED, session)
+        assert result is True  # Transition still succeeds
+
+
+# ---------------------------------------------------------------------------
+# Policy-based cleanup (_on_job_terminal)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupPolicy:
+    """Test that _on_job_terminal respects the configured policy."""
+
+    def _make_job_manager(self):
+        """Create a minimal JobManager with mocked dependencies."""
+        with patch("app.services.job_manager.DriveMonitor"), \
+             patch("app.services.job_manager.MakeMKVExtractor"), \
+             patch("app.services.job_manager.DiscAnalyst"):
+            from app.services.job_manager import JobManager
+            jm = JobManager()
+            jm._delete_staging = AsyncMock()
+            return jm
+
+    @pytest.mark.asyncio
+    async def test_on_success_cleans_completed(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="on_success")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(1, JobState.COMPLETED)
+        jm._delete_staging.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_on_success_skips_failed(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="on_success")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(2, JobState.FAILED)
+        jm._delete_staging.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_completion_cleans_completed(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="on_completion")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(3, JobState.COMPLETED)
+        jm._delete_staging.assert_awaited_once_with(3)
+
+    @pytest.mark.asyncio
+    async def test_on_completion_cleans_failed(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="on_completion")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(4, JobState.FAILED)
+        jm._delete_staging.assert_awaited_once_with(4)
+
+    @pytest.mark.asyncio
+    async def test_manual_never_cleans(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="manual")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(5, JobState.COMPLETED)
+            await jm._on_job_terminal(6, JobState.FAILED)
+        jm._delete_staging.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_after_days_defers_to_background(self):
+        jm = self._make_job_manager()
+        config = MagicMock(staging_cleanup_policy="after_days")
+        with patch("app.services.config_service.get_config", return_value=config):
+            await jm._on_job_terminal(7, JobState.COMPLETED)
+        jm._delete_staging.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Timed cleanup (_run_timed_cleanup)
+# ---------------------------------------------------------------------------
+
+
+class TestTimedCleanup:
+    """Test the background timed cleanup task."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_directories(self, tmp_path):
+        """Directories older than max_age_days should be deleted."""
+        # Create a "job_1" dir and backdate it
+        old_dir = tmp_path / "job_1"
+        old_dir.mkdir()
+        (old_dir / "title_0.mkv").write_text("fake")
+        # Set mtime to 10 days ago
+        old_time = time.time() - (10 * 86400)
+        os.utime(old_dir, (old_time, old_time))
+
+        # Create a "job_2" dir that's recent
+        new_dir = tmp_path / "job_2"
+        new_dir.mkdir()
+        (new_dir / "title_0.mkv").write_text("fake")
+
+        with patch("app.services.job_manager.DriveMonitor"), \
+             patch("app.services.job_manager.MakeMKVExtractor"), \
+             patch("app.services.job_manager.DiscAnalyst"):
+            from app.services.job_manager import JobManager
+            jm = JobManager()
+
+        # Monkey-patch sleep: first call returns immediately (lets cleanup run),
+        # second call cancels.
+        call_count = 0
+
+        async def mock_sleep(duration):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return  # Let the first iteration proceed
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=mock_sleep):
+            try:
+                await jm._run_timed_cleanup(str(tmp_path), max_age_days=7)
+            except asyncio.CancelledError:
+                pass
+
+        assert not old_dir.exists(), "Old staging dir should be deleted"
+        assert new_dir.exists(), "Recent staging dir should be preserved"
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_job_directories(self, tmp_path):
+        """Directories not matching job_* prefix should be ignored."""
+        other_dir = tmp_path / "other_stuff"
+        other_dir.mkdir()
+        old_time = time.time() - (30 * 86400)
+        os.utime(other_dir, (old_time, old_time))
+
+        with patch("app.services.job_manager.DriveMonitor"), \
+             patch("app.services.job_manager.MakeMKVExtractor"), \
+             patch("app.services.job_manager.DiscAnalyst"):
+            from app.services.job_manager import JobManager
+            jm = JobManager()
+
+        call_count = 0
+
+        async def mock_sleep(duration):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return
+            raise asyncio.CancelledError()
+
+        with patch("asyncio.sleep", side_effect=mock_sleep):
+            try:
+                await jm._run_timed_cleanup(str(tmp_path), max_age_days=7)
+            except asyncio.CancelledError:
+                pass
+
+        assert other_dir.exists(), "Non-job directory should not be deleted"

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -18,6 +18,8 @@ interface ConfigData {
     maxConcurrentMatches: number;
     ffmpegPath: string;
     conflictResolutionDefault: string;
+    stagingCleanupPolicy: string;
+    stagingCleanupDays: number;
 }
 
 interface ToolDetectionResult {
@@ -47,6 +49,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         maxConcurrentMatches: 2,
         ffmpegPath: '',
         conflictResolutionDefault: 'ask',
+        stagingCleanupPolicy: 'on_success',
+        stagingCleanupDays: 7,
     });
     const [isSaving, setIsSaving] = useState(false);
     const [toolDetection, setToolDetection] = useState<DetectToolsResponse | null>(null);
@@ -84,6 +88,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     maxConcurrentMatches: data.max_concurrent_matches ?? 2,
                     ffmpegPath: data.ffmpeg_path || '',
                     conflictResolutionDefault: data.conflict_resolution_default || 'ask',
+                    stagingCleanupPolicy: data.staging_cleanup_policy || 'on_success',
+                    stagingCleanupDays: data.staging_cleanup_days ?? 7,
                 });
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -161,6 +167,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     max_concurrent_matches: config.maxConcurrentMatches,
                     ffmpeg_path: config.ffmpegPath,
                     conflict_resolution_default: config.conflictResolutionDefault,
+                    staging_cleanup_policy: config.stagingCleanupPolicy,
+                    staging_cleanup_days: config.stagingCleanupDays,
                     setup_complete: true,
                 }),
             });
@@ -469,6 +477,40 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 What should Engram do when a file already exists in your library?
                             </span>
                         </div>
+
+                        <div className="form-group">
+                            <label htmlFor="stagingCleanup">Staging Cleanup Policy</label>
+                            <select
+                                id="stagingCleanup"
+                                value={config.stagingCleanupPolicy}
+                                onChange={(e) => handleInputChange('stagingCleanupPolicy', e.target.value)}
+                            >
+                                <option value="on_success">Clean on success (delete after organization)</option>
+                                <option value="on_completion">Clean on completion (delete after success or failure)</option>
+                                <option value="after_days">Clean after N days</option>
+                                <option value="manual">Manual only (never auto-delete)</option>
+                            </select>
+                            <span className="form-hint">
+                                When should staging files be automatically deleted? A single Blu-ray rip can be 30-50GB.
+                            </span>
+                        </div>
+
+                        {config.stagingCleanupPolicy === 'after_days' && (
+                            <div className="form-group">
+                                <label htmlFor="stagingCleanupDays">Cleanup After (days)</label>
+                                <input
+                                    id="stagingCleanupDays"
+                                    type="number"
+                                    min={1}
+                                    max={365}
+                                    value={config.stagingCleanupDays}
+                                    onChange={(e) => handleInputChange('stagingCleanupDays', Math.max(1, parseInt(e.target.value) || 7))}
+                                />
+                                <span className="form-hint">
+                                    Delete staging files older than this many days.
+                                </span>
+                            </div>
+                        )}
 
                         <div className="config-summary">
                             <h4>Configuration Summary</h4>


### PR DESCRIPTION
## Summary
Closes #28

- **Configurable cleanup policies**: `on_success` (default), `on_completion`, `after_days`, `manual`
- **State machine terminal callback**: COMPLETED/FAILED transitions fire cleanup hook — removes scattered cleanup calls
- **Per-job cleanup API**: `DELETE /api/staging/job/{id}` with safety check (only terminal jobs)
- **Staging size API**: `GET /api/staging/size` returns per-directory breakdown
- **Background timed cleanup**: hourly scan deletes `job_*` dirs older than configured days
- **ConfigWizard UI**: dropdown for policy selection + conditional days input

## Files changed
| File | Change |
|------|--------|
| `backend/app/models/app_config.py` | Add `staging_cleanup_policy`, `staging_cleanup_days` |
| `backend/app/services/job_state_machine.py` | Add `on_terminal_state()` callback hook |
| `backend/app/services/job_manager.py` | Policy-aware cleanup, timed background task |
| `backend/app/api/routes.py` | New endpoints + config fields |
| `frontend/src/components/ConfigWizard.tsx` | Cleanup policy UI controls |
| `backend/tests/unit/test_staging_cleanup.py` | 12 tests (callbacks, policies, timed cleanup) |

## Test plan
- [x] 12 new unit tests covering all 4 policies, terminal callbacks, and timed cleanup
- [x] All 292 existing unit tests pass
- [x] Frontend builds clean (tsc + vite)
- [x] Ruff lint passes
- [ ] Manual test: simulate disc → verify staging cleaned per policy
- [ ] Manual test: change policy in ConfigWizard → verify persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)