### PR TITLE
feat: AI-powered disc title resolution (#24)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -186,6 +186,10 @@ class ConfigResponse(BaseModel):
     naming_season_format: str
     naming_episode_format: str
     naming_movie_format: str
+    # AI identification
+    ai_identification_enabled: bool
+    ai_provider: str
+    ai_api_key: str
     # TheDiscDB
     discdb_enabled: bool
     # Onboarding
@@ -226,6 +230,10 @@ class ConfigUpdate(BaseModel):
     naming_season_format: str | None = None
     naming_episode_format: str | None = None
     naming_movie_format: str | None = None
+    # AI identification
+    ai_identification_enabled: bool | None = None
+    ai_provider: str | None = None
+    ai_api_key: str | None = None
     # TheDiscDB
     discdb_enabled: bool | None = None
     # Onboarding
@@ -651,6 +659,10 @@ async def get_config() -> ConfigResponse:
         naming_season_format=config.naming_season_format,
         naming_episode_format=config.naming_episode_format,
         naming_movie_format=config.naming_movie_format,
+        # AI identification
+        ai_identification_enabled=config.ai_identification_enabled,
+        ai_provider=config.ai_provider,
+        ai_api_key="***" if config.ai_api_key else "",  # Redacted
         # TheDiscDB
         discdb_enabled=config.discdb_enabled,
         # Onboarding

--- a/backend/app/core/ai_identifier.py
+++ b/backend/app/core/ai_identifier.py
@@ -1,0 +1,152 @@
+"""AI-powered disc title resolution.
+
+When TMDB lookup fails (obscure titles, non-English discs, abbreviations),
+this module sends the volume label to an LLM API to identify the title,
+then re-queries TMDB with the corrected name.
+
+Supports Anthropic (Claude) and OpenAI as providers.
+"""
+
+import json
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Provider API endpoints
+ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+
+# Models to use per provider
+ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+OPENAI_MODEL = "gpt-4o-mini"
+
+IDENTIFICATION_PROMPT = """You are a media identification assistant. Given a disc volume label from a Blu-ray or DVD, identify the movie or TV show it contains.
+
+Volume label: {volume_label}
+
+Respond with ONLY a JSON object (no markdown, no explanation) in this exact format:
+{{"title": "Official Title", "year": 2020, "type": "movie" or "tv"}}
+
+Rules:
+- "title" must be the official English title as it appears on TMDB/IMDb
+- "year" is the original release year (integer)
+- "type" is either "movie" or "tv"
+- If you cannot identify the disc, respond with: {{"title": null, "year": null, "type": null}}
+- Do NOT guess — only identify if you are confident"""
+
+
+async def identify_from_label(
+    volume_label: str,
+    provider: str,
+    api_key: str,
+) -> dict | None:
+    """Send volume label to an LLM to identify the disc content.
+
+    Returns dict with keys: title, year, type (or None on failure).
+    """
+    prompt = IDENTIFICATION_PROMPT.format(volume_label=volume_label)
+
+    try:
+        if provider == "anthropic":
+            result = await _call_anthropic(prompt, api_key)
+        elif provider == "openai":
+            result = await _call_openai(prompt, api_key)
+        else:
+            logger.warning(f"Unknown AI provider: {provider}")
+            return None
+
+        if not result:
+            return None
+
+        parsed = _parse_response(result)
+        if parsed and parsed.get("title"):
+            logger.info(
+                f"AI identified '{volume_label}' as: "
+                f"{parsed['title']} ({parsed.get('year')}) [{parsed.get('type')}]"
+            )
+            return parsed
+        return None
+
+    except Exception as e:
+        logger.warning(f"AI identification failed for '{volume_label}': {e}")
+        return None
+
+
+async def _call_anthropic(prompt: str, api_key: str) -> str | None:
+    """Call the Anthropic Messages API."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            ANTHROPIC_API_URL,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": ANTHROPIC_MODEL,
+                "max_tokens": 200,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data.get("content") and len(data["content"]) > 0:
+            return data["content"][0].get("text", "")
+        return None
+
+
+async def _call_openai(prompt: str, api_key: str) -> str | None:
+    """Call the OpenAI Chat Completions API."""
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            OPENAI_API_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": OPENAI_MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 200,
+                "temperature": 0,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        choices = data.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "")
+        return None
+
+
+def _parse_response(text: str) -> dict | None:
+    """Parse the LLM response JSON."""
+    # Strip markdown code fences if present
+    text = text.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last lines (```json and ```)
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning(f"Failed to parse AI response as JSON: {text[:200]}")
+        return None
+
+    # Validate expected fields
+    if not isinstance(data, dict):
+        return None
+
+    title = data.get("title")
+    if not title:
+        return None
+
+    return {
+        "title": str(title),
+        "year": int(data["year"]) if data.get("year") else None,
+        "type": data.get("type"),
+    }

--- a/backend/app/core/ai_identifier.py
+++ b/backend/app/core/ai_identifier.py
@@ -4,7 +4,7 @@ When TMDB lookup fails (obscure titles, non-English discs, abbreviations),
 this module sends the volume label to an LLM API to identify the title,
 then re-queries TMDB with the corrected name.
 
-Supports Anthropic (Claude) and OpenAI as providers.
+Supports Anthropic (Claude), OpenAI, and OpenRouter as providers.
 """
 
 import json
@@ -17,10 +17,12 @@ logger = logging.getLogger(__name__)
 # Provider API endpoints
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
 # Models to use per provider
 ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 OPENAI_MODEL = "gpt-4o-mini"
+OPENROUTER_MODEL = "anthropic/claude-haiku-4-5-20251001"
 
 IDENTIFICATION_PROMPT = """You are a media identification assistant. Given a disc volume label from a Blu-ray or DVD, identify the movie or TV show it contains.
 
@@ -52,7 +54,11 @@ async def identify_from_label(
         if provider == "anthropic":
             result = await _call_anthropic(prompt, api_key)
         elif provider == "openai":
-            result = await _call_openai(prompt, api_key)
+            result = await _call_openai_compatible(prompt, api_key, OPENAI_API_URL, OPENAI_MODEL)
+        elif provider == "openrouter":
+            result = await _call_openai_compatible(
+                prompt, api_key, OPENROUTER_API_URL, OPENROUTER_MODEL
+            )
         else:
             logger.warning(f"Unknown AI provider: {provider}")
             return None
@@ -97,17 +103,19 @@ async def _call_anthropic(prompt: str, api_key: str) -> str | None:
         return None
 
 
-async def _call_openai(prompt: str, api_key: str) -> str | None:
-    """Call the OpenAI Chat Completions API."""
+async def _call_openai_compatible(
+    prompt: str, api_key: str, api_url: str, model: str
+) -> str | None:
+    """Call an OpenAI-compatible Chat Completions API (OpenAI, OpenRouter, etc.)."""
     async with httpx.AsyncClient(timeout=15.0) as client:
         response = await client.post(
-            OPENAI_API_URL,
+            api_url,
             headers={
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
             json={
-                "model": OPENAI_MODEL,
+                "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": 200,
                 "temperature": 0,

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -75,6 +75,11 @@ class AppConfig(SQLModel, table=True):
     naming_episode_format: str = "{show} - S{season:02d}E{episode:02d}"
     naming_movie_format: str = "{title} ({year})"
 
+    # AI-powered disc identification
+    ai_identification_enabled: bool = False  # Enable AI-powered title resolution
+    ai_provider: str = "anthropic"  # "anthropic" or "openai"
+    ai_api_key: str = ""  # API key for the selected provider
+
     # TheDiscDB
     discdb_enabled: bool = True  # Enable TheDiscDB lookups for disc identification
 

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -77,7 +77,7 @@ class AppConfig(SQLModel, table=True):
 
     # AI-powered disc identification
     ai_identification_enabled: bool = False  # Enable AI-powered title resolution
-    ai_provider: str = "anthropic"  # "anthropic" or "openai"
+    ai_provider: str = "anthropic"  # "anthropic" | "openai" | "openrouter"
     ai_api_key: str = ""  # API key for the selected provider
 
     # TheDiscDB

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -327,8 +327,62 @@ class JobManager:
                             f"Job {job_id}: TMDB lookup failed, using heuristics only: {e}"
                         )
 
+                # AI-powered identification fallback
+                # Triggers when: TMDB failed AND DiscDB didn't produce a high-confidence match
+                ai_identified_name = None
+                if (
+                    not tmdb_signal
+                    and not (discdb_signal and discdb_signal.confidence >= 0.90)
+                    and config.ai_identification_enabled
+                    and config.ai_api_key
+                ):
+                    try:
+                        from app.core.ai_identifier import identify_from_label
+
+                        logger.info(
+                            f"Job {job_id}: TMDB lookup failed, trying AI identification "
+                            f"for '{job.volume_label}'"
+                        )
+                        ai_result = await identify_from_label(
+                            job.volume_label,
+                            config.ai_provider,
+                            config.ai_api_key,
+                        )
+                        if ai_result and ai_result.get("title"):
+                            ai_identified_name = ai_result["title"]
+                            logger.info(f"Job {job_id}: AI identified as '{ai_identified_name}'")
+                            # Re-query TMDB with the AI-corrected name
+                            if config.tmdb_api_key:
+                                try:
+                                    from app.core.tmdb_classifier import classify_from_tmdb
+
+                                    tmdb_signal = classify_from_tmdb(
+                                        ai_identified_name, config.tmdb_api_key
+                                    )
+                                    if tmdb_signal:
+                                        logger.info(
+                                            f"Job {job_id}: TMDB re-query with AI name: "
+                                            f"{tmdb_signal.content_type.value} "
+                                            f"({tmdb_signal.confidence:.0%}) - "
+                                            f"{tmdb_signal.tmdb_name}"
+                                        )
+                                except Exception as e:
+                                    logger.warning(
+                                        f"Job {job_id}: TMDB re-query after AI failed: {e}"
+                                    )
+                    except Exception as e:
+                        logger.warning(
+                            f"Job {job_id}: AI identification failed: {e}", exc_info=True
+                        )
+
                 # Analyze disc content (DiscDB signal overrides when high-confidence)
                 analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
+
+                # If AI identified a name but TMDB re-query also failed,
+                # use the AI name as the detected title
+                if ai_identified_name and not analysis.detected_name:
+                    analysis.detected_name = ai_identified_name
+                    analysis.classification_source = "ai"
 
                 # If TheDiscDB returned a high-confidence match, override the analysis
                 if discdb_signal and discdb_signal.confidence >= 0.90:

--- a/backend/tests/unit/test_ai_identifier.py
+++ b/backend/tests/unit/test_ai_identifier.py
@@ -1,0 +1,138 @@
+"""Tests for AI-powered disc title resolution."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.ai_identifier import _parse_response, identify_from_label
+
+
+class TestParseResponse:
+    def test_valid_json(self):
+        result = _parse_response('{"title": "Inception", "year": 2010, "type": "movie"}')
+        assert result == {"title": "Inception", "year": 2010, "type": "movie"}
+
+    def test_json_with_code_fences(self):
+        text = '```json\n{"title": "Inception", "year": 2010, "type": "movie"}\n```'
+        result = _parse_response(text)
+        assert result == {"title": "Inception", "year": 2010, "type": "movie"}
+
+    def test_null_title(self):
+        result = _parse_response('{"title": null, "year": null, "type": null}')
+        assert result is None
+
+    def test_empty_title(self):
+        result = _parse_response('{"title": "", "year": null, "type": null}')
+        assert result is None
+
+    def test_invalid_json(self):
+        result = _parse_response("I don't know what this disc is")
+        assert result is None
+
+    def test_missing_year(self):
+        result = _parse_response('{"title": "Some Movie", "type": "movie"}')
+        assert result == {"title": "Some Movie", "year": None, "type": "movie"}
+
+    def test_year_as_string(self):
+        result = _parse_response('{"title": "Test", "year": "2020", "type": "movie"}')
+        assert result["year"] == 2020
+
+    def test_non_dict_json(self):
+        result = _parse_response('["not", "a", "dict"]')
+        assert result is None
+
+    def test_code_fence_without_json_label(self):
+        text = '```\n{"title": "Test", "year": 2020, "type": "tv"}\n```'
+        result = _parse_response(text)
+        assert result == {"title": "Test", "year": 2020, "type": "tv"}
+
+
+def _make_mock_client(response_json: dict):
+    """Create a mock httpx.AsyncClient with the given response."""
+    # Use MagicMock for response — httpx.Response.json() is sync, not async
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_json
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+    return mock_client
+
+
+class TestIdentifyFromLabel:
+    @pytest.mark.asyncio
+    async def test_anthropic_success(self):
+        mock_client = _make_mock_client(
+            {"content": [{"text": '{"title": "Inception", "year": 2010, "type": "movie"}'}]}
+        )
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("INCEPTION_2010", "anthropic", "sk-ant-test")
+
+        assert result is not None
+        assert result["title"] == "Inception"
+        assert result["year"] == 2010
+
+    @pytest.mark.asyncio
+    async def test_openai_success(self):
+        mock_client = _make_mock_client(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"title": "Breaking Bad", "year": 2008, "type": "tv"}'
+                        }
+                    }
+                ]
+            }
+        )
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("BB_S1D1", "openai", "sk-test")
+
+        assert result is not None
+        assert result["title"] == "Breaking Bad"
+        assert result["type"] == "tv"
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider(self):
+        result = await identify_from_label("TEST", "gemini", "key")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("TEST", "anthropic", "key")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ai_returns_null_title(self):
+        mock_client = _make_mock_client(
+            {"content": [{"text": '{"title": null, "year": null, "type": null}'}]}
+        )
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("RANDOM_GARBAGE", "anthropic", "key")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_content_list(self):
+        mock_client = _make_mock_client({"content": []})
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("TEST", "anthropic", "key")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_openai_empty_choices(self):
+        mock_client = _make_mock_client({"choices": []})
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("TEST", "openai", "key")
+
+        assert result is None

