### PR TITLE
feat: job history & analytics dashboard

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,7 +1,12 @@
 """REST API routes for Engram."""
 
 import logging
+import platform
+import re
+import sys
 from datetime import datetime
+from pathlib import Path
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -954,3 +959,154 @@ async def cleanup_job_staging(job_id: int, session: AsyncSession = Depends(get_s
         return {"deleted": True, "reclaimed_bytes": size}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete staging: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+_HOME_PATH = str(Path.home())
+_SENSITIVE_RE = re.compile(
+    r"(eyJ[A-Za-z0-9_-]{20,})"  # JWT tokens
+    r"|(?<=key=)[^\s,;'\"]{8,}"  # key=VALUE
+    r"|(?<=token=)[^\s,;'\"]{8,}",  # token=VALUE
+    re.IGNORECASE,
+)
+
+
+def _sanitize_line(line: str) -> str:
+    """Redact sensitive data from a single log line."""
+    line = line.replace(_HOME_PATH, "~")
+    return _SENSITIVE_RE.sub("***REDACTED***", line)
+
+
+@router.get("/diagnostics/logs")
+async def get_recent_logs(
+    lines: int = Query(default=50, ge=1, le=200),
+) -> dict:
+    """Return the last N lines from the engram log file, sanitized."""
+    log_path = Path.home() / ".engram" / "engram.log"
+    if not log_path.exists():
+        return {"lines": [], "log_path": str(log_path).replace(_HOME_PATH, "~")}
+
+    try:
+        raw = log_path.read_text(encoding="utf-8", errors="replace")
+        tail = raw.splitlines()[-lines:]
+        sanitized = [_sanitize_line(line) for line in tail]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read log: {e}") from e
+
+    return {
+        "lines": sanitized,
+        "log_path": str(log_path).replace(_HOME_PATH, "~"),
+    }
+
+
+@router.get("/diagnostics/report")
+async def generate_bug_report(
+    job_id: int | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Generate a sanitized bug report with optional job context."""
+    from app import __version__
+    from app.services.config_service import get_config
+
+    config = await get_config()
+
+    # --- Job summary (optional) ---
+    job_summary = None
+    if job_id is not None:
+        job = await session.get(DiscJob, job_id)
+        if job:
+            job_summary = {
+                "id": job.id,
+                "volume_label": job.volume_label,
+                "content_type": job.content_type.value if job.content_type else "unknown",
+                "state": job.state.value if job.state else "unknown",
+                "error": job.error_message,
+                "created_at": str(job.created_at) if job.created_at else None,
+                "completed_at": str(job.completed_at) if job.completed_at else None,
+            }
+
+    # --- Recent error lines from log ---
+    log_path = Path.home() / ".engram" / "engram.log"
+    recent_errors: list[str] = []
+    if log_path.exists():
+        try:
+            raw = log_path.read_text(encoding="utf-8", errors="replace")
+            all_lines = raw.splitlines()
+            error_lines = [ln for ln in all_lines if "ERROR" in ln or "CRITICAL" in ln]
+            recent_errors = [_sanitize_line(line) for line in error_lines[-20:]]
+        except Exception:
+            recent_errors = ["(could not read log file)"]
+
+    # --- Redacted config ---
+    redacted_config = {
+        "staging_path": str(config.staging_path).replace(_HOME_PATH, "~"),
+        "library_movies_path": str(config.library_movies_path).replace(_HOME_PATH, "~"),
+        "library_tv_path": str(config.library_tv_path).replace(_HOME_PATH, "~"),
+        "transcoding_enabled": config.transcoding_enabled,
+        "max_concurrent_matches": config.max_concurrent_matches,
+        "conflict_resolution_default": config.conflict_resolution_default,
+        "extras_policy": config.extras_policy,
+        "discdb_enabled": config.discdb_enabled,
+    }
+
+    # --- Build report ---
+    report = {
+        "app_version": __version__,
+        "python_version": sys.version.split()[0],
+        "os": f"{platform.system()} {platform.release()}",
+        "job": job_summary,
+        "recent_errors": recent_errors,
+        "config": redacted_config,
+    }
+
+    # --- Build GitHub issue body ---
+    body_parts = [
+        "## Bug Report",
+        "",
+        f"**Engram version**: {__version__}",
+        f"**OS**: {report['os']}",
+        f"**Python**: {report['python_version']}",
+        "",
+    ]
+    if job_summary:
+        body_parts += [
+            "### Job Context",
+            f"- **ID**: {job_summary['id']}",
+            f"- **Label**: {job_summary['volume_label']}",
+            f"- **Type**: {job_summary['content_type']}",
+            f"- **State**: {job_summary['state']}",
+        ]
+        if job_summary["error"]:
+            body_parts.append(f"- **Error**: {job_summary['error']}")
+        body_parts.append("")
+
+    if recent_errors:
+        body_parts += ["### Recent Errors", "```"]
+        body_parts += recent_errors[-10:]
+        body_parts += ["```", ""]
+
+    body_parts += [
+        "### Steps to Reproduce",
+        "1. ",
+        "",
+        "### Expected Behavior",
+        "",
+        "",
+        "### Actual Behavior",
+        "",
+    ]
+
+    issue_body = "\n".join(body_parts)
+    title = "[Bug] " + (
+        f"Job {job_id} failed in {job_summary['state']}" if job_summary else "Describe the issue"
+    )
+    github_url = (
+        f"https://github.com/Jsakkos/engram/issues/new"
+        f"?title={quote(title)}&body={quote(issue_body)}"
+    )
+
+    report["github_url"] = github_url
+    return report

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3,15 +3,16 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.config import settings
 from app.database import get_session
 from app.models import DiscJob, JobState
-from app.models.disc_job import DiscTitle
+from app.models.disc_job import ContentType, DiscTitle
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,39 @@ class JobResponse(BaseModel):
     subtitles_failed: int | None = None
     review_reason: str | None = None
     created_at: datetime | str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class HistoryJobResponse(BaseModel):
+    """Response model for a job in history view."""
+
+    id: int
+    volume_label: str
+    content_type: str
+    state: str
+    detected_title: str | None = None
+    detected_season: int | None = None
+    error_message: str | None = None
+    classification_source: str = "heuristic"
+    total_titles: int = 0
+    created_at: str | None = None
+    completed_at: str | None = None
+    cleared_at: str | None = None
+
+
+class StatsResponse(BaseModel):
+    """Response model for job analytics."""
+
+    total_jobs: int = 0
+    completed_jobs: int = 0
+    failed_jobs: int = 0
+    tv_count: int = 0
+    movie_count: int = 0
+    total_titles_ripped: int = 0
+    avg_processing_seconds: float | None = None
+    common_errors: list[dict] = []
+    recent_jobs: list[HistoryJobResponse] = []
 
 
 class ConfigResponse(BaseModel):
@@ -158,9 +192,126 @@ class TitleResponse(BaseModel):
 # Routes
 @router.get("/jobs", response_model=list[JobResponse])
 async def list_jobs(session: AsyncSession = Depends(get_session)) -> list[DiscJob]:
-    """List disc jobs (limited to 10 most recent)."""
-    result = await session.execute(select(DiscJob).order_by(DiscJob.created_at.desc()).limit(10))
+    """List active disc jobs (excludes cleared/archived jobs)."""
+    result = await session.execute(
+        select(DiscJob)
+        .where(DiscJob.cleared_at.is_(None))
+        .order_by(DiscJob.created_at.desc())
+        .limit(10)
+    )
     return list(result.scalars().all())
+
+
+@router.get("/jobs/history", response_model=list[HistoryJobResponse])
+async def get_job_history(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    content_type: str | None = None,
+    state: str | None = None,
+    session: AsyncSession = Depends(get_session),
+) -> list[dict]:
+    """Get cleared/archived job history with pagination and filtering."""
+    query = select(DiscJob).where(DiscJob.cleared_at.is_not(None))
+
+    if content_type:
+        query = query.where(DiscJob.content_type == content_type)
+    if state:
+        query = query.where(DiscJob.state == state)
+
+    query = query.order_by(DiscJob.cleared_at.desc()).offset((page - 1) * per_page).limit(per_page)
+    result = await session.execute(query)
+    jobs = result.scalars().all()
+
+    return [
+        {
+            "id": j.id,
+            "volume_label": j.volume_label,
+            "content_type": j.content_type,
+            "state": j.state,
+            "detected_title": j.detected_title,
+            "detected_season": j.detected_season,
+            "error_message": j.error_message,
+            "classification_source": j.classification_source,
+            "total_titles": j.total_titles,
+            "created_at": j.created_at.isoformat() if j.created_at else None,
+            "completed_at": j.completed_at.isoformat() if j.completed_at else None,
+            "cleared_at": j.cleared_at.isoformat() if j.cleared_at else None,
+        }
+        for j in jobs
+    ]
+
+
+@router.get("/jobs/stats", response_model=StatsResponse)
+async def get_job_stats(session: AsyncSession = Depends(get_session)) -> dict:
+    """Get job analytics and statistics."""
+    all_jobs = await session.execute(select(DiscJob))
+    jobs = list(all_jobs.scalars().all())
+
+    completed = [j for j in jobs if j.state == JobState.COMPLETED]
+    failed = [j for j in jobs if j.state == JobState.FAILED]
+    tv_jobs = [j for j in jobs if j.content_type == ContentType.TV]
+    movie_jobs = [j for j in jobs if j.content_type == ContentType.MOVIE]
+
+    # Total titles ripped
+    title_count_result = await session.execute(select(func.count(DiscTitle.id)))
+    total_titles = title_count_result.scalar() or 0
+
+    # Avg processing time (for completed jobs with both timestamps)
+    processing_times = []
+    for j in completed:
+        if j.completed_at and j.created_at:
+            delta = (j.completed_at - j.created_at).total_seconds()
+            if delta > 0:
+                processing_times.append(delta)
+
+    avg_processing = sum(processing_times) / len(processing_times) if processing_times else None
+
+    # Common errors
+    error_counts: dict[str, int] = {}
+    for j in failed:
+        msg = j.error_message or "Unknown error"
+        key = msg[:100]
+        error_counts[key] = error_counts.get(key, 0) + 1
+
+    common_errors = sorted(
+        [{"message": k, "count": v} for k, v in error_counts.items()],
+        key=lambda x: x["count"],
+        reverse=True,
+    )[:5]
+
+    # Recent 10 jobs
+    recent_result = await session.execute(
+        select(DiscJob).order_by(DiscJob.created_at.desc()).limit(10)
+    )
+    recent = recent_result.scalars().all()
+
+    return {
+        "total_jobs": len(jobs),
+        "completed_jobs": len(completed),
+        "failed_jobs": len(failed),
+        "tv_count": len(tv_jobs),
+        "movie_count": len(movie_jobs),
+        "total_titles_ripped": total_titles,
+        "avg_processing_seconds": avg_processing,
+        "common_errors": common_errors,
+        "recent_jobs": [
+            {
+                "id": j.id,
+                "volume_label": j.volume_label,
+                "content_type": j.content_type,
+                "state": j.state,
+                "detected_title": j.detected_title,
+                "detected_season": j.detected_season,
+                "error_message": j.error_message,
+                "classification_source": j.classification_source,
+                "total_titles": j.total_titles,
+                "created_at": j.created_at.isoformat() if j.created_at else None,
+                "completed_at": j.completed_at.isoformat() if j.completed_at else None,
+                "cleared_at": j.cleared_at.isoformat() if j.cleared_at else None,
+            }
+            for j in recent
+        ],
+    }
 
 
 @router.get("/jobs/{job_id}", response_model=JobResponse)
@@ -467,33 +618,29 @@ async def list_drives() -> list[dict]:
 
 @router.delete("/jobs/completed")
 async def clear_completed_jobs(session: AsyncSession = Depends(get_session)) -> dict:
-    """Clear all completed and failed jobs and their titles from the database."""
-    from sqlalchemy import delete
-
-    # 1. Find job IDs to delete
-    terminal_jobs = await session.execute(
-        select(DiscJob.id).where(DiscJob.state.in_([JobState.COMPLETED, JobState.FAILED]))
+    """Soft-delete all completed and failed jobs (moves to history)."""
+    now = datetime.utcnow()
+    result = await session.execute(
+        select(DiscJob).where(
+            DiscJob.state.in_([JobState.COMPLETED, JobState.FAILED]),
+            DiscJob.cleared_at.is_(None),
+        )
     )
-    job_ids = [row[0] for row in terminal_jobs.all()]
+    jobs = list(result.scalars().all())
 
-    if not job_ids:
-        return {"status": "cleared", "deleted_count": 0}
+    if not jobs:
+        return {"status": "cleared", "cleared_count": 0}
 
-    # 2. Delete child DiscTitle rows first (prevents orphans)
-    await session.execute(delete(DiscTitle).where(DiscTitle.job_id.in_(job_ids)))
+    for job in jobs:
+        job.cleared_at = now
 
-    # 3. Delete the jobs themselves
-    result = await session.execute(delete(DiscJob).where(DiscJob.id.in_(job_ids)))
     await session.commit()
-
-    return {"status": "cleared", "deleted_count": result.rowcount}
+    return {"status": "cleared", "cleared_count": len(jobs)}
 
 
 @router.delete("/jobs/{job_id}")
 async def delete_job(job_id: int, session: AsyncSession = Depends(get_session)) -> dict:
-    """Delete a single completed or failed job and its titles."""
-    from sqlalchemy import delete
-
+    """Soft-delete a single completed or failed job (moves to history)."""
     job = await session.get(DiscJob, job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -501,15 +648,13 @@ async def delete_job(job_id: int, session: AsyncSession = Depends(get_session)) 
     if job.state not in (JobState.COMPLETED, JobState.FAILED):
         raise HTTPException(
             status_code=400,
-            detail=f"Can only delete completed or failed jobs (current state: {job.state})",
+            detail=f"Can only clear completed or failed jobs (current state: {job.state})",
         )
 
-    # Delete child titles first
-    await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
-    await session.delete(job)
+    job.cleared_at = datetime.utcnow()
     await session.commit()
 
-    return {"status": "deleted", "job_id": job_id}
+    return {"status": "cleared", "job_id": job_id}
 
 
 # --- Simulation Endpoints (debug mode only) ---

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -87,6 +87,8 @@ class DiscJob(SQLModel, table=True):
     # Metadata
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: datetime | None = Field(default=None)  # When job reached terminal state
+    cleared_at: datetime | None = Field(default=None)  # Soft-delete: hidden from dashboard
     error_message: str | None = None
     review_reason: str | None = None  # Human-readable reason why review is needed
 

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -123,6 +123,10 @@ class JobStateMachine:
         if to_state == JobState.FAILED and error_message:
             job.error_message = error_message
 
+        # Set completed_at timestamp for terminal states
+        if to_state in (JobState.COMPLETED, JobState.FAILED):
+            job.completed_at = datetime.utcnow()
+
         # Persist to database
         await session.commit()
 

--- a/backend/tests/integration/test_error_recovery.py
+++ b/backend/tests/integration/test_error_recovery.py
@@ -177,6 +177,10 @@ class TestJobCleanup:
         response = await client.delete(f"/api/jobs/{job_id}")
         assert response.status_code == 200
 
-        # Verify it's gone
+        # Verify it's soft-deleted (still accessible but hidden from list)
         response = await client.get(f"/api/jobs/{job_id}")
-        assert response.status_code == 404
+        assert response.status_code == 200
+        # But hidden from active jobs list
+        response = await client.get("/api/jobs")
+        job_ids = [j["id"] for j in response.json()]
+        assert job_id not in job_ids

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -244,8 +244,16 @@ class TestErrorHandling:
         assert response.status_code == 422
 
     async def test_delete_single_job(self, client):
+        """Clearing a job soft-deletes it (sets cleared_at), hiding from list."""
         job = await _seed_job(state=JobState.COMPLETED)
         response = await client.delete(f"/api/jobs/{job.id}")
         assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "cleared"
+        # Job still accessible directly (soft-deleted)
         verify = await client.get(f"/api/jobs/{job.id}")
-        assert verify.status_code == 404
+        assert verify.status_code == 200
+        # But hidden from the active list
+        list_resp = await client.get("/api/jobs")
+        job_ids = [j["id"] for j in list_resp.json()]
+        assert job.id not in job_ids

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -10,7 +10,6 @@ import ReviewQueue from "../components/ReviewQueue";
 import ConfigWizard from "../components/ConfigWizard";
 import NamePromptModal from "../components/NamePromptModal";
 import HistoryPage from "../components/HistoryPage";
-import HistoryPage from "../components/HistoryPage";
 import type { Job } from "../types";
 
 type ViewMode = "expanded" | "compact";

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -9,6 +9,8 @@ import { useNotifications } from "./hooks/useNotifications";
 import ReviewQueue from "../components/ReviewQueue";
 import ConfigWizard from "../components/ConfigWizard";
 import NamePromptModal from "../components/NamePromptModal";
+import HistoryPage from "../components/HistoryPage";
+import HistoryPage from "../components/HistoryPage";
 import type { Job } from "../types";
 
 type ViewMode = "expanded" | "compact";
@@ -427,6 +429,7 @@ function App() {
   return (
     <Routes>
       <Route path="/" element={<MainDashboard />} />
+      <Route path="/history" element={<HistoryPage />} />
       <Route path="/review/:jobId" element={<ReviewQueue />} />
     </Routes>
   );

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -1,0 +1,411 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion } from "motion/react";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  XCircle,
+  Film,
+  Tv,
+  Clock,
+  BarChart3,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+
+interface HistoryJob {
+  id: number;
+  volume_label: string;
+  content_type: string;
+  state: string;
+  detected_title: string | null;
+  detected_season: number | null;
+  error_message: string | null;
+  classification_source: string;
+  total_titles: number;
+  created_at: string | null;
+  completed_at: string | null;
+  cleared_at: string | null;
+}
+
+interface Stats {
+  total_jobs: number;
+  completed_jobs: number;
+  failed_jobs: number;
+  tv_count: number;
+  movie_count: number;
+  total_titles_ripped: number;
+  avg_processing_seconds: number | null;
+  common_errors: { message: string; count: number }[];
+  recent_jobs: HistoryJob[];
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  color,
+}: {
+  label: string;
+  value: string | number;
+  icon: React.ReactNode;
+  color: string;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="border-2 border-transparent bg-black/80 p-4"
+      style={{
+        borderImage: `linear-gradient(135deg, ${color}66, ${color}33) 1`,
+        boxShadow: `0 0 15px ${color}22`,
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <div style={{ color }} className="opacity-80">
+          {icon}
+        </div>
+        <div>
+          <div
+            className="text-2xl font-bold font-mono"
+            style={{ color, textShadow: `0 0 8px ${color}88` }}
+          >
+            {value}
+          </div>
+          <div className="text-xs text-slate-400 font-mono uppercase tracking-wider">
+            {label}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+export default function HistoryPage() {
+  const navigate = useNavigate();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [history, setHistory] = useState<HistoryJob[]>([]);
+  const [page, setPage] = useState(1);
+  const [filterType, setFilterType] = useState<string>("");
+  const [filterState, setFilterState] = useState<string>("");
+  const [hasMore, setHasMore] = useState(true);
+  const perPage = 20;
+
+  useEffect(() => {
+    fetch("/api/jobs/stats")
+      .then((r) => r.json())
+      .then(setStats)
+      .catch(() => {});
+  }, []);
+
+  const fetchHistory = useCallback(() => {
+    const params = new URLSearchParams({
+      page: String(page),
+      per_page: String(perPage),
+    });
+    if (filterType) params.set("content_type", filterType);
+    if (filterState) params.set("state", filterState);
+
+    fetch(`/api/jobs/history?${params}`)
+      .then((r) => r.json())
+      .then((data: HistoryJob[]) => {
+        setHistory(data);
+        setHasMore(data.length === perPage);
+      })
+      .catch(() => {});
+  }, [page, filterType, filterState]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  return (
+    <div className="min-h-screen bg-black">
+      {/* Grid background */}
+      <div className="fixed inset-0 opacity-10 pointer-events-none">
+        <div
+          className="h-full w-full"
+          style={{
+            backgroundImage: `
+              linear-gradient(rgba(6, 182, 212, 0.3) 1px, transparent 1px),
+              linear-gradient(90deg, rgba(6, 182, 212, 0.3) 1px, transparent 1px)
+            `,
+            backgroundSize: "50px 50px",
+          }}
+        />
+      </div>
+
+      {/* Header */}
+      <div
+        className="border-b-2 border-cyan-500/30 backdrop-blur-xl bg-black/80 sticky top-0 z-10"
+        style={{
+          boxShadow:
+            "0 0 20px rgba(6, 182, 212, 0.2), 0 0 40px rgba(236, 72, 153, 0.1)",
+        }}
+      >
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => navigate("/")}
+              className="text-cyan-400 hover:text-cyan-300 transition-colors"
+            >
+              <ArrowLeft className="w-6 h-6" />
+            </button>
+            <div className="flex items-center gap-3">
+              <BarChart3
+                className="w-6 h-6 text-cyan-400"
+                style={{
+                  filter: "drop-shadow(0 0 8px rgba(6, 182, 212, 0.8))",
+                }}
+              />
+              <h1
+                className="text-xl sm:text-2xl font-bold text-cyan-400 tracking-wider font-mono uppercase"
+                style={{
+                  textShadow:
+                    "0 0 10px rgba(6, 182, 212, 1), 0 0 30px rgba(6, 182, 212, 0.6)",
+                }}
+              >
+                Job History & Analytics
+              </h1>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-8">
+        {/* Stats Grid */}
+        {stats && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+            <StatCard
+              label="Total Jobs"
+              value={stats.total_jobs}
+              icon={<BarChart3 className="w-5 h-5" />}
+              color="#06b6d4"
+            />
+            <StatCard
+              label="Completed"
+              value={stats.completed_jobs}
+              icon={<CheckCircle2 className="w-5 h-5" />}
+              color="#10b981"
+            />
+            <StatCard
+              label="Failed"
+              value={stats.failed_jobs}
+              icon={<XCircle className="w-5 h-5" />}
+              color="#ef4444"
+            />
+            <StatCard
+              label="TV Shows"
+              value={stats.tv_count}
+              icon={<Tv className="w-5 h-5" />}
+              color="#f59e0b"
+            />
+            <StatCard
+              label="Movies"
+              value={stats.movie_count}
+              icon={<Film className="w-5 h-5" />}
+              color="#ec4899"
+            />
+            <StatCard
+              label="Avg Time"
+              value={
+                stats.avg_processing_seconds
+                  ? formatDuration(stats.avg_processing_seconds)
+                  : "—"
+              }
+              icon={<Clock className="w-5 h-5" />}
+              color="#8b5cf6"
+            />
+          </div>
+        )}
+
+        {/* Common Errors */}
+        {stats && stats.common_errors.length > 0 && (
+          <div className="border-2 border-red-500/30 bg-black/80 p-4">
+            <h2 className="text-sm font-mono font-bold text-red-400 uppercase tracking-wider mb-3">
+              &gt; Common Errors
+            </h2>
+            <div className="space-y-2">
+              {stats.common_errors.map((err, i) => (
+                <div
+                  key={i}
+                  className="flex items-start gap-3 text-xs font-mono"
+                >
+                  <span className="text-red-400 font-bold min-w-[2rem] text-right">
+                    x{err.count}
+                  </span>
+                  <span className="text-slate-400 break-all">
+                    {err.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="text-xs font-mono text-slate-500 uppercase tracking-wider">
+            Filter:
+          </span>
+          <select
+            value={filterType}
+            onChange={(e) => {
+              setFilterType(e.target.value);
+              setPage(1);
+            }}
+            className="bg-black border-2 border-slate-700 text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
+          >
+            <option value="">All Types</option>
+            <option value="tv">TV</option>
+            <option value="movie">Movie</option>
+          </select>
+          <select
+            value={filterState}
+            onChange={(e) => {
+              setFilterState(e.target.value);
+              setPage(1);
+            }}
+            className="bg-black border-2 border-slate-700 text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
+          >
+            <option value="">All States</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+          </select>
+        </div>
+
+        {/* History Table */}
+        <div className="border-2 border-cyan-500/20 bg-black/80 overflow-x-auto">
+          <table className="w-full text-xs sm:text-sm font-mono">
+            <thead>
+              <tr className="border-b-2 border-cyan-500/20 text-left">
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold">
+                  Title
+                </th>
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold hidden sm:table-cell">
+                  Type
+                </th>
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold">
+                  State
+                </th>
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold hidden md:table-cell">
+                  Titles
+                </th>
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold hidden lg:table-cell">
+                  Source
+                </th>
+                <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold hidden sm:table-cell">
+                  Date
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-8 text-center text-slate-500"
+                  >
+                    No archived jobs found
+                  </td>
+                </tr>
+              ) : (
+                history.map((job) => (
+                  <tr
+                    key={job.id}
+                    className="border-b border-slate-800 hover:bg-cyan-500/5 transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <div className="text-slate-200">
+                        {job.detected_title || job.volume_label}
+                      </div>
+                      {job.detected_title && (
+                        <div className="text-[10px] text-slate-500">
+                          {job.volume_label}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 hidden sm:table-cell">
+                      <span
+                        className={`uppercase ${
+                          job.content_type === "tv"
+                            ? "text-amber-400"
+                            : job.content_type === "movie"
+                              ? "text-magenta-400"
+                              : "text-slate-500"
+                        }`}
+                      >
+                        {job.content_type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      {job.state === "completed" ? (
+                        <span className="text-green-400 flex items-center gap-1">
+                          <CheckCircle2 className="w-3 h-3" /> OK
+                        </span>
+                      ) : (
+                        <span className="text-red-400 flex items-center gap-1">
+                          <XCircle className="w-3 h-3" /> FAIL
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-slate-400 hidden md:table-cell">
+                      {job.total_titles}
+                    </td>
+                    <td className="px-4 py-3 text-slate-500 hidden lg:table-cell">
+                      {job.classification_source}
+                    </td>
+                    <td className="px-4 py-3 text-slate-500 hidden sm:table-cell">
+                      {formatDate(job.completed_at || job.created_at)}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="flex items-center gap-1 px-3 py-2 font-mono text-xs uppercase tracking-wider border-2 border-slate-700 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" /> Prev
+          </button>
+          <span className="text-xs font-mono text-slate-500">
+            Page {page}
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!hasMore}
+            className="flex items-center gap-1 px-3 py-2 font-mono text-xs uppercase tracking-wider border-2 border-slate-700 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          >
+            Next <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -11,6 +11,7 @@ import {
   BarChart3,
   ChevronLeft,
   ChevronRight,
+  Bug,
 } from "lucide-react";
 
 interface HistoryJob {
@@ -49,7 +50,7 @@ function formatDuration(seconds: number): string {
 }
 
 function formatDate(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "\u2014";
   const d = new Date(iso);
   return d.toLocaleDateString(undefined, {
     month: "short",
@@ -75,9 +76,8 @@ function StatCard({
     <motion.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
-      className="border-2 border-transparent bg-black/80 p-4"
+      className="rounded-lg border border-cyan-500/20 bg-navy-800/80 p-4"
       style={{
-        borderImage: `linear-gradient(135deg, ${color}66, ${color}33) 1`,
         boxShadow: `0 0 15px ${color}22`,
       }}
     >
@@ -109,6 +109,7 @@ export default function HistoryPage() {
   const [filterType, setFilterType] = useState<string>("");
   const [filterState, setFilterState] = useState<string>("");
   const [hasMore, setHasMore] = useState(true);
+  const [reportLoading, setReportLoading] = useState(false);
   const perPage = 20;
 
   useEffect(() => {
@@ -139,55 +140,67 @@ export default function HistoryPage() {
     fetchHistory();
   }, [fetchHistory]);
 
-  return (
-    <div className="min-h-screen bg-black">
-      {/* Grid background */}
-      <div className="fixed inset-0 opacity-10 pointer-events-none">
-        <div
-          className="h-full w-full"
-          style={{
-            backgroundImage: `
-              linear-gradient(rgba(6, 182, 212, 0.3) 1px, transparent 1px),
-              linear-gradient(90deg, rgba(6, 182, 212, 0.3) 1px, transparent 1px)
-            `,
-            backgroundSize: "50px 50px",
-          }}
-        />
-      </div>
+  const handleReportBug = async () => {
+    setReportLoading(true);
+    try {
+      const resp = await fetch("/api/diagnostics/report");
+      if (!resp.ok) throw new Error("Failed to generate report");
+      const data = await resp.json();
+      window.open(data.github_url, "_blank");
+    } catch {
+      alert("Could not generate bug report. Is the backend running?");
+    } finally {
+      setReportLoading(false);
+    }
+  };
 
+  return (
+    <div className="min-h-screen bg-navy-900 circuit-bg">
       {/* Header */}
       <div
-        className="border-b-2 border-cyan-500/30 backdrop-blur-xl bg-black/80 sticky top-0 z-10"
+        className="border-b border-cyan-500/20 backdrop-blur-xl bg-navy-900/80 sticky top-0 z-10"
         style={{
           boxShadow:
             "0 0 20px rgba(6, 182, 212, 0.2), 0 0 40px rgba(236, 72, 153, 0.1)",
         }}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
-          <div className="flex items-center gap-4">
-            <button
-              onClick={() => navigate("/")}
-              className="text-cyan-400 hover:text-cyan-300 transition-colors"
-            >
-              <ArrowLeft className="w-6 h-6" />
-            </button>
-            <div className="flex items-center gap-3">
-              <BarChart3
-                className="w-6 h-6 text-cyan-400"
-                style={{
-                  filter: "drop-shadow(0 0 8px rgba(6, 182, 212, 0.8))",
-                }}
-              />
-              <h1
-                className="text-xl sm:text-2xl font-bold text-cyan-400 tracking-wider font-mono uppercase"
-                style={{
-                  textShadow:
-                    "0 0 10px rgba(6, 182, 212, 1), 0 0 30px rgba(6, 182, 212, 0.6)",
-                }}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => navigate("/")}
+                className="text-cyan-400 hover:text-cyan-300 transition-colors"
               >
-                Job History & Analytics
-              </h1>
+                <ArrowLeft className="w-6 h-6" />
+              </button>
+              <div className="flex items-center gap-3">
+                <BarChart3
+                  className="w-6 h-6 text-cyan-400"
+                  style={{
+                    filter: "drop-shadow(0 0 8px rgba(6, 182, 212, 0.8))",
+                  }}
+                />
+                <h1
+                  className="text-xl sm:text-2xl font-bold text-cyan-400 tracking-wider font-mono uppercase"
+                  style={{
+                    textShadow:
+                      "0 0 10px rgba(6, 182, 212, 1), 0 0 30px rgba(6, 182, 212, 0.6)",
+                  }}
+                >
+                  Job History & Analytics
+                </h1>
+              </div>
             </div>
+            <button
+              onClick={handleReportBug}
+              disabled={reportLoading}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg border border-red-500/30 text-red-400 hover:border-red-500/60 hover:bg-red-500/10 transition-all font-mono text-xs uppercase tracking-wider disabled:opacity-50"
+            >
+              <Bug className="w-4 h-4" />
+              <span className="hidden sm:inline">
+                {reportLoading ? "Generating..." : "Report Bug"}
+              </span>
+            </button>
           </div>
         </div>
       </div>
@@ -231,7 +244,7 @@ export default function HistoryPage() {
               value={
                 stats.avg_processing_seconds
                   ? formatDuration(stats.avg_processing_seconds)
-                  : "—"
+                  : "\u2014"
               }
               icon={<Clock className="w-5 h-5" />}
               color="#8b5cf6"
@@ -241,7 +254,7 @@ export default function HistoryPage() {
 
         {/* Common Errors */}
         {stats && stats.common_errors.length > 0 && (
-          <div className="border-2 border-red-500/30 bg-black/80 p-4">
+          <div className="rounded-lg border border-red-500/30 bg-navy-800/80 p-4">
             <h2 className="text-sm font-mono font-bold text-red-400 uppercase tracking-wider mb-3">
               &gt; Common Errors
             </h2>
@@ -274,7 +287,7 @@ export default function HistoryPage() {
               setFilterType(e.target.value);
               setPage(1);
             }}
-            className="bg-black border-2 border-slate-700 text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
+            className="bg-navy-800 border border-cyan-500/20 rounded-md text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
           >
             <option value="">All Types</option>
             <option value="tv">TV</option>
@@ -286,7 +299,7 @@ export default function HistoryPage() {
               setFilterState(e.target.value);
               setPage(1);
             }}
-            className="bg-black border-2 border-slate-700 text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
+            className="bg-navy-800 border border-cyan-500/20 rounded-md text-slate-300 font-mono text-xs px-3 py-1.5 focus:border-cyan-500/50 outline-none"
           >
             <option value="">All States</option>
             <option value="completed">Completed</option>
@@ -295,10 +308,10 @@ export default function HistoryPage() {
         </div>
 
         {/* History Table */}
-        <div className="border-2 border-cyan-500/20 bg-black/80 overflow-x-auto">
+        <div className="rounded-lg border border-cyan-500/20 bg-navy-800/80 overflow-x-auto">
           <table className="w-full text-xs sm:text-sm font-mono">
             <thead>
-              <tr className="border-b-2 border-cyan-500/20 text-left">
+              <tr className="border-b border-cyan-500/20 text-left">
                 <th className="px-4 py-3 text-cyan-400 uppercase tracking-wider font-bold">
                   Title
                 </th>
@@ -333,7 +346,7 @@ export default function HistoryPage() {
                 history.map((job) => (
                   <tr
                     key={job.id}
-                    className="border-b border-slate-800 hover:bg-cyan-500/5 transition-colors"
+                    className="border-b border-navy-700/50 hover:bg-cyan-500/5 transition-colors"
                   >
                     <td className="px-4 py-3">
                       <div className="text-slate-200">
@@ -390,7 +403,7 @@ export default function HistoryPage() {
           <button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="flex items-center gap-1 px-3 py-2 font-mono text-xs uppercase tracking-wider border-2 border-slate-700 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center gap-1 px-3 py-2 rounded-md font-mono text-xs uppercase tracking-wider border border-cyan-500/20 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             <ChevronLeft className="w-4 h-4" /> Prev
           </button>
@@ -400,7 +413,7 @@ export default function HistoryPage() {
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={!hasMore}
-            className="flex items-center gap-1 px-3 py-2 font-mono text-xs uppercase tracking-wider border-2 border-slate-700 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center gap-1 px-3 py-2 rounded-md font-mono text-xs uppercase tracking-wider border border-cyan-500/20 text-slate-400 hover:border-cyan-500/50 hover:text-cyan-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
             Next <ChevronRight className="w-4 h-4" />
           </button>


### PR DESCRIPTION
## Summary
- **Soft delete**: Clearing jobs now sets `cleared_at` timestamp instead of deleting, preserving data for history
- **History API**: `GET /api/jobs/history` with pagination, content_type/state filters
- **Stats API**: `GET /api/jobs/stats` returns totals, content breakdown, avg processing time, common errors
- **History page**: New `/history` route with stat cards, error summary table, paginated job history, and filter dropdowns
- **completed_at**: Automatically set in state machine on COMPLETED/FAILED transitions
- **Diagnostics**: `GET /api/diagnostics/logs` for sanitized log retrieval, `GET /api/diagnostics/report` for bug report generation
- **Report Bug button**: Opens pre-filled GitHub issue with system info, job context, and recent errors
- **Navy theme**: History page updated to match v0.4.0 UI overhaul

## Changes
- `disc_job.py`: Added `completed_at` and `cleared_at` fields
- `job_state_machine.py`: Set `completed_at` on terminal state transitions
- `routes.py`: New history/stats/diagnostics endpoints, soft-delete for clear operations, route ordering fix
- `HistoryPage.tsx`: Full analytics dashboard with navy theme and Report Bug button
- `App.tsx`: Added history route and HistoryPage import

## Test plan
- [x] Unit tests pass (340/342 — 2 pre-existing organizer failures)
- [x] Frontend builds and lints clean (`npm run build && npm run lint`)
- [x] Backend lints clean (`ruff check . && ruff format --check .`)
- [x] History page loads at `/history` with navy theme
- [x] Stats cards display correct counts from `GET /api/jobs/stats`
- [x] Clearing jobs moves them to history (soft-delete via `cleared_at`)
- [x] History table shows cleared jobs with pagination and filters
- [x] `GET /api/diagnostics/logs?lines=10` returns sanitized log lines
- [x] `GET /api/diagnostics/report` returns report JSON with `github_url`
- [x] `GET /api/diagnostics/report?job_id=N` includes job context in report
- [x] "Report Bug" button visible in history page header

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)