### PR TITLE
feat: WebSocket heartbeat, memory leak fix, async config, configurable CORS

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -41,7 +41,13 @@ class ConnectionManager:
         logger.info(f"Client disconnected. Total connections: {len(self.active_connections)}")
 
     async def _heartbeat_loop(self, websocket: WebSocket) -> None:
-        """Send periodic pings to detect stale connections."""
+        """Send periodic pings to detect stale connections.
+
+        On failure, closes the socket directly instead of calling disconnect()
+        to avoid deadlocking on self._lock (which broadcast() may hold).
+        The main receive loop in websocket_endpoint will catch the disconnect
+        and call disconnect() to clean up.
+        """
         try:
             while True:
                 await asyncio.sleep(HEARTBEAT_INTERVAL)
@@ -51,8 +57,7 @@ class ConnectionManager:
                         timeout=HEARTBEAT_TIMEOUT,
                     )
                 except Exception:
-                    logger.warning("Heartbeat failed, removing stale connection")
-                    await self.disconnect(websocket)
+                    logger.warning("Heartbeat failed, closing stale connection")
                     try:
                         await websocket.close()
                     except Exception:

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -9,12 +9,16 @@ from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
 
+HEARTBEAT_INTERVAL = 30  # seconds between pings
+HEARTBEAT_TIMEOUT = 10  # seconds to wait for pong
+
 
 class ConnectionManager:
     """Manages WebSocket connections for broadcasting updates."""
 
     def __init__(self) -> None:
         self.active_connections: list[WebSocket] = []
+        self._heartbeat_tasks: dict[WebSocket, asyncio.Task] = {}
         self._lock = asyncio.Lock()
 
     async def connect(self, websocket: WebSocket) -> None:
@@ -22,6 +26,8 @@ class ConnectionManager:
         await websocket.accept()
         async with self._lock:
             self.active_connections.append(websocket)
+            task = asyncio.create_task(self._heartbeat_loop(websocket))
+            self._heartbeat_tasks[websocket] = task
         logger.info(f"Client connected. Total connections: {len(self.active_connections)}")
 
     async def disconnect(self, websocket: WebSocket) -> None:
@@ -29,7 +35,31 @@ class ConnectionManager:
         async with self._lock:
             if websocket in self.active_connections:
                 self.active_connections.remove(websocket)
+            task = self._heartbeat_tasks.pop(websocket, None)
+            if task:
+                task.cancel()
         logger.info(f"Client disconnected. Total connections: {len(self.active_connections)}")
+
+    async def _heartbeat_loop(self, websocket: WebSocket) -> None:
+        """Send periodic pings to detect stale connections."""
+        try:
+            while True:
+                await asyncio.sleep(HEARTBEAT_INTERVAL)
+                try:
+                    await asyncio.wait_for(
+                        websocket.send_json({"type": "ping"}),
+                        timeout=HEARTBEAT_TIMEOUT,
+                    )
+                except Exception:
+                    logger.warning("Heartbeat failed, removing stale connection")
+                    await self.disconnect(websocket)
+                    try:
+                        await websocket.close()
+                    except Exception:
+                        pass
+                    return
+        except asyncio.CancelledError:
+            return
 
     async def broadcast(self, message: dict[str, Any]) -> None:
         """Broadcast a message to all connected clients."""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,5 +43,8 @@ class Settings(BaseSettings):
     port: int = 8000
     debug: bool = False
 
+    # CORS (comma-separated origins, or leave empty for dev defaults)
+    cors_origins: str = ""
+
 
 settings = Settings()

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -107,6 +107,10 @@ class DiscAnalyst:
             self._config = get_config_sync()
         return self._config
 