--- a/backend/tests/unit/test_ai_identifier.py
+++ b/backend/tests/unit/test_ai_identifier.py
@@ -95,6 +95,26 @@ class TestIdentifyFromLabel:
         assert result["type"] == "tv"
 
     @pytest.mark.asyncio
+    async def test_openrouter_success(self):
+        mock_client = _make_mock_client(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"title": "The Office", "year": 2005, "type": "tv"}'
+                        }
+                    }
+                ]
+            }
+        )
+        with patch("app.core.ai_identifier.httpx.AsyncClient", return_value=mock_client):
+            result = await identify_from_label("THE_OFFICE_S1D1", "openrouter", "sk-or-test")
+
+        assert result is not None
+        assert result["title"] == "The Office"
+        assert result["year"] == 2005
+
+    @pytest.mark.asyncio
     async def test_unknown_provider(self):
         result = await identify_from_label("TEST", "gemini", "key")
         assert result is None

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -25,6 +25,9 @@ interface ConfigData {
     namingEpisodeFormat: string;
     namingMovieFormat: string;
     discdbEnabled: boolean;
+    aiIdentificationEnabled: boolean;
+    aiProvider: string;
+    aiApiKey: string;
 }
 
 interface ToolDetectionResult {
@@ -61,6 +64,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
         namingMovieFormat: '{title} ({year})',
         discdbEnabled: true,
+        aiIdentificationEnabled: false,
+        aiProvider: 'anthropic',
+        aiApiKey: '',
     });
     const [isSaving, setIsSaving] = useState(false);
     const [toolDetection, setToolDetection] = useState<DetectToolsResponse | null>(null);
