### PR TITLE
feat: production staging import endpoint (no DEBUG required)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -993,6 +993,47 @@ async def simulate_insert_disc_from_staging(
     return {"status": "simulated", "job_id": job_id, "titles_count": len(titles)}
 
 
+class StagingImportRequest(BaseModel):
+    """Request model for importing pre-ripped MKV files from a staging directory."""
+
+    staging_path: str
+    volume_label: str = ""
+    content_type: str = "unknown"
+    detected_title: str | None = None
+    detected_season: int | None = None
+
+
+@router.post("/staging/import")
+async def import_from_staging(request: StagingImportRequest) -> dict:
+    """Import pre-ripped MKV files from a staging directory.
+
+    Creates a real job that skips the ripping phase and proceeds
+    directly to identification, matching, and organization.
+    Available in all modes (no DEBUG required).
+    """
+    from app.services.job_manager import job_manager
+
+    staging_dir = Path(request.staging_path)
+    if not staging_dir.exists():
+        raise HTTPException(
+            status_code=404, detail=f"Staging directory not found: {request.staging_path}"
+        )
+
+    mkv_files = sorted(staging_dir.glob("*.mkv"))
+    if not mkv_files:
+        raise HTTPException(status_code=404, detail=f"No MKV files found in {request.staging_path}")
+
+    job_id = await job_manager.create_job_from_staging(
+        staging_path=str(staging_dir),
+        volume_label=request.volume_label,
+        content_type=request.content_type,
+        detected_title=request.detected_title,
+        detected_season=request.detected_season,
+    )
+
+    return {"status": "created", "job_id": job_id, "titles_count": len(mkv_files)}
+
+
 @router.get("/staging/orphaned")
 async def get_orphaned_staging(session: AsyncSession = Depends(get_session)) -> dict:
     """Find staging directories that don't belong to active jobs."""

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -249,6 +249,333 @@ class JobManager:
                 task = asyncio.create_task(self._identify_disc(job.id))
                 self._active_jobs[job.id] = task
 
+    async def create_job_from_staging(
+        self,
+        staging_path: str,
+        volume_label: str = "",
+        content_type: str = "unknown",
+        detected_title: str | None = None,
+        detected_season: int | None = None,
+    ) -> int:
+        """Create a job from pre-ripped MKV files in a staging directory.
+
+        Skips the ripping phase entirely — files are already on disk.
+        Runs identification (classification), then matching/organization.
+        """
+        staging_dir = Path(staging_path)
+
+        # Use directory name as volume label if none provided
+        if not volume_label:
+            volume_label = staging_dir.name.upper().replace(" ", "_")
+
+        # Create job record
+        async with async_session() as session:
+            job = DiscJob(
+                drive_id="staging",
+                volume_label=volume_label,
+                staging_path=str(staging_dir),
+                state=JobState.IDENTIFYING,
+            )
+
+            # Apply user-provided hints
+            if content_type in ("tv", "movie"):
+                job.content_type = ContentType(content_type)
+            if detected_title:
+                job.detected_title = detected_title
+            if detected_season is not None:
+                job.detected_season = detected_season
+
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+
+            job_id = job.id
+            logger.info(
+                f"Created staging import job {job_id} from {staging_path} (label: {volume_label})"
+            )
+
+        # Broadcast job creation
+        await event_broadcaster.broadcast_drive_inserted("staging", volume_label)
+
+        # Run identification pipeline in background
+        task = asyncio.create_task(self._identify_from_staging(job_id))
+        self._active_jobs[job_id] = task
+
+        return job_id
+
+    async def _identify_from_staging(self, job_id: int) -> None:
+        """Identify and process pre-ripped MKV files from staging.
+
+        Similar to _identify_disc() but skips the MakeMKV scan — constructs
+        TitleInfo objects from the existing MKV files via ffprobe instead.
+        """
+        from app.core.analyst import TitleInfo
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+
+            try:
+                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
+
+                staging_dir = Path(job.staging_path)
+                mkv_files = sorted(staging_dir.glob("*.mkv"))
+
+                if not mkv_files:
+                    await state_machine.transition_to_failed(
+                        job, session, "No MKV files found in staging directory"
+                    )
+                    return
+
+                # Build TitleInfo objects from MKV files using ffprobe
+                titles: list[TitleInfo] = []
+                for idx, mkv_file in enumerate(mkv_files):
+                    duration = await self._probe_duration(mkv_file)
+                    file_size = mkv_file.stat().st_size
+
+                    titles.append(
+                        TitleInfo(
+                            index=idx,
+                            duration_seconds=int(duration),
+                            size_bytes=file_size,
+                            chapter_count=0,
+                            name=mkv_file.stem,
+                        )
+                    )
+
+                # Run classification pipeline (same as _identify_disc)
+                from app.services.config_service import get_config_sync
+
+                config = get_config_sync()
+
+                # Attempt TheDiscDB lookup
+                discdb_signal = None
+                if config.discdb_enabled:
+                    try:
+                        from app.core.discdb_classifier import classify_from_discdb
+
+                        discdb_signal = classify_from_discdb(
+                            job.volume_label, titles, content_hash=None
+                        )
+                        if discdb_signal:
+                            logger.info(
+                                f"Job {job_id}: TheDiscDB signal: "
+                                f"{discdb_signal.content_type.value} "
+                                f"({discdb_signal.confidence:.0%}) - "
+                                f"{discdb_signal.matched_title}"
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Job {job_id}: TheDiscDB lookup failed: {e}",
+                            exc_info=True,
+                        )
+
+                # Attempt TMDB lookup
+                tmdb_signal = None
+                detected_name, _, _ = DiscAnalyst._parse_volume_label(job.volume_label)
+                if detected_name:
+                    try:
+                        from app.core.tmdb_classifier import classify_from_tmdb
+
+                        if config.tmdb_api_key:
+                            tmdb_signal = classify_from_tmdb(detected_name, config.tmdb_api_key)
+                            if tmdb_signal:
+                                logger.info(
+                                    f"Job {job_id}: TMDB signal: "
+                                    f"{tmdb_signal.content_type.value} "
+                                    f"({tmdb_signal.confidence:.0%}) - "
+                                    f"{tmdb_signal.tmdb_name}"
+                                )
+                    except Exception as e:
+                        logger.warning(f"Job {job_id}: TMDB lookup failed: {e}")
+
+                # Analyze disc content
+                analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
+
+                # Apply DiscDB override if high-confidence
+                if discdb_signal and discdb_signal.confidence >= 0.90:
+                    analysis.content_type = discdb_signal.content_type
+                    analysis.confidence = discdb_signal.confidence
+                    analysis.classification_source = f"discdb_{discdb_signal.source}"
+                    analysis.detected_name = discdb_signal.matched_title
+                    analysis.needs_review = False
+                    if discdb_signal.tmdb_id:
+                        analysis.tmdb_id = discdb_signal.tmdb_id
+                    if discdb_signal.title_mappings:
+                        self._discdb_mappings[job_id] = discdb_signal.title_mappings
+                        job.discdb_mappings_json = json.dumps(
+                            [asdict(m) for m in discdb_signal.title_mappings]
+                        )
+                elif discdb_signal and not analysis.detected_name:
+                    analysis.detected_name = discdb_signal.matched_title
+
+                # Apply user-provided hints (override classification if given)
+                if job.content_type and job.content_type != ContentType.UNKNOWN:
+                    analysis.content_type = job.content_type
+                if job.detected_title:
+                    analysis.detected_name = job.detected_title
+
+                # Update job with analysis results
+                job.content_type = analysis.content_type
+                job.detected_title = analysis.detected_name or job.detected_title
+                job.detected_season = analysis.detected_season or job.detected_season
+                job.total_titles = len(titles)
+                job.updated_at = datetime.utcnow()
+                job.classification_confidence = analysis.confidence
+                job.classification_source = analysis.classification_source or "staging_import"
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.is_ambiguous_movie = analysis.is_ambiguous_movie
+                if analysis.play_all_title_indices:
+                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
+
+                # Extract disc number from volume label
+                import re
+
+                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
+                job.disc_number = int(disc_match.group(1)) if disc_match else 1
+
+                # Create DiscTitle records with output_filename already set
+                from sqlalchemy import delete
+
+                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
+
+                for title, mkv_file in zip(titles, mkv_files, strict=True):
+                    disc_title = DiscTitle(
+                        job_id=job_id,
+                        title_index=title.index,
+                        duration_seconds=title.duration_seconds,
+                        file_size_bytes=title.size_bytes,
+                        chapter_count=title.chapter_count,
+                        output_filename=str(mkv_file),
+                    )
+                    session.add(disc_title)
+
+                await session.commit()
+
+                # Broadcast titles discovered
+                titles_result = await session.execute(
+                    select(DiscTitle).where(DiscTitle.job_id == job_id)
+                )
+                title_list = build_title_list(titles_result.scalars().all())
+                await ws_manager.broadcast_titles_discovered(
+                    job_id,
+                    title_list,
+                    content_type=job.content_type.value,
+                    detected_title=job.detected_title,
+                    detected_season=job.detected_season,
+                )
+
+                # If no title detected, ask user
+                if not job.detected_title:
+                    await state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason="Could not determine title. Please enter the title to continue.",
+                        broadcast=False,
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.REVIEW_NEEDED.value,
+                        content_type=(job.content_type.value if job.content_type else None),
+                        total_titles=job.total_titles,
+                        review_reason="Could not determine title. Please enter the title to continue.",
+                    )
+                    return
+
+                # Skip ripping — files already exist. Proceed to matching/organization.
+                if job.content_type == ContentType.TV:
+                    # Start subtitle download
+                    if job.detected_title and job.detected_season:
+                        self._subtitle_ready[job_id] = asyncio.Event()
+                        self._subtitle_tasks[job_id] = asyncio.create_task(
+                            self._download_subtitles(
+                                job_id, job.detected_title, job.detected_season
+                            )
+                        )
+
+                    # Transition to MATCHING and kick off per-title matching
+                    succeeded = await state_machine.transition(
+                        job, JobState.MATCHING, session, broadcast=False
+                    )
+                    if succeeded:
+                        await ws_manager.broadcast_job_update(job_id, JobState.MATCHING.value)
+
+                    # Queue matching for each title
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHING
+                        session.add(dt)
+                    await session.commit()
+
+                    for dt in db_titles:
+                        if dt.output_filename:
+                            file_path = Path(dt.output_filename)
+                            discdb_applied = await self._try_discdb_assignment(job_id, dt, session)
+                            if not discdb_applied:
+                                task = asyncio.create_task(
+                                    self._match_single_file(job_id, dt.id, file_path)
+                                )
+                                task.add_done_callback(
+                                    lambda t, jid=job_id, tid=dt.id: (
+                                        self._on_match_task_done(t, jid, tid)
+                                    )
+                                )
+                else:
+                    # Movie: skip matching, go straight to organization
+                    job.state = JobState.ORGANIZING
+                    await session.commit()
+                    await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
+
+                    # Mark titles as MATCHED
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHED
+                        session.add(dt)
+                    await session.commit()
+
+                    # Run organization
+                    await self._finalize_disc_job(job_id)
+
+            except Exception as e:
+                logger.exception(f"Error processing staging import for job {job_id}")
+                async with async_session() as err_session:
+                    err_job = await err_session.get(DiscJob, job_id)
+                    if err_job:
+                        await state_machine.transition_to_failed(err_job, err_session, str(e))
+
+    async def _probe_duration(self, mkv_file: Path) -> float:
+        """Get duration of an MKV file using ffprobe."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(mkv_file),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            return float(stdout.decode().strip()) if stdout.decode().strip() else 1800
+        except (TimeoutError, OSError, ValueError) as e:
+            logger.debug(f"Could not determine MKV duration via ffprobe: {e}")
+            return 1800  # Default 30 minutes
+
     async def _identify_disc(self, job_id: int) -> None:
         """Identify the disc contents using MakeMKV and the Analyst."""
         async with async_session() as session:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -523,8 +523,8 @@ class JobManager:
                                     self._match_single_file(job_id, dt.id, file_path)
                                 )
                                 task.add_done_callback(
-                                    lambda t, jid=job_id, tid=dt.id: (
-                                        self._on_match_task_done(t, jid, tid)
+                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                        t, jid, tid
                                     )
                                 )
                 else:

--- a/backend/tests/unit/test_ai_identifier.py
+++ b/backend/tests/unit/test_ai_identifier.py
@@ -99,11 +99,7 @@ class TestIdentifyFromLabel:
         mock_client = _make_mock_client(
             {
                 "choices": [
-                    {
-                        "message": {
-                            "content": '{"title": "The Office", "year": 2005, "type": "tv"}'
-                        }
-                    }
+                    {"message": {"content": '{"title": "The Office", "year": 2005, "type": "tv"}'}}
                 ]
             }
         )

--- a/backend/tests/unit/test_staging_import.py
+++ b/backend/tests/unit/test_staging_import.py
@@ -4,13 +4,13 @@ Tests that the endpoint is accessible without DEBUG mode, validates paths,
 and creates jobs from directories containing MKV files.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from httpx import ASGITransport, AsyncClient
-from unittest.mock import AsyncMock, patch
 
 from app.database import get_session
 from app.main import app
-
 from tests.unit.conftest import _unit_session_factory
 
 

--- a/backend/tests/unit/test_staging_import.py
+++ b/backend/tests/unit/test_staging_import.py
@@ -1,0 +1,173 @@
+"""Unit tests for the staging import endpoint (POST /api/staging/import).
+
+Tests that the endpoint is accessible without DEBUG mode, validates paths,
+and creates jobs from directories containing MKV files.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from app.database import get_session
+from app.main import app
+
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture
+async def client():
+    """Provide an async HTTP client with the patched DB session."""
+
+    async def override_get_session():
+        async with _unit_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+class TestStagingImportEndpoint:
+    """Tests for POST /api/staging/import."""
+
+    async def test_missing_staging_path_returns_404(self, client: AsyncClient):
+        """A nonexistent staging path should return 404."""
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": "/nonexistent/path/to/nowhere"},
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    async def test_empty_directory_returns_404(self, client: AsyncClient, tmp_path):
+        """A directory with no MKV files should return 404."""
+        empty_dir = tmp_path / "empty_staging"
+        empty_dir.mkdir()
+
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": str(empty_dir)},
+        )
+        assert resp.status_code == 404
+        assert "no mkv files" in resp.json()["detail"].lower()
+
+    async def test_directory_with_non_mkv_files_returns_404(self, client: AsyncClient, tmp_path):
+        """A directory with only non-MKV files should return 404."""
+        staging_dir = tmp_path / "staging_txt"
+        staging_dir.mkdir()
+        (staging_dir / "readme.txt").write_text("not a video")
+        (staging_dir / "image.jpg").write_bytes(b"\xff\xd8\xff")
+
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": str(staging_dir)},
+        )
+        assert resp.status_code == 404
+
+    async def test_valid_staging_creates_job(self, client: AsyncClient, tmp_path):
+        """A valid directory with MKV files should create a job."""
+        staging_dir = tmp_path / "MY_SHOW_S1D1"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+        (staging_dir / "title_t01.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        # Mock create_job_from_staging to avoid running the full pipeline
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            new_callable=AsyncMock,
+            return_value=42,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={
+                    "staging_path": str(staging_dir),
+                    "volume_label": "MY_SHOW_S1D1",
+                    "content_type": "tv",
+                    "detected_title": "My Show",
+                    "detected_season": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "created"
+        assert data["job_id"] == 42
+        assert data["titles_count"] == 2
+
+    async def test_available_without_debug_mode(self, client: AsyncClient, tmp_path):
+        """The endpoint must be accessible even when DEBUG=false."""
+        staging_dir = tmp_path / "test_disc"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        with (
+            patch(
+                "app.services.job_manager.job_manager.create_job_from_staging",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch("app.config.settings.debug", False),
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={"staging_path": str(staging_dir)},
+            )
+
+        # Should succeed (200), not 403
+        assert resp.status_code == 200
+
+    async def test_default_volume_label_from_directory_name(self, client: AsyncClient, tmp_path):
+        """When no volume_label is provided, it should default to empty string."""
+        staging_dir = tmp_path / "my_disc"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        mock_create = AsyncMock(return_value=1)
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            mock_create,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={"staging_path": str(staging_dir)},
+            )
+
+        assert resp.status_code == 200
+        # Verify the method was called with default empty volume_label
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs["volume_label"] == ""
+        assert call_kwargs.kwargs["content_type"] == "unknown"
+
+    async def test_all_parameters_passed_through(self, client: AsyncClient, tmp_path):
+        """All request parameters should be forwarded to create_job_from_staging."""
+        staging_dir = tmp_path / "test"
+        staging_dir.mkdir()
+        (staging_dir / "movie.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        mock_create = AsyncMock(return_value=7)
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            mock_create,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={
+                    "staging_path": str(staging_dir),
+                    "volume_label": "INCEPTION_2010",
+                    "content_type": "movie",
+                    "detected_title": "Inception",
+                    "detected_season": None,
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_create.assert_called_once_with(
+            staging_path=str(staging_dir),
+            volume_label="INCEPTION_2010",
+            content_type="movie",
+            detected_title="Inception",
+            detected_season=None,
+        )


### PR DESCRIPTION
## Summary

- Adds `POST /api/staging/import` endpoint that creates jobs from pre-ripped MKV files **without requiring `DEBUG=true`**
- Adds `JobManager.create_job_from_staging()` which builds title metadata via ffprobe and runs the full classification → matching → organization pipeline (skipping the rip phase)
- Enables Linux/macOS users to import media as a first-class workflow, not a debug-only simulation

Closes #68
Related: #66

## Changes

### New endpoint: `POST /api/staging/import`
Accepts JSON body:
```json
{
  "staging_path": "/path/to/mkv/files",
  "volume_label": "MY_SHOW_S1D1",
  "content_type": "tv",
  "detected_title": "My Show",
  "detected_season": 1
}
```

### New method: `JobManager.create_job_from_staging()`
- Constructs `TitleInfo` objects from MKV files using ffprobe (duration, file size)
- Reuses existing classification pipeline (Analyst, TMDB, TheDiscDB)
- For TV: transitions to MATCHING and kicks off per-title episode matching
- For movies: transitions to ORGANIZING and runs finalization directly

### Tests
7 unit tests covering: path validation, no-debug-required, parameter passthrough, edge cases.

## Test plan

- [x] `uv run pytest tests/unit/test_staging_import.py` — 7/7 passing
- [x] `uv run pytest tests/unit/` — 360 passed (no regressions)
- [x] `uv run pytest tests/pipeline/` — 77 passed (no regressions)
- [x] `uv run ruff check` — clean
- [ ] Manual test: start backend, POST to `/api/staging/import` with real MKV files
- [ ] Verify job progresses through full pipeline on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)