+    def set_config(self, config) -> None:
+        """Set config from an async caller to avoid blocking get_config_sync()."""
+        self._config = config
+
     def analyze(
         self,
         titles: list[TitleInfo],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,8 +99,11 @@ app = FastAPI(
 
 # Add CORS middleware for frontend communication
 _default_origins = ["http://localhost:5173", "http://127.0.0.1:5173"]
-_cors_origins = os.environ.get("CORS_ORIGINS", "").strip()
-_allowed_origins = [o.strip() for o in _cors_origins.split(",") if o.strip()] if _cors_origins else _default_origins
+_allowed_origins = (
+    [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
+    if settings.cors_origins
+    else _default_origins
+)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -98,9 +98,13 @@ app = FastAPI(
 )
 
 # Add CORS middleware for frontend communication
+_default_origins = ["http://localhost:5173", "http://127.0.0.1:5173"]
+_cors_origins = os.environ.get("CORS_ORIGINS", "").strip()
+_allowed_origins = [o.strip() for o in _cors_origins.split(",") if o.strip()] if _cors_origins else _default_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],  # Vite dev server
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -52,19 +52,27 @@ async def get_config() -> AppConfig:
         return config
 
 
+_sync_engine = None
+
+
+def _get_sync_engine():
+    """Get or create a cached synchronous engine for sync DB access."""
+    global _sync_engine
+    if _sync_engine is None:
+        from sqlmodel import create_engine
+
+        from app.config import settings
+
+        sync_db_url = settings.database_url.replace("+aiosqlite", "")
+        _sync_engine = create_engine(sync_db_url)
+    return _sync_engine
+
+
 def get_config_sync() -> AppConfig:
     """Get configuration synchronously for non-async contexts."""
-    from sqlmodel import Session, create_engine, select
+    from sqlmodel import Session, select
 
-    from app.config import settings
-
-    # Create a synchronous engine for this specific operation
-    # This is a bit expensive but safe for occasional use in background threads
-    # Transform 'sqlite+aiosqlite:///...' to 'sqlite:///...'
-    sync_db_url = settings.database_url.replace("+aiosqlite", "")
-    engine = create_engine(sync_db_url)
-
-    with Session(engine) as session:
+    with Session(_get_sync_engine()) as session:
         statement = select(AppConfig).limit(1)
         config = session.exec(statement).first()
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -418,7 +418,11 @@ class JobManager:
                     except Exception as e:
                         logger.warning(f"Job {job_id}: TMDB lookup failed: {e}")
 
-                # Analyze disc content
+                # Analyze disc content (pre-load config to avoid blocking sync call)
+                from app.services.config_service import get_config
+
+                config = await get_config()
+                self._analyst.set_config(config)
                 analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
 
                 # Apply DiscDB override if high-confidence
@@ -735,6 +739,10 @@ class JobManager:
                         )
 
                 # Analyze disc content (DiscDB signal overrides when high-confidence)
+                from app.services.config_service import get_config
+
+                config = await get_config()
+                self._analyst.set_config(config)
                 analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
 
                 # If AI identified a name but TMDB re-query also failed,
@@ -1422,6 +1430,10 @@ class JobManager:
     async def _on_job_terminal(self, job_id: int, state: JobState) -> None:
         """Called by state machine when a job reaches COMPLETED or FAILED."""
         from app.services.config_service import get_config
+
+        # Clear per-job caches to prevent memory leaks
+        self._episode_runtimes.pop(job_id, None)
+        self._discdb_mappings.pop(job_id, None)
 
         config = await get_config()
         policy = config.staging_cleanup_policy


### PR DESCRIPTION
## Summary
- **WebSocket heartbeat**: Server sends ping every 30s; stale connections that fail to respond are cleaned up. Prevents silent connection accumulation during long dashboard sessions.
- **Memory leak fix**: `_episode_runtimes` and `_discdb_mappings` dicts now cleared in `_on_job_terminal()` — previously grew indefinitely as jobs completed.
- **Async config for Analyst**: Added `set_config()` so async callers pre-load config instead of blocking the event loop via `get_config_sync()`.
- **Configurable CORS**: Origins now read from `CORS_ORIGINS` env var (comma-separated), defaulting to `localhost:5173` for dev.

Part of #58 (Priority 5 + additional recommendations)

## Test plan
- [x] `uv run pytest tests/unit/` — 413 tests pass
- [x] `uv run ruff check` — all clean
- [ ] Manual: open dashboard, wait 60s+ — connection stays alive via heartbeat
- [ ] Verify `CORS_ORIGINS=http://example.com` restricts origins correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)