@@ -106,6 +112,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
                     namingMovieFormat: data.naming_movie_format || '{title} ({year})',
                     discdbEnabled: data.discdb_enabled ?? true,
+                    aiIdentificationEnabled: data.ai_identification_enabled ?? false,
+                    aiProvider: data.ai_provider || 'anthropic',
+                    aiApiKey: data.ai_api_key === '***' ? '' : (data.ai_api_key || ''),
                 });
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -190,6 +199,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     naming_episode_format: config.namingEpisodeFormat,
                     naming_movie_format: config.namingMovieFormat,
                     discdb_enabled: config.discdbEnabled,
+                    ai_identification_enabled: config.aiIdentificationEnabled,
+                    ai_provider: config.aiProvider,
+                    ...(config.aiApiKey ? { ai_api_key: config.aiApiKey } : {}),
                     setup_complete: true,
                 }),
             });
@@ -526,6 +538,53 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 </span>
                             </label>
                         </div>
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    checked={config.aiIdentificationEnabled}
+                                    onChange={(e) => handleInputChange('aiIdentificationEnabled', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>AI-Powered Title Resolution</strong>
+                                    <span className="checkbox-hint">
+                                        When TMDB lookup fails (obscure titles, abbreviations), use an LLM to identify the disc. Requires an API key below.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
+
+                        {config.aiIdentificationEnabled && (
+                            <>
+                                <div className="form-group">
+                                    <label htmlFor="aiProvider">AI Provider</label>
+                                    <select
+                                        id="aiProvider"
+                                        value={config.aiProvider}
+                                        onChange={(e) => handleInputChange('aiProvider', e.target.value)}
+                                    >
+                                        <option value="anthropic">Anthropic (Claude)</option>
+                                        <option value="openai">OpenAI</option>
+                                    </select>
+                                </div>
+                                <div className="form-group">
+                                    <label htmlFor="aiApiKey">
+                                        {config.aiProvider === 'anthropic' ? 'Anthropic' : 'OpenAI'} API Key
+                                    </label>
+                                    <input
+                                        id="aiApiKey"
+                                        type="password"
+                                        placeholder={config.aiProvider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+                                        value={config.aiApiKey}
+                                        onChange={(e) => handleInputChange('aiApiKey', e.target.value)}
+                                    />
+                                    <span className="form-hint">
+                                        API key for {config.aiProvider === 'anthropic' ? 'Anthropic' : 'OpenAI'}. Used only when TMDB lookup fails.
+                                    </span>
+                                </div>
+                            </>
+                        )}
 
                         <div className="form-group">
                             <label htmlFor="maxConcurrentMatches">Max Concurrent Matches</label>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -566,21 +566,22 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                     >
                                         <option value="anthropic">Anthropic (Claude)</option>
                                         <option value="openai">OpenAI</option>
+                                        <option value="openrouter">OpenRouter</option>
                                     </select>
                                 </div>
                                 <div className="form-group">
                                     <label htmlFor="aiApiKey">
-                                        {config.aiProvider === 'anthropic' ? 'Anthropic' : 'OpenAI'} API Key
+                                        {{ anthropic: 'Anthropic', openai: 'OpenAI', openrouter: 'OpenRouter' }[config.aiProvider] || config.aiProvider} API Key
                                     </label>
                                     <input
                                         id="aiApiKey"
                                         type="password"
-                                        placeholder={config.aiProvider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+                                        placeholder={{ anthropic: 'sk-ant-...', openai: 'sk-...', openrouter: 'sk-or-...' }[config.aiProvider] || ''}
                                         value={config.aiApiKey}
                                         onChange={(e) => handleInputChange('aiApiKey', e.target.value)}
                                     />
                                     <span className="form-hint">
-                                        API key for {config.aiProvider === 'anthropic' ? 'Anthropic' : 'OpenAI'}. Used only when TMDB lookup fails.
+                                        API key for {{ anthropic: 'Anthropic', openai: 'OpenAI', openrouter: 'OpenRouter' }[config.aiProvider] || config.aiProvider}. Used only when TMDB lookup fails.
                                     </span>
                                 </div>
                             </>


### PR DESCRIPTION
## Summary
- Add LLM-based fallback for disc identification when both DiscDB and TMDB lookups fail
- Supports **Anthropic (Claude)** and **OpenAI** as providers — uses lightweight models (Haiku / GPT-4o-mini) for cost efficiency
- When enabled, sends the volume label to the AI, parses the response, then re-queries TMDB with the corrected name for full metadata
- Frontend ConfigWizard gets a toggle, provider selector, and API key input (conditionally shown)
- Disabled by default — requires user to enable and provide an API key

## Architecture
```
Disc inserted → DiscDB lookup → TMDB lookup → [AI fallback] → Heuristic analysis
                                                    ↓
                                          Re-query TMDB with
                                          AI-identified name
```

The AI step only triggers when:
1. TMDB returned no signal
2. DiscDB didn't produce a high-confidence (≥90%) match
3. `ai_identification_enabled` is `True` and `ai_api_key` is set

## Files changed
- `backend/app/core/ai_identifier.py` — New module with provider abstraction
- `backend/app/models/app_config.py` — 3 new config fields
- `backend/app/api/routes.py` — ConfigResponse/ConfigUpdate updated, API key redacted
- `backend/app/services/job_manager.py` — AI fallback integrated into `_identify_disc`
- `frontend/src/components/ConfigWizard.tsx` — UI controls for AI settings
- `backend/tests/unit/test_ai_identifier.py` — 16 tests

Closes #24

## Test plan
- [ ] CI passes (lint + 449 tests + frontend build)
- [ ] Unit tests cover: JSON parsing, code fence stripping, both providers, error handling, null responses
- [ ] Manual: enable AI identification, insert disc with obscure label, verify AI → TMDB re-query flow in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)