### PR TITLE
fix: remove unused MUI/Emotion deps and react-router v7 conflict

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,6 @@
             "name": "engram-frontend",
             "version": "0.4.5",
             "dependencies": {
-                "@emotion/react": "11.14.0",
-                "@emotion/styled": "11.14.1",
-                "@mui/icons-material": "7.3.5",
-                "@mui/material": "7.3.5",
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.3",
                 "@radix-ui/react-alert-dialog": "1.1.6",
@@ -57,7 +53,6 @@
                 "react-popper": "2.3.0",
                 "react-resizable-panels": "2.1.7",
                 "react-responsive-masonry": "2.7.1",
-                "react-router": "7.13.0",
                 "react-router-dom": "^6.21.0",
                 "react-slick": "0.31.0",
                 "recharts": "2.15.2",
@@ -166,6 +161,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -239,6 +235,7 @@
             "version": "7.29.1",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -282,6 +279,7 @@
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -291,6 +289,7 @@
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
             "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
@@ -332,6 +331,7 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -341,6 +341,7 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -374,6 +375,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -430,6 +432,7 @@
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
@@ -444,6 +447,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
@@ -462,6 +466,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -618,153 +623,12 @@
                 "node": ">=20.19.0"
             }
         },
-        "node_modules/@emotion/babel-plugin": {
-            "version": "11.13.5",
-            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/runtime": "^7.18.3",
-                "@emotion/hash": "^0.9.2",
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/serialize": "^1.3.3",
-                "babel-plugin-macros": "^3.1.0",
-                "convert-source-map": "^1.5.0",
-                "escape-string-regexp": "^4.0.0",
-                "find-root": "^1.1.0",
-                "source-map": "^0.5.7",
-                "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/cache": {
-            "version": "11.14.0",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/sheet": "^1.4.0",
-                "@emotion/utils": "^1.4.2",
-                "@emotion/weak-memoize": "^0.4.0",
-                "stylis": "4.2.0"
-            }
-        },
-        "node_modules/@emotion/hash": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/is-prop-valid": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/memoize": "^0.9.0"
-            }
-        },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
             "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/react": {
-            "version": "11.14.0",
-            "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-            "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
             "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.13.5",
-                "@emotion/cache": "^11.14.0",
-                "@emotion/serialize": "^1.3.3",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-                "@emotion/utils": "^1.4.2",
-                "@emotion/weak-memoize": "^0.4.0",
-                "hoist-non-react-statics": "^3.3.1"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emotion/serialize": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/hash": "^0.9.2",
-                "@emotion/memoize": "^0.9.0",
-                "@emotion/unitless": "^0.10.0",
-                "@emotion/utils": "^1.4.2",
-                "csstype": "^3.0.2"
-            }
-        },
-        "node_modules/@emotion/sheet": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/styled": {
-            "version": "11.14.1",
-            "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-            "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.18.3",
-                "@emotion/babel-plugin": "^11.13.5",
-                "@emotion/is-prop-valid": "^1.3.0",
-                "@emotion/serialize": "^1.3.3",
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-                "@emotion/utils": "^1.4.2"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.0.0-rc.0",
-                "react": ">=16.8.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@emotion/unitless": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            }
-        },
-        "node_modules/@emotion/utils": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/weak-memoize": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-            "license": "MIT"
+            "optional": true
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -1430,6 +1294,7 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1451,6 +1316,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -1460,250 +1326,18 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
-        },
-        "node_modules/@mui/core-downloads-tracker": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.8.tgz",
-            "integrity": "sha512-s9UHZo7QJVly7gNArEZkbbsimHqJZhElgBpXIJdehZ4OWXt+CCr0SBDgUCDJnQrqpd1dWK2dLq5rmO4mCBmI3w==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            }
-        },
-        "node_modules/@mui/icons-material": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.5.tgz",
-            "integrity": "sha512-LciL1GLMZ+VlzyHAALSVAR22t8IST4LCXmljcUSx2NOutgO2XnxdIp8ilFbeNf9wpo0iUFbAuoQcB7h+HHIf3A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.4"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@mui/material": "^7.3.5",
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/material": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.5.tgz",
-            "integrity": "sha512-8VVxFmp1GIm9PpmnQoCoYo0UWHoOrdA57tDL62vkpzEgvb/d71Wsbv4FRg7r1Gyx7PuSo0tflH34cdl/NvfHNQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/runtime": "^7.28.4",
-                "@mui/core-downloads-tracker": "^7.3.5",
-                "@mui/system": "^7.3.5",
-                "@mui/types": "^7.4.8",
-                "@mui/utils": "^7.3.5",
-                "@popperjs/core": "^2.11.8",
-                "@types/react-transition-group": "^4.4.12",
-                "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
-                "prop-types": "^15.8.1",
-                "react-is": "^19.2.0",
-                "react-transition-group": "^4.4.5"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.5.0",
-                "@emotion/styled": "^11.3.0",
-                "@mui/material-pigment-css": "^7.3.5",
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/react": {
-                    "optional": true
-                },
-                "@emotion/styled": {
-                    "optional": true
-                },
-                "@mui/material-pigment-css": {
-                    "optional": true
-                },
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/private-theming": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.8.tgz",
-            "integrity": "sha512-du5dlPZ9XL3xW2apHoGDXBI+QLtyVJGrXNCfcNYfP/ojkz1RQ0rRV6VG9Rkm1DqEFRG8mjjTL7zmE1Bvn1eR4A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6",
-                "@mui/utils": "^7.3.8",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styled-engine": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.8.tgz",
-            "integrity": "sha512-JHAeXQzS0tJ+Fq3C6J4TVDsW+yKhO4uuxuiLaopNStJeQYBIUCXpKYyUCcgXym4AmhbznQnv9RlHywSH6b0FOg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6",
-                "@emotion/cache": "^11.14.0",
-                "@emotion/serialize": "^1.3.3",
-                "@emotion/sheet": "^1.4.0",
-                "csstype": "^3.2.3",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.4.1",
-                "@emotion/styled": "^11.3.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/react": {
-                    "optional": true
-                },
-                "@emotion/styled": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/system": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.8.tgz",
-            "integrity": "sha512-hoFRj4Zw2Km8DPWZp/nKG+ao5Jw5LSk2m/e4EGc6M3RRwXKEkMSG4TgtfVJg7dS2homRwtdXSMW+iRO0ZJ4+IA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6",
-                "@mui/private-theming": "^7.3.8",
-                "@mui/styled-engine": "^7.3.8",
-                "@mui/types": "^7.4.11",
-                "@mui/utils": "^7.3.8",
-                "clsx": "^2.1.1",
-                "csstype": "^3.2.3",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@emotion/react": "^11.5.0",
-                "@emotion/styled": "^11.3.0",
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@emotion/react": {
-                    "optional": true
-                },
-                "@emotion/styled": {
-                    "optional": true
-                },
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/types": {
-            "version": "7.4.11",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.11.tgz",
-            "integrity": "sha512-fZ2xO9D08IKOxO2oUBi1nnVKH6oJUD+64cnv4YAaFoC0E5+i1+S5AHbNqqvZlYYsbPEQ6qEVwuBqY3jl5W4G+Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/utils": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.8.tgz",
-            "integrity": "sha512-kZRcE2620CBGr+XI8YMmwPj6WIPwSF7uMJjvSfqd8zXVvlz0MCJbzRRUGNf8NgflCLthdji2DdS643TeyJ3+nA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.28.6",
-                "@mui/types": "^7.4.11",
-                "@types/prop-types": "^15.7.15",
-                "clsx": "^2.1.1",
-                "prop-types": "^15.8.1",
-                "react-is": "^19.2.3"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -5435,22 +5069,18 @@
                 "undici-types": "~7.18.0"
             }
         },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "license": "MIT"
