### PR TITLE
feat: staging folder auto-import watcher

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -190,6 +190,8 @@ class ConfigResponse(BaseModel):
     ai_identification_enabled: bool
     ai_provider: str
     ai_api_key: str
+    # Staging watcher
+    staging_watch_enabled: bool
     # TheDiscDB
     discdb_enabled: bool
     # Onboarding
@@ -234,6 +236,8 @@ class ConfigUpdate(BaseModel):
     ai_identification_enabled: bool | None = None
     ai_provider: str | None = None
     ai_api_key: str | None = None
+    # Staging watcher
+    staging_watch_enabled: bool | None = None
     # TheDiscDB
     discdb_enabled: bool | None = None
     # Onboarding
@@ -663,6 +667,8 @@ async def get_config() -> ConfigResponse:
         ai_identification_enabled=config.ai_identification_enabled,
         ai_provider=config.ai_provider,
         ai_api_key="***" if config.ai_api_key else "",  # Redacted
+        # Staging watcher
+        staging_watch_enabled=config.staging_watch_enabled,
         # TheDiscDB
         discdb_enabled=config.discdb_enabled,
         # Onboarding

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -993,6 +993,47 @@ async def simulate_insert_disc_from_staging(
     return {"status": "simulated", "job_id": job_id, "titles_count": len(titles)}
 
 
+class StagingImportRequest(BaseModel):
+    """Request model for importing pre-ripped MKV files from a staging directory."""
+
+    staging_path: str
+    volume_label: str = ""
+    content_type: str = "unknown"
+    detected_title: str | None = None
+    detected_season: int | None = None
+
+
+@router.post("/staging/import")
+async def import_from_staging(request: StagingImportRequest) -> dict:
+    """Import pre-ripped MKV files from a staging directory.
+
+    Creates a real job that skips the ripping phase and proceeds
+    directly to identification, matching, and organization.
+    Available in all modes (no DEBUG required).
+    """
+    from app.services.job_manager import job_manager
+
+    staging_dir = Path(request.staging_path)
+    if not staging_dir.exists():
+        raise HTTPException(
+            status_code=404, detail=f"Staging directory not found: {request.staging_path}"
+        )
+
+    mkv_files = sorted(staging_dir.glob("*.mkv"))
+    if not mkv_files:
+        raise HTTPException(status_code=404, detail=f"No MKV files found in {request.staging_path}")
+
+    job_id = await job_manager.create_job_from_staging(
+        staging_path=str(staging_dir),
+        volume_label=request.volume_label,
+        content_type=request.content_type,
+        detected_title=request.detected_title,
+        detected_season=request.detected_season,
+    )
+
+    return {"status": "created", "job_id": job_id, "titles_count": len(mkv_files)}
+
+
 @router.get("/staging/orphaned")
 async def get_orphaned_staging(session: AsyncSession = Depends(get_session)) -> dict:
     """Find staging directories that don't belong to active jobs."""

--- a/backend/app/core/staging_watcher.py
+++ b/backend/app/core/staging_watcher.py
@@ -1,0 +1,207 @@
+"""Staging directory watcher for auto-importing pre-ripped MKV files.
+
+Polls the staging directory for new subdirectories containing MKV files.
+When a stable directory is detected (file sizes unchanged across consecutive
+polls), fires a callback to create a job for processing.
+
+Follows the same polling/callback pattern as DriveMonitor in sentinel.py.
+"""
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Number of consecutive polls with stable file sizes before triggering import
+STABILITY_THRESHOLD = 2
+
+
+class StagingWatcher:
+    """Watches a staging directory for new subdirectories with MKV files.
+
+    Uses polling (not filesystem events) for cross-platform reliability,
+    matching the DriveMonitor approach.
+    """
+
+    def __init__(self, staging_path: str, config=None) -> None:
+        self._staging_path = Path(staging_path).expanduser()
+        self._running = False
+        self._task: asyncio.Task | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._async_callback: Callable[[str, str, str], Any] | None = None
+        self._config = config
+        self._poll_interval: float = 2.0
+
+        # Tracking state for each discovered subdirectory
+        # path_str -> {"mkv_count": int, "total_size": int, "stable_polls": int}
+        self._known_dirs: dict[str, dict] = {}
+        # Directories that have already been processed (won't trigger again)
+        self._processed_dirs: set[str] = set()
+
+    def set_async_callback(
+        self,
+        callback: Callable[[str, str, str], Any],
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Set an async callback for staging events.
+
+        Callback signature: (event, staging_dir_path, volume_label)
+        """
+        self._async_callback = callback
+        self._loop = loop
+
+    def start(self) -> None:
+        """Start watching the staging directory."""
+        if self._running:
+            return
+
+        self._running = True
+
+        # Load poll interval from config
+        if self._config:
+            self._poll_interval = getattr(self._config, "sentinel_poll_interval", 2.0)
+
+        if self._loop:
+            self._task = self._loop.create_task(self._poll_loop())
+
+        logger.info(
+            f"Staging watcher started (path={self._staging_path}, interval={self._poll_interval}s)"
+        )
+
+    def stop(self) -> None:
+        """Stop watching."""
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            self._task = None
+
+        logger.info("Staging watcher stopped")
+
+    async def _poll_loop(self) -> None:
+        """Poll for new staging directories."""
+        while self._running:
+            try:
+                await self._check_staging()
+                await asyncio.sleep(self._poll_interval)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in staging watcher poll: {e}")
+                await asyncio.sleep(self._poll_interval)
+
+    async def _check_staging(self) -> None:
+        """Scan staging directory for new subdirectories with MKV files."""
+        if not self._staging_path.exists():
+            return
+
+        # List subdirectories (run in thread to avoid blocking)
+        try:
+            entries = await asyncio.to_thread(self._scan_staging_dir)
+        except OSError as e:
+            logger.debug(f"Could not scan staging directory: {e}")
+            return
+
+        # Track which dirs we saw this poll (for cleanup of stale entries)
+        seen_dirs: set[str] = set()
+
+        for dir_path, mkv_count, total_size in entries:
+            dir_str = str(dir_path)
+            seen_dirs.add(dir_str)
+
+            # Skip already-processed directories
+            if dir_str in self._processed_dirs:
+                continue
+
+            # Skip directories with no MKV files
+            if mkv_count == 0:
+                continue
+
+            prev = self._known_dirs.get(dir_str)
+
+            if prev is None:
+                # New directory — start tracking
+                self._known_dirs[dir_str] = {
+                    "mkv_count": mkv_count,
+                    "total_size": total_size,
+                    "stable_polls": 0,
+                }
+                logger.debug(
+                    f"Staging watcher: new directory {dir_path.name} "
+                    f"({mkv_count} MKV files, {total_size} bytes)"
+                )
+            elif prev["mkv_count"] != mkv_count or prev["total_size"] != total_size:
+                # Files changed — reset stability counter
+                self._known_dirs[dir_str] = {
+                    "mkv_count": mkv_count,
+                    "total_size": total_size,
+                    "stable_polls": 0,
+                }
+                logger.debug(
+                    f"Staging watcher: {dir_path.name} changed "
+                    f"(files: {prev['mkv_count']}→{mkv_count}, "
+                    f"size: {prev['total_size']}→{total_size})"
+                )
+            else:
+                # Same state — increment stability
+                prev["stable_polls"] += 1
+
+                if prev["stable_polls"] >= STABILITY_THRESHOLD:
+                    # Directory is stable — fire callback
+                    label = dir_path.name.upper().replace(" ", "_")
+                    logger.info(
+                        f"Staging watcher: {dir_path.name} is stable "
+                        f"({mkv_count} MKV files, {total_size} bytes) — "
+                        f"triggering import"
+                    )
+                    self._processed_dirs.add(dir_str)
+                    del self._known_dirs[dir_str]
+                    await self._notify("staging_ready", dir_str, label)
+
+        # Clean up tracking for directories that disappeared
+        stale_keys = [k for k in self._known_dirs if k not in seen_dirs]
+        for key in stale_keys:
+            del self._known_dirs[key]
+
+    def _scan_staging_dir(self) -> list[tuple[Path, int, int]]:
+        """Scan staging directory for subdirectories with MKV files.
+
+        Returns list of (dir_path, mkv_count, total_size) tuples.
+        Runs in a thread via asyncio.to_thread().
+        """
+        results = []
+        try:
+            for entry in os.scandir(self._staging_path):
+                if not entry.is_dir():
+                    continue
+                # Skip job_* directories (managed by ripping pipeline)
+                if entry.name.startswith("job_"):
+                    continue
+                dir_path = Path(entry.path)
+                mkv_count = 0
+                total_size = 0
+                for f in dir_path.iterdir():
+                    if f.suffix.lower() == ".mkv" and f.is_file():
+                        mkv_count += 1
+                        try:
+                            total_size += f.stat().st_size
+                        except OSError:
+                            pass
+                results.append((dir_path, mkv_count, total_size))
+        except OSError:
+            pass
+        return results
+
+    async def _notify(self, event: str, staging_dir: str, label: str) -> None:
+        """Fire the async callback."""
+        if self._async_callback:
+            try:
+                await self._async_callback(event, staging_dir, label)
+            except Exception as e:
+                logger.error(f"Staging watcher callback error: {e}", exc_info=True)

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -79,6 +79,8 @@ class AppConfig(SQLModel, table=True):
     ai_identification_enabled: bool = False  # Enable AI-powered title resolution
     ai_provider: str = "anthropic"  # "anthropic" | "openai" | "openrouter"
     ai_api_key: str = ""  # API key for the selected provider
+    # Staging auto-import watcher
+    staging_watch_enabled: bool = False  # Auto-import MKV folders from staging directory
 
     # TheDiscDB
     discdb_enabled: bool = True  # Enable TheDiscDB lookups for disc identification

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -30,6 +30,7 @@ def _platform_default_paths() -> dict[str, str]:
         "staging_path": str(base / "staging"),
         "library_movies_path": str(base / "movies"),
         "library_tv_path": str(base / "tv"),
+        "staging_watch_enabled": True,  # Enable by default on Linux/macOS
     }
 
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -21,6 +21,7 @@ from app.core.errors import MatchingError
 from app.core.extractor import MakeMKVExtractor, RipProgress, ScanTimeoutError
 from app.core.organizer import movie_organizer
 from app.core.sentinel import DriveMonitor
+from app.core.staging_watcher import StagingWatcher
 from app.database import async_session
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
@@ -58,6 +59,7 @@ class JobManager:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._match_semaphore: asyncio.Semaphore | None = None
         self._timed_cleanup_task: asyncio.Task | None = None
+        self._staging_watcher: StagingWatcher | None = None
 
         # Register staging cleanup on terminal job states
         state_machine.on_terminal_state(self._on_job_terminal)
@@ -101,6 +103,12 @@ class JobManager:
             self._timed_cleanup_task = asyncio.create_task(
                 self._run_timed_cleanup(config.staging_path, config.staging_cleanup_days)
             )
+
+        # Start staging watcher if enabled (default on Linux/macOS)
+        if config.staging_watch_enabled and config.staging_path:
+            self._staging_watcher = StagingWatcher(config.staging_path, config=config)
+            self._staging_watcher.set_async_callback(self._on_staging_event, self._loop)
+            self._staging_watcher.start()
 
         logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
 
@@ -155,6 +163,8 @@ class JobManager:
     async def stop(self) -> None:
         """Stop the job manager and clean up."""
         self._drive_monitor.stop()
+        if self._staging_watcher:
+            self._staging_watcher.stop()
 
         # Cancel all active jobs
         for job_id, task in self._active_jobs.items():
@@ -185,6 +195,24 @@ class JobManager:
             await event_broadcaster.broadcast_drive_inserted(drive_letter, volume_label)
         else:
             await event_broadcaster.broadcast_drive_removed(drive_letter, volume_label)
+
+    async def _on_staging_event(self, event: str, staging_dir: str, label: str) -> None:
+        """Handle new staging directory detection from StagingWatcher."""
+        logger.info(f"Staging event: {event} dir={staging_dir} label={label}")
+        if event == "staging_ready":
+            try:
+                await self.create_job_from_staging(
+                    staging_path=staging_dir,
+                    volume_label=label,
+                    content_type="unknown",
+                    detected_title=None,
+                    detected_season=None,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to create job from staging directory {staging_dir}: {e}",
+                    exc_info=True,
+                )
 
     async def _create_job_for_disc(self, drive_letter: str, volume_label: str) -> None:
         """Create a new job when a disc is inserted."""
@@ -523,8 +551,8 @@ class JobManager:
                                     self._match_single_file(job_id, dt.id, file_path)
                                 )
                                 task.add_done_callback(
-                                    lambda t, jid=job_id, tid=dt.id: (
-                                        self._on_match_task_done(t, jid, tid)
+                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                        t, jid, tid
                                     )
                                 )
                 else:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -249,6 +249,333 @@ class JobManager:
                 task = asyncio.create_task(self._identify_disc(job.id))
                 self._active_jobs[job.id] = task
 
+    async def create_job_from_staging(
+        self,
+        staging_path: str,
+        volume_label: str = "",
+        content_type: str = "unknown",
+        detected_title: str | None = None,
+        detected_season: int | None = None,
+    ) -> int:
+        """Create a job from pre-ripped MKV files in a staging directory.
+
+        Skips the ripping phase entirely — files are already on disk.
+        Runs identification (classification), then matching/organization.
+        """
+        staging_dir = Path(staging_path)
+
+        # Use directory name as volume label if none provided
+        if not volume_label:
+            volume_label = staging_dir.name.upper().replace(" ", "_")
+
+        # Create job record
+        async with async_session() as session:
+            job = DiscJob(
+                drive_id="staging",
+                volume_label=volume_label,
+                staging_path=str(staging_dir),
+                state=JobState.IDENTIFYING,
+            )
+
+            # Apply user-provided hints
+            if content_type in ("tv", "movie"):
+                job.content_type = ContentType(content_type)
+            if detected_title:
+                job.detected_title = detected_title
+            if detected_season is not None:
+                job.detected_season = detected_season
+
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+
+            job_id = job.id
+            logger.info(
+                f"Created staging import job {job_id} from {staging_path} (label: {volume_label})"
+            )
+
+        # Broadcast job creation
+        await event_broadcaster.broadcast_drive_inserted("staging", volume_label)
+
+        # Run identification pipeline in background
+        task = asyncio.create_task(self._identify_from_staging(job_id))
+        self._active_jobs[job_id] = task
+
+        return job_id
+
+    async def _identify_from_staging(self, job_id: int) -> None:
+        """Identify and process pre-ripped MKV files from staging.
+
+        Similar to _identify_disc() but skips the MakeMKV scan — constructs
+        TitleInfo objects from the existing MKV files via ffprobe instead.
+        """
+        from app.core.analyst import TitleInfo
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+
+            try:
+                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
+
+                staging_dir = Path(job.staging_path)
+                mkv_files = sorted(staging_dir.glob("*.mkv"))
+
+                if not mkv_files:
+                    await state_machine.transition_to_failed(
+                        job, session, "No MKV files found in staging directory"
+                    )
+                    return
+
+                # Build TitleInfo objects from MKV files using ffprobe
+                titles: list[TitleInfo] = []
+                for idx, mkv_file in enumerate(mkv_files):
+                    duration = await self._probe_duration(mkv_file)
+                    file_size = mkv_file.stat().st_size
+
+                    titles.append(
+                        TitleInfo(
+                            index=idx,
+                            duration_seconds=int(duration),
+                            size_bytes=file_size,
+                            chapter_count=0,
+                            name=mkv_file.stem,
+                        )
+                    )
+
+                # Run classification pipeline (same as _identify_disc)
+                from app.services.config_service import get_config_sync
+
+                config = get_config_sync()
+
+                # Attempt TheDiscDB lookup
+                discdb_signal = None
+                if config.discdb_enabled:
+                    try:
+                        from app.core.discdb_classifier import classify_from_discdb
+
+                        discdb_signal = classify_from_discdb(
+                            job.volume_label, titles, content_hash=None
+                        )
+                        if discdb_signal:
+                            logger.info(
+                                f"Job {job_id}: TheDiscDB signal: "
+                                f"{discdb_signal.content_type.value} "
+                                f"({discdb_signal.confidence:.0%}) - "
+                                f"{discdb_signal.matched_title}"
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Job {job_id}: TheDiscDB lookup failed: {e}",
+                            exc_info=True,
+                        )
+
+                # Attempt TMDB lookup
+                tmdb_signal = None
+                detected_name, _, _ = DiscAnalyst._parse_volume_label(job.volume_label)
+                if detected_name:
+                    try:
+                        from app.core.tmdb_classifier import classify_from_tmdb
+
+                        if config.tmdb_api_key:
+                            tmdb_signal = classify_from_tmdb(detected_name, config.tmdb_api_key)
+                            if tmdb_signal:
+                                logger.info(
+                                    f"Job {job_id}: TMDB signal: "
+                                    f"{tmdb_signal.content_type.value} "
+                                    f"({tmdb_signal.confidence:.0%}) - "
+                                    f"{tmdb_signal.tmdb_name}"
+                                )
+                    except Exception as e:
+                        logger.warning(f"Job {job_id}: TMDB lookup failed: {e}")
+
+                # Analyze disc content
+                analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
+
+                # Apply DiscDB override if high-confidence
+                if discdb_signal and discdb_signal.confidence >= 0.90:
+                    analysis.content_type = discdb_signal.content_type
+                    analysis.confidence = discdb_signal.confidence
+                    analysis.classification_source = f"discdb_{discdb_signal.source}"
+                    analysis.detected_name = discdb_signal.matched_title
+                    analysis.needs_review = False
+                    if discdb_signal.tmdb_id:
+                        analysis.tmdb_id = discdb_signal.tmdb_id
+                    if discdb_signal.title_mappings:
+                        self._discdb_mappings[job_id] = discdb_signal.title_mappings
+                        job.discdb_mappings_json = json.dumps(
+                            [asdict(m) for m in discdb_signal.title_mappings]
+                        )
+                elif discdb_signal and not analysis.detected_name:
+                    analysis.detected_name = discdb_signal.matched_title
+
+                # Apply user-provided hints (override classification if given)
+                if job.content_type and job.content_type != ContentType.UNKNOWN:
+                    analysis.content_type = job.content_type
+                if job.detected_title:
+                    analysis.detected_name = job.detected_title
+
+                # Update job with analysis results
+                job.content_type = analysis.content_type
+                job.detected_title = analysis.detected_name or job.detected_title
+                job.detected_season = analysis.detected_season or job.detected_season
+                job.total_titles = len(titles)
+                job.updated_at = datetime.utcnow()
+                job.classification_confidence = analysis.confidence
+                job.classification_source = analysis.classification_source or "staging_import"
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.is_ambiguous_movie = analysis.is_ambiguous_movie
+                if analysis.play_all_title_indices:
+                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
+
+                # Extract disc number from volume label
+                import re
+
+                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
+                job.disc_number = int(disc_match.group(1)) if disc_match else 1
+
+                # Create DiscTitle records with output_filename already set
+                from sqlalchemy import delete
+
+                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
+
+                for title, mkv_file in zip(titles, mkv_files, strict=True):
+                    disc_title = DiscTitle(
+                        job_id=job_id,
+                        title_index=title.index,
+                        duration_seconds=title.duration_seconds,
+                        file_size_bytes=title.size_bytes,
+                        chapter_count=title.chapter_count,
+                        output_filename=str(mkv_file),
+                    )
+                    session.add(disc_title)
+
+                await session.commit()
+
+                # Broadcast titles discovered
+                titles_result = await session.execute(
+                    select(DiscTitle).where(DiscTitle.job_id == job_id)
+                )
+                title_list = build_title_list(titles_result.scalars().all())
+                await ws_manager.broadcast_titles_discovered(
+                    job_id,
+                    title_list,
+                    content_type=job.content_type.value,
+                    detected_title=job.detected_title,
+                    detected_season=job.detected_season,
+                )
+
+                # If no title detected, ask user
+                if not job.detected_title:
+                    await state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason="Could not determine title. Please enter the title to continue.",
+                        broadcast=False,
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.REVIEW_NEEDED.value,
+                        content_type=(job.content_type.value if job.content_type else None),
+                        total_titles=job.total_titles,
+                        review_reason="Could not determine title. Please enter the title to continue.",
+                    )
+                    return
+
+                # Skip ripping — files already exist. Proceed to matching/organization.
+                if job.content_type == ContentType.TV:
+                    # Start subtitle download
+                    if job.detected_title and job.detected_season:
+                        self._subtitle_ready[job_id] = asyncio.Event()
+                        self._subtitle_tasks[job_id] = asyncio.create_task(
+                            self._download_subtitles(
+                                job_id, job.detected_title, job.detected_season
+                            )
+                        )
+
+                    # Transition to MATCHING and kick off per-title matching
+                    succeeded = await state_machine.transition(
+                        job, JobState.MATCHING, session, broadcast=False
+                    )
+                    if succeeded:
+                        await ws_manager.broadcast_job_update(job_id, JobState.MATCHING.value)
+
+                    # Queue matching for each title
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHING
+                        session.add(dt)
+                    await session.commit()
+
+                    for dt in db_titles:
+                        if dt.output_filename:
+                            file_path = Path(dt.output_filename)
+                            discdb_applied = await self._try_discdb_assignment(job_id, dt, session)
+                            if not discdb_applied:
+                                task = asyncio.create_task(
+                                    self._match_single_file(job_id, dt.id, file_path)
+                                )
+                                task.add_done_callback(
+                                    lambda t, jid=job_id, tid=dt.id: (
+                                        self._on_match_task_done(t, jid, tid)
+                                    )
+                                )
+                else:
+                    # Movie: skip matching, go straight to organization
+                    job.state = JobState.ORGANIZING
+                    await session.commit()
+                    await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
+
+                    # Mark titles as MATCHED
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHED
+                        session.add(dt)
+                    await session.commit()
+
+                    # Run organization
+                    await self._finalize_disc_job(job_id)
+
+            except Exception as e:
+                logger.exception(f"Error processing staging import for job {job_id}")
+                async with async_session() as err_session:
+                    err_job = await err_session.get(DiscJob, job_id)
+                    if err_job:
+                        await state_machine.transition_to_failed(err_job, err_session, str(e))
+
+    async def _probe_duration(self, mkv_file: Path) -> float:
+        """Get duration of an MKV file using ffprobe."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(mkv_file),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            return float(stdout.decode().strip()) if stdout.decode().strip() else 1800
+        except (TimeoutError, OSError, ValueError) as e:
+            logger.debug(f"Could not determine MKV duration via ffprobe: {e}")
+            return 1800  # Default 30 minutes
+
     async def _identify_disc(self, job_id: int) -> None:
         """Identify the disc contents using MakeMKV and the Analyst."""
         async with async_session() as session:

--- a/backend/tests/unit/test_ai_identifier.py
+++ b/backend/tests/unit/test_ai_identifier.py
@@ -99,11 +99,7 @@ class TestIdentifyFromLabel:
         mock_client = _make_mock_client(
             {
                 "choices": [
-                    {
-                        "message": {
-                            "content": '{"title": "The Office", "year": 2005, "type": "tv"}'
-                        }
-                    }
+                    {"message": {"content": '{"title": "The Office", "year": 2005, "type": "tv"}'}}
                 ]
             }
         )

--- a/backend/tests/unit/test_staging_import.py
+++ b/backend/tests/unit/test_staging_import.py
@@ -4,13 +4,13 @@ Tests that the endpoint is accessible without DEBUG mode, validates paths,
 and creates jobs from directories containing MKV files.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from httpx import ASGITransport, AsyncClient
-from unittest.mock import AsyncMock, patch
 
 from app.database import get_session
 from app.main import app
-
 from tests.unit.conftest import _unit_session_factory
 
 

--- a/backend/tests/unit/test_staging_import.py
+++ b/backend/tests/unit/test_staging_import.py
@@ -1,0 +1,173 @@
+"""Unit tests for the staging import endpoint (POST /api/staging/import).
+
+Tests that the endpoint is accessible without DEBUG mode, validates paths,
+and creates jobs from directories containing MKV files.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from app.database import get_session
+from app.main import app
+
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture
+async def client():
+    """Provide an async HTTP client with the patched DB session."""
+
+    async def override_get_session():
+        async with _unit_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+class TestStagingImportEndpoint:
+    """Tests for POST /api/staging/import."""
+
+    async def test_missing_staging_path_returns_404(self, client: AsyncClient):
+        """A nonexistent staging path should return 404."""
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": "/nonexistent/path/to/nowhere"},
+        )
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    async def test_empty_directory_returns_404(self, client: AsyncClient, tmp_path):
+        """A directory with no MKV files should return 404."""
+        empty_dir = tmp_path / "empty_staging"
+        empty_dir.mkdir()
+
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": str(empty_dir)},
+        )
+        assert resp.status_code == 404
+        assert "no mkv files" in resp.json()["detail"].lower()
+
+    async def test_directory_with_non_mkv_files_returns_404(self, client: AsyncClient, tmp_path):
+        """A directory with only non-MKV files should return 404."""
+        staging_dir = tmp_path / "staging_txt"
+        staging_dir.mkdir()
+        (staging_dir / "readme.txt").write_text("not a video")
+        (staging_dir / "image.jpg").write_bytes(b"\xff\xd8\xff")
+
+        resp = await client.post(
+            "/api/staging/import",
+            json={"staging_path": str(staging_dir)},
+        )
+        assert resp.status_code == 404
+
+    async def test_valid_staging_creates_job(self, client: AsyncClient, tmp_path):
+        """A valid directory with MKV files should create a job."""
+        staging_dir = tmp_path / "MY_SHOW_S1D1"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+        (staging_dir / "title_t01.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        # Mock create_job_from_staging to avoid running the full pipeline
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            new_callable=AsyncMock,
+            return_value=42,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={
+                    "staging_path": str(staging_dir),
+                    "volume_label": "MY_SHOW_S1D1",
+                    "content_type": "tv",
+                    "detected_title": "My Show",
+                    "detected_season": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "created"
+        assert data["job_id"] == 42
+        assert data["titles_count"] == 2
+
+    async def test_available_without_debug_mode(self, client: AsyncClient, tmp_path):
+        """The endpoint must be accessible even when DEBUG=false."""
+        staging_dir = tmp_path / "test_disc"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        with (
+            patch(
+                "app.services.job_manager.job_manager.create_job_from_staging",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+            patch("app.config.settings.debug", False),
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={"staging_path": str(staging_dir)},
+            )
+
+        # Should succeed (200), not 403
+        assert resp.status_code == 200
+
+    async def test_default_volume_label_from_directory_name(self, client: AsyncClient, tmp_path):
+        """When no volume_label is provided, it should default to empty string."""
+        staging_dir = tmp_path / "my_disc"
+        staging_dir.mkdir()
+        (staging_dir / "title_t00.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        mock_create = AsyncMock(return_value=1)
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            mock_create,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={"staging_path": str(staging_dir)},
+            )
+
+        assert resp.status_code == 200
+        # Verify the method was called with default empty volume_label
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs["volume_label"] == ""
+        assert call_kwargs.kwargs["content_type"] == "unknown"
+
+    async def test_all_parameters_passed_through(self, client: AsyncClient, tmp_path):
+        """All request parameters should be forwarded to create_job_from_staging."""
+        staging_dir = tmp_path / "test"
+        staging_dir.mkdir()
+        (staging_dir / "movie.mkv").write_bytes(b"\x1a\x45\xdf\xa3" + b"\x00" * 1024)
+
+        mock_create = AsyncMock(return_value=7)
+        with patch(
+            "app.services.job_manager.job_manager.create_job_from_staging",
+            mock_create,
+        ):
+            resp = await client.post(
+                "/api/staging/import",
+                json={
+                    "staging_path": str(staging_dir),
+                    "volume_label": "INCEPTION_2010",
+                    "content_type": "movie",
+                    "detected_title": "Inception",
+                    "detected_season": None,
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_create.assert_called_once_with(
+            staging_path=str(staging_dir),
+            volume_label="INCEPTION_2010",
+            content_type="movie",
+            detected_title="Inception",
+            detected_season=None,
+        )

--- a/backend/tests/unit/test_staging_watcher.py
+++ b/backend/tests/unit/test_staging_watcher.py
@@ -1,0 +1,261 @@
+"""Unit tests for the StagingWatcher.
+
+Tests directory detection, debouncing, stability threshold, and callback firing.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.staging_watcher import StagingWatcher
+
+
+@pytest.fixture
+def staging_dir(tmp_path):
+    """Create a staging directory."""
+    d = tmp_path / "staging"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def watcher(staging_dir):
+    """Create a StagingWatcher instance (not started)."""
+    return StagingWatcher(str(staging_dir))
+
+
+class TestStagingWatcherDetection:
+    """Tests for directory detection and scanning."""
+
+    async def test_empty_staging_dir_no_callback(self, watcher, staging_dir):
+        """An empty staging directory should not fire any callbacks."""
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+    async def test_dir_without_mkv_files_ignored(self, watcher, staging_dir):
+        """Subdirectories with no MKV files should be ignored."""
+        sub = staging_dir / "some_disc"
+        sub.mkdir()
+        (sub / "readme.txt").write_text("not a video")
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Run multiple polls to exceed stability threshold
+        for _ in range(5):
+            await watcher._check_staging()
+
+        callback.assert_not_called()
+
+    async def test_job_prefix_dirs_skipped(self, watcher, staging_dir):
+        """Directories starting with job_ should be skipped (managed by ripping pipeline)."""
+        sub = staging_dir / "job_20260404_120000"
+        sub.mkdir()
+        (sub / "title_t00.mkv").write_bytes(b"\x00" * 1024)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        for _ in range(5):
+            await watcher._check_staging()
+
+        callback.assert_not_called()
+
+    async def test_nonexistent_staging_dir_no_error(self, tmp_path):
+        """A nonexistent staging path should not raise errors."""
+        watcher = StagingWatcher(str(tmp_path / "nonexistent"))
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        await watcher._check_staging()  # Should not raise
+        callback.assert_not_called()
+
+
+class TestStagingWatcherStability:
+    """Tests for the stability debouncing mechanism."""
+
+    async def test_fires_after_stability_threshold(self, watcher, staging_dir):
+        """Callback should fire after STABILITY_THRESHOLD consecutive stable polls."""
+        sub = staging_dir / "MY_SHOW_S1D1"
+        sub.mkdir()
+        (sub / "title_t00.mkv").write_bytes(b"\x00" * 1024)
+        (sub / "title_t01.mkv").write_bytes(b"\x00" * 2048)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Poll 1: directory discovered, stable_polls=0
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        # Poll 2: same state, stable_polls=1
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        # Poll 3: same state, stable_polls=2 → fires
+        await watcher._check_staging()
+        callback.assert_called_once()
+
+        # Verify callback args
+        args = callback.call_args[0]
+        assert args[0] == "staging_ready"
+        assert args[1] == str(sub)
+        assert args[2] == "MY_SHOW_S1D1"  # Label derived from dir name
+
+    async def test_changing_file_size_resets_stability(self, watcher, staging_dir):
+        """If file sizes change between polls, stability counter should reset."""
+        sub = staging_dir / "COPYING_DISC"
+        sub.mkdir()
+        mkv_file = sub / "title_t00.mkv"
+        mkv_file.write_bytes(b"\x00" * 1024)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Poll 1: discovered
+        await watcher._check_staging()
+
+        # Poll 2: same size, stable_polls=1
+        await watcher._check_staging()
+
+        # File grows (still copying)
+        mkv_file.write_bytes(b"\x00" * 2048)
+
+        # Poll 3: size changed, stability reset to 0
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        # Poll 4: same size, stable_polls=1
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        # Poll 5: same size, stable_polls=2 → fires
+        await watcher._check_staging()
+        callback.assert_called_once()
+
+    async def test_adding_new_file_resets_stability(self, watcher, staging_dir):
+        """Adding a new MKV file should reset the stability counter."""
+        sub = staging_dir / "DISC"
+        sub.mkdir()
+        (sub / "title_t00.mkv").write_bytes(b"\x00" * 1024)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Polls 1-2
+        await watcher._check_staging()
+        await watcher._check_staging()
+
+        # Add another file
+        (sub / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+
+        # Poll 3: file count changed, stability reset
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        # Need 2 more stable polls
+        await watcher._check_staging()
+        callback.assert_not_called()
+        await watcher._check_staging()
+        callback.assert_called_once()
+
+
+class TestStagingWatcherProcessedTracking:
+    """Tests for preventing re-processing of already imported directories."""
+
+    async def test_processed_dir_not_retriggered(self, watcher, staging_dir):
+        """Once a directory is processed, it should not trigger again."""
+        sub = staging_dir / "DISC"
+        sub.mkdir()
+        (sub / "title.mkv").write_bytes(b"\x00" * 1024)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Reach stability and fire
+        for _ in range(3):
+            await watcher._check_staging()
+
+        assert callback.call_count == 1
+
+        # Additional polls should not fire again
+        for _ in range(5):
+            await watcher._check_staging()
+
+        assert callback.call_count == 1
+
+    async def test_multiple_directories_independent(self, watcher, staging_dir):
+        """Multiple directories should be tracked independently."""
+        sub1 = staging_dir / "DISC_1"
+        sub1.mkdir()
+        (sub1 / "title.mkv").write_bytes(b"\x00" * 1024)
+
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        # Polls 1-3: DISC_1 fires
+        for _ in range(3):
+            await watcher._check_staging()
+        assert callback.call_count == 1
+
+        # Add second directory
+        sub2 = staging_dir / "DISC_2"
+        sub2.mkdir()
+        (sub2 / "movie.mkv").write_bytes(b"\x00" * 2048)
+
+        # Polls 4-6: DISC_2 fires
+        for _ in range(3):
+            await watcher._check_staging()
+        assert callback.call_count == 2
+
+        # Verify both callbacks had correct paths
+        calls = callback.call_args_list
+        assert calls[0][0][1] == str(sub1)
+        assert calls[1][0][1] == str(sub2)
+
+
+class TestStagingWatcherLifecycle:
+    """Tests for start/stop lifecycle."""
+
+    async def test_start_stop(self, staging_dir):
+        """Watcher should start and stop cleanly."""
+        watcher = StagingWatcher(str(staging_dir))
+        loop = asyncio.get_event_loop()
+        callback = AsyncMock()
+        watcher.set_async_callback(callback, loop)
+
+        watcher.start()
+        assert watcher._running is True
+        assert watcher._task is not None
+
+        watcher.stop()
+        assert watcher._running is False
+        assert watcher._task is None
+
+    async def test_double_start_idempotent(self, staging_dir):
+        """Calling start() twice should be safe."""
+        watcher = StagingWatcher(str(staging_dir))
+        loop = asyncio.get_event_loop()
+        watcher.set_async_callback(AsyncMock(), loop)
+
+        watcher.start()
+        first_task = watcher._task
+        watcher.start()  # Should be no-op
+        assert watcher._task is first_task
+
+        watcher.stop()
+
+    async def test_double_stop_idempotent(self, staging_dir):
+        """Calling stop() twice should be safe."""
+        watcher = StagingWatcher(str(staging_dir))
+        loop = asyncio.get_event_loop()
+        watcher.set_async_callback(AsyncMock(), loop)
+
+        watcher.start()
+        watcher.stop()
+        watcher.stop()  # Should be no-op, no error
+        assert watcher._running is False

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -191,6 +191,29 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -571,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.4.2"
+version = "0.4.5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -601,6 +624,10 @@ dev = [
     { name = "ipykernel" },
     { name = "pandas" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
 gpu = [
     { name = "gputil" },
     { name = "nvidia-cudnn-cu12" },
@@ -629,6 +656,8 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.2.0" },
     { name = "librosa", specifier = ">=0.10.1" },
     { name = "loguru", specifier = ">=0.7.0" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "nvidia-cudnn-cu12", extras = ["nvidia-cublas-cu12"], marker = "extra == 'gpu'", specifier = ">=9.19.0.56" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -644,7 +673,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["gpu", "dev"]
+provides-extras = ["gpu", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -724,6 +753,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "gputil"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -774,6 +815,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
     { url = "https://files.pythonhosted.org/packages/e1/2b/98c7f93e6db9977aaee07eb1e51ca63bd5f779b900d362791d3252e60558/greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451", size = 233181, upload-time = "2026-01-23T15:33:00.29Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1012,6 +1062,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1125,6 +1187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1134,6 +1205,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1155,6 +1300,134 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/62/0dfc5719514115bf1781f44b1d7f2a0923fcc01e9c5d7990e48a05c9ae5d/mkdocstrings-1.0.3.tar.gz", hash = "sha256:ab670f55040722b49bb45865b2e93b824450fb4aef638b00d7acb493a9020434", size = 100946, upload-time = "2026-02-07T14:31:40.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/41/1cf02e3df279d2dd846a1bf235a928254eba9006dd22b4a14caa71aed0f7/mkdocstrings-1.0.3-py3-none-any.whl", hash = "sha256:0d66d18430c2201dc7fe85134277382baaa15e6b30979f3f3bdbabd6dbdb6046", size = 35523, upload-time = "2026-02-07T14:31:39.27Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
 ]
 
 [[package]]
@@ -1402,6 +1675,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1468,6 +1750,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -1732,6 +2023,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyreadline3"
 version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1888,6 +2192,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -2668,6 +2984,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `StagingWatcher` class that polls the staging directory for new subdirectories containing MKV files
- Auto-creates jobs when files are stable (unchanged across 2 consecutive polls), enabling a drop-and-forget workflow
- New config field `staging_watch_enabled` — defaults to **enabled on Linux/macOS**, disabled on Windows
- Integrated into JobManager lifecycle (start/stop) alongside DriveMonitor

Closes #69
Related: #66, #68
Depends on: #73 (staging import endpoint — `create_job_from_staging` method)

## How it works

1. User drops a folder of MKV files into the staging directory (e.g., `~/engram/staging/MY_SHOW_S1D1/`)
2. StagingWatcher detects the new directory, tracks file count + total size
3. After 2 consecutive polls with identical state (~4-6 seconds), fires callback
4. JobManager creates a job via `create_job_from_staging()` → identification → matching → organization

### Design decisions
- **Polling over filesystem events**: Matches DriveMonitor's approach for cross-platform reliability
- **Skips `job_*` directories**: These are managed by the ripping pipeline, not user-dropped
- **Debounce by file size stability**: Prevents importing while files are still being copied

## Changes

| File | Change |
|------|--------|
| `backend/app/core/staging_watcher.py` | New `StagingWatcher` class |
| `backend/app/models/app_config.py` | `staging_watch_enabled` field |
| `backend/app/services/config_service.py` | Default to enabled on Linux/macOS |
| `backend/app/services/job_manager.py` | Start/stop watcher, `_on_staging_event` callback |
| `backend/app/api/routes.py` | Expose in config response/update models |
| `backend/tests/unit/test_staging_watcher.py` | 12 unit tests |

## Test plan

- [x] `uv run pytest tests/unit/test_staging_watcher.py` — 12/12 passing
- [x] `uv run pytest tests/unit/ tests/pipeline/` — 448 passed (no regressions)
- [x] `uv run ruff check` — clean
- [ ] Manual test: drop MKV folder into staging, verify job auto-created on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)