### PR TITLE
fix: multi-drive cancel isolation, elapsed time, catalog labels, season selector

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -5,7 +5,7 @@ import logging
 import platform
 import re
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -761,7 +761,7 @@ async def list_drives() -> list[dict]:
 @router.delete("/jobs/completed")
 async def clear_completed_jobs(session: AsyncSession = Depends(get_session)) -> dict:
     """Soft-delete all completed and failed jobs (moves to history)."""
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     result = await session.execute(
         select(DiscJob).where(
             DiscJob.state.in_([JobState.COMPLETED, JobState.FAILED]),
@@ -793,7 +793,7 @@ async def delete_job(job_id: int, session: AsyncSession = Depends(get_session)) 
             detail=f"Can only clear completed or failed jobs (current state: {job.state})",
         )
 
-    job.cleared_at = datetime.utcnow()
+    job.cleared_at = datetime.now(UTC)
     await session.commit()
 
     return {"status": "cleared", "job_id": job_id}

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -637,6 +637,20 @@ class DiscAnalyst:
 
         return name, season, disc
 
+    # Pattern for catalog-number-style labels like BBCDVD1550, MGMHV1234, FHED3456
+    _CATALOG_PATTERN = re.compile(r"^[A-Z]{2,6}\d{3,}$")
+
+    @staticmethod
+    def _looks_like_catalog_number(label: str) -> bool:
+        """Detect catalog-number labels (e.g. BBCDVD1550, FHED3456).
+
+        These are publisher catalog codes, not human-readable titles.
+        The parsed 'name' from such labels is garbage and should not be
+        used as detected_title.
+        """
+        normalized = re.sub(r"[_\s]", "", label).upper()
+        return bool(DiscAnalyst._CATALOG_PATTERN.match(normalized))
+
     def _get_ambiguity_reason(self, titles: list[TitleInfo]) -> str:
         """Generate a human-readable reason for ambiguity."""
         long_titles = [

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -101,8 +101,11 @@ class MakeMKVExtractor:
 
     def __init__(self, makemkv_path: Path | None = None) -> None:
         self._makemkv_path_override = makemkv_path
-        self._current_process: asyncio.subprocess.Process | None = None
-        self._cancelled = False
+        # Per-job process tracking for multi-drive cancel isolation.
+        # Each running job registers its subprocess here so cancel() only
+        # terminates the correct process.
+        self._processes: dict[int, subprocess.Popen] = {}  # job_id -> process
+        self._cancelled_jobs: set[int] = set()
         # Per-drive locks prevent concurrent MakeMKV operations on the same drive.
         # Two makemkvcon processes fighting over one drive causes both to stall/fail.
         self._drive_locks: dict[str, asyncio.Lock] = {}
@@ -124,7 +127,7 @@ class MakeMKVExtractor:
             self._drive_locks[key] = asyncio.Lock()
         return self._drive_locks[key]
 
-    async def scan_disc(self, drive: str) -> list[TitleInfo]:
+    async def scan_disc(self, drive: str, *, job_id: int = 0) -> list[TitleInfo]:
         """Scan a disc and return title information.
 
         Args:
@@ -141,9 +144,9 @@ class MakeMKVExtractor:
             )
 
         async with lock:
-            return await self._scan_disc_unlocked(drive)
+            return await self._scan_disc_unlocked(drive, job_id=job_id)
 
-    async def _scan_disc_unlocked(self, drive: str) -> list[TitleInfo]:
+    async def _scan_disc_unlocked(self, drive: str, *, job_id: int = 0) -> list[TitleInfo]:
         """Internal scan implementation (caller must hold drive lock)."""
         # Normalize drive specification
         if not drive.startswith("disc:"):
@@ -162,12 +165,12 @@ class MakeMKVExtractor:
         start = time.monotonic()
         logger.info(f"Scanning disc: {' '.join(cmd)}")
 
-        self._cancelled = False
+        self._cancelled_jobs.discard(job_id)
 
         def run_makemkv() -> subprocess.CompletedProcess:
             """Run MakeMKV in a thread (Windows asyncio subprocess workaround)."""
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            self._current_process = proc
+            self._processes[job_id] = proc
             try:
                 stdout, stderr = proc.communicate(timeout=600)
                 return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
@@ -176,8 +179,7 @@ class MakeMKVExtractor:
                 proc.communicate()  # Clean up zombie process
                 raise
             finally:
-                if self._current_process is proc:
-                    self._current_process = None
+                self._processes.pop(job_id, None)
 
         try:
             # Run in thread to avoid blocking event loop
@@ -219,6 +221,8 @@ class MakeMKVExtractor:
         title_complete_callback: TitleCompleteCallback | None = None,
         stall_timeout: float | None = None,
         title_error_callback: TitleErrorCallback | None = None,
+        *,
+        job_id: int = 0,
     ) -> RipResult:
         """Rip selected titles from a disc.
 
@@ -252,6 +256,7 @@ class MakeMKVExtractor:
                 title_complete_callback,
                 stall_timeout=stall_timeout,
                 title_error_callback=title_error_callback,
+                job_id=job_id,
             )
 
     async def _rip_titles_unlocked(
@@ -263,9 +268,11 @@ class MakeMKVExtractor:
         title_complete_callback: TitleCompleteCallback | None = None,
         stall_timeout: float | None = None,
         title_error_callback: TitleErrorCallback | None = None,
+        *,
+        job_id: int = 0,
     ) -> RipResult:
         """Internal rip implementation (caller must hold drive lock)."""
-        self._cancelled = False
+        self._cancelled_jobs.discard(job_id)
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Normalize drive specification
@@ -450,10 +457,10 @@ class MakeMKVExtractor:
                     prev_sizes = current_sizes
 
             try:
-                self._cancelled = False
+                self._cancelled_jobs.discard(job_id)
 
                 for cmd in commands:
-                    if self._cancelled:
+                    if job_id in self._cancelled_jobs:
                         break
 
                     current_title_idx += 1
@@ -469,7 +476,7 @@ class MakeMKVExtractor:
                         text=True,
                         bufsize=1,  # Line buffered
                     )