-        },
         "node_modules/@types/prop-types": {
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.28",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+            "devOptional": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -5467,15 +5097,6 @@
             "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
-            }
-        },
-        "node_modules/@types/react-transition-group": {
-            "version": "4.4.12",
-            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-            "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "*"
             }
         },
         "node_modules/@types/semver": {
@@ -5959,21 +5580,6 @@
                 "postcss": "^8.1.0"
             }
         },
-        "node_modules/babel-plugin-macros": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "cosmiconfig": "^7.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6066,6 +5672,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -6198,41 +5805,6 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
-        },
-        "node_modules/cookie": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -6452,6 +6024,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -6628,15 +6201,6 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
-        "node_modules/error-ex": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.2.1"
-            }
-        },
         "node_modules/es-module-lexer": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -6697,6 +6261,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -7025,12 +6590,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/find-root": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "license": "MIT"
-        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7131,15 +6690,6 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/gensync": {
@@ -7281,18 +6831,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -7363,6 +6901,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
             "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
@@ -7431,27 +6970,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-            "license": "MIT"
-        },
-        "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-extglob": {
@@ -7586,6 +7104,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -7599,12 +7118,6 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
@@ -7906,12 +7419,6 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "license": "MIT"
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8123,6 +7630,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -8252,30 +7760,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parse5": {
@@ -8321,16 +7812,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "license": "MIT"
-        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8347,6 +7833,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -8626,12 +8113,6 @@
                 "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
-        "node_modules/react-is": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-            "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-            "license": "MIT"
-        },
         "node_modules/react-popper": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
