### PR TITLE
feat: Linux optical drive detection

### DIFF
--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -1,11 +1,15 @@
 """Sentinel - Drive Monitor (Hardware Abstraction Layer).
 
-Detects disc insertion/removal using polling on Windows.
-This is a more reliable approach than WM_DEVICECHANGE for cross-platform compatibility.
+Detects disc insertion/removal using platform-specific APIs:
+- Windows: kernel32 ctypes (GetDriveTypeW, GetVolumeInformationW)
+- Linux: /sys/block/sr* enumeration, blkid, eject
 """
 
 import asyncio
+import glob
 import logging
+import os
+import subprocess
 import sys
 from collections.abc import Callable
 from typing import Any
@@ -23,11 +27,13 @@ DRIVE_CDROM = 5  # Optical drive type
 DriveCallback = Callable[[str, str, str], None]  # (drive_letter, event, volume_label)
 
 
-def get_optical_drives() -> list[str]:
-    """Get list of optical drive letters on the system."""
-    if sys.platform != "win32":
-        return []
+# ---------------------------------------------------------------------------
+# Windows implementations
+# ---------------------------------------------------------------------------
 
+
+def _get_optical_drives_windows() -> list[str]:
+    """Get optical drive letters on Windows via kernel32."""
     drives = []
     kernel32 = ctypes.windll.kernel32
     get_drive_type = kernel32.GetDriveTypeW
@@ -41,11 +47,8 @@ def get_optical_drives() -> list[str]:
     return drives
 
 
-def get_volume_label(drive_letter: str) -> str:
-    """Get the volume label for a drive."""
-    if sys.platform != "win32":
-        return ""
-
+def _get_volume_label_windows(drive_letter: str) -> str:
+    """Get the volume label for a drive on Windows."""
     kernel32 = ctypes.windll.kernel32
     volume_name = ctypes.create_unicode_buffer(261)
     fs_name = ctypes.create_unicode_buffer(261)
@@ -66,14 +69,9 @@ def get_volume_label(drive_letter: str) -> str:
     return ""
 
 
-def is_disc_present(drive_letter: str) -> bool:
-    """Check if a disc is present in the drive."""
-    if sys.platform != "win32":
-        return False
-
+def _is_disc_present_windows(drive_letter: str) -> bool:
+    """Check if a disc is present on Windows."""
     kernel32 = ctypes.windll.kernel32
-
-    # Try to get volume information - fails if no disc
     volume_name = ctypes.create_unicode_buffer(261)
     result = kernel32.GetVolumeInformationW(
         f"{drive_letter}\\",
@@ -85,29 +83,17 @@ def is_disc_present(drive_letter: str) -> bool:
         None,
         0,
     )
-
     return bool(result)
 
 
-def eject_disc(drive_letter: str) -> bool:
-    """Eject a disc from the specified drive on Windows.
-
-    Uses the Win32 mciSendString API for reliable disc ejection.
-    Returns True if eject was successful.
-    """
-    if sys.platform != "win32":
-        logger.warning("Disc eject only supported on Windows")
-        return False
-
+def _eject_disc_windows(drive_letter: str) -> bool:
+    """Eject a disc on Windows using mciSendString."""
     try:
         winmm = ctypes.windll.winmm
         mci_send = winmm.mciSendStringW
-
-        # Normalize drive letter (e.g., "F:" -> "F:")
         drive = drive_letter.rstrip("\\")
-
-        # Open the CD drive, send eject, then close
         buf = ctypes.create_unicode_buffer(256)
+
         err = mci_send(f"open {drive} type cdaudio alias disc_eject", buf, 256, 0)
         if err != 0:
             logger.warning(f"mciSendString open failed for {drive} (error {err})")
@@ -127,10 +113,117 @@ def eject_disc(drive_letter: str) -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Linux implementations
+# ---------------------------------------------------------------------------
+
+
+def _get_optical_drives_linux() -> list[str]:
+    """Get optical drive device paths on Linux via /sys/block/sr*."""
+    drives = []
+    for block_dev in sorted(glob.glob("/sys/block/sr*")):
+        dev_name = os.path.basename(block_dev)
+        drives.append(f"/dev/{dev_name}")
+    return drives
+
+
+def _get_volume_label_linux(drive: str) -> str:
+    """Get the volume label for a drive on Linux using blkid."""
+    try:
+        result = subprocess.run(
+            ["blkid", "-s", "LABEL", "-o", "value", drive],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.debug(f"blkid failed for {drive}: {e}")
+        return ""
+
+
+def _is_disc_present_linux(drive: str) -> bool:
+    """Check if a disc is present on Linux by reading /sys/block size."""
+    try:
+        dev_name = os.path.basename(drive)  # "sr0" from "/dev/sr0"
+        size_path = f"/sys/block/{dev_name}/size"
+        with open(size_path) as f:
+            size = int(f.read().strip())
+        return size > 0
+    except (FileNotFoundError, ValueError, PermissionError, OSError):
+        return False
+
+
+def _eject_disc_linux(drive: str) -> bool:
+    """Eject a disc on Linux using the eject command."""
+    try:
+        result = subprocess.run(
+            ["eject", drive],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            logger.info(f"Disc ejected from {drive}")
+            return True
+        logger.warning(f"eject failed for {drive}: {result.stderr.strip()}")
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.warning(f"eject command failed for {drive}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public API (dispatches by platform)
+# ---------------------------------------------------------------------------
+
+
+def get_optical_drives() -> list[str]:
+    """Get list of optical drives on the system."""
+    if sys.platform == "win32":
+        return _get_optical_drives_windows()
+    elif sys.platform == "linux":
+        return _get_optical_drives_linux()
+    return []
+
+
+def get_volume_label(drive: str) -> str:
+    """Get the volume label for a drive."""
+    if sys.platform == "win32":
+        return _get_volume_label_windows(drive)
+    elif sys.platform == "linux":
+        return _get_volume_label_linux(drive)
+    return ""
+
+
+def is_disc_present(drive: str) -> bool:
+    """Check if a disc is present in the drive."""
+    if sys.platform == "win32":
+        return _is_disc_present_windows(drive)
+    elif sys.platform == "linux":
+        return _is_disc_present_linux(drive)
+    return False
+
+
+def eject_disc(drive: str) -> bool:
+    """Eject a disc from the specified drive."""
+    if sys.platform == "win32":
+        return _eject_disc_windows(drive)
+    elif sys.platform == "linux":
+        return _eject_disc_linux(drive)
+    logger.warning(f"Disc eject not supported on {sys.platform}")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# DriveMonitor class (platform-independent)
+# ---------------------------------------------------------------------------
+
+
 class DriveMonitor:
     """Monitors optical drives for disc insertion/removal.
 
-    Uses a polling approach for maximum reliability across Windows versions.
+    Uses a polling approach for maximum reliability across platforms.
     Poll interval is configurable via AppConfig.
     """
 

--- a/backend/tests/unit/test_linux_drives.py
+++ b/backend/tests/unit/test_linux_drives.py
@@ -1,0 +1,190 @@
+"""Unit tests for Linux optical drive detection in sentinel.py.
+
+Tests the Linux-specific implementations with mocked /sys/block
+filesystem and subprocess calls. Also verifies Windows behavior
+is unchanged.
+"""
+
+from unittest.mock import MagicMock, mock_open, patch
+
+from app.core import sentinel
+
+
+class TestGetOpticalDrivesLinux:
+    """Tests for _get_optical_drives_linux."""
+
+    def test_finds_sr_devices(self):
+        with patch("glob.glob", return_value=["/sys/block/sr0", "/sys/block/sr1"]):
+            drives = sentinel._get_optical_drives_linux()
+        assert drives == ["/dev/sr0", "/dev/sr1"]
+
+    def test_no_optical_drives(self):
+        with patch("glob.glob", return_value=[]):
+            drives = sentinel._get_optical_drives_linux()
+        assert drives == []
+
+    def test_single_drive(self):
+        with patch("glob.glob", return_value=["/sys/block/sr0"]):
+            drives = sentinel._get_optical_drives_linux()
+        assert drives == ["/dev/sr0"]
+
+    def test_sorted_output(self):
+        with patch(
+            "glob.glob", return_value=["/sys/block/sr2", "/sys/block/sr0", "/sys/block/sr1"]
+        ):
+            drives = sentinel._get_optical_drives_linux()
+        assert drives == ["/dev/sr0", "/dev/sr1", "/dev/sr2"]
+
+
+class TestGetVolumeLabelLinux:
+    """Tests for _get_volume_label_linux."""
+
+    def test_returns_label_from_blkid(self):
+        mock_result = MagicMock(returncode=0, stdout="MY_DISC_LABEL\n")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            label = sentinel._get_volume_label_linux("/dev/sr0")
+
+        assert label == "MY_DISC_LABEL"
+        mock_run.assert_called_once_with(
+            ["blkid", "-s", "LABEL", "-o", "value", "/dev/sr0"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_returns_empty_on_failure(self):
+        mock_result = MagicMock(returncode=2, stdout="")
+        with patch("subprocess.run", return_value=mock_result):
+            label = sentinel._get_volume_label_linux("/dev/sr0")
+        assert label == ""
+
+    def test_returns_empty_when_blkid_not_found(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            label = sentinel._get_volume_label_linux("/dev/sr0")
+        assert label == ""
+
+    def test_returns_empty_on_timeout(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("blkid", 10)):
+            label = sentinel._get_volume_label_linux("/dev/sr0")
+        assert label == ""
+
+
+class TestIsDiscPresentLinux:
+    """Tests for _is_disc_present_linux."""
+
+    def test_disc_present_nonzero_size(self):
+        with patch("builtins.open", mock_open(read_data="4194304\n")):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is True
+
+    def test_no_disc_zero_size(self):
+        with patch("builtins.open", mock_open(read_data="0\n")):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is False
+
+    def test_no_device_file(self):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is False
+
+    def test_permission_denied(self):
+        with patch("builtins.open", side_effect=PermissionError):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is False
+
+
+class TestEjectDiscLinux:
+    """Tests for _eject_disc_linux."""
+
+    def test_successful_eject(self):
+        mock_result = MagicMock(returncode=0)
+        with patch("subprocess.run", return_value=mock_result):
+            assert sentinel._eject_disc_linux("/dev/sr0") is True
+
+    def test_eject_failure(self):
+        mock_result = MagicMock(returncode=1, stderr="device busy")
+        with patch("subprocess.run", return_value=mock_result):
+            assert sentinel._eject_disc_linux("/dev/sr0") is False
+
+    def test_eject_command_not_found(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert sentinel._eject_disc_linux("/dev/sr0") is False
+
+    def test_eject_timeout(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("eject", 30)):
+            assert sentinel._eject_disc_linux("/dev/sr0") is False
+
+
+class TestPlatformDispatch:
+    """Tests that the public API dispatches correctly by platform."""
+
+    def test_get_optical_drives_dispatches_linux(self):
+        with (
+            patch.object(sentinel, "sys") as mock_sys,
+            patch.object(
+                sentinel, "_get_optical_drives_linux", return_value=["/dev/sr0"]
+            ) as mock_linux,
+        ):
+            mock_sys.platform = "linux"
+            drives = sentinel.get_optical_drives()
+        assert drives == ["/dev/sr0"]
+        mock_linux.assert_called_once()
+
+    def test_get_optical_drives_dispatches_windows(self):
+        with (
+            patch.object(sentinel, "sys") as mock_sys,
+            patch.object(sentinel, "_get_optical_drives_windows", return_value=["D:"]) as mock_win,
+        ):
+            mock_sys.platform = "win32"
+            drives = sentinel.get_optical_drives()
+        assert drives == ["D:"]
+        mock_win.assert_called_once()
+
+    def test_get_optical_drives_unsupported_platform(self):
+        with patch.object(sentinel, "sys") as mock_sys:
+            mock_sys.platform = "darwin"
+            drives = sentinel.get_optical_drives()
+        assert drives == []
+
+    def test_is_disc_present_dispatches_linux(self):
+        with (
+            patch.object(sentinel, "sys") as mock_sys,
+            patch.object(sentinel, "_is_disc_present_linux", return_value=True) as mock_linux,
+        ):
+            mock_sys.platform = "linux"
+            result = sentinel.is_disc_present("/dev/sr0")
+        assert result is True
+        mock_linux.assert_called_once_with("/dev/sr0")
+
+    def test_eject_disc_dispatches_linux(self):
+        with (
+            patch.object(sentinel, "sys") as mock_sys,
+            patch.object(sentinel, "_eject_disc_linux", return_value=True) as mock_linux,
+        ):
+            mock_sys.platform = "linux"
+            result = sentinel.eject_disc("/dev/sr0")
+        assert result is True
+        mock_linux.assert_called_once_with("/dev/sr0")
+
+
+class TestMakeMKVDriveFormat:
+    """Tests that Linux drive IDs work with MakeMKV's dev: format."""
+
+    def test_linux_drive_id_produces_valid_makemkv_spec(self):
+        """Verify /dev/sr0 becomes dev:/dev/sr0 for MakeMKV."""
+        drive = "/dev/sr0"
+        # This is the logic from extractor.py _scan_disc_unlocked
+        if not drive.startswith("disc:"):
+            drive_spec = f"dev:{drive}"
+        else:
+            drive_spec = drive
+        assert drive_spec == "dev:/dev/sr0"
+
+    def test_windows_drive_id_produces_valid_makemkv_spec(self):
+        """Verify E: becomes dev:E: for MakeMKV."""
+        drive = "E:"
+        if not drive.startswith("disc:"):
+            drive_spec = f"dev:{drive}"
+        else:
+            drive_spec = drive
+        assert drive_spec == "dev:E:"


### PR DESCRIPTION
## Summary

- Implements Linux-native versions of all four sentinel functions (`get_optical_drives`, `get_volume_label`, `is_disc_present`, `eject_disc`)
- Each public function now dispatches by `sys.platform`: `win32` → Windows impl, `linux` → Linux impl, else → safe defaults
- No new dependencies — uses `/sys/block`, `blkid`, and `eject` (standard Linux tools)
- MakeMKV's `dev:` format works transparently with Linux paths (`/dev/sr0` → `dev:/dev/sr0`)

Closes #70
Related: #66

## Linux implementations

| Function | Mechanism |
|----------|-----------|
| `_get_optical_drives_linux()` | Enumerate `/sys/block/sr*` |
| `_get_volume_label_linux()` | `blkid -s LABEL -o value <drive>` (10s timeout) |
| `_is_disc_present_linux()` | Read `/sys/block/<dev>/size` (>0 = disc present) |
| `_eject_disc_linux()` | `eject <drive>` command (30s timeout) |

All gracefully degrade: if `blkid`/`eject` aren't installed, functions return safe defaults.

## Test plan

- [x] `uv run pytest tests/unit/test_linux_drives.py` — 23/23 passing
- [x] `uv run pytest tests/unit/ tests/pipeline/` — 452 passed (no regressions)
- [x] `uv run ruff check` — clean
- [ ] Test on actual Linux machine with optical drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)