-                    self._current_process = process
+                    self._processes[job_id] = process
 
                     # Start stall watchdog thread if timeout is configured
                     watchdog_thread = None
@@ -485,7 +492,7 @@ class MakeMKVExtractor:
 
                     # Read stdout line by line
                     for line in iter(process.stdout.readline, ""):
-                        if self._cancelled:
+                        if job_id in self._cancelled_jobs:
                             process.terminate()
                             break
 
@@ -602,15 +609,15 @@ class MakeMKVExtractor:
 
             except Exception as e:
                 logger.exception("Error in rip subprocess")
-                try:
-                    if self._current_process:
-                        self._current_process.terminate()
-                except (ProcessLookupError, PermissionError) as e:
-                    logger.debug(f"Could not terminate MakeMKV process: {e}")
-                    pass
+                proc = self._processes.get(job_id)
+                if proc:
+                    try:
+                        proc.terminate()
+                    except (ProcessLookupError, PermissionError) as term_err:
+                        logger.debug(f"Could not terminate MakeMKV process: {term_err}")
                 return (-1, str(e), set())
             finally:
-                self._current_process = None
+                self._processes.pop(job_id, None)
 
         try:
             # Start ripping in thread
@@ -659,7 +666,7 @@ class MakeMKVExtractor:
 
             logger.debug(f"Rip completed with return code {returncode}")
 
-            if self._cancelled:
+            if job_id in self._cancelled_jobs:
                 return RipResult(
                     success=False,
                     output_files=[],
@@ -706,15 +713,15 @@ class MakeMKVExtractor:
                 error_message=str(e),
             )
 
-    def cancel(self) -> None:
-        """Cancel the current ripping operation."""
-        self._cancelled = True
-        if self._current_process:
+    def cancel(self, job_id: int) -> None:
+        """Cancel ripping for a specific job."""
+        self._cancelled_jobs.add(job_id)
+        proc = self._processes.get(job_id)
+        if proc:
             try:
-                self._current_process.terminate()
+                proc.terminate()
             except (ProcessLookupError, PermissionError) as e:
-                logger.debug(f"Could not terminate MakeMKV process during cancel: {e}")
-                pass
+                logger.debug(f"Could not terminate MakeMKV process for job {job_id}: {e}")
 
     def _parse_disc_info(self, output: str) -> list[TitleInfo]:
         """Parse MakeMKV robot-mode output to extract title information.

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -1,6 +1,6 @@
 """DiscJob model - the core state machine for disc processing."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 
 from sqlmodel import Field, SQLModel
@@ -85,8 +85,8 @@ class DiscJob(SQLModel, table=True):
     subtitles_failed: int = 0
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     completed_at: datetime | None = Field(default=None)  # When job reached terminal state
     cleared_at: datetime | None = Field(default=None)  # Soft-delete: hidden from dashboard
     error_message: str | None = None

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -8,7 +8,7 @@ import json
 import logging
 import time
 from dataclasses import asdict
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -129,7 +129,7 @@ class JobManager:
                 old_state = job.state
                 job.state = JobState.FAILED
                 job.error_message = f"Server restarted while job was in {old_state.value} state"
-                job.updated_at = datetime.utcnow()
+                job.updated_at = datetime.now(UTC)
                 logger.info(f"Cleaned up stale job {job.id} (was {old_state.value}, now FAILED)")
 
             await session.commit()
@@ -261,7 +261,7 @@ class JobManager:
                 await event_broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
 
                 try:
-                    titles = await self._extractor.scan_disc(job.drive_id)
+                    titles = await self._extractor.scan_disc(job.drive_id, job_id=job_id)
                 except ScanTimeoutError:
                     await state_machine.transition_to_failed(
                         job,
@@ -372,7 +372,23 @@ class JobManager:
                 job.detected_title = analysis.detected_name
                 job.detected_season = analysis.detected_season
                 job.total_titles = len(titles)
-                job.updated_at = datetime.utcnow()
+                job.updated_at = datetime.now(UTC)
+
+                # If TMDB and DiscDB both failed and label looks like a catalog
+                # number (e.g. BBCDVD1550), the parsed name is garbage —
+                # clear it so the NamePromptModal triggers.
+                if (
+                    not tmdb_signal
+                    and not discdb_signal
+                    and job.detected_title
+                    and DiscAnalyst._looks_like_catalog_number(job.volume_label)
+                ):
+                    logger.info(
+                        f"Job {job_id}: Label '{job.volume_label}' looks like a catalog "
+                        f"number and no external match found — clearing detected_title "
+                        f"to trigger name prompt"
+                    )
+                    job.detected_title = None
 
                 # Persist classification metadata
                 job.classification_confidence = analysis.confidence
@@ -638,7 +654,7 @@ class JobManager:
             if season is not None:
                 job.detected_season = season
             job.state = JobState.RIPPING
-            job.updated_at = datetime.utcnow()
+            job.updated_at = datetime.now(UTC)
             await session.commit()
 
             await ws_manager.broadcast_job_update(
@@ -668,7 +684,7 @@ class JobManager:
                 raise ValueError(f"Cannot start job in state: {job.state}")
 
             job.state = JobState.RIPPING
-            job.updated_at = datetime.utcnow()
+            job.updated_at = datetime.now(UTC)
             await session.commit()
 
             # Start ripping in background
@@ -1505,6 +1521,7 @@ class JobManager:
                         title_complete_callback=on_title_complete,
                         stall_timeout=stall_timeout,
                         title_error_callback=on_title_error,
+                        job_id=job_id,
                     )
                 finally:
                     monitor_task.cancel()
@@ -2653,7 +2670,7 @@ class JobManager:
             self._active_jobs[job_id].cancel()
             del self._active_jobs[job_id]
 
-        self._extractor.cancel()
+        self._extractor.cancel(job_id)
 
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
@@ -2736,7 +2753,7 @@ class JobManager:
 
                         # Option: Update state to RIPPING here, then spawn the task.
                         job.state = JobState.RIPPING
-                        job.updated_at = datetime.utcnow()
+                        job.updated_at = datetime.now(UTC)
                         session.add(job)
                         await session.commit()
                         await event_broadcaster.broadcast_job_state_changed(job_id, job.state)
@@ -3791,7 +3808,7 @@ class JobManager:
                 raise ValueError(f"Cannot advance from state: {job.state}")
 
             job.state = next_state
-            job.updated_at = datetime.utcnow()
+            job.updated_at = datetime.now(UTC)
             if next_state == JobState.COMPLETED:
                 job.progress_percent = 100.0
             await session.commit()

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -4,7 +4,7 @@ Centralizes state transition logic, validation, and persistence.
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -117,7 +117,7 @@ class JobStateMachine:
 
         # Update job state
         job.state = to_state
-        job.updated_at = datetime.utcnow()
+        job.updated_at = datetime.now(UTC)
 
         # Set error message if transitioning to failed state
         if to_state == JobState.FAILED and error_message:
@@ -125,7 +125,7 @@ class JobStateMachine:
 
         # Set completed_at timestamp for terminal states
         if to_state in (JobState.COMPLETED, JobState.FAILED):
-            job.completed_at = datetime.utcnow()
+            job.completed_at = datetime.now(UTC)
 
         # Persist to database
         await session.commit()

--- a/backend/app/services/ripping_coordinator.py
+++ b/backend/app/services/ripping_coordinator.py
@@ -249,6 +249,7 @@ class RippingCoordinator:
                 title_indices=rip_indices,
                 progress_callback=lambda p: asyncio.create_task(progress_callback(p)),
                 title_complete_callback=on_title_complete,
+                job_id=job_id,
             )
 
             if not result.success:

--- a/backend/tests/integration/test_multi_drive.py
+++ b/backend/tests/integration/test_multi_drive.py
@@ -1,0 +1,220 @@
+"""Integration tests for multi-drive scenarios.
+
+Validates that two optical drives can operate independently:
+- Concurrent ripping on different drives
+- Cancel isolation (canceling one job doesn't affect another)
+- Drive removal isolation
+- Mixed content types (TV + movie on different drives)
+
+Ref: https://github.com/Jsakkos/engram/issues/57
+Ref: https://github.com/Jsakkos/engram/issues/64
+Ref: https://github.com/Jsakkos/engram/issues/65
+"""
+
+import asyncio
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Initialize test database and clean data between tests."""
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+async def client():
+    """Create async test client."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def insert_disc(client, drive_id: str, volume_label: str, **kwargs):
+    """Helper to insert a simulated disc on a specific drive."""
+    payload = {
+        "drive_id": drive_id,
+        "volume_label": volume_label,
+        "content_type": kwargs.get("content_type", "tv"),
+        "detected_title": kwargs.get("detected_title", "Test Show"),
+        "detected_season": kwargs.get("detected_season", 1),
+        "simulate_ripping": kwargs.get("simulate_ripping", True),
+        "rip_speed_multiplier": kwargs.get("rip_speed_multiplier", 100),
+    }
+    if "force_review_needed" in kwargs:
+        payload["force_review_needed"] = kwargs["force_review_needed"]
+    response = await client.post("/api/simulate/insert-disc", json=payload)
+    assert response.status_code == 200, f"Insert failed: {response.text}"
+    return response.json()["job_id"]
+
+
+async def get_job(client, job_id: int) -> dict:
+    """Helper to get a job's current state."""
+    response = await client.get(f"/api/jobs/{job_id}")
+    assert response.status_code == 200
+    return response.json()
+
+
+async def wait_for_state(client, job_id: int, states: set[str], timeout: float = 10.0) -> dict:
+    """Poll until job reaches one of the target states, or timeout."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        job = await get_job(client, job_id)
+        if job["state"] in states:
+            return job
+        await asyncio.sleep(0.2)
+    raise TimeoutError(
+        f"Job {job_id} did not reach {states} within {timeout}s (stuck at {job['state']})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ripping_on_two_drives(client):
+    """Two drives ripping simultaneously should both complete independently."""
+    job_a = await insert_disc(client, "E:", "SHOW_S01D1", detected_title="Show A")
+    job_b = await insert_disc(client, "F:", "SHOW_S02D1", detected_title="Show B")
+
+    assert job_a != job_b, "Jobs on different drives should have different IDs"
+
+    # Both jobs should progress (at minimum past IDLE)
+    job_a_data = await wait_for_state(
+        client, job_a, {"ripping", "matching", "organizing", "completed"}, timeout=10.0
+    )
+    job_b_data = await wait_for_state(
+        client, job_b, {"ripping", "matching", "organizing", "completed"}, timeout=10.0
+    )
+
+    # Verify they're on different drives
+    assert job_a_data["drive_id"] == "E:"
+    assert job_b_data["drive_id"] == "F:"
+
+    # Neither should have failed
+    assert job_a_data["state"] != "failed"
+    assert job_b_data["state"] != "failed"
+
+
+@pytest.mark.asyncio
+async def test_cancel_one_drive_does_not_affect_other(client):
+    """Canceling a job on drive E: must not affect a job ripping on drive F:."""
+    job_a = await insert_disc(client, "E:", "CANCEL_ME", detected_title="Cancel Show")
+    job_b = await insert_disc(client, "F:", "KEEP_GOING", detected_title="Keep Show")
+
+    # Wait for both to start ripping
+    await wait_for_state(client, job_a, {"ripping", "matching", "organizing", "completed"})
+    await wait_for_state(client, job_b, {"ripping", "matching", "organizing", "completed"})
+
+    # Cancel job A
+    cancel_response = await client.post(f"/api/jobs/{job_a}/cancel")
+    assert cancel_response.status_code == 200
+
+    # Verify job A is failed/cancelled
+    job_a_data = await get_job(client, job_a)
+    assert job_a_data["state"] == "failed"
+    assert "Cancelled" in (job_a_data.get("error_message") or "")
+
+    # Give a moment for any cross-contamination to manifest
+    await asyncio.sleep(0.5)
+
+    # Job B must NOT be failed — it should still be running or completed
+    job_b_data = await get_job(client, job_b)
+    assert job_b_data["state"] != "failed", (
+        f"Job B on drive F: was incorrectly affected by canceling Job A on drive E:. "
+        f"State: {job_b_data['state']}, Error: {job_b_data.get('error_message')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_drive_removal_does_not_affect_other_drive(client):
+    """Simulating disc removal on drive E: must not affect drive F:."""
+    await insert_disc(
+        client, "E:", "REMOVE_ME", detected_title="Remove Show", simulate_ripping=False
+    )
+    job_b = await insert_disc(client, "F:", "KEEP_ME", detected_title="Keep Show")
+
+    # Wait for job B to start ripping
+    await wait_for_state(client, job_b, {"ripping", "matching", "organizing", "completed"})
+
+    # Simulate disc removal on drive E:
+    remove_response = await client.post("/api/simulate/remove-disc?drive_id=E%3A")
+    assert remove_response.status_code == 200
+
+    await asyncio.sleep(0.5)
+
+    # Job B must still be running or completed, NOT failed
+    job_b_data = await get_job(client, job_b)
+    assert job_b_data["state"] != "failed", (
+        f"Job B on drive F: was incorrectly affected by disc removal on drive E:. "
+        f"State: {job_b_data['state']}, Error: {job_b_data.get('error_message')}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_content_types_on_different_drives(client):
+    """TV on drive E: and movie on drive F: should both work independently."""
+    job_tv = await insert_disc(
+        client,
+        "E:",
+        "TV_SHOW_S01D1",
+        content_type="tv",
+        detected_title="Some TV Show",
+        detected_season=1,
+    )
+    job_movie = await insert_disc(
+        client,
+        "F:",
+        "INCEPTION_2010",
+        content_type="movie",
+        detected_title="Inception",
+    )
+
+    # Both should progress
+    tv_data = await wait_for_state(
+        client, job_tv, {"ripping", "matching", "organizing", "completed"}, timeout=10.0
+    )
+    movie_data = await wait_for_state(
+        client, job_movie, {"ripping", "matching", "organizing", "completed"}, timeout=10.0
+    )
+
+    assert tv_data["content_type"] == "tv"
+    assert movie_data["content_type"] == "movie"
+    assert tv_data["state"] != "failed"
+    assert movie_data["state"] != "failed"
+
+
+@pytest.mark.asyncio
+async def test_dual_identification_independent(client):
+    """Two discs inserted near-simultaneously get identified independently."""
+    job_a = await insert_disc(
+        client,
+        "E:",
+        "DISC_A",
+        detected_title="Show Alpha",
+        simulate_ripping=False,
+    )
+    job_b = await insert_disc(
+        client,
+        "F:",
+        "DISC_B",
+        detected_title="Show Beta",
+        simulate_ripping=False,
+    )
+
+    # Both should exist with correct metadata
+    data_a = await get_job(client, job_a)
+    data_b = await get_job(client, job_b)
+
+    assert data_a["volume_label"] == "DISC_A"
+    assert data_b["volume_label"] == "DISC_B"
+    assert data_a["detected_title"] == "Show Alpha"
+    assert data_b["detected_title"] == "Show Beta"
+    assert data_a["drive_id"] == "E:"
+    assert data_b["drive_id"] == "F:"

--- a/backend/tests/pipeline/test_generic_label_flow.py
+++ b/backend/tests/pipeline/test_generic_label_flow.py
@@ -88,3 +88,42 @@ class TestGenericLabelNamePromptFlow:
         # Colon should be removed/replaced by sanitize_filename
         assert ":" not in folder
         assert "Italian" in folder
+
+
+@pytest.mark.pipeline
+class TestCatalogNumberDetection:
+    """Verify that catalog-number labels (e.g. BBCDVD1550) are detected."""
+
+    CATALOG_LABELS = [
+        "BBCDVD1550",
+        "MGMHV1234",
+        "FHED3456",
+        "PHEUK789",
+        "REV1234",
+    ]
+
+    NON_CATALOG_LABELS = [
+        "THE_OFFICE_S01D01",
+        "INCEPTION_2010",
+        "FIREFLY_DISC1",
+        "BREAKING_BAD",
+        "LOGICAL_VOLUME_ID",  # generic, not catalog
+    ]
+
+    @pytest.mark.parametrize("label", CATALOG_LABELS)
+    def test_catalog_label_detected(self, label):
+        assert DiscAnalyst._looks_like_catalog_number(label)
+
+    @pytest.mark.parametrize("label", NON_CATALOG_LABELS)
+    def test_non_catalog_label_not_detected(self, label):
+        assert not DiscAnalyst._looks_like_catalog_number(label)
+
+    def test_catalog_label_still_parses_a_name(self):
+        """Catalog labels DO parse into a garbage name — that's the problem we fix."""
+        name, season, disc = DiscAnalyst._parse_volume_label("BBCDVD1550")
+        # Parser extracts "Bbcdv" — not useful, but non-None
+        assert name is not None
+
+    def test_catalog_detection_with_underscores(self):
+        """Underscores in catalog labels should be normalized."""
+        assert DiscAnalyst._looks_like_catalog_number("BBC_DVD1550")

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -557,6 +557,7 @@ function TVTitleRow({
     onToggleExpand,
     variant,
 }: TVTitleRowProps) {
+    const [season, setSeason] = useState(job?.detected_season || 1);
     const details = parseMatchDetails(title);
     const isConflict = details.error === 'file_exists';
     const reasons = getReviewReasons(title);
@@ -635,12 +636,22 @@ function TVTitleRow({
                         </div>
                     )}
 
-                    {/* Episode selector */}
-                    <div className="w-44 flex-shrink-0">
+                    {/* Episode selector with season input */}
+                    <div className="w-52 flex-shrink-0 flex items-center gap-1">
+                        <label className="text-xs text-slate-400 font-mono" title="Season">S</label>
+                        <input
+                            type="number"
+                            min={1}
+                            max={20}
+                            value={season}
+                            onChange={(e) => setSeason(Math.max(1, Math.min(20, parseInt(e.target.value) || 1)))}
+                            className="w-10 bg-slate-800 border border-slate-600 rounded px-1 py-1 text-xs text-center font-mono text-slate-200"
+                            title="Season number"
+                        />
                         <select
                             value={selectedEpisode}
                             onChange={(e) => onEpisodeChange(title.id, e.target.value)}
-                            className="w-full px-2 py-1.5 text-xs font-mono bg-navy-800 border border-slate-700 text-slate-300 focus:border-cyan-500/50 focus:outline-none"
+                            className="flex-1 px-2 py-1.5 text-xs font-mono bg-navy-800 border border-slate-700 text-slate-300 focus:border-cyan-500/50 focus:outline-none"
                         >
                             <option value="">Select episode...</option>
                             {title.matched_episode && (
@@ -656,7 +667,7 @@ function TVTitleRow({
                             {(title.matched_episode || alternatives.length > 0) && (
                                 <option disabled>{'─'.repeat(20)}</option>
                             )}
-                            {generateEpisodeOptions(job.detected_season || 1, EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON).map(ep => (
+                            {generateEpisodeOptions(season, EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON).map(ep => (
                                 <option key={ep} value={ep}>{ep}</option>
                             ))}
                         </select>

--- a/frontend/src/components/ReviewQueue/EpisodeSelector.tsx
+++ b/frontend/src/components/ReviewQueue/EpisodeSelector.tsx
@@ -1,7 +1,8 @@
 /**
- * Episode selection dropdown component
+ * Episode selection dropdown component with season selector
  */
 
+import { useState } from 'react';
 import { DiscTitle, Job } from '../../types';
 import { MatchDetails } from './types';
 import { generateEpisodeOptions, parseMatchDetails } from './utils';
@@ -15,42 +16,56 @@ interface EpisodeSelectorProps {
 }
 
 export function EpisodeSelector({ title, job, selectedEpisode, onEpisodeChange }: EpisodeSelectorProps) {
+    const [season, setSeason] = useState(job?.detected_season || 1);
+
     const getAlternativeMatches = (title: DiscTitle): Array<{ episode: string; confidence: number; vote_count?: number }> => {
         const details: MatchDetails = parseMatchDetails(title);
         return details.runner_ups || [];
     };
 
     return (
-        <select
-            value={selectedEpisode}
-            onChange={(e) => onEpisodeChange(title.id, e.target.value)}
-        >
-            <option value="">Select episode...</option>
+        <div className="flex items-center gap-1">
+            <label className="text-xs text-slate-400 font-mono whitespace-nowrap" title="Season">S</label>
+            <input
+                type="number"
+                min={1}
+                max={20}
+                value={season}
+                onChange={(e) => setSeason(Math.max(1, Math.min(20, parseInt(e.target.value) || 1)))}
+                className="w-10 bg-slate-800 border border-slate-600 rounded px-1 py-0.5 text-xs text-center font-mono text-slate-200"
+                title="Season number"
+            />
+            <select
+                value={selectedEpisode}
+                onChange={(e) => onEpisodeChange(title.id, e.target.value)}
+            >
+                <option value="">Select episode...</option>
 
-            {/* Primary match - show confidence */}
-            {title.matched_episode && (
-                <option value={title.matched_episode}>
-                    {title.matched_episode} - Best Match ({Math.round(title.match_confidence * 100)}%)
-                </option>
-            )}
+                {/* Primary match - show confidence */}
+                {title.matched_episode && (
+                    <option value={title.matched_episode}>
+                        {title.matched_episode} - Best Match ({Math.round(title.match_confidence * 100)}%)
+                    </option>
+                )}
 
-            {/* Alternative matches from runner_ups */}
-            {getAlternativeMatches(title).map((alt, idx) => (
-                <option key={`alt-${idx}`} value={alt.episode}>
-                    {alt.episode} - Alternative ({Math.round(alt.confidence * 100)}%)
-                </option>
-            ))}
+                {/* Alternative matches from runner_ups */}
+                {getAlternativeMatches(title).map((alt, idx) => (
+                    <option key={`alt-${idx}`} value={alt.episode}>
+                        {alt.episode} - Alternative ({Math.round(alt.confidence * 100)}%)
+                    </option>
+                ))}
 
-            {(title.matched_episode || getAlternativeMatches(title).length > 0) && (
-                <option disabled>──────────</option>
-            )}
+                {(title.matched_episode || getAlternativeMatches(title).length > 0) && (
+                    <option disabled>──────────</option>
+                )}
 
-            {/* All episodes (manual fallback) */}
-            {generateEpisodeOptions(job?.detected_season || 1, EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON).map(ep => (
-                <option key={ep} value={ep}>{ep}</option>
-            ))}
+                {/* All episodes (manual fallback) */}
+                {generateEpisodeOptions(season, EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON).map(ep => (
+                    <option key={ep} value={ep}>{ep}</option>
+                ))}
 
-            <option value="skip">Skip this title</option>
-        </select>
+                <option value="skip">Skip this title</option>
+            </select>
+        </div>
     );
 }

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -61,7 +61,9 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     currentSpeed: job.current_speed,
     etaSeconds: job.eta_seconds,
     subtitleStatus: job.subtitle_status || undefined,
-    startedAt: job.created_at,
+    startedAt: job.created_at
+      ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')
+      : undefined,
     tracks: titles.map(title => transformDiscTitleToTrack(title, job))
   };
 }


### PR DESCRIPTION
## Summary

Fixes 4 bugs reported by a real user with two optical drives (#57), plus adds multi-drive test coverage.

- **#64 Cancel isolation**: `MakeMKVExtractor` now tracks processes per `job_id` instead of globally — canceling one drive's job no longer kills another drive's rip
- **#61 Elapsed time**: Fixed 1-hour offset by replacing deprecated `datetime.utcnow()` with `datetime.now(UTC)` and ensuring frontend interprets timestamps as UTC
- **#62 Catalog labels**: Detects catalog-number volume labels (e.g. `BBCDVD1550`) and triggers the name prompt when TMDB/DiscDB lookups fail
- **#63 Season selector**: Added season number input (S01–S20) to the episode review UI
- **#65 Multi-drive tests**: 5 new integration tests for concurrent ripping, cancel isolation, drive removal isolation, mixed content, and dual identification

## Test plan

- [x] 430 unit/pipeline tests pass
- [x] 43 integration tests pass (excludes 2 pre-existing failures)
- [x] 5 new multi-drive integration tests pass
- [x] Frontend builds clean (`tsc && vite build`)
- [x] Ruff lint + format pass
- [x] ESLint passes
- [ ] Manual test: simulate two drives concurrently, cancel one, verify other continues
- [ ] Manual test: simulate catalog label disc, verify name prompt appears

Closes #61, closes #62, closes #63, closes #64, closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)