@@ -8719,28 +8200,6 @@
             "resolved": "https://registry.npmjs.org/react-responsive-masonry/-/react-responsive-masonry-2.7.1.tgz",
             "integrity": "sha512-Q+u+nOH87PzjqGFd2PgTcmLpHPZnCmUPREHYoNBc8dwJv6fi51p9U6hqwG8g/T8MN86HrFjrU+uQU6yvETU7cA==",
             "license": "MIT"
-        },
-        "node_modules/react-router": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-            "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
-            "license": "MIT",
-            "dependencies": {
-                "cookie": "^1.0.1",
-                "set-cookie-parser": "^2.6.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=18",
-                "react-dom": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "react-dom": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/react-router-dom": {
             "version": "6.30.3",
@@ -8920,30 +8379,11 @@
             "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
             "license": "MIT"
         },
-        "node_modules/resolve": {
-            "version": "1.22.11",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -9081,12 +8521,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/set-cookie-parser": {
-            "version": "2.7.2",
-            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-            "license": "MIT"
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9135,15 +8569,6 @@
             "peerDependencies": {
                 "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
                 "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-js": {
@@ -9215,12 +8640,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/stylis": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-            "license": "MIT"
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9232,18 +8651,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/symbol-tree": {
@@ -10540,15 +9947,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,10 +14,6 @@
         "test:e2e:headed": "playwright test --headed"
     },
     "dependencies": {
-        "@emotion/react": "11.14.0",
-        "@emotion/styled": "11.14.1",
-        "@mui/icons-material": "7.3.5",
-        "@mui/material": "7.3.5",
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",
         "@radix-ui/react-alert-dialog": "1.1.6",
@@ -63,7 +59,6 @@
         "react-popper": "2.3.0",
         "react-resizable-panels": "2.1.7",
         "react-responsive-masonry": "2.7.1",
-        "react-router": "7.13.0",
         "react-router-dom": "^6.21.0",
         "react-slick": "0.31.0",
         "recharts": "2.15.2",


### PR DESCRIPTION
## Summary
- Remove `@mui/material`, `@mui/icons-material`, `@emotion/react`, `@emotion/styled` — zero imports found anywhere in frontend, project uses Radix UI + Tailwind
- Remove `react-router` v7.13.0 which conflicted with the actually-used `react-router-dom` v6
- ~600 lines removed from package-lock.json

Part of #58 (Priority 3: Remove Dead Frontend Dependencies)

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` (tsc + vite) passes cleanly
- [x] `npm run lint` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)