### PR TITLE
refactor: decompose JobManager into focused coordinators

### DIFF
--- a/backend/app/services/cleanup_service.py
+++ b/backend/app/services/cleanup_service.py
@@ -1,0 +1,118 @@
+"""Cleanup Service - Handles staging directory cleanup and DiscDB export.
+
+Extracted from JobManager to isolate cleanup concerns.
+"""
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+from sqlmodel import select
+
+from app.database import async_session
+from app.models import DiscJob, JobState
+from app.models.disc_job import DiscTitle
+
+logger = logging.getLogger(__name__)
+
+
+class CleanupService:
+    """Manages staging cleanup policies and auto-export."""
+
+    async def on_job_terminal(self, job_id: int, state: JobState) -> None:
+        """Called by state machine when a job reaches COMPLETED or FAILED."""
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        policy = config.staging_cleanup_policy
+
+        if policy == "manual":
+            pass
+        elif policy == "after_days":
+            # Timed cleanup handled by background task, not here
+            pass
+        elif policy == "on_success" and state == JobState.COMPLETED:
+            await self.delete_staging(job_id)
+        elif policy == "on_completion":
+            await self.delete_staging(job_id)
+
+        # Auto-export for TheDiscDB contributions
+        if state == JobState.COMPLETED and config.discdb_contributions_enabled:
+            await self.auto_export_for_discdb(job_id, config)
+
+    async def delete_staging(self, job_id: int) -> None:
+        """Delete the staging directory for a job."""
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job or not job.staging_path:
+                return
+
+            staging_path = Path(job.staging_path)
+            if not staging_path.exists():
+                return
+
+            try:
+                import shutil
+
+                shutil.rmtree(staging_path)
+                logger.info(f"Cleaned up staging directory: {staging_path}")
+            except Exception as e:
+                logger.warning(f"Failed to clean staging for job {job_id}: {e}")
+
+    async def auto_export_for_discdb(self, job_id: int, config) -> None:
+        """Auto-export disc data for TheDiscDB contribution."""
+        # Brief delay to let MakeMKV log files flush to disk
+        await asyncio.sleep(2)
+        try:
+            from app.core.discdb_exporter import generate_export, mark_exported
+
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                if not job or not job.content_hash:
+                    return
+
+                stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
+                titles = list((await session.execute(stmt)).scalars().all())
+
+                from app import __version__
+
+                export_dir = generate_export(job, titles, config, app_version=__version__)
+                if export_dir:
+                    await mark_exported(job_id, session)
+                    logger.info(f"Job {job_id}: Auto-exported disc data to {export_dir}")
+        except Exception as e:
+            logger.warning(f"Job {job_id}: Failed to auto-export disc data: {e}")
+
+    async def run_timed_cleanup(self, staging_root: str, max_age_days: int) -> None:
+        """Background task: periodically delete staging dirs older than max_age_days."""
+        import shutil
+
+        interval = 3600  # Check every hour
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                root = Path(staging_root)
+                if not root.exists():
+                    continue
+
+                now = time.time()
+                cutoff = now - (max_age_days * 86400)
+
+                for d in root.iterdir():
+                    if not d.is_dir() or not d.name.startswith("job_"):
+                        continue
+                    try:
+                        mtime = d.stat().st_mtime
+                        if mtime < cutoff:
+                            shutil.rmtree(d)
+                            logger.info(
+                                f"Timed cleanup: deleted staging dir {d.name} "
+                                f"(age: {(now - mtime) / 86400:.1f} days)"
+                            )
+                    except Exception as e:
+                        logger.warning(f"Timed cleanup: failed to delete {d}: {e}")
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Timed cleanup error: {e}", exc_info=True)

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -1,0 +1,721 @@
+"""Finalization Coordinator - Conflict resolution, organization, and job completion.
+
+Extracted from JobManager to isolate finalization concerns.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.database import async_session
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.event_broadcaster import EventBroadcaster
+from app.services.job_state_machine import JobStateMachine
+
+logger = logging.getLogger(__name__)
+
+
+class FinalizationCoordinator:
+    """Coordinates conflict resolution, file organization, and job completion."""
+
+    def __init__(
+        self,
+        event_broadcaster: EventBroadcaster,
+        state_machine: JobStateMachine,
+    ) -> None:
+        self._broadcaster = event_broadcaster
+        self._state_machine = state_machine
+
+        # Cross-coordinator callbacks (set by JobManager)
+        self._run_ripping: callable = None
+        self._on_task_done: callable = None
+        self._active_jobs: dict = None
+        self._match_single_file: callable = None
+
+    def set_callbacks(
+        self, *, run_ripping, on_task_done, active_jobs, match_single_file=None
+    ) -> None:
+        """Set cross-coordinator callbacks."""
+        self._run_ripping = run_ripping
+        self._on_task_done = on_task_done
+        self._active_jobs = active_jobs
+        self._match_single_file = match_single_file
+
+    async def check_job_completion(self, session, job_id: int):
+        """Check if all titles in a job are processed, and if so, finalize."""
+        session.expire_all()
+
+        job = await session.get(DiscJob, job_id)
+        if not job:
+            return
+
+        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
+        result = await session.execute(statement)
+        titles = result.scalars().all()
+
+        active_states = [TitleState.PENDING, TitleState.RIPPING, TitleState.MATCHING]
+        active_titles = [t for t in titles if t.state in active_states]
+
+        # Diagnostic: log ALL title states every time this is called
+        state_summary = ", ".join(
+            f"t{t.title_index}={t.state.value}" for t in sorted(titles, key=lambda x: x.title_index)
+        )
+        logger.info(
+            f"[COMPLETION-CHECK] Job {job_id}: {len(active_titles)} active / "
+            f"{len(titles)} total — [{state_summary}]"
+        )
+
+        if active_titles:
+            logger.debug(
+                f"Job {job_id}: {len(active_titles)} still active "
+                f"({', '.join(f'{t.id}:{t.state.value}' for t in active_titles[:5])})"
+            )
+            return
+
+        # All titles are terminal
+        logger.info(f"All titles for job {job_id} effectively processed. Finalizing...")
+
+        has_matched = any(t.state == TitleState.MATCHED for t in titles)
+        has_review = any(t.state == TitleState.REVIEW for t in titles)
+        has_completed = any(t.state == TitleState.COMPLETED for t in titles)
+        all_failed = all(t.state == TitleState.FAILED for t in titles)
+
+        if has_matched:
+            try:
+                await self.finalize_disc_job(job_id)
+            except Exception as e:
+                logger.exception(f"Job {job_id}: _finalize_disc_job failed: {e}")
+                await self._state_machine.transition_to_failed(
+                    job, session, error_message=f"Finalization failed: {e}"
+                )
+        elif has_review:
+            await self._state_machine.transition_to_review(
+                job,
+                session,
+                reason=f"{sum(1 for t in titles if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
+            )
+        elif all_failed and not has_completed:
+            await self._state_machine.transition_to_failed(
+                job, session, error_message="All titles failed to process"
+            )
+        else:
+            job.progress_percent = 100.0
+            await self._state_machine.transition_to_completed(job, session)
+
+    async def finalize_disc_job(self, job_id: int):
+        """Run conflict resolution with cascading reassignment and organize matches."""
+        from app.core.organizer import tv_organizer
+
+        logger.info(f"Running conflict resolution for Job {job_id}")
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
+            titles = (await session.execute(statement)).scalars().all()
+
+            def _find_source_file(title):
+                if title.output_filename:
+                    p = Path(title.output_filename)
+                    if p.exists():
+                        return p
+                staging_path = Path(job.staging_path)
+                matches = list(staging_path.glob(f"*_t{title.title_index:02d}.mkv"))
+                return matches[0] if matches else None
+
+            def _get_metrics(t):
+                score = 0.0
+                vote_count = 0
+                file_cov = 0.0
+                runner_ups = []
+                if t.match_details:
+                    try:
+                        details = json.loads(t.match_details)
+                        score = details.get("score", 0.0)
+                        vote_count = details.get("vote_count", 0)
+                        file_cov = details.get("file_cov", 0.0)
+                        runner_ups = details.get("runner_ups", [])
+                    except (json.JSONDecodeError, KeyError, TypeError) as e:
+                        logger.debug(f"Could not parse match_details JSON: {e}")
+                if score == 0.0:
+                    score = t.match_confidence
+                return score, vote_count, file_cov, runner_ups
+
+            # Iterative conflict resolution (max 3 rounds)
+            for round_num in range(3):
+                candidates = {}
+                for t in titles:
+                    if t.state == TitleState.MATCHED and t.matched_episode:
+                        candidates.setdefault(t.matched_episode, []).append(t)
+
+                conflicts = {ep: tlist for ep, tlist in candidates.items() if len(tlist) > 1}
+                if not conflicts:
+                    logger.info(
+                        f"Conflict resolution round {round_num + 1}: no conflicts remaining"
+                    )
+                    break
+
+                logger.info(
+                    f"Conflict resolution round {round_num + 1}: "
+                    f"{len(conflicts)} episode(s) have conflicts"
+                )
+
+                reassigned_any = False
+                for ep_code, title_list in conflicts.items():
+                    logger.info(f"Conflict for {ep_code}: titles {[t.id for t in title_list]}")
+
+                    ranked = []
+                    for t in title_list:
+                        score, vote_count, file_cov, runner_ups = _get_metrics(t)
+                        ranked.append(
+                            {
+                                "title": t,
+                                "score": score,
+                                "vote_count": vote_count,
+                                "file_coverage": file_cov,
+                                "runner_ups": runner_ups,
+                            }
+                        )
+
+                    ranked.sort(
+                        key=lambda x: (
+                            x["vote_count"],
+                            x["score"],
+                            x["file_coverage"],
+                        ),
+                        reverse=True,
+                    )
+
+                    winner = ranked[0]
+                    logger.info(
+                        f"  Winner: Title {winner['title'].id} "
+                        f"(votes={winner['vote_count']}, score={winner['score']:.3f})"
+                    )
+
+                    for cand in ranked[1:]:
+                        loser = cand["title"]
+                        reassigned = False
+
+                        for ru in cand["runner_ups"]:
+                            alt_ep = ru["episode"]
+                            current_claimants = candidates.get(alt_ep, [])
+                            if not current_claimants:
+                                loser.matched_episode = alt_ep
+                                loser.match_confidence = ru["score"]
+                                candidates.setdefault(alt_ep, []).append(loser)
+                                reassigned = True
+                                reassigned_any = True
+                                logger.info(
+                                    f"  Reassigned Title {loser.id}: {ep_code} -> {alt_ep} "
+                                    f"(runner-up score={ru['score']:.3f})"
+                                )
+                                break
+                            elif len(current_claimants) == 1:
+                                claimant = current_claimants[0]
+                                claimant_score, _, _, _ = _get_metrics(claimant)
+                                if ru["score"] > claimant_score:
+                                    loser.matched_episode = alt_ep
+                                    loser.match_confidence = ru["score"]
+                                    candidates[alt_ep].append(loser)
+                                    reassigned = True
+                                    reassigned_any = True
+                                    logger.info(
+                                        f"  Reassigned Title {loser.id}: {ep_code} -> {alt_ep} "
+                                        f"(beats claimant {claimant.id}: "
+                                        f"{ru['score']:.3f} > {claimant_score:.3f})"
+                                    )
+                                    break
+
+                        if not reassigned:
+                            loser.state = TitleState.REVIEW
+                            if loser.match_details:
+                                try:
+                                    details = json.loads(loser.match_details)
+                                    details["conflict_reason"] = (
+                                        f"Lost conflict for {ep_code}, no viable runner-up"
+                                    )
+                                    loser.match_details = json.dumps(details)
+                                except (
+                                    json.JSONDecodeError,
+                                    KeyError,
+                                    TypeError,
+                                ) as e:
+                                    logger.debug(f"Could not update conflict details: {e}")
+                            session.add(loser)
+                            logger.info(
+                                f"  Title {loser.id}: no viable alternative, marked for REVIEW"
+                            )
+
+                if not reassigned_any:
+                    break
+
+            # Organize all MATCHED winners
+            for t in titles:
+                if t.state != TitleState.MATCHED or not t.matched_episode:
+                    continue
+
+                source_file = _find_source_file(t)
+                if not source_file:
+                    logger.error(f"Could not find source file for title {t.title_index}")
+                    t.state = TitleState.REVIEW
+                    session.add(t)
+                    continue
+
+                logger.info(f"Organizing Title {t.id} ({source_file.name}) -> {t.matched_episode}")
+
+                org_result = await asyncio.to_thread(
+                    tv_organizer.organize,
+                    source_file,
+                    job.detected_title,
+                    t.matched_episode,
+                )
+
+                if org_result["success"]:
+                    t.state = TitleState.COMPLETED
+                    t.organized_from = source_file.name
+                    t.organized_to = (
+                        str(org_result.get("final_path")) if org_result.get("final_path") else None
+                    )
+                    t.is_extra = False
+                else:
+                    t.state = TitleState.REVIEW
+                    logger.error(f"Organize failed for Title {t.id}: {org_result['error']}")
+
+                session.add(t)
+
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    t.id,
+                    t.state.value,
+                    matched_episode=t.matched_episode,
+                    match_confidence=t.match_confidence,
+                    organized_from=t.organized_from,
+                    organized_to=t.organized_to,
+                    output_filename=t.output_filename,
+                    is_extra=t.is_extra,
+                    match_details=t.match_details,
+                )
+
+            await session.commit()
+
+            # Determine final job state
+            has_review = any(t.state == TitleState.REVIEW for t in titles)
+            has_completed = any(t.state == TitleState.COMPLETED for t in titles)
+
+            if has_review:
+                review_count = sum(1 for t in titles if t.state == TitleState.REVIEW)
+                await self._state_machine.transition_to_review(
+                    job,
+                    session,
+                    reason=f"{review_count} title(s) need manual episode assignment",
+                )
+            elif has_completed:
+                job.progress_percent = 100.0
+                from app.services.config_service import get_config as get_db_config
+
+                db_config = await get_db_config()
+                job.final_path = str(
+                    Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
+                )
+                await self._state_machine.transition_to_completed(job, session)
+            else:
+                job.progress_percent = 100.0
+                await self._state_machine.transition_to_completed(job, session)
+
+    async def apply_review(
+        self,
+        job_id: int,
+        title_id: int,
+        episode_code: str | None = None,
+        edition: str | None = None,
+    ) -> None:
+        """Apply a user's review decision for a title."""
+        from datetime import UTC, datetime
+
+        from app.core.organizer import movie_organizer, tv_organizer
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                raise ValueError("Job not found")
+
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                raise ValueError("Title not found for this job")
+
+            if episode_code:
+                title.matched_episode = episode_code
+
+            if edition:
+                title.edition = edition
+
+            title.match_confidence = 1.0  # User-confirmed
+            session.add(title)
+            await session.commit()
+
+            # Handle Movie Workflow
+            if job.content_type == ContentType.MOVIE:
+                if episode_code == "skip":
+                    title.state = TitleState.FAILED
+                    session.add(title)
+                    await session.commit()
+                    return
+
+                if title.output_filename:
+                    source_file = Path(title.output_filename)
+                    if not source_file.exists():
+                        logger.info(
+                            f"Source file {source_file} not found. "
+                            f"Triggering ripping for selected title."
+                        )
+
+                        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
+                        all_titles = (await session.execute(statement)).scalars().all()
+                        for t in all_titles:
+                            t.is_selected = t.id == title.id
+                            session.add(t)
+
+                        await session.commit()
+
+                        job.state = JobState.RIPPING
+                        job.updated_at = datetime.now(UTC)
+                        session.add(job)
+                        await session.commit()
+                        await self._broadcaster.broadcast_job_state_changed(job_id, job.state)
+
+                        task = asyncio.create_task(self._run_ripping(job_id))
+                        task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
+                        self._active_jobs[job_id] = task
+                        return
+
+                    else:
+                        # File exists — Post-Rip workflow
+                        job.state = JobState.ORGANIZING
+                        await session.commit()
+                        await self._broadcaster.broadcast_job_state_changed(job_id, job.state)
+
+                        # Clean up unselected ripped files
+                        cleanup_statement = select(DiscTitle).where(
+                            DiscTitle.job_id == job_id,
+                            DiscTitle.id != title_id,
+                            DiscTitle.output_filename.isnot(None),
+                        )
+                        unselected_titles = (
+                            (await session.execute(cleanup_statement)).scalars().all()
+                        )
+
+                        for unselected in unselected_titles:
+                            try:
+                                p = Path(unselected.output_filename)
+                                if p.exists():
+                                    p.unlink()
+                                    logger.info(f"Deleted unselected file: {p}")
+
+                                unselected.state = TitleState.FAILED
+                                unselected.match_details = json.dumps(
+                                    {"reason": "Unselected by user"}
+                                )
+                                session.add(unselected)
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to delete unselected file "
+                                    f"{unselected.output_filename}: {e}"
+                                )
+
+                        final_title = job.detected_title or job.volume_label
+                        if edition and edition.lower() not in final_title.lower():
+                            final_title = f"{final_title} {{edition-{edition}}}"
+
+                        org_result = await asyncio.to_thread(
+                            movie_organizer.organize,
+                            source_file,
+                            job.volume_label,
+                            final_title,
+                        )
+
+                        if org_result["success"]:
+                            title.state = TitleState.COMPLETED
+                            job.progress_percent = 100.0
+                            job.error_message = None
+                            job.final_path = str(org_result["main_file"])
+                            await self._state_machine.transition_to_completed(job, session)
+                            logger.info(f"Organized movie: {org_result['main_file']}")
+                        elif org_result.get("error_code") == "FILE_EXISTS":
+                            title.state = TitleState.REVIEW
+                            try:
+                                existing_details = (
+                                    json.loads(title.match_details) if title.match_details else {}
+                                )
+                                existing_details.update(
+                                    {
+                                        "error": "file_exists",
+                                        "message": str(org_result["error"]),
+                                    }
+                                )
+                                title.match_details = json.dumps(existing_details)
+                            except (json.JSONDecodeError, TypeError):
+                                title.match_details = json.dumps(
+                                    {
+                                        "error": "file_exists",
+                                        "message": str(org_result["error"]),
+                                    }
+                                )
+
+                            await self._state_machine.transition_to_review(
+                                job,
+                                session,
+                                reason="File already exists in library",
+                            )
+                            logger.warning(
+                                f"Organization conflict for movie: {org_result['error']}"
+                            )
+                        else:
+                            title.state = TitleState.FAILED
+                            logger.error(f"Failed to organize movie: {org_result['error']}")
+                            await self._state_machine.transition_to_failed(
+                                job,
+                                session,
+                                error_message=org_result["error"],
+                            )
+
+                return
+
+            # Handle TV Workflow
+            result = await session.execute(
+                select(DiscTitle).where(
+                    DiscTitle.job_id == job_id,
+                    DiscTitle.matched_episode.is_(None),
+                )
+            )
+            unresolved = result.scalars().all()
+
+            if not unresolved:
+                job.state = JobState.ORGANIZING
+                session.add(job)
+                await session.commit()
+                await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
+
+                all_titles_result = await session.execute(
+                    select(DiscTitle).where(
+                        DiscTitle.job_id == job_id,
+                        DiscTitle.matched_episode.isnot(None),
+                    )
+                )
+                resolved_titles = all_titles_result.scalars().all()
+
+                success_count = 0
+                conflict_count = 0
+
+                for disc_title in resolved_titles:
+                    if disc_title.output_filename and disc_title.matched_episode != "skip":
+                        source_file = Path(disc_title.output_filename)
+                        if source_file.exists():
+                            org_result = await asyncio.to_thread(
+                                tv_organizer.organize,
+                                source_file,
+                                job.detected_title or job.volume_label,
+                                disc_title.matched_episode,
+                            )
+                            if org_result["success"]:
+                                success_count += 1
+                                disc_title.organized_from = source_file.name
+                                disc_title.organized_to = (
+                                    str(org_result.get("final_path"))
+                                    if org_result.get("final_path")
+                                    else None
+                                )
+                                disc_title.is_extra = False
+                                disc_title.state = TitleState.COMPLETED
+                                logger.info(f"Organized: {org_result['final_path']}")
+                            elif org_result.get("error_code") == "FILE_EXISTS":
+                                conflict_count += 1
+                                disc_title.state = TitleState.REVIEW
+                                try:
+                                    existing = (
+                                        json.loads(disc_title.match_details)
+                                        if disc_title.match_details
+                                        else {}
+                                    )
+                                    existing.update(
+                                        {
+                                            "error": "file_exists",
+                                            "message": str(org_result["error"]),
+                                        }
+                                    )
+                                    disc_title.match_details = json.dumps(existing)
+                                except (json.JSONDecodeError, TypeError):
+                                    disc_title.match_details = json.dumps(
+                                        {
+                                            "error": "file_exists",
+                                            "message": str(org_result["error"]),
+                                        }
+                                    )
+                                logger.warning(
+                                    f"Organization conflict for TV: {org_result['error']}"
+                                )
+                            else:
+                                logger.error(f"Failed to organize: {org_result['error']}")
+
+                            session.add(disc_title)
+                            await session.commit()
+                            await ws_manager.broadcast_title_update(
+                                job_id,
+                                disc_title.id,
+                                disc_title.state.value,
+                                matched_episode=disc_title.matched_episode,
+                                match_confidence=disc_title.match_confidence,
+                                organized_from=disc_title.organized_from,
+                                organized_to=disc_title.organized_to,
+                                output_filename=disc_title.output_filename,
+                                is_extra=disc_title.is_extra,
+                                match_details=disc_title.match_details,
+                            )
+                        else:
+                            logger.warning(f"Source file not found: {source_file}")
+
+                if conflict_count > 0:
+                    await self._state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason=f"{conflict_count} files already exist in library",
+                    )
+                elif success_count > 0:
+                    job.progress_percent = 100.0
+                    job.error_message = None
+                    from app.services.config_service import (
+                        get_config as get_db_config,
+                    )
+
+                    db_config = await get_db_config()
+                    job.final_path = str(
+                        Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
+                    )
+                    await self._state_machine.transition_to_completed(job, session)
+                else:
+                    await self._state_machine.transition_to_failed(
+                        job,
+                        session,
+                        error_message="Failed to organize files",
+                    )
+            else:
+                await session.commit()
+
+    async def process_matched_titles(self, job_id: int) -> dict:
+        """Process all matched titles for a job without waiting for unresolved ones."""
+        from app.core.organizer import tv_organizer
+        from app.services.config_service import get_config as get_db_config
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                raise ValueError("Job not found")
+
+            result = await session.execute(
+                select(DiscTitle).where(
+                    DiscTitle.job_id == job_id,
+                    DiscTitle.matched_episode.isnot(None),
+                    DiscTitle.matched_episode != "skip",
+                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
+                )
+            )
+            matched_titles = result.scalars().all()
+
+            success_count = 0
+            conflict_count = 0
+
+            for disc_title in matched_titles:
+                if not disc_title.output_filename:
+                    continue
+
+                source_file = Path(disc_title.output_filename)
+                if not source_file.exists():
+                    logger.warning(f"Source file not found: {source_file}")
+                    continue
+
+                org_result = await asyncio.to_thread(
+                    tv_organizer.organize,
+                    source_file,
+                    job.detected_title or job.volume_label,
+                    disc_title.matched_episode,
+                )
+
+                if org_result["success"]:
+                    success_count += 1
+                    disc_title.organized_from = source_file.name
+                    disc_title.organized_to = (
+                        str(org_result.get("final_path")) if org_result.get("final_path") else None
+                    )
+                    disc_title.is_extra = disc_title.matched_episode == "extra"
+                    disc_title.state = TitleState.COMPLETED
+                    logger.info(f"Organized: {org_result['final_path']}")
+                elif org_result.get("error_code") == "FILE_EXISTS":
+                    conflict_count += 1
+                    disc_title.state = TitleState.REVIEW
+                    try:
+                        existing = (
+                            json.loads(disc_title.match_details) if disc_title.match_details else {}
+                        )
+                        existing.update(
+                            {
+                                "error": "file_exists",
+                                "message": str(org_result["error"]),
+                            }
+                        )
+                        disc_title.match_details = json.dumps(existing)
+                    except (json.JSONDecodeError, TypeError):
+                        disc_title.match_details = json.dumps(
+                            {
+                                "error": "file_exists",
+                                "message": str(org_result["error"]),
+                            }
+                        )
+                    logger.warning(f"Organization conflict for TV: {org_result['error']}")
+                else:
+                    logger.error(f"Failed to organize: {org_result['error']}")
+                    continue
+
+                session.add(disc_title)
+                await session.commit()
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    disc_title.id,
+                    disc_title.state.value,
+                    matched_episode=disc_title.matched_episode,
+                    match_confidence=disc_title.match_confidence,
+                    organized_from=disc_title.organized_from,
+                    organized_to=disc_title.organized_to,
+                    output_filename=disc_title.output_filename,
+                    is_extra=disc_title.is_extra,
+                    match_details=disc_title.match_details,
+                )
+
+            # Check if any unresolved titles remain
+            unresolved_result = await session.execute(
+                select(DiscTitle).where(
+                    DiscTitle.job_id == job_id,
+                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
+                    DiscTitle.matched_episode.is_(None),
+                )
+            )
+            unresolved = unresolved_result.scalars().all()
+
+            if not unresolved and conflict_count == 0:
+                job.progress_percent = 100.0
+                job.error_message = None
+                db_config = await get_db_config()
+                job.final_path = str(
+                    Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
+                )
+                await self._state_machine.transition_to_completed(job, session)
+            else:
+                await session.commit()
+
+        return {
+            "organized": success_count,
+            "conflicts": conflict_count,
+            "unresolved": len(unresolved),
+        }

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1,0 +1,745 @@
+"""Identification Coordinator - Disc scanning, classification, and DiscDB/TMDB lookup.
+
+Extracted from JobManager to isolate the disc identification pipeline.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.core.analyst import DiscAnalyst
+from app.core.extractor import MakeMKVExtractor, ScanTimeoutError
+from app.database import async_session
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.event_broadcaster import EventBroadcaster
+from app.services.job_state_machine import JobStateMachine
+from app.services.ripping_helpers import build_title_list
+
+logger = logging.getLogger(__name__)
+
+
+class IdentificationCoordinator:
+    """Coordinates disc identification: scanning, classification, and metadata lookup."""
+
+    def __init__(
+        self,
+        analyst: DiscAnalyst,
+        extractor: MakeMKVExtractor,
+        event_broadcaster: EventBroadcaster,
+        state_machine: JobStateMachine,
+    ) -> None:
+        self._analyst = analyst
+        self._extractor = extractor
+        self._broadcaster = event_broadcaster
+        self._state_machine = state_machine
+
+        # These will be set by JobManager after MatchingCoordinator is created
+        self._get_discdb_mappings: callable = None
+        self._set_discdb_mappings: callable = None
+        self._start_subtitle_download: callable = None
+        self._try_discdb_assignment: callable = None
+        self._match_single_file: callable = None
+        self._on_match_task_done: callable = None
+        self._check_job_completion: callable = None
+        self._run_ripping: callable = None
+        self._finalize_disc_job: callable = None
+
+    def set_callbacks(
+        self,
+        *,
+        get_discdb_mappings,
+        set_discdb_mappings,
+        start_subtitle_download,
+        try_discdb_assignment,
+        match_single_file,
+        on_match_task_done,
+        check_job_completion,
+        run_ripping,
+        finalize_disc_job,
+    ) -> None:
+        """Set cross-coordinator callbacks after all coordinators are constructed."""
+        self._get_discdb_mappings = get_discdb_mappings
+        self._set_discdb_mappings = set_discdb_mappings
+        self._start_subtitle_download = start_subtitle_download
+        self._try_discdb_assignment = try_discdb_assignment
+        self._match_single_file = match_single_file
+        self._on_match_task_done = on_match_task_done
+        self._check_job_completion = check_job_completion
+        self._run_ripping = run_ripping
+        self._finalize_disc_job = finalize_disc_job
+
+    async def identify_disc(self, job_id: int) -> None:
+        """Identify the disc contents using MakeMKV and the Analyst."""
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+
+            try:
+                # Scan disc with MakeMKV
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
+
+                try:
+                    from app.core.discdb_exporter import get_makemkv_log_dir
+
+                    titles = await self._extractor.scan_disc(
+                        job.drive_id, log_dir=get_makemkv_log_dir(job_id), job_id=job_id
+                    )
+                except ScanTimeoutError:
+                    await self._state_machine.transition_to_failed(
+                        job,
+                        session,
+                        "Disc scan timed out after 10 minutes — disc may be encrypted or damaged",
+                    )
+                    return
+
+                if not titles:
+                    await self._state_machine.transition_to_failed(
+                        job, session, "No titles found on disc"
+                    )
+                    return
+
+                # Run classification pipeline
+                analysis = await self._run_classification(job, job_id, titles, session)
+
+                logger.info(f"Job {job_id} Analysis Result: {analysis}")
+
+                # Save snapshot for debugging and test fixture generation
+                from app.core.snapshot import save_snapshot
+
+                save_snapshot(job.volume_label, analysis)
+
+                # Update job with analysis results
+                job.content_type = analysis.content_type
+                job.detected_title = analysis.detected_name
+                job.detected_season = analysis.detected_season
+                job.total_titles = len(titles)
+                job.updated_at = datetime.now(UTC)
+
+                # If TMDB and DiscDB both failed and label looks like a catalog
+                # number, clear detected_title so the NamePromptModal triggers.
+                discdb_signal = getattr(analysis, "_discdb_signal", None)
+                tmdb_signal = getattr(analysis, "_tmdb_signal", None)
+                if (
+                    not tmdb_signal
+                    and not discdb_signal
+                    and job.detected_title
+                    and DiscAnalyst._looks_like_catalog_number(job.volume_label)
+                ):
+                    logger.info(
+                        f"Job {job_id}: Label '{job.volume_label}' looks like a catalog "
+                        f"number and no external match found — clearing detected_title "
+                        f"to trigger name prompt"
+                    )
+                    job.detected_title = None
+
+                # Persist classification metadata
+                job.classification_confidence = analysis.confidence
+                job.classification_source = analysis.classification_source
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.is_ambiguous_movie = analysis.is_ambiguous_movie
+                if analysis.play_all_title_indices:
+                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
+
+                # Extract disc number from volume label
+                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
+                if disc_match:
+                    job.disc_number = int(disc_match.group(1))
+                    logger.info(
+                        f"Detected disc number: {job.disc_number} from volume label: {job.volume_label}"
+                    )
+                else:
+                    job.disc_number = 1
+                    logger.info("No disc number detected in volume label, defaulting to 1")
+
+                # Clear any existing titles for this job
+                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
+
+                # Save title information
+                for title in titles:
+                    disc_title = DiscTitle(
+                        job_id=job_id,
+                        title_index=title.index,
+                        duration_seconds=title.duration_seconds,
+                        file_size_bytes=title.size_bytes,
+                        chapter_count=title.chapter_count,
+                        video_resolution=title.video_resolution,
+                        source_filename=title.source_filename or None,
+                        segment_count=title.segment_count,
+                        segment_map=title.segment_map or None,
+                    )
+                    session.add(disc_title)
+
+                # For TV discs, deselect "Play All" concatenation titles
+                if analysis.content_type == ContentType.TV and analysis.play_all_title_indices:
+                    await session.flush()
+                    play_all_set = set(analysis.play_all_title_indices)
+                    stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
+                    db_titles_for_filter = (await session.execute(stmt)).scalars().all()
+
+                    deselected = 0
+                    for dt in db_titles_for_filter:
+                        if dt.title_index in play_all_set:
+                            dt.is_selected = False
+                            dt.state = TitleState.COMPLETED
+                            dt.is_extra = True
+                            dt.match_details = json.dumps(
+                                {"reason": "Play All concatenation title"}
+                            )
+                            deselected += 1
+                            logger.info(
+                                f"Job {job_id}: Deselected 'Play All' title {dt.title_index} "
+                                f"({dt.duration_seconds // 60}min) → COMPLETED/extra"
+                            )
+
+                    if deselected:
+                        logger.info(f"Job {job_id}: Deselected {deselected} 'Play All' title(s)")
+
+                # For movies with DiscDB mappings, tag extras
+                discdb_maps = self._get_discdb_mappings(job_id)
+                if analysis.content_type == ContentType.MOVIE and discdb_maps:
+                    main_indices = {m.index for m in discdb_maps if m.title_type == "MainMovie"}
+                    extra_indices = {
+                        m.index
+                        for m in discdb_maps
+                        if m.title_type in ("Extra", "") and m.index not in main_indices
+                    }
+                    if main_indices:
+                        await session.flush()
+                        stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
+                        db_titles_for_select = (await session.execute(stmt)).scalars().all()
+                        for dt in db_titles_for_select:
+                            if dt.title_index in extra_indices:
+                                dt.is_extra = True
+                            elif dt.title_index not in main_indices:
+                                dt.is_extra = True
+                            session.add(dt)
+                        logger.info(
+                            f"Job {job_id}: TheDiscDB tagged MainMovie={main_indices}, "
+                            f"extras={extra_indices}"
+                        )
+
+                # Broadcast titles discovered with full metadata
+                titles_result = await session.execute(
+                    select(DiscTitle).where(DiscTitle.job_id == job_id)
+                )
+                title_list = build_title_list(
+                    titles_result.scalars().all(), include_video_resolution=True
+                )
+                await ws_manager.broadcast_titles_discovered(
+                    job_id,
+                    title_list,
+                    content_type=job.content_type.value,
+                    detected_title=job.detected_title,
+                    detected_season=job.detected_season,
+                )
+
+                # If no title could be determined, ask user
+                if not job.detected_title:
+                    await self._state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason="Disc label unreadable. Please enter the title to continue.",
+                        broadcast=False,
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.REVIEW_NEEDED.value,
+                        content_type=(job.content_type.value if job.content_type else None),
+                        total_titles=job.total_titles,
+                        review_reason="Disc label unreadable. Please enter the title to continue.",
+                    )
+                    logger.info(
+                        f"Job {job_id}: no title detected (volume label: '{job.volume_label}'), "
+                        f"waiting for user to supply name"
+                    )
+                    return
+
+                # Start subtitle download for ALL TV content
+                if (
+                    job.content_type == ContentType.TV
+                    and job.detected_title
+                    and job.detected_season
+                ):
+                    self._start_subtitle_download(job_id, job.detected_title, job.detected_season)
+                    logger.info(
+                        f"Job {job_id}: starting subtitle download for "
+                        f"{job.detected_title} S{job.detected_season}"
+                    )
+
+                if analysis.needs_review:
+                    # Special handling for Ambiguous Movies
+                    is_ambiguous_movie = (
+                        job.content_type == ContentType.MOVIE and analysis.is_ambiguous_movie
+                    )
+
+                    if is_ambiguous_movie:
+                        logger.info(
+                            f"Job {job_id}: Ambiguous movie detected. "
+                            f"Auto-ripping candidates for later review."
+                        )
+                        await session.commit()
+
+                        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
+                        db_titles = (await session.execute(statement)).scalars().all()
+
+                        candidate_count = 0
+                        for dt in db_titles:
+                            if dt.duration_seconds and dt.duration_seconds >= 80 * 60:
+                                dt.is_selected = True
+                                candidate_count += 1
+                                session.add(dt)
+
+                        await session.commit()
+
+                        job.state = JobState.RIPPING
+                        await session.commit()
+                        await ws_manager.broadcast_job_update(
+                            job_id,
+                            job.state.value,
+                            content_type=job.content_type.value,
+                            detected_title=job.detected_title,
+                        )
+
+                        await self._run_ripping(job_id)
+                        return
+
+                    await self._state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason=analysis.review_reason,
+                        broadcast=False,
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        job.state.value,
+                        content_type=job.content_type.value,
+                        detected_title=job.detected_title,
+                        detected_season=job.detected_season,
+                        total_titles=job.total_titles,
+                    )
+                    logger.info(f"Job {job_id} needs review: {analysis.review_reason}")
+                else:
+                    # High-confidence detection - auto-start ripping
+                    job.state = JobState.RIPPING
+                    await session.commit()
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        job.state.value,
+                        content_type=job.content_type.value,
+                        detected_title=job.detected_title,
+                        detected_season=job.detected_season,
+                        total_titles=job.total_titles,
+                    )
+
+                    logger.info(
+                        f"Job {job_id} identified as {analysis.content_type.value} "
+                        f"(confidence: {analysis.confidence:.1%}) - auto-starting rip"
+                    )
+
+                    await self._run_ripping(job_id)
+                    return
+
+            except Exception as e:
+                logger.exception(f"Error identifying disc for job {job_id}")
+                await self._state_machine.transition_to_failed(job, session, str(e))
+
+    async def identify_from_staging(self, job_id: int) -> None:
+        """Identify and process pre-ripped MKV files from staging."""
+        from app.core.analyst import TitleInfo
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+
+            try:
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
+
+                staging_dir = Path(job.staging_path)
+                mkv_files = sorted(staging_dir.glob("*.mkv"))
+
+                if not mkv_files:
+                    await self._state_machine.transition_to_failed(
+                        job, session, "No MKV files found in staging directory"
+                    )
+                    return
+
+                # Build TitleInfo objects from MKV files using ffprobe
+                titles: list[TitleInfo] = []
+                for idx, mkv_file in enumerate(mkv_files):
+                    duration = await self._probe_duration(mkv_file)
+                    file_size = mkv_file.stat().st_size
+
+                    titles.append(
+                        TitleInfo(
+                            index=idx,
+                            duration_seconds=int(duration),
+                            size_bytes=file_size,
+                            chapter_count=0,
+                            name=mkv_file.stem,
+                        )
+                    )
+
+                # Run classification pipeline
+                analysis = await self._run_classification(
+                    job, job_id, titles, session, is_staging=True
+                )
+
+                # Apply user-provided hints (override classification if given)
+                if job.content_type and job.content_type != ContentType.UNKNOWN:
+                    analysis.content_type = job.content_type
+                if job.detected_title:
+                    analysis.detected_name = job.detected_title
+
+                # Update job with analysis results
+                job.content_type = analysis.content_type
+                job.detected_title = analysis.detected_name or job.detected_title
+                job.detected_season = analysis.detected_season or job.detected_season
+                job.total_titles = len(titles)
+                job.updated_at = datetime.utcnow()
+                job.classification_confidence = analysis.confidence
+                job.classification_source = analysis.classification_source or "staging_import"
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.is_ambiguous_movie = analysis.is_ambiguous_movie
+                if analysis.play_all_title_indices:
+                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
+
+                # Extract disc number from volume label
+                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
+                job.disc_number = int(disc_match.group(1)) if disc_match else 1
+
+                # Create DiscTitle records with output_filename already set
+                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
+
+                for title, mkv_file in zip(titles, mkv_files, strict=True):
+                    disc_title = DiscTitle(
+                        job_id=job_id,
+                        title_index=title.index,
+                        duration_seconds=title.duration_seconds,
+                        file_size_bytes=title.size_bytes,
+                        chapter_count=title.chapter_count,
+                        output_filename=str(mkv_file),
+                    )
+                    session.add(disc_title)
+
+                await session.commit()
+
+                # Broadcast titles discovered
+                titles_result = await session.execute(
+                    select(DiscTitle).where(DiscTitle.job_id == job_id)
+                )
+                title_list = build_title_list(titles_result.scalars().all())
+                await ws_manager.broadcast_titles_discovered(
+                    job_id,
+                    title_list,
+                    content_type=job.content_type.value,
+                    detected_title=job.detected_title,
+                    detected_season=job.detected_season,
+                )
+
+                # If no title detected, ask user
+                if not job.detected_title:
+                    await self._state_machine.transition_to_review(
+                        job,
+                        session,
+                        reason="Could not determine title. Please enter the title to continue.",
+                        broadcast=False,
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.REVIEW_NEEDED.value,
+                        content_type=(job.content_type.value if job.content_type else None),
+                        total_titles=job.total_titles,
+                        review_reason="Could not determine title. Please enter the title to continue.",
+                    )
+                    return
+
+                # Skip ripping — files already exist. Proceed to matching/organization.
+                if job.content_type == ContentType.TV:
+                    # Start subtitle download
+                    if job.detected_title and job.detected_season:
+                        self._start_subtitle_download(
+                            job_id, job.detected_title, job.detected_season
+                        )
+
+                    # Transition to MATCHING and kick off per-title matching
+                    succeeded = await self._state_machine.transition(
+                        job, JobState.MATCHING, session, broadcast=False
+                    )
+                    if succeeded:
+                        await ws_manager.broadcast_job_update(job_id, JobState.MATCHING.value)
+
+                    # Queue matching for each title
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHING
+                        session.add(dt)
+                    await session.commit()
+
+                    for dt in db_titles:
+                        if dt.output_filename:
+                            file_path = Path(dt.output_filename)
+                            discdb_applied = await self._try_discdb_assignment(job_id, dt, session)
+                            if not discdb_applied:
+                                task = asyncio.create_task(
+                                    self._match_single_file(job_id, dt.id, file_path)
+                                )
+                                task.add_done_callback(
+                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                        t, jid, tid
+                                    )
+                                )
+                else:
+                    # Movie: skip matching, go straight to organization
+                    job.state = JobState.ORGANIZING
+                    await session.commit()
+                    await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
+
+                    # Mark titles as MATCHED
+                    db_titles = (
+                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                        .scalars()
+                        .all()
+                    )
+
+                    for dt in db_titles:
+                        dt.state = TitleState.MATCHED
+                        session.add(dt)
+                    await session.commit()
+
+                    # Run organization
+                    await self._finalize_disc_job(job_id)
+
+            except Exception as e:
+                logger.exception(f"Error processing staging import for job {job_id}")
+                async with async_session() as err_session:
+                    err_job = await err_session.get(DiscJob, job_id)
+                    if err_job:
+                        await self._state_machine.transition_to_failed(err_job, err_session, str(e))
+
+    async def _probe_duration(self, mkv_file: Path) -> float:
+        """Get duration of an MKV file using ffprobe."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(mkv_file),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+            return float(stdout.decode().strip()) if stdout.decode().strip() else 1800
+        except (TimeoutError, OSError, ValueError) as e:
+            logger.debug(f"Could not determine MKV duration via ffprobe: {e}")
+            return 1800  # Default 30 minutes
+
+    async def set_name_and_resume(
+        self,
+        job_id: int,
+        name: str,
+        content_type_str: str,
+        season: int | None = None,
+    ) -> None:
+        """Set a user-provided name for an unlabeled disc and resume ripping."""
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                raise ValueError(f"Job {job_id} not found")
+
+            if job.state != JobState.REVIEW_NEEDED:
+                raise ValueError(f"Cannot set name on job in state: {job.state}")
+
+            job.detected_title = name
+            job.content_type = ContentType(content_type_str)
+            if season is not None:
+                job.detected_season = season
+            job.state = JobState.RIPPING
+            job.updated_at = datetime.now(UTC)
+            await session.commit()
+
+            await ws_manager.broadcast_job_update(
+                job_id,
+                JobState.RIPPING.value,
+                content_type=job.content_type.value,
+                detected_title=job.detected_title,
+                detected_season=job.detected_season,
+            )
+
+            logger.info(
+                f"Job {job_id}: user set name to '{name}' ({content_type_str}), resuming rip"
+            )
+
+        return job_id  # Signal to JobManager to create the ripping task
+
+    async def _run_classification(self, job, job_id, titles, session, is_staging=False):
+        """Run the full classification pipeline (DiscDB, TMDB, AI, Analyst)."""
+        from app.services.config_service import get_config_sync
+
+        config = get_config_sync()
+
+        # Attempt TheDiscDB lookup
+        discdb_signal = None
+        if config.discdb_enabled:
+            try:
+                from app.core.discdb_classifier import classify_from_discdb
+
+                if is_staging:
+                    content_hash = None
+                else:
+                    from app.core.extractor import compute_content_hash
+
+                    content_hash = await asyncio.to_thread(compute_content_hash, job.drive_id)
+                    if content_hash:
+                        job.content_hash = content_hash
+
+                discdb_signal = classify_from_discdb(
+                    job.volume_label, titles, content_hash=content_hash
+                )
+                if discdb_signal:
+                    logger.info(
+                        f"Job {job_id}: TheDiscDB signal: "
+                        f"{discdb_signal.content_type.value} "
+                        f"({discdb_signal.confidence:.0%}) - "
+                        f"{discdb_signal.matched_title}"
+                        + (f" [{discdb_signal.source}]" if not is_staging else "")
+                    )
+                    if not is_staging:
+                        job.discdb_slug = discdb_signal.matched_title.lower().replace(" ", "-")
+                        job.discdb_disc_slug = discdb_signal.disc_slug
+            except Exception as e:
+                logger.warning(f"Job {job_id}: TheDiscDB lookup failed: {e}", exc_info=True)
+
+        # Attempt TMDB lookup
+        tmdb_signal = None
+        detected_name, _, _ = DiscAnalyst._parse_volume_label(job.volume_label)
+        if detected_name:
+            try:
+                from app.core.tmdb_classifier import classify_from_tmdb
+
+                if config.tmdb_api_key:
+                    tmdb_signal = classify_from_tmdb(detected_name, config.tmdb_api_key)
+                    if tmdb_signal:
+                        logger.info(
+                            f"Job {job_id}: TMDB signal: "
+                            f"{tmdb_signal.content_type.value} "
+                            f"({tmdb_signal.confidence:.0%}) - "
+                            f"{tmdb_signal.tmdb_name}"
+                        )
+            except Exception as e:
+                logger.warning(
+                    f"Job {job_id}: TMDB lookup failed: {e}"
+                    if is_staging
+                    else f"Job {job_id}: TMDB lookup failed, using heuristics only: {e}"
+                )
+
+        # AI-powered identification fallback (not for staging)
+        ai_identified_name = None
+        if (
+            not is_staging
+            and not tmdb_signal
+            and not (discdb_signal and discdb_signal.confidence >= 0.90)
+            and config.ai_identification_enabled
+            and config.ai_api_key
+        ):
+            try:
+                from app.core.ai_identifier import identify_from_label
+
+                logger.info(
+                    f"Job {job_id}: TMDB lookup failed, trying AI identification "
+                    f"for '{job.volume_label}'"
+                )
+                ai_result = await identify_from_label(
+                    job.volume_label,
+                    config.ai_provider,
+                    config.ai_api_key,
+                )
+                if ai_result and ai_result.get("title"):
+                    ai_identified_name = ai_result["title"]
+                    logger.info(f"Job {job_id}: AI identified as '{ai_identified_name}'")
+                    # Re-query TMDB with the AI-corrected name
+                    if config.tmdb_api_key:
+                        try:
+                            from app.core.tmdb_classifier import classify_from_tmdb
+
+                            tmdb_signal = classify_from_tmdb(
+                                ai_identified_name, config.tmdb_api_key
+                            )
+                            if tmdb_signal:
+                                logger.info(
+                                    f"Job {job_id}: TMDB re-query with AI name: "
+                                    f"{tmdb_signal.content_type.value} "
+                                    f"({tmdb_signal.confidence:.0%}) - "
+                                    f"{tmdb_signal.tmdb_name}"
+                                )
+                        except Exception as e:
+                            logger.warning(f"Job {job_id}: TMDB re-query after AI failed: {e}")
+            except Exception as e:
+                logger.warning(f"Job {job_id}: AI identification failed: {e}", exc_info=True)
+
+        # Analyze disc content
+        analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
+
+        # If AI identified a name but TMDB re-query also failed
+        if ai_identified_name and not analysis.detected_name:
+            analysis.detected_name = ai_identified_name
+            analysis.classification_source = "ai"
+
+        # If TheDiscDB returned a high-confidence match, override the analysis
+        if discdb_signal and discdb_signal.confidence >= 0.90:
+            if not is_staging:
+                logger.info(
+                    f"Job {job_id}: TheDiscDB override — "
+                    f"{discdb_signal.content_type.value} "
+                    f"({discdb_signal.confidence:.0%})"
+                )
+            analysis.content_type = discdb_signal.content_type
+            analysis.confidence = discdb_signal.confidence
+            analysis.classification_source = f"discdb_{discdb_signal.source}"
+            analysis.detected_name = discdb_signal.matched_title
+            analysis.needs_review = False
+            if discdb_signal.tmdb_id:
+                analysis.tmdb_id = discdb_signal.tmdb_id
+            # Store title mappings for use during matching phase
+            if discdb_signal.title_mappings:
+                self._set_discdb_mappings(job_id, discdb_signal.title_mappings)
+                # Persist to DB so mappings survive server restarts
+                job.discdb_mappings_json = json.dumps(
+                    [asdict(m) for m in discdb_signal.title_mappings]
+                )
+        elif discdb_signal:
+            if not is_staging:
+                logger.info(
+                    f"Job {job_id}: TheDiscDB low-confidence signal "
+                    f"({discdb_signal.confidence:.0%}), using as supplementary"
+                )
+            if not analysis.detected_name:
+                analysis.detected_name = discdb_signal.matched_title
+
+        # Stash signals on the analysis object for the caller to check
+        # (used by identify_disc for catalog number detection)
+        analysis._discdb_signal = discdb_signal
+        analysis._tmdb_signal = tmdb_signal
+
+        return analysis

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -471,15 +471,14 @@ class JobManager:
                 )
                 disc_titles = titles_result.scalars().all()
 
+                has_selection = any(dt.is_selected for dt in disc_titles)
                 for t in disc_titles:
-                    has_selection = any(dt.is_selected for dt in disc_titles if dt.is_selected)
                     if has_selection and not t.is_selected:
                         continue
 
                     total_job_bytes += t.file_size_bytes
                     title_sizes[t.title_index] = t.file_size_bytes
 
-                has_selection = any(dt.is_selected for dt in disc_titles)
                 if not has_selection and job.content_type == ContentType.MOVIE and disc_titles:
                     longest = max(disc_titles, key=lambda t: t.duration_seconds or 0)
                     longest.is_selected = True

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1,37 +1,42 @@
-"""Job Manager - Orchestrates the disc processing workflow.
+"""Job Manager - Thin orchestrator for the disc processing workflow.
 
-Coordinates between the Sentinel, Analyst, Extractor, and Curator modules.
+Coordinates between the Sentinel, and the extracted coordinators:
+- IdentificationCoordinator: disc scanning, classification, DiscDB/TMDB lookup
+- MatchingCoordinator: episode matching, subtitle download, DiscDB assignment
+- FinalizationCoordinator: conflict resolution, organization, job completion
+- CleanupService: staging cleanup, DiscDB export
+- SimulationService: test/debug simulation endpoints
 """
 
 import asyncio
 import json
 import logging
 import time
-from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
-from app.core.curator import curator as episode_curator
-from app.core.errors import MatchingError
-from app.core.extractor import MakeMKVExtractor, RipProgress, ScanTimeoutError
+from app.core.extractor import MakeMKVExtractor, RipProgress
 from app.core.organizer import movie_organizer
 from app.core.sentinel import DriveMonitor
 from app.core.staging_watcher import StagingWatcher
 from app.database import async_session
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.cleanup_service import CleanupService
 from app.services.event_broadcaster import EventBroadcaster
+from app.services.finalization_coordinator import FinalizationCoordinator
+from app.services.identification_coordinator import IdentificationCoordinator
 from app.services.job_state_machine import JobStateMachine
+from app.services.matching_coordinator import MatchingCoordinator
 from app.services.ripping_helpers import (
     SpeedCalculator,
-    build_title_list,
     resolve_title_from_filename,
 )
+from app.services.simulation_service import SimulationService
 
 logger = logging.getLogger(__name__)
 
@@ -43,68 +48,96 @@ state_machine = JobStateMachine(event_broadcaster)
 
 
 class JobManager:
-    """Manages the lifecycle of disc processing jobs."""
+    """Manages the lifecycle of disc processing jobs.
+
+    Thin orchestrator that delegates to focused coordinators.
+    """
 
     def __init__(self) -> None:
         self._drive_monitor = DriveMonitor()
         self._extractor = MakeMKVExtractor()
         self._analyst = DiscAnalyst()
         self._active_jobs: dict[int, asyncio.Task] = {}
-        self._subtitle_tasks: dict[int, asyncio.Task] = {}
-        self._subtitle_ready: dict[int, asyncio.Event] = {}
-        self._drive_locks: dict[str, asyncio.Lock] = {}  # Per-drive lock to prevent duplicate jobs
-        self._last_job_created_at: dict[str, float] = {}  # drive → monotonic timestamp
-        self._episode_runtimes: dict[int, list[int]] = {}  # job_id → episode runtimes in minutes
-        self._discdb_mappings: dict[int, list] = {}  # job_id → DiscDbTitleMapping list
+        self._drive_locks: dict[str, asyncio.Lock] = {}
+        self._last_job_created_at: dict[str, float] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._match_semaphore: asyncio.Semaphore | None = None
         self._timed_cleanup_task: asyncio.Task | None = None
         self._staging_watcher: StagingWatcher | None = None
 
+        # Create coordinators
+        self._cleanup = CleanupService()
+        self._matching = MatchingCoordinator(event_broadcaster, state_machine)
+        self._finalization = FinalizationCoordinator(event_broadcaster, state_machine)
+        self._identification = IdentificationCoordinator(
+            self._analyst, self._extractor, event_broadcaster, state_machine
+        )
+        self._simulation = SimulationService(event_broadcaster, state_machine)
+
+        # Wire cross-coordinator callbacks
+        self._matching.set_callbacks(
+            check_job_completion=self._finalization.check_job_completion,
+        )
+        self._identification.set_callbacks(
+            get_discdb_mappings=self._matching.get_discdb_mappings,
+            set_discdb_mappings=self._matching.set_discdb_mappings,
+            start_subtitle_download=self._matching.start_subtitle_download,
+            try_discdb_assignment=self._matching.try_discdb_assignment,
+            match_single_file=self._matching.match_single_file,
+            on_match_task_done=self._matching.on_match_task_done,
+            check_job_completion=self._finalization.check_job_completion,
+            run_ripping=self._run_ripping,
+            finalize_disc_job=self._finalization.finalize_disc_job,
+        )
+        self._finalization.set_callbacks(
+            run_ripping=self._run_ripping,
+            on_task_done=self._on_task_done,
+            active_jobs=self._active_jobs,
+            match_single_file=self._matching.match_single_file,
+        )
+        self._simulation.set_callbacks(
+            subtitle_ready=self._matching._subtitle_ready,
+            subtitle_tasks=self._matching._subtitle_tasks,
+            active_jobs=self._active_jobs,
+            on_task_done=self._on_task_done,
+        )
+
         # Register staging cleanup on terminal job states
-        state_machine.on_terminal_state(self._on_job_terminal)
+        state_machine.on_terminal_state(self._cleanup.on_job_terminal)
 
     async def start(self) -> None:
         """Start the job manager and begin monitoring drives."""
         self._loop = asyncio.get_event_loop()
 
-        # Clean up stale jobs from previous crashes/restarts.
-        # Jobs stuck in IDENTIFYING or RIPPING can't be resumed because the
-        # MakeMKV subprocess is gone. Mark them FAILED so a fresh job can start.
         await self._cleanup_stale_jobs()
-
-        # Restore persisted DiscDB mappings for any active (non-terminal) jobs
         await self._restore_discdb_mappings()
 
-        # Set up drive monitor callback
         self._drive_monitor.set_async_callback(
             self._on_drive_event,
             self._loop,
         )
         self._drive_monitor.start()
 
-        # Ensure required directories exist
         from app.services.config_service import ensure_paths_exist, get_config
 
         config = await get_config()
         await ensure_paths_exist(config)
 
-        # Initialize matching concurrency limiter (guard against invalid DB values)
+        # Initialize matching concurrency limiter
         concurrency = max(1, config.max_concurrent_matches)
         if concurrency != config.max_concurrent_matches:
             logger.warning(
                 f"Invalid max_concurrent_matches={config.max_concurrent_matches} "
                 f"in config, using {concurrency}"
             )
-        self._match_semaphore = asyncio.Semaphore(concurrency)
+        self._matching.init_semaphore(concurrency)
 
         # Start timed staging cleanup if policy is "after_days"
         if config.staging_cleanup_policy == "after_days":
             self._timed_cleanup_task = asyncio.create_task(
-                self._run_timed_cleanup(config.staging_path, config.staging_cleanup_days)
+                self._cleanup.run_timed_cleanup(config.staging_path, config.staging_cleanup_days)
             )
 
-        # Start staging watcher if enabled (default on Linux/macOS)
+        # Start staging watcher if enabled
         if config.staging_watch_enabled and config.staging_path:
             self._staging_watcher = StagingWatcher(config.staging_path, config=config)
             self._staging_watcher.set_async_callback(self._on_staging_event, self._loop)
@@ -113,13 +146,7 @@ class JobManager:
         logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
 
     async def _cleanup_stale_jobs(self) -> None:
-        """Mark stale jobs as FAILED on startup.
-
-        Jobs left in IDENTIFYING, RIPPING, or MATCHING states from a previous
-        process cannot be resumed (their subprocesses/tasks are gone). Marking
-        them FAILED allows the sentinel to create fresh jobs when it detects
-        discs still in the drive.
-        """
+        """Mark stale jobs as FAILED on startup."""
         stale_states = [
             JobState.IDENTIFYING,
             JobState.RIPPING,
@@ -157,7 +184,9 @@ class JobManager:
             )
             for job in result.scalars():
                 mappings_data = json.loads(job.discdb_mappings_json)
-                self._discdb_mappings[job.id] = [DiscDbTitleMapping(**m) for m in mappings_data]
+                self._matching.set_discdb_mappings(
+                    job.id, [DiscDbTitleMapping(**m) for m in mappings_data]
+                )
                 logger.info(f"Restored {len(mappings_data)} DiscDB mappings for job {job.id}")
 
     async def stop(self) -> None:
@@ -166,13 +195,14 @@ class JobManager:
         if self._staging_watcher:
             self._staging_watcher.stop()
 
-        # Cancel all active jobs
         for job_id, task in self._active_jobs.items():
             task.cancel()
             logger.info(f"Cancelled job {job_id}")
 
         self._active_jobs.clear()
         logger.info("Job manager stopped")
+
+    # --- Drive/Staging Event Handlers ---
 
     async def _on_drive_event(
         self,
@@ -186,11 +216,8 @@ class JobManager:
         if event == "inserted":
             await self._create_job_for_disc(drive_letter, volume_label)
         elif event == "removed":
-            # Cancel any active job for this drive
             await self._cancel_jobs_for_drive(drive_letter)
 
-        # Broadcast to WebSocket clients AFTER processing
-        # This ensures that if a job was created, the client can fetch it immediately
         if event == "inserted":
             await event_broadcaster.broadcast_drive_inserted(drive_letter, volume_label)
         else:
@@ -214,16 +241,15 @@ class JobManager:
                     exc_info=True,
                 )
 
+    # --- Job Creation ---
+
     async def _create_job_for_disc(self, drive_letter: str, volume_label: str) -> None:
         """Create a new job when a disc is inserted."""
-        # Per-drive lock prevents race condition when multiple insert events
-        # fire concurrently (e.g., startup + first poll cycle overlap)
         if drive_letter not in self._drive_locks:
             self._drive_locks[drive_letter] = asyncio.Lock()
 
         async with self._drive_locks[drive_letter]:
             async with async_session() as session:
-                # Check if there's already an active job for this drive
                 result = await session.execute(
                     select(DiscJob).where(
                         DiscJob.drive_id == drive_letter,
@@ -238,9 +264,6 @@ class JobManager:
                     logger.info(f"Job already exists for drive {drive_letter}")
                     return
 
-                # In-memory cooldown: prevent creating multiple jobs for the
-                # same drive within a short window (sentinel flicker during
-                # disc spinup can fire multiple "inserted" events).
                 last_created = self._last_job_created_at.get(drive_letter, 0)
                 if time.monotonic() - last_created < 15:
                     logger.info(
@@ -249,7 +272,6 @@ class JobManager:
                     )
                     return
 
-                # Create staging directory for this job
                 from app.services.config_service import get_config as get_db_config
 
                 db_config = await get_db_config()
@@ -258,7 +280,6 @@ class JobManager:
                     / f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
                 )
 
-                # Create new job
                 job = DiscJob(
                     drive_id=drive_letter,
                     volume_label=volume_label,
@@ -273,8 +294,7 @@ class JobManager:
                 logger.info(f"Created job {job.id} for disc in {drive_letter}")
                 self._last_job_created_at[drive_letter] = time.monotonic()
 
-                # Start identification in background
-                task = asyncio.create_task(self._identify_disc(job.id))
+                task = asyncio.create_task(self._identification.identify_disc(job.id))
                 self._active_jobs[job.id] = task
 
     async def create_job_from_staging(
@@ -285,18 +305,12 @@ class JobManager:
         detected_title: str | None = None,
         detected_season: int | None = None,
     ) -> int:
-        """Create a job from pre-ripped MKV files in a staging directory.
-
-        Skips the ripping phase entirely — files are already on disk.
-        Runs identification (classification), then matching/organization.
-        """
+        """Create a job from pre-ripped MKV files in a staging directory."""
         staging_dir = Path(staging_path)
 
-        # Use directory name as volume label if none provided
         if not volume_label:
             volume_label = staging_dir.name.upper().replace(" ", "_")
 
-        # Create job record
         async with async_session() as session:
             job = DiscJob(
                 drive_id="staging",
@@ -305,7 +319,6 @@ class JobManager:
                 state=JobState.IDENTIFYING,
             )
 
-            # Apply user-provided hints
             if content_type in ("tv", "movie"):
                 job.content_type = ContentType(content_type)
             if detected_title:
@@ -322,728 +335,14 @@ class JobManager:
                 f"Created staging import job {job_id} from {staging_path} (label: {volume_label})"
             )
 
-        # Broadcast job creation
         await event_broadcaster.broadcast_drive_inserted("staging", volume_label)
 
-        # Run identification pipeline in background
-        task = asyncio.create_task(self._identify_from_staging(job_id))
+        task = asyncio.create_task(self._identification.identify_from_staging(job_id))
         self._active_jobs[job_id] = task
 
         return job_id
 
-    async def _identify_from_staging(self, job_id: int) -> None:
-        """Identify and process pre-ripped MKV files from staging.
-
-        Similar to _identify_disc() but skips the MakeMKV scan — constructs
-        TitleInfo objects from the existing MKV files via ffprobe instead.
-        """
-        from app.core.analyst import TitleInfo
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                return
-
-            try:
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
-
-                staging_dir = Path(job.staging_path)
-                mkv_files = sorted(staging_dir.glob("*.mkv"))
-
-                if not mkv_files:
-                    await state_machine.transition_to_failed(
-                        job, session, "No MKV files found in staging directory"
-                    )
-                    return
-
-                # Build TitleInfo objects from MKV files using ffprobe
-                titles: list[TitleInfo] = []
-                for idx, mkv_file in enumerate(mkv_files):
-                    duration = await self._probe_duration(mkv_file)
-                    file_size = mkv_file.stat().st_size
-
-                    titles.append(
-                        TitleInfo(
-                            index=idx,
-                            duration_seconds=int(duration),
-                            size_bytes=file_size,
-                            chapter_count=0,
-                            name=mkv_file.stem,
-                        )
-                    )
-
-                # Run classification pipeline (same as _identify_disc)
-                from app.services.config_service import get_config_sync
-
-                config = get_config_sync()
-
-                # Attempt TheDiscDB lookup
-                discdb_signal = None
-                if config.discdb_enabled:
-                    try:
-                        from app.core.discdb_classifier import classify_from_discdb
-
-                        discdb_signal = classify_from_discdb(
-                            job.volume_label, titles, content_hash=None
-                        )
-                        if discdb_signal:
-                            logger.info(
-                                f"Job {job_id}: TheDiscDB signal: "
-                                f"{discdb_signal.content_type.value} "
-                                f"({discdb_signal.confidence:.0%}) - "
-                                f"{discdb_signal.matched_title}"
-                            )
-                    except Exception as e:
-                        logger.warning(
-                            f"Job {job_id}: TheDiscDB lookup failed: {e}",
-                            exc_info=True,
-                        )
-
-                # Attempt TMDB lookup
-                tmdb_signal = None
-                detected_name, _, _ = DiscAnalyst._parse_volume_label(job.volume_label)
-                if detected_name:
-                    try:
-                        from app.core.tmdb_classifier import classify_from_tmdb
-
-                        if config.tmdb_api_key:
-                            tmdb_signal = classify_from_tmdb(detected_name, config.tmdb_api_key)
-                            if tmdb_signal:
-                                logger.info(
-                                    f"Job {job_id}: TMDB signal: "
-                                    f"{tmdb_signal.content_type.value} "
-                                    f"({tmdb_signal.confidence:.0%}) - "
-                                    f"{tmdb_signal.tmdb_name}"
-                                )
-                    except Exception as e:
-                        logger.warning(f"Job {job_id}: TMDB lookup failed: {e}")
-
-                # Analyze disc content
-                analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
-
-                # Apply DiscDB override if high-confidence
-                if discdb_signal and discdb_signal.confidence >= 0.90:
-                    analysis.content_type = discdb_signal.content_type
-                    analysis.confidence = discdb_signal.confidence
-                    analysis.classification_source = f"discdb_{discdb_signal.source}"
-                    analysis.detected_name = discdb_signal.matched_title
-                    analysis.needs_review = False
-                    if discdb_signal.tmdb_id:
-                        analysis.tmdb_id = discdb_signal.tmdb_id
-                    if discdb_signal.title_mappings:
-                        self._discdb_mappings[job_id] = discdb_signal.title_mappings
-                        job.discdb_mappings_json = json.dumps(
-                            [asdict(m) for m in discdb_signal.title_mappings]
-                        )
-                elif discdb_signal and not analysis.detected_name:
-                    analysis.detected_name = discdb_signal.matched_title
-
-                # Apply user-provided hints (override classification if given)
-                if job.content_type and job.content_type != ContentType.UNKNOWN:
-                    analysis.content_type = job.content_type
-                if job.detected_title:
-                    analysis.detected_name = job.detected_title
-
-                # Update job with analysis results
-                job.content_type = analysis.content_type
-                job.detected_title = analysis.detected_name or job.detected_title
-                job.detected_season = analysis.detected_season or job.detected_season
-                job.total_titles = len(titles)
-                job.updated_at = datetime.utcnow()
-                job.classification_confidence = analysis.confidence
-                job.classification_source = analysis.classification_source or "staging_import"
-                job.tmdb_id = analysis.tmdb_id
-                job.tmdb_name = analysis.tmdb_name
-                job.is_ambiguous_movie = analysis.is_ambiguous_movie
-                if analysis.play_all_title_indices:
-                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
-
-                # Extract disc number from volume label
-                import re
-
-                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
-                job.disc_number = int(disc_match.group(1)) if disc_match else 1
-
-                # Create DiscTitle records with output_filename already set
-                from sqlalchemy import delete
-
-                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
-
-                for title, mkv_file in zip(titles, mkv_files, strict=True):
-                    disc_title = DiscTitle(
-                        job_id=job_id,
-                        title_index=title.index,
-                        duration_seconds=title.duration_seconds,
-                        file_size_bytes=title.size_bytes,
-                        chapter_count=title.chapter_count,
-                        output_filename=str(mkv_file),
-                    )
-                    session.add(disc_title)
-
-                await session.commit()
-
-                # Broadcast titles discovered
-                titles_result = await session.execute(
-                    select(DiscTitle).where(DiscTitle.job_id == job_id)
-                )
-                title_list = build_title_list(titles_result.scalars().all())
-                await ws_manager.broadcast_titles_discovered(
-                    job_id,
-                    title_list,
-                    content_type=job.content_type.value,
-                    detected_title=job.detected_title,
-                    detected_season=job.detected_season,
-                )
-
-                # If no title detected, ask user
-                if not job.detected_title:
-                    await state_machine.transition_to_review(
-                        job,
-                        session,
-                        reason="Could not determine title. Please enter the title to continue.",
-                        broadcast=False,
-                    )
-                    await ws_manager.broadcast_job_update(
-                        job_id,
-                        JobState.REVIEW_NEEDED.value,
-                        content_type=(job.content_type.value if job.content_type else None),
-                        total_titles=job.total_titles,
-                        review_reason="Could not determine title. Please enter the title to continue.",
-                    )
-                    return
-
-                # Skip ripping — files already exist. Proceed to matching/organization.
-                if job.content_type == ContentType.TV:
-                    # Start subtitle download
-                    if job.detected_title and job.detected_season:
-                        self._subtitle_ready[job_id] = asyncio.Event()
-                        self._subtitle_tasks[job_id] = asyncio.create_task(
-                            self._download_subtitles(
-                                job_id, job.detected_title, job.detected_season
-                            )
-                        )
-
-                    # Transition to MATCHING and kick off per-title matching
-                    succeeded = await state_machine.transition(
-                        job, JobState.MATCHING, session, broadcast=False
-                    )
-                    if succeeded:
-                        await ws_manager.broadcast_job_update(job_id, JobState.MATCHING.value)
-
-                    # Queue matching for each title
-                    db_titles = (
-                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
-                        .scalars()
-                        .all()
-                    )
-
-                    for dt in db_titles:
-                        dt.state = TitleState.MATCHING
-                        session.add(dt)
-                    await session.commit()
-
-                    for dt in db_titles:
-                        if dt.output_filename:
-                            file_path = Path(dt.output_filename)
-                            discdb_applied = await self._try_discdb_assignment(job_id, dt, session)
-                            if not discdb_applied:
-                                task = asyncio.create_task(
-                                    self._match_single_file(job_id, dt.id, file_path)
-                                )
-                                task.add_done_callback(
-                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
-                                        t, jid, tid
-                                    )
-                                )
-                else:
-                    # Movie: skip matching, go straight to organization
-                    job.state = JobState.ORGANIZING
-                    await session.commit()
-                    await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
-
-                    # Mark titles as MATCHED
-                    db_titles = (
-                        (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
-                        .scalars()
-                        .all()
-                    )
-
-                    for dt in db_titles:
-                        dt.state = TitleState.MATCHED
-                        session.add(dt)
-                    await session.commit()
-
-                    # Run organization
-                    await self._finalize_disc_job(job_id)
-
-            except Exception as e:
-                logger.exception(f"Error processing staging import for job {job_id}")
-                async with async_session() as err_session:
-                    err_job = await err_session.get(DiscJob, job_id)
-                    if err_job:
-                        await state_machine.transition_to_failed(err_job, err_session, str(e))
-
-    async def _probe_duration(self, mkv_file: Path) -> float:
-        """Get duration of an MKV file using ffprobe."""
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "ffprobe",
-                "-v",
-                "error",
-                "-show_entries",
-                "format=duration",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                str(mkv_file),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-            return float(stdout.decode().strip()) if stdout.decode().strip() else 1800
-        except (TimeoutError, OSError, ValueError) as e:
-            logger.debug(f"Could not determine MKV duration via ffprobe: {e}")
-            return 1800  # Default 30 minutes
-
-    async def _identify_disc(self, job_id: int) -> None:
-        """Identify the disc contents using MakeMKV and the Analyst."""
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                return
-
-            try:
-                # Scan disc with MakeMKV
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.IDENTIFYING)
-
-                try:
-                    from app.core.discdb_exporter import get_makemkv_log_dir
-
-                    titles = await self._extractor.scan_disc(
-                        job.drive_id, log_dir=get_makemkv_log_dir(job_id), job_id=job_id
-                    )
-                except ScanTimeoutError:
-                    await state_machine.transition_to_failed(
-                        job,
-                        session,
-                        "Disc scan timed out after 10 minutes — disc may be encrypted or damaged",
-                    )
-                    return
-
-                if not titles:
-                    await state_machine.transition_to_failed(
-                        job, session, "No titles found on disc"
-                    )
-                    return
-
-                # Attempt TheDiscDB lookup (highest priority signal)
-                discdb_signal = None
-                from app.services.config_service import get_config_sync
-
-                config = get_config_sync()
-                if config.discdb_enabled:
-                    try:
-                        from app.core.discdb_classifier import classify_from_discdb
-                        from app.core.extractor import compute_content_hash
-
-                        content_hash = await asyncio.to_thread(compute_content_hash, job.drive_id)
-                        if content_hash:
-                            job.content_hash = content_hash
-
-                        discdb_signal = classify_from_discdb(
-                            job.volume_label, titles, content_hash=content_hash
-                        )
-                        if discdb_signal:
-                            logger.info(
-                                f"Job {job_id}: TheDiscDB signal: "
-                                f"{discdb_signal.content_type.value} "
-                                f"({discdb_signal.confidence:.0%}) - "
-                                f"{discdb_signal.matched_title} "
-                                f"[{discdb_signal.source}]"
-                            )
-                            job.discdb_slug = discdb_signal.matched_title.lower().replace(" ", "-")
-                            job.discdb_disc_slug = discdb_signal.disc_slug
-                    except Exception as e:
-                        logger.warning(f"Job {job_id}: TheDiscDB lookup failed: {e}", exc_info=True)
-
-                # Attempt TMDB lookup for classification signal
-                tmdb_signal = None
-                detected_name, _, _ = DiscAnalyst._parse_volume_label(job.volume_label)
-                if detected_name:
-                    try:
-                        from app.core.tmdb_classifier import classify_from_tmdb
-
-                        if config.tmdb_api_key:
-                            tmdb_signal = classify_from_tmdb(detected_name, config.tmdb_api_key)
-                            if tmdb_signal:
-                                logger.info(
-                                    f"Job {job_id}: TMDB signal: "
-                                    f"{tmdb_signal.content_type.value} "
-                                    f"({tmdb_signal.confidence:.0%}) - "
-                                    f"{tmdb_signal.tmdb_name}"
-                                )
-                    except Exception as e:
-                        logger.warning(
-                            f"Job {job_id}: TMDB lookup failed, using heuristics only: {e}"
-                        )
-
-                # AI-powered identification fallback
-                # Triggers when: TMDB failed AND DiscDB didn't produce a high-confidence match
-                ai_identified_name = None
-                if (
-                    not tmdb_signal
-                    and not (discdb_signal and discdb_signal.confidence >= 0.90)
-                    and config.ai_identification_enabled
-                    and config.ai_api_key
-                ):
-                    try:
-                        from app.core.ai_identifier import identify_from_label
-
-                        logger.info(
-                            f"Job {job_id}: TMDB lookup failed, trying AI identification "
-                            f"for '{job.volume_label}'"
-                        )
-                        ai_result = await identify_from_label(
-                            job.volume_label,
-                            config.ai_provider,
-                            config.ai_api_key,
-                        )
-                        if ai_result and ai_result.get("title"):
-                            ai_identified_name = ai_result["title"]
-                            logger.info(f"Job {job_id}: AI identified as '{ai_identified_name}'")
-                            # Re-query TMDB with the AI-corrected name
-                            if config.tmdb_api_key:
-                                try:
-                                    from app.core.tmdb_classifier import classify_from_tmdb
-
-                                    tmdb_signal = classify_from_tmdb(
-                                        ai_identified_name, config.tmdb_api_key
-                                    )
-                                    if tmdb_signal:
-                                        logger.info(
-                                            f"Job {job_id}: TMDB re-query with AI name: "
-                                            f"{tmdb_signal.content_type.value} "
-                                            f"({tmdb_signal.confidence:.0%}) - "
-                                            f"{tmdb_signal.tmdb_name}"
-                                        )
-                                except Exception as e:
-                                    logger.warning(
-                                        f"Job {job_id}: TMDB re-query after AI failed: {e}"
-                                    )
-                    except Exception as e:
-                        logger.warning(
-                            f"Job {job_id}: AI identification failed: {e}", exc_info=True
-                        )
-
-                # Analyze disc content (DiscDB signal overrides when high-confidence)
-                analysis = self._analyst.analyze(titles, job.volume_label, tmdb_signal=tmdb_signal)
-
-                # If AI identified a name but TMDB re-query also failed,
-                # use the AI name as the detected title
-                if ai_identified_name and not analysis.detected_name:
-                    analysis.detected_name = ai_identified_name
-                    analysis.classification_source = "ai"
-
-                # If TheDiscDB returned a high-confidence match, override the analysis
-                if discdb_signal and discdb_signal.confidence >= 0.90:
-                    logger.info(
-                        f"Job {job_id}: TheDiscDB override — "
-                        f"{discdb_signal.content_type.value} "
-                        f"({discdb_signal.confidence:.0%})"
-                    )
-                    analysis.content_type = discdb_signal.content_type
-                    analysis.confidence = discdb_signal.confidence
-                    analysis.classification_source = f"discdb_{discdb_signal.source}"
-                    analysis.detected_name = discdb_signal.matched_title
-                    analysis.needs_review = False
-                    if discdb_signal.tmdb_id:
-                        analysis.tmdb_id = discdb_signal.tmdb_id
-                    # Store title mappings for use during matching phase
-                    if discdb_signal.title_mappings:
-                        self._discdb_mappings[job_id] = discdb_signal.title_mappings
-                        # Persist to DB so mappings survive server restarts
-                        job.discdb_mappings_json = json.dumps(
-                            [asdict(m) for m in discdb_signal.title_mappings]
-                        )
-                elif discdb_signal:
-                    # Lower confidence — use as supporting signal but don't override
-                    logger.info(
-                        f"Job {job_id}: TheDiscDB low-confidence signal "
-                        f"({discdb_signal.confidence:.0%}), using as supplementary"
-                    )
-                    if not analysis.detected_name:
-                        analysis.detected_name = discdb_signal.matched_title
-
-                logger.info(f"Job {job_id} Analysis Result: {analysis}")
-
-                # Save snapshot for debugging and test fixture generation
-                from app.core.snapshot import save_snapshot
-
-                save_snapshot(job.volume_label, analysis)
-
-                # Update job with analysis results
-                job.content_type = analysis.content_type
-                job.detected_title = analysis.detected_name
-                job.detected_season = analysis.detected_season
-                job.total_titles = len(titles)
-                job.updated_at = datetime.now(UTC)
-
-                # If TMDB and DiscDB both failed and label looks like a catalog
-                # number (e.g. BBCDVD1550), the parsed name is garbage —
-                # clear it so the NamePromptModal triggers.
-                if (
-                    not tmdb_signal
-                    and not discdb_signal
-                    and job.detected_title
-                    and DiscAnalyst._looks_like_catalog_number(job.volume_label)
-                ):
-                    logger.info(
-                        f"Job {job_id}: Label '{job.volume_label}' looks like a catalog "
-                        f"number and no external match found — clearing detected_title "
-                        f"to trigger name prompt"
-                    )
-                    job.detected_title = None
-
-                # Persist classification metadata
-                job.classification_confidence = analysis.confidence
-                job.classification_source = analysis.classification_source
-                job.tmdb_id = analysis.tmdb_id
-                job.tmdb_name = analysis.tmdb_name
-                job.is_ambiguous_movie = analysis.is_ambiguous_movie
-                if analysis.play_all_title_indices:
-                    job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
-
-                # Extract disc number from volume label (e.g., "SHOW_S01D2" -> 2)
-                import re
-
-                disc_match = re.search(r"d(?:isc)?[_\s]*(\d+)", job.volume_label, re.IGNORECASE)
-                if disc_match:
-                    job.disc_number = int(disc_match.group(1))
-                    logger.info(
-                        f"Detected disc number: {job.disc_number} from volume label: {job.volume_label}"
-                    )
-                else:
-                    job.disc_number = 1  # Default per user preference
-                    logger.info("No disc number detected in volume label, defaulting to 1")
-
-                # Clear any existing titles for this job (e.g. from a previous scan)
-                from sqlalchemy import delete
-
-                await session.execute(delete(DiscTitle).where(DiscTitle.job_id == job_id))
-
-                # Save title information
-                for title in titles:
-                    disc_title = DiscTitle(
-                        job_id=job_id,
-                        title_index=title.index,
-                        duration_seconds=title.duration_seconds,
-                        file_size_bytes=title.size_bytes,
-                        chapter_count=title.chapter_count,
-                        video_resolution=title.video_resolution,
-                        source_filename=title.source_filename or None,
-                        segment_count=title.segment_count,
-                        segment_map=title.segment_map or None,
-                    )
-                    session.add(disc_title)
-
-                # For TV discs, deselect "Play All" concatenation titles
-                if analysis.content_type == ContentType.TV and analysis.play_all_title_indices:
-                    await session.flush()  # Ensure titles have IDs
-                    play_all_set = set(analysis.play_all_title_indices)
-                    stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
-                    db_titles_for_filter = (await session.execute(stmt)).scalars().all()
-
-                    deselected = 0
-                    for dt in db_titles_for_filter:
-                        if dt.title_index in play_all_set:
-                            dt.is_selected = False
-                            dt.state = TitleState.COMPLETED
-                            dt.is_extra = True
-                            dt.match_details = json.dumps(
-                                {"reason": "Play All concatenation title"}
-                            )
-                            deselected += 1
-                            logger.info(
-                                f"Job {job_id}: Deselected 'Play All' title {dt.title_index} "
-                                f"({dt.duration_seconds // 60}min) → COMPLETED/extra"
-                            )
-
-                    if deselected:
-                        logger.info(f"Job {job_id}: Deselected {deselected} 'Play All' title(s)")
-
-                # For movies with DiscDB mappings, tag extras so post-rip can
-                # handle them according to extras policy (keep/skip/ask)
-                discdb_maps = self._discdb_mappings.get(job_id, [])
-                if analysis.content_type == ContentType.MOVIE and discdb_maps:
-                    main_indices = {m.index for m in discdb_maps if m.title_type == "MainMovie"}
-                    extra_indices = {
-                        m.index
-                        for m in discdb_maps
-                        if m.title_type in ("Extra", "") and m.index not in main_indices
-                    }
-                    if main_indices:
-                        await session.flush()
-                        stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
-                        db_titles_for_select = (await session.execute(stmt)).scalars().all()
-                        for dt in db_titles_for_select:
-                            if dt.title_index in extra_indices:
-                                dt.is_extra = True
-                            elif dt.title_index not in main_indices:
-                                # Unknown title not in DiscDB — treat as extra
-                                dt.is_extra = True
-                            session.add(dt)
-                        logger.info(
-                            f"Job {job_id}: TheDiscDB tagged MainMovie={main_indices}, "
-                            f"extras={extra_indices}"
-                        )
-
-                # Broadcast titles discovered with full metadata
-                titles_result = await session.execute(
-                    select(DiscTitle).where(DiscTitle.job_id == job_id)
-                )
-                title_list = build_title_list(
-                    titles_result.scalars().all(), include_video_resolution=True
-                )
-                await ws_manager.broadcast_titles_discovered(
-                    job_id,
-                    title_list,
-                    content_type=job.content_type.value,
-                    detected_title=job.detected_title,
-                    detected_season=job.detected_season,
-                )
-
-                # If no title could be determined (e.g. generic volume label like LOGICAL_VOLUME_ID),
-                # block ripping and ask the user to supply a name.
-                if not job.detected_title:
-                    await state_machine.transition_to_review(
-                        job,
-                        session,
-                        reason="Disc label unreadable. Please enter the title to continue.",
-                        broadcast=False,
-                    )
-                    await ws_manager.broadcast_job_update(
-                        job_id,
-                        JobState.REVIEW_NEEDED.value,
-                        content_type=job.content_type.value if job.content_type else None,
-                        total_titles=job.total_titles,
-                        review_reason="Disc label unreadable. Please enter the title to continue.",
-                    )
-                    logger.info(
-                        f"Job {job_id}: no title detected (volume label: '{job.volume_label}'), "
-                        f"waiting for user to supply name"
-                    )
-                    return
-
-                # Start subtitle download for ALL TV content (regardless of review status)
-                if (
-                    job.content_type == ContentType.TV
-                    and job.detected_title
-                    and job.detected_season
-                ):
-                    # Start background subtitle download with tracking
-                    self._subtitle_ready[job_id] = asyncio.Event()
-                    self._subtitle_tasks[job_id] = asyncio.create_task(
-                        self._download_subtitles(job_id, job.detected_title, job.detected_season)
-                    )
-                    logger.info(
-                        f"Job {job_id}: starting subtitle download for "
-                        f"{job.detected_title} S{job.detected_season}"
-                    )
-
-                if analysis.needs_review:
-                    # Special handling for Ambiguous Movies (Multiple Feature-Length Titles)
-                    # "Rip First, Review Later" workflow
-                    is_ambiguous_movie = (
-                        job.content_type == ContentType.MOVIE and analysis.is_ambiguous_movie
-                    )
-
-                    if is_ambiguous_movie:
-                        logger.info(
-                            f"Job {job_id}: Ambiguous movie detected. Auto-ripping candidates for later review."
-                        )
-
-                        # Select all long titles (candidates) for ripping
-                        # We need to re-fetch the titles we just added to session?
-                        # We just added them to session but didn't commit?
-                        # Wait, the code above adds them to session: `session.add(disc_title)`
-                        # We can iterate over `titles` (the MakeMKV TitleInfo objects) and match by index?
-                        # Or just query them back.
-
-                        # Let's use the `titles` list we have from scan_disc and the session objects
-                        # Actually, we haven't committed `disc_title` inserts yet.
-                        # We can iterate through the session.new objects? or just use a query after flush.
-
-                        # Commit first to save titles
-                        await session.commit()
-
-                        # Fetch back to update is_selected
-                        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
-                        db_titles = (await session.execute(statement)).scalars().all()
-
-                        candidate_count = 0
-                        for dt in db_titles:
-                            # Heuristic: Select titles > 80 mins (same as Analyst)
-                            if dt.duration_seconds and dt.duration_seconds >= 80 * 60:
-                                dt.is_selected = True
-                                candidate_count += 1
-                                session.add(dt)
-
-                        await session.commit()
-
-                        # Broadcast title updates so UI shows them selected?
-                        # Actually broadcast_titles_discovered is called above, but before selection.
-                        # The UI might need an update?
-                        # We can send a job update.
-
-                        job.state = JobState.RIPPING
-                        await session.commit()
-                        await ws_manager.broadcast_job_update(
-                            job_id,
-                            job.state.value,
-                            content_type=job.content_type.value,
-                            detected_title=job.detected_title,
-                        )
-
-                        # Run ripping
-                        await self._run_ripping(job_id)
-                        return
-
-                    await state_machine.transition_to_review(
-                        job, session, reason=analysis.review_reason, broadcast=False
-                    )
-                    await ws_manager.broadcast_job_update(
-                        job_id,
-                        job.state.value,
-                        content_type=job.content_type.value,
-                        detected_title=job.detected_title,
-                        detected_season=job.detected_season,
-                        total_titles=job.total_titles,
-                    )
-                    logger.info(f"Job {job_id} needs review: {analysis.review_reason}")
-                else:
-                    # High-confidence detection - auto-start ripping
-                    job.state = JobState.RIPPING
-                    await session.commit()
-                    await ws_manager.broadcast_job_update(
-                        job_id,
-                        job.state.value,
-                        content_type=job.content_type.value,
-                        detected_title=job.detected_title,
-                        detected_season=job.detected_season,
-                        total_titles=job.total_titles,
-                    )
-
-                    logger.info(
-                        f"Job {job_id} identified as {analysis.content_type.value} "
-                        f"(confidence: {analysis.confidence:.1%}) - auto-starting rip"
-                    )
-
-                    # Run ripping directly (no need to create a new task)
-                    await self._run_ripping(job_id)
-                    return  # Exit early since ripping handles the rest
-
-            except Exception as e:
-                logger.exception(f"Error identifying disc for job {job_id}")
-                await state_machine.transition_to_failed(job, session, str(e))
+    # --- Public API (delegated to coordinators) ---
 
     async def set_name_and_resume(
         self,
@@ -1052,38 +351,8 @@ class JobManager:
         content_type_str: str,
         season: int | None = None,
     ) -> None:
-        """Set a user-provided name for an unlabeled disc and resume ripping.
-
-        Called when a disc had no readable volume label and the user has entered
-        the title manually via the NamePromptModal.
-        """
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                raise ValueError(f"Job {job_id} not found")
-
-            if job.state != JobState.REVIEW_NEEDED:
-                raise ValueError(f"Cannot set name on job in state: {job.state}")
-
-            job.detected_title = name
-            job.content_type = ContentType(content_type_str)
-            if season is not None:
-                job.detected_season = season
-            job.state = JobState.RIPPING
-            job.updated_at = datetime.now(UTC)
-            await session.commit()
-
-            await ws_manager.broadcast_job_update(
-                job_id,
-                JobState.RIPPING.value,
-                content_type=job.content_type.value,
-                detected_title=job.detected_title,
-                detected_season=job.detected_season,
-            )
-
-            logger.info(
-                f"Job {job_id}: user set name to '{name}' ({content_type_str}), resuming rip"
-            )
+        """Set a user-provided name for an unlabeled disc and resume ripping."""
+        await self._identification.set_name_and_resume(job_id, name, content_type_str, season)
 
         task = asyncio.create_task(self._run_ripping(job_id))
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
@@ -1103,418 +372,79 @@ class JobManager:
             job.updated_at = datetime.now(UTC)
             await session.commit()
 
-            # Start ripping in background
             task = asyncio.create_task(self._run_ripping(job_id))
             task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
             self._active_jobs[job_id] = task
 
-    async def _check_job_completion(self, session, job_id: int):
-        """Check if all titles in a job are processed, and if so, finalize."""
-        # Expire cached objects to ensure fresh reads from DB
-        session.expire_all()
+    async def cancel_job(self, job_id: int) -> None:
+        """Cancel a running job."""
+        if job_id in self._active_jobs:
+            self._active_jobs[job_id].cancel()
+            del self._active_jobs[job_id]
 
-        job = await session.get(DiscJob, job_id)
-        if not job:
-            return
-
-        # Check for any active titles
-        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
-        result = await session.execute(statement)
-        titles = result.scalars().all()
-
-        active_states = [TitleState.PENDING, TitleState.RIPPING, TitleState.MATCHING]
-        active_titles = [t for t in titles if t.state in active_states]
-
-        # ── Diagnostic: log ALL title states every time this is called ──
-        state_summary = ", ".join(
-            f"t{t.title_index}={t.state.value}" for t in sorted(titles, key=lambda x: x.title_index)
-        )
-        logger.info(
-            f"[COMPLETION-CHECK] Job {job_id}: {len(active_titles)} active / {len(titles)} total — [{state_summary}]"
-        )
-
-        if active_titles:
-            logger.debug(
-                f"Job {job_id}: {len(active_titles)} still active "
-                f"({', '.join(f'{t.id}:{t.state.value}' for t in active_titles[:5])})"
-            )
-            return
-
-        # All titles are terminal (COMPLETED, FAILED, MATCHED, or REVIEW)
-        logger.info(f"All titles for job {job_id} effectively processed. Finalizing...")
-
-        has_matched = any(t.state == TitleState.MATCHED for t in titles)
-        has_review = any(t.state == TitleState.REVIEW for t in titles)
-        has_completed = any(t.state == TitleState.COMPLETED for t in titles)
-        all_failed = all(t.state == TitleState.FAILED for t in titles)
-
-        if has_matched:
-            # Run conflict resolution and organization
-            try:
-                await self._finalize_disc_job(job_id)
-            except Exception as e:
-                logger.exception(f"Job {job_id}: _finalize_disc_job failed: {e}")
-                await state_machine.transition_to_failed(
-                    job, session, error_message=f"Finalization failed: {e}"
-                )
-        elif has_review:
-            # No matched titles but some need review → send to review
-            await state_machine.transition_to_review(
-                job,
-                session,
-                reason=f"{sum(1 for t in titles if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
-            )
-        elif all_failed and not has_completed:
-            # Only FAILED if ALL titles failed (actual errors)
-            await state_machine.transition_to_failed(
-                job, session, error_message="All titles failed to process"
-            )
-        else:
-            # Some completed, some failed — still mark completed
-            job.progress_percent = 100.0
-            await state_machine.transition_to_completed(job, session)
-
-    async def _finalize_disc_job(self, job_id: int):
-        """
-        Run conflict resolution with cascading reassignment and organize matches.
-
-        1. Group MATCHED titles by episode code
-        2. For conflicts, pick winner via ranked voting
-        3. Losers try runner-up episodes (cascading reassignment, max 3 rounds)
-        4. Organize all resolved winners
-        5. Unresolvable losers → REVIEW (not FAILED)
-        6. Set job state based on final title states
-        """
-        from app.core.organizer import tv_organizer
-
-        logger.info(f"Running conflict resolution for Job {job_id}")
+        self._extractor.cancel(job_id)
 
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
-            statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
-            titles = (await session.execute(statement)).scalars().all()
-
-            # Helper: get source file path for a title
-            def _find_source_file(title):
-                # Use output_filename if available
-                if title.output_filename:
-                    p = Path(title.output_filename)
-                    if p.exists():
-                        return p
-                # Fallback: glob staging dir
-                staging_path = Path(job.staging_path)
-                matches = list(staging_path.glob(f"*_t{title.title_index:02d}.mkv"))
-                return matches[0] if matches else None
-
-            # Helper: extract match metrics from a title
-            def _get_metrics(t):
-                score = 0.0
-                vote_count = 0
-                file_cov = 0.0
-                runner_ups = []
-                if t.match_details:
-                    try:
-                        details = json.loads(t.match_details)
-                        score = details.get("score", 0.0)
-                        vote_count = details.get("vote_count", 0)
-                        file_cov = details.get("file_cov", 0.0)
-                        runner_ups = details.get("runner_ups", [])
-                    except (json.JSONDecodeError, KeyError, TypeError) as e:
-                        logger.debug(f"Could not parse match_details JSON: {e}")
-                        pass
-                if score == 0.0:
-                    score = t.match_confidence
-                return score, vote_count, file_cov, runner_ups
-
-            # Iterative conflict resolution (max 3 rounds)
-            for round_num in range(3):
-                # Group MATCHED titles by episode code
-                candidates = {}
-                for t in titles:
-                    if t.state == TitleState.MATCHED and t.matched_episode:
-                        candidates.setdefault(t.matched_episode, []).append(t)
-
-                # Find conflicts
-                conflicts = {ep: tlist for ep, tlist in candidates.items() if len(tlist) > 1}
-                if not conflicts:
-                    logger.info(
-                        f"Conflict resolution round {round_num + 1}: no conflicts remaining"
-                    )
-                    break
-
-                logger.info(
-                    f"Conflict resolution round {round_num + 1}: "
-                    f"{len(conflicts)} episode(s) have conflicts"
+            if job and job.state not in (JobState.COMPLETED, JobState.FAILED):
+                await state_machine.transition_to_failed(
+                    job, session, error_message="Cancelled by user"
                 )
 
-                reassigned_any = False
-                for ep_code, title_list in conflicts.items():
-                    logger.info(f"Conflict for {ep_code}: titles {[t.id for t in title_list]}")
+    async def apply_review(
+        self,
+        job_id: int,
+        title_id: int,
+        episode_code: str | None = None,
+        edition: str | None = None,
+    ) -> None:
+        """Apply a user's review decision for a title."""
+        await self._finalization.apply_review(job_id, title_id, episode_code, edition)
 
-                    # Rank candidates
-                    ranked = []
-                    for t in title_list:
-                        score, vote_count, file_cov, runner_ups = _get_metrics(t)
-                        ranked.append(
-                            {
-                                "title": t,
-                                "score": score,
-                                "vote_count": vote_count,
-                                "file_coverage": file_cov,
-                                "runner_ups": runner_ups,
-                            }
-                        )
+    async def process_matched_titles(self, job_id: int) -> dict:
+        """Process all matched titles for a job."""
+        return await self._finalization.process_matched_titles(job_id)
 
-                    ranked.sort(
-                        key=lambda x: (x["vote_count"], x["score"], x["file_coverage"]),
-                        reverse=True,
-                    )
+    async def advance_job(self, job_id: int) -> str:
+        """Manually advance a job to the next state. Returns new state."""
+        state_flow = {
+            JobState.IDLE: JobState.IDENTIFYING,
+            JobState.IDENTIFYING: JobState.RIPPING,
+            JobState.RIPPING: JobState.MATCHING,
+            JobState.MATCHING: JobState.ORGANIZING,
+            JobState.ORGANIZING: JobState.COMPLETED,
+            JobState.REVIEW_NEEDED: JobState.RIPPING,
+        }
 
-                    winner = ranked[0]
-                    logger.info(
-                        f"  Winner: Title {winner['title'].id} "
-                        f"(votes={winner['vote_count']}, score={winner['score']:.3f})"
-                    )
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                raise ValueError(f"Job {job_id} not found")
 
-                    # Try to reassign losers to runner-up episodes
-                    for cand in ranked[1:]:
-                        loser = cand["title"]
-                        reassigned = False
+            next_state = state_flow.get(job.state)
+            if not next_state:
+                raise ValueError(f"Cannot advance from state: {job.state}")
 
-                        for ru in cand["runner_ups"]:
-                            alt_ep = ru["episode"]
-                            # Check if alt episode is unclaimed or this loser beats current claimant
-                            current_claimants = candidates.get(alt_ep, [])
-                            if not current_claimants:
-                                # Unclaimed episode — reassign
-                                loser.matched_episode = alt_ep
-                                loser.match_confidence = ru["score"]
-                                candidates.setdefault(alt_ep, []).append(loser)
-                                reassigned = True
-                                reassigned_any = True
-                                logger.info(
-                                    f"  Reassigned Title {loser.id}: {ep_code} -> {alt_ep} "
-                                    f"(runner-up score={ru['score']:.3f})"
-                                )
-                                break
-                            elif len(current_claimants) == 1:
-                                # Check if loser beats current claimant
-                                claimant = current_claimants[0]
-                                claimant_score, _, _, _ = _get_metrics(claimant)
-                                if ru["score"] > claimant_score:
-                                    loser.matched_episode = alt_ep
-                                    loser.match_confidence = ru["score"]
-                                    candidates[alt_ep].append(loser)
-                                    reassigned = True
-                                    reassigned_any = True
-                                    logger.info(
-                                        f"  Reassigned Title {loser.id}: {ep_code} -> {alt_ep} "
-                                        f"(beats claimant {claimant.id}: {ru['score']:.3f} > {claimant_score:.3f})"
-                                    )
-                                    break
-
-                        if not reassigned:
-                            # No viable alternative — mark for review
-                            loser.state = TitleState.REVIEW
-                            if loser.match_details:
-                                try:
-                                    details = json.loads(loser.match_details)
-                                    details["conflict_reason"] = (
-                                        f"Lost conflict for {ep_code}, no viable runner-up"
-                                    )
-                                    loser.match_details = json.dumps(details)
-                                except (json.JSONDecodeError, KeyError, TypeError) as e:
-                                    logger.debug(f"Could not update conflict details: {e}")
-                                    pass
-                            session.add(loser)
-                            logger.info(
-                                f"  Title {loser.id}: no viable alternative, marked for REVIEW"
-                            )
-
-                if not reassigned_any:
-                    break  # Stable — no more reassignments possible
-
-            # Organize all MATCHED winners
-            for t in titles:
-                if t.state != TitleState.MATCHED or not t.matched_episode:
-                    continue
-
-                source_file = _find_source_file(t)
-                if not source_file:
-                    logger.error(f"Could not find source file for title {t.title_index}")
-                    t.state = TitleState.REVIEW
-                    session.add(t)
-                    continue
-
-                logger.info(f"Organizing Title {t.id} ({source_file.name}) -> {t.matched_episode}")
-
-                org_result = await asyncio.to_thread(
-                    tv_organizer.organize,
-                    source_file,
-                    job.detected_title,
-                    t.matched_episode,
-                )
-
-                if org_result["success"]:
-                    t.state = TitleState.COMPLETED
-                    # Store organization tracking info
-                    t.organized_from = source_file.name
-                    t.organized_to = (
-                        str(org_result.get("final_path")) if org_result.get("final_path") else None
-                    )
-                    t.is_extra = False
-                else:
-                    t.state = TitleState.REVIEW
-                    logger.error(f"Organize failed for Title {t.id}: {org_result['error']}")
-
-                session.add(t)
-
-                # Broadcast title update with organization paths
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    t.id,
-                    t.state.value,
-                    matched_episode=t.matched_episode,
-                    match_confidence=t.match_confidence,
-                    organized_from=t.organized_from,
-                    organized_to=t.organized_to,
-                    output_filename=t.output_filename,
-                    is_extra=t.is_extra,
-                    match_details=t.match_details,
-                )
-
-            # Persist title states before determining job outcome —
-            # if anything fails between here and the job transition,
-            # the title states are still correctly saved.
+            job.state = next_state
+            job.updated_at = datetime.now(UTC)
+            if next_state == JobState.COMPLETED:
+                job.progress_percent = 100.0
             await session.commit()
 
-            # Determine final job state
-            has_review = any(t.state == TitleState.REVIEW for t in titles)
-            has_completed = any(t.state == TitleState.COMPLETED for t in titles)
+            await ws_manager.broadcast_job_update(job_id, next_state.value)
+            return next_state.value
 
-            if has_review:
-                review_count = sum(1 for t in titles if t.state == TitleState.REVIEW)
-                await state_machine.transition_to_review(
-                    job, session, reason=f"{review_count} title(s) need manual episode assignment"
-                )
-            elif has_completed:
-                job.progress_percent = 100.0
-                from app.services.config_service import get_config as get_db_config
+    # --- Simulation (delegated) ---
 
-                db_config = await get_db_config()
-                job.final_path = str(
-                    Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
-                )
-                await state_machine.transition_to_completed(job, session)
-            else:
-                job.progress_percent = 100.0
-                await state_machine.transition_to_completed(job, session)
+    async def simulate_disc_insert(self, params: dict) -> int:
+        """Simulate a disc insertion for testing purposes."""
+        return await self._simulation.simulate_disc_insert(params)
 
-            # Staging cleanup is now handled by the state machine's terminal-state callback
+    async def simulate_disc_insert_realistic(self, params: dict) -> int:
+        """Simulate disc insertion using real MKV files from staging."""
+        return await self._simulation.simulate_disc_insert_realistic(params)
 
-    def _on_task_done(self, task: asyncio.Task, job_id: int) -> None:
-        """Callback for background tasks to log any unhandled exceptions."""
-        if task.cancelled():
-            logger.info(f"Job {job_id} task was cancelled")
-        elif exc := task.exception():
-            logger.error(f"Job {job_id} task failed with exception: {exc}", exc_info=exc)
-
-    async def _on_job_terminal(self, job_id: int, state: JobState) -> None:
-        """Called by state machine when a job reaches COMPLETED or FAILED."""
-        from app.services.config_service import get_config
-
-        config = await get_config()
-        policy = config.staging_cleanup_policy
-
-        if policy == "manual":
-            pass
-        elif policy == "after_days":
-            # Timed cleanup handled by background task, not here
-            pass
-        elif policy == "on_success" and state == JobState.COMPLETED:
-            await self._delete_staging(job_id)
-        elif policy == "on_completion":
-            await self._delete_staging(job_id)
-
-        # Auto-export for TheDiscDB contributions
-        if state == JobState.COMPLETED and config.discdb_contributions_enabled:
-            await self._auto_export_for_discdb(job_id, config)
-
-    async def _delete_staging(self, job_id: int) -> None:
-        """Delete the staging directory for a job."""
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job or not job.staging_path:
-                return
-
-            staging_path = Path(job.staging_path)
-            if not staging_path.exists():
-                return
-
-            try:
-                import shutil
-
-                shutil.rmtree(staging_path)
-                logger.info(f"Cleaned up staging directory: {staging_path}")
-            except Exception as e:
-                logger.warning(f"Failed to clean staging for job {job_id}: {e}")
-
-    async def _auto_export_for_discdb(self, job_id: int, config) -> None:
-        """Auto-export disc data for TheDiscDB contribution."""
-        # Brief delay to let MakeMKV log files flush to disk
-        await asyncio.sleep(2)
-        try:
-            from app.core.discdb_exporter import generate_export, mark_exported
-
-            async with async_session() as session:
-                job = await session.get(DiscJob, job_id)
-                if not job or not job.content_hash:
-                    return
-
-                stmt = select(DiscTitle).where(DiscTitle.job_id == job_id)
-                titles = list((await session.execute(stmt)).scalars().all())
-
-                from app import __version__
-
-                export_dir = generate_export(job, titles, config, app_version=__version__)
-                if export_dir:
-                    await mark_exported(job_id, session)
-                    logger.info(f"Job {job_id}: Auto-exported disc data to {export_dir}")
-        except Exception as e:
-            logger.warning(f"Job {job_id}: Failed to auto-export disc data: {e}")
-
-    async def _run_timed_cleanup(self, staging_root: str, max_age_days: int) -> None:
-        """Background task: periodically delete staging dirs older than max_age_days."""
-        import shutil
-
-        interval = 3600  # Check every hour
-        while True:
-            try:
-                await asyncio.sleep(interval)
-                root = Path(staging_root)
-                if not root.exists():
-                    continue
-
-                now = time.time()
-                cutoff = now - (max_age_days * 86400)
-
-                for d in root.iterdir():
-                    if not d.is_dir() or not d.name.startswith("job_"):
-                        continue
-                    try:
-                        mtime = d.stat().st_mtime
-                        if mtime < cutoff:
-                            shutil.rmtree(d)
-                            logger.info(
-                                f"Timed cleanup: deleted staging dir {d.name} "
-                                f"(age: {(now - mtime) / 86400:.1f} days)"
-                            )
-                    except Exception as e:
-                        logger.warning(f"Timed cleanup: failed to delete {d}: {e}")
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.error(f"Timed cleanup error: {e}", exc_info=True)
+    # --- Ripping ---
 
     async def _run_ripping(self, job_id: int) -> None:
         """Execute the ripping process."""
@@ -1523,7 +453,6 @@ class JobManager:
             if not job:
                 return
 
-            # Calculate title count for initial update
             title_count = job.total_titles or 0
 
             await ws_manager.broadcast_job_update(
@@ -1537,15 +466,12 @@ class JobManager:
                 total_job_bytes = 0
                 title_sizes = {}
 
-                # Fetch titles to get sizes
                 titles_result = await session.execute(
                     select(DiscTitle).where(DiscTitle.job_id == job_id)
                 )
                 disc_titles = titles_result.scalars().all()
 
                 for t in disc_titles:
-                    # If any titles are explicitly selected, skip unselected ones
-                    # (This supports Pre-Rip selection workflow)
                     has_selection = any(dt.is_selected for dt in disc_titles if dt.is_selected)
                     if has_selection and not t.is_selected:
                         continue
@@ -1553,7 +479,6 @@ class JobManager:
                     total_job_bytes += t.file_size_bytes
                     title_sizes[t.title_index] = t.file_size_bytes
 
-                # For movies without explicit selection, auto-select the main feature
                 has_selection = any(dt.is_selected for dt in disc_titles)
                 if not has_selection and job.content_type == ContentType.MOVIE and disc_titles:
                     longest = max(disc_titles, key=lambda t: t.duration_seconds or 0)
@@ -1565,13 +490,11 @@ class JobManager:
                             await select_session.commit()
                     has_selection = True
 
-                # Filter disc_titles for ripping if selection exists
                 titles_to_rip = disc_titles
                 if has_selection:
                     titles_to_rip = [dt for dt in disc_titles if dt.is_selected]
 
-                # Safety net: transition any deselected PENDING titles to terminal
-                # state so they don't block _check_job_completion().
+                # Safety net: transition deselected PENDING titles to terminal state
                 deselected_ids = [
                     dt.id
                     for dt in disc_titles
@@ -1594,38 +517,23 @@ class JobManager:
                                 )
                         await cleanup_session.commit()
 
-                # Sort titles by index for mapping rip order to title records
                 sorted_titles = sorted(titles_to_rip, key=lambda t: t.title_index)
 
-                # Detach title objects from session so in-memory state changes
-                # don't get committed alongside the job state update later.
-                # Without this, the session.commit() after ripping finishes would
-                # overwrite title states (e.g. MATCHED → RIPPING) with stale values.
                 for t in disc_titles:
                     session.expunge(t)
 
-                # Initialize calculator
                 speed_calc = SpeedCalculator(total_job_bytes)
 
-                # Track which titles have been set to RIPPING locally
-                # (since we expunged title objects from the session)
                 _titles_marked_ripping: set[int] = set()
                 _last_title_idx: int | None = None
-                _title_file_cache: dict[int, Path] = {}  # title_index → resolved Path
+                _title_file_cache: dict[int, Path] = {}
                 _progress_lock = asyncio.Lock()
-
-                # Set to hold background task references (prevents GC)
                 _background_tasks: set[asyncio.Task] = set()
 
                 # Progress callback
                 async def progress_callback(progress: RipProgress) -> None:
                     nonlocal _last_title_idx
 
-                    # Serialize all progress handling to prevent race conditions.
-                    # MakeMKV emits PRGC/PRGV messages rapidly and each spawns a
-                    # concurrent asyncio task. Without the lock, interleaved DB
-                    # reads/writes corrupt _last_title_idx and _titles_marked_ripping,
-                    # causing multiple titles to enter RIPPING state simultaneously.
                     async with _progress_lock:
                         logger.debug(
                             f"Job {job_id}: PRGV progress update — "
@@ -1643,14 +551,6 @@ class JobManager:
 
                         current_title_bytes = int((progress.percent / 100.0) * active_title_size)
 
-                        # NOTE: Overall job progress (progress bar, speed, ETA) is handled
-                        # exclusively by _filesystem_progress_monitor to avoid two sources
-                        # fighting over the same SpeedCalculator and broadcasting conflicting
-                        # values. This callback only manages title-level state transitions
-                        # and per-title byte broadcasts.
-
-                        # When active title changes, transition previous title out of RIPPING.
-                        # This ensures only one track shows as RIPPING at a time.
                         if _last_title_idx is not None and current_idx != _last_title_idx:
                             prev_list_idx = _last_title_idx - 1
                             if 0 <= prev_list_idx < len(sorted_titles):
@@ -1659,7 +559,6 @@ class JobManager:
                                     async with async_session() as sess:
                                         prev_db = await sess.get(DiscTitle, prev_title.id)
                                         if prev_db and prev_db.state == TitleState.RIPPING:
-                                            # Movies skip matching — go straight to MATCHED
                                             if job.content_type == ContentType.TV:
                                                 new_state = TitleState.MATCHING
                                             else:
@@ -1682,7 +581,6 @@ class JobManager:
                                     )
                         _last_title_idx = current_idx
 
-                        # Set active title to RIPPING state if not already
                         if active_title and active_title.id not in _titles_marked_ripping:
                             async with async_session() as session:
                                 title_db = await session.get(DiscTitle, active_title.id)
@@ -1699,16 +597,11 @@ class JobManager:
                                         expected_size_bytes=title_db.file_size_bytes,
                                         actual_size_bytes=0,
                                     )
-                            # Track locally — don't modify expunged ORM objects
                             _titles_marked_ripping.add(active_title.id)
 
-                        # Broadcast per-title byte progress.
-                        # Only broadcast RIPPING if this title is actually the current one
-                        # being ripped — don't re-broadcast RIPPING for titles that have
-                        # already transitioned to MATCHED/MATCHING.
                         if active_title and active_title.file_size_bytes:
                             if active_title.id in _titles_marked_ripping:
-                                actual_bytes = current_title_bytes  # Fallback
+                                actual_bytes = current_title_bytes
                                 tidx = active_title.title_index
                                 try:
                                     if tidx in _title_file_cache:
@@ -1719,7 +612,7 @@ class JobManager:
                                             _title_file_cache[tidx] = matches[0]
                                             actual_bytes = matches[0].stat().st_size
                                 except OSError:
-                                    pass  # Use calculated fallback
+                                    pass
                                 await ws_manager.broadcast_title_update(
                                     job_id,
                                     active_title.id,
@@ -1730,7 +623,7 @@ class JobManager:
                                     ),
                                 )
 
-                # Define granular callback — called from extractor thread
+                # Title complete callback — called from extractor thread
                 def on_title_complete(idx: int, path: Path):
                     logger.info(
                         f"[CALLBACK] Title complete: idx={idx} path={path.name} (Job {job_id})"
@@ -1740,13 +633,13 @@ class JobManager:
                         self._loop,
                     )
 
-                    # Log errors from the coroutine (runs in the thread)
                     def _check_result(fut):
                         try:
                             fut.result(timeout=30)
                         except TimeoutError as e:
                             logger.error(
-                                f"[CALLBACK] _on_title_ripped timed out for {path.name} (Job {job_id}): {e}"
+                                f"[CALLBACK] _on_title_ripped timed out for {path.name} "
+                                f"(Job {job_id}): {e}"
                             )
                         except Exception as e:
                             logger.exception(
@@ -1756,7 +649,7 @@ class JobManager:
 
                     future.add_done_callback(_check_result)
 
-                # Define error callback — called from extractor thread on stall
+                # Error callback — called from extractor thread on stall
                 def on_title_error(cmd_idx: int, reason: str):
                     logger.warning(
                         f"[CALLBACK] Title error: cmd_idx={cmd_idx} reason={reason} (Job {job_id})"
@@ -1766,43 +659,26 @@ class JobManager:
                         self._loop,
                     )
 
-                # Load config for stall detection settings
                 from app.services.config_service import get_config
 
                 rip_config = await get_config()
 
-                # Determine indices to pass to extractor
-                # If we are ripping ALL detected titles, pass None to use "all" mode (faster/supported)
-                # If we are ripping a SUBSET, pass the list (extractor will loop)
                 rip_indices = [t.title_index for t in sorted_titles]
                 stall_timeout = rip_config.ripping_stall_timeout if rip_config else 120.0
 
-                # Force multi-command mode when stall detection is enabled
-                # so individual tracks can be skipped on stall
                 if stall_timeout and stall_timeout > 0:
-                    pass  # Always keep rip_indices as a list
+                    pass
                 elif len(rip_indices) == len(disc_titles):
                     rip_indices = None
 
-                # Store task refs to prevent GC of fire-and-forget tasks
                 def _fire_progress(p):
                     t = asyncio.create_task(progress_callback(p))
                     _background_tasks.add(t)
                     t.add_done_callback(_background_tasks.discard)
 
-                # Filesystem-based progress monitor — ground truth independent of PRGV
+                # Filesystem-based progress monitor
                 async def _filesystem_progress_monitor():
-                    """Periodically check actual file sizes and broadcast progress.
-
-                    Also drives per-title state transitions (PENDING → RIPPING →
-                    MATCHED/MATCHING) so that the UI shows correct track states even
-                    when MakeMKV PRGV messages are delayed or lost.
-
-                    Uses size-change detection between polls (not comparison against
-                    predicted size) because MakeMKV size predictions are estimates —
-                    completed files are typically 1-2% smaller than predicted.
-                    """
-                    _prev_file_sizes: dict[int, int] = {}  # title_id → size at previous poll
+                    _prev_file_sizes: dict[int, int] = {}
 
                     while True:
                         await asyncio.sleep(2.0)
@@ -1810,16 +686,13 @@ class JobManager:
                             async with _progress_lock:
                                 total_done = 0
                                 current_title_num = 0
-                                # First pass: collect current file sizes
-                                file_sizes: dict[int, int] = {}  # title_id → current size
+                                file_sizes: dict[int, int] = {}
                                 for t in sorted_titles:
                                     pattern = f"*_t{t.title_index:02d}.mkv"
                                     matches = list(output_dir.glob(pattern))
                                     if matches:
                                         file_sizes[t.id] = matches[0].stat().st_size
 
-                                # Determine which title is actively growing
-                                # (size changed since last poll)
                                 active_title_id = None
                                 for t in sorted_titles:
                                     if t.id not in file_sizes:
@@ -1829,7 +702,6 @@ class JobManager:
                                     if fsize > prev and fsize > 0:
                                         active_title_id = t.id
 
-                                # Second pass: apply state transitions and accumulate progress
                                 for i, t in enumerate(sorted_titles):
                                     if t.id not in file_sizes:
                                         continue
@@ -1837,7 +709,6 @@ class JobManager:
                                     total_done += fsize
 
                                     if t.id == active_title_id:
-                                        # This file is actively growing — RIPPING
                                         current_title_num = i + 1
 
                                         if t.id not in _titles_marked_ripping:
@@ -1867,7 +738,6 @@ class JobManager:
                                                 )
                                             _titles_marked_ripping.add(t.id)
 
-                                        # Broadcast byte progress for the active title
                                         await ws_manager.broadcast_title_update(
                                             job_id,
                                             t.id,
@@ -1880,11 +750,6 @@ class JobManager:
                                         and active_title_id is not None
                                         and active_title_id != t.id
                                     ):
-                                        # Was RIPPING but a DIFFERENT title is now active
-                                        # — this one is done ripping.
-                                        # Only transition when another title takes over,
-                                        # NOT on "no activity" polls (MakeMKV can pause
-                                        # briefly during seeks without the title being done).
                                         new_state = (
                                             TitleState.MATCHING
                                             if job.content_type == ContentType.TV
@@ -1914,14 +779,12 @@ class JobManager:
                                             )
                                         _titles_marked_ripping.discard(t.id)
 
-                                # Update previous sizes for next poll
                                 _prev_file_sizes.update(file_sizes)
 
                             if total_job_bytes > 0:
                                 pct = min((total_done / total_job_bytes) * 100, 100.0)
                                 speed_calc.update(total_done)
 
-                                # Update DB so REST API returns current progress
                                 try:
                                     async with async_session() as prog_session:
                                         db_job = await prog_session.get(DiscJob, job_id)
@@ -1983,8 +846,7 @@ class JobManager:
                     )
                     return
 
-                # Fallback: mark stalled titles as FAILED if the real-time callback
-                # didn't already handle them (e.g. callback failed or timed out)
+                # Fallback: mark stalled titles as FAILED
                 if result.stalled_titles:
                     async with async_session() as stall_session:
                         for cmd_idx in result.stalled_titles:
@@ -2013,7 +875,7 @@ class JobManager:
                                     )
                         await stall_session.commit()
 
-                # Eject disc now that ripping is complete — disc is no longer needed
+                # Eject disc
                 try:
                     from app.core.sentinel import eject_disc
 
@@ -2021,23 +883,16 @@ class JobManager:
                 except (OSError, RuntimeError) as e:
                     logger.warning(f"Could not eject disc from {job.drive_id}: {e}")
 
-                # For TV, we rely on the granular callbacks to handle moving/matching.
-                # Once ripping returns, we update job state to MATCHING if still ripping?
                 if job.content_type == ContentType.TV:
                     logger.info(
                         f"[RIP-DONE] Job {job_id}: rip_titles returned, "
                         f"{len(result.output_files)} files produced. "
                         f"Job state={job.state.value}. Running backfill..."
                     )
-                    # Fallback: fire _on_title_ripped for any .mkv files that the
-                    # filesystem polling didn't catch (e.g. timing edge cases).
                     await self._backfill_unmatched_titles(
                         job_id, Path(job.staging_path), sorted_titles
                     )
 
-                    # Refresh job from DB — matching tasks may have already
-                    # advanced the job past RIPPING (same stale-state issue
-                    # that required expunging title objects at line 776-781).
                     session.expire(job)
                     await session.refresh(job)
 
@@ -2054,14 +909,11 @@ class JobManager:
                         )
 
                 else:
-                    # For movies, check if we have multiple ripped versions (Ambiguous Movie workflow)
-                    # We can check how many titles were selected for ripping
+                    # Movie post-ripping flow
                     ripped_titles = [t for t in disc_titles if t.is_selected]
 
-                    # If multiple titles were ripped, check if DiscDB can resolve it
                     if len(ripped_titles) > 1:
-                        # Check DiscDB mappings for a MainMovie designation
-                        discdb_maps = self._discdb_mappings.get(job_id, [])
+                        discdb_maps = self._matching.get_discdb_mappings(job_id)
                         main_movie_idx = None
                         for m in discdb_maps:
                             if m.title_type == "MainMovie":
@@ -2069,7 +921,6 @@ class JobManager:
                                 break
 
                         if main_movie_idx is not None:
-                            # Auto-select the MainMovie title, deselect others
                             for dt in ripped_titles:
                                 if dt.title_index == main_movie_idx:
                                     dt.is_selected = True
@@ -2085,7 +936,6 @@ class JobManager:
                                 f"title index {main_movie_idx}, skipping review"
                             )
                         else:
-                            # No DiscDB info — ask user to pick
                             await state_machine.transition_to_review(
                                 job,
                                 session,
@@ -2108,43 +958,8 @@ class JobManager:
                     await session.commit()
                     await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
 
-                    # Identify the file to organize
-                    # If we have a single selected title, use its index to find the file
-                    # File naming usually `*_tXX.mkv`
-
                     Path(job.staging_path)
 
-                    # If we know exactly which title index we ripped (ripped_titles has 1 item)
-                    # We can try to be specific to avoid "largest file" heuristics which might be wrong if extras are huge?
-                    # But MakeMKV robot mode output filenames are not always predictable ID-wise.
-                    # Generally `title_t00.mkv`.
-
-                    # Let's rely on `movie_organizer`'s directory scan for the single-file case
-                    # OR if we have `ripped_titles`, we can try to find that specific file.
-                    # But `DiscTitle` doesn't store the output filename until we verify it exists.
-                    # `extractor` output `output_files`. We didn't save them to `DiscTitle` yet?
-                    # `_on_title_ripped` SAVES `output_filename` to `DiscTitle`.
-
-                    # So `ripped_titles[0].output_filename` should be set?
-                    # `_on_title_ripped` is called via callback. It might race with this code?
-                    # We use `await self._extractor.rip_titles` which waits for process.
-                    # And `title_complete_callback` fires `_on_title_ripped`.
-                    # But `_on_title_ripped` is async.
-                    # `rip_titles` implementation waits for callbacks?
-                    # Looking at `extractor.py`: `title_complete_callback` is called synchronously from the thread?
-                    # No, `job_manager` wraps it in `run_coroutine_threadsafe`.
-                    # The `progress_callback` in `rip_titles` waits for queue.
-                    # The `title_complete_callback` is called from `_check_for_completed_files`.
-
-                    # We should refresh the session/titles to ensure we have the latest data (output_filenames).
-                    # `session` here is open. `_on_title_ripped` uses its own session?
-                    # `_on_title_ripped` uses `async with async_session()`.
-                    # So we need to `session.refresh` the titles or re-query.
-
-                    # If we only have 1 title, let's just let existing `movie_organizer` logic work
-                    # (it finds largest file). It's robust enough for single-movie discs.
-
-                    # Run organizer in thread to not block
                     organize_result = await asyncio.to_thread(
                         movie_organizer.organize,
                         Path(job.staging_path),
@@ -2156,12 +971,14 @@ class JobManager:
                         job.final_path = str(organize_result["main_file"])
                         job.progress_percent = 100.0
 
-                        # Transition all movie titles to COMPLETED
                         result = await session.execute(
                             select(DiscTitle).where(DiscTitle.job_id == job_id)
                         )
                         for t in result.scalars().all():
-                            if t.state not in (TitleState.COMPLETED, TitleState.FAILED):
+                            if t.state not in (
+                                TitleState.COMPLETED,
+                                TitleState.FAILED,
+                            ):
                                 t.state = TitleState.COMPLETED
                                 t.organized_from = t.output_filename
                                 t.organized_to = str(organize_result.get("main_file", ""))
@@ -2179,7 +996,9 @@ class JobManager:
                         logger.info(f"Job {job_id} completed: {organize_result['main_file']}")
                     else:
                         await state_machine.transition_to_failed(
-                            job, session, error_message=organize_result["error"]
+                            job,
+                            session,
+                            error_message=organize_result["error"],
                         )
 
             except asyncio.CancelledError:
@@ -2204,10 +1023,6 @@ class JobManager:
 
             title.output_filename = str(path)
 
-            # Transition out of RIPPING/PENDING — ripping is done for this track,
-            # matcher will handle the rest. Without this, the UI shows "RIPPING 0.0%"
-            # indefinitely because progress updates stop when MakeMKV moves to the
-            # next title.
             job = await session.get(DiscJob, job_id)
             if title.state in (TitleState.PENDING, TitleState.RIPPING):
                 if job and job.content_type == ContentType.TV:
@@ -2231,17 +1046,19 @@ class JobManager:
                 f"(Title {title.id}, Job {job_id}) — queuing for matching"
             )
 
-            # If TV, try DiscDB pre-assignment first, otherwise queue matching
             job = await session.get(DiscJob, job_id)
             if job and job.content_type == ContentType.TV:
-                discdb_applied = await self._try_discdb_assignment(job_id, title, session)
+                discdb_applied = await self._matching.try_discdb_assignment(job_id, title, session)
                 if discdb_applied:
-                    # DiscDB pre-assigned — check if all titles are now done
-                    await self._check_job_completion(session, job_id)
+                    await self._finalization.check_job_completion(session, job_id)
                 else:
-                    task = asyncio.create_task(self._match_single_file(job_id, title.id, path))
+                    task = asyncio.create_task(
+                        self._matching.match_single_file(job_id, title.id, path)
+                    )
                     task.add_done_callback(
-                        lambda t, jid=job_id, tid=title.id: self._on_match_task_done(t, jid, tid)
+                        lambda t, jid=job_id, tid=title.id: self._matching.on_match_task_done(
+                            t, jid, tid
+                        )
                     )
 
     async def _on_title_error(
@@ -2251,8 +1068,8 @@ class JobManager:
         reason: str,
         sorted_titles: list[DiscTitle],
     ) -> None:
-        """Handle a title error (e.g., ripping stall) — mark FAILED immediately."""
-        list_idx = cmd_idx - 1  # cmd_idx is 1-based
+        """Handle a title error (e.g., ripping stall)."""
+        list_idx = cmd_idx - 1
         if not (0 <= list_idx < len(sorted_titles)):
             logger.error(
                 f"Job {job_id}: title error cmd_idx={cmd_idx} out of range "
@@ -2266,7 +1083,7 @@ class JobManager:
             if not db_title:
                 return
             if db_title.state in (TitleState.COMPLETED, TitleState.MATCHED):
-                return  # Already finished successfully, don't overwrite
+                return
 
             db_title.state = TitleState.FAILED
             db_title.match_details = json.dumps({"reason": reason})
@@ -2283,24 +1100,17 @@ class JobManager:
     async def _backfill_unmatched_titles(
         self, job_id: int, staging_dir: Path, sorted_titles: list[DiscTitle]
     ) -> None:
-        """Scan staging dir for .mkv files not yet assigned to a title.
-
-        This catches any files missed by the real-time filesystem polling
-        (e.g. timing edge cases or the final file completing after the check).
-        """
+        """Scan staging dir for .mkv files not yet assigned to a title."""
         import re as _re
 
         async with async_session() as session:
-            # Get current title states
             result = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id))
             titles = result.scalars().all()
             assigned_indices = {t.title_index for t in titles if t.output_filename is not None}
 
-            # Scan staging dir for .mkv files
             mkv_files = list(staging_dir.glob("*.mkv")) if staging_dir.exists() else []
 
             for mkv in mkv_files:
-                # Extract title index from filename
                 idx_match = _re.search(r"t(\d+)\.mkv$", mkv.name, _re.IGNORECASE)
                 if not idx_match:
                     idx_match = _re.search(r"title[_]?(\d+)\.mkv$", mkv.name, _re.IGNORECASE)
@@ -2309,7 +1119,7 @@ class JobManager:
 
                 title_index = int(idx_match.group(1))
                 if title_index in assigned_indices:
-                    continue  # Already handled by real-time callback
+                    continue
 
                 logger.info(
                     f"Backfill: found unmatched file {mkv.name} "
@@ -2317,1960 +1127,15 @@ class JobManager:
                 )
                 await self._on_title_ripped(job_id, 0, mkv, sorted_titles)
 
-    async def _wait_for_file_ready(
-        self, file_path: Path, title_id: int, job_id: int, timeout: float | None = None
-    ) -> bool:
-        """Wait until a ripped file is fully written and ready for processing.
-
-        MakeMKV creates output files immediately but writes to them over minutes.
-        We poll the file size and require it to be stable (unchanged) for several
-        consecutive checks before considering it complete.
-
-        Returns True if file is ready, False on timeout.
-        """
-        from app.services.config_service import get_config
-
-        config = await get_config()
-        check_interval = config.ripping_file_poll_interval
-        required_stable = config.ripping_stability_checks
-
-        # Get expected size from DB
-        expected_size = 0
-        async with async_session() as session:
-            title = await session.get(DiscTitle, title_id)
-            if title and title.file_size_bytes:
-                expected_size = title.file_size_bytes
-
-        # Calculate dynamic timeout based on file size
-        # Assume minimum rip speed of 1 MB/s (slow disc), add 2x buffer for safety
-        if timeout is None:
-            if expected_size > 0:
-                base_timeout = (expected_size / (1024 * 1024)) * 2  # 2 seconds per MB
-                timeout = max(config.ripping_file_ready_timeout, base_timeout)
-            else:
-                timeout = config.ripping_file_ready_timeout
-
-        last_size = -1
-        stable_count = 0
-        start = time.monotonic()
-
-        logger.info(
-            f"[MATCH] Title {title_id} (Job {job_id}): waiting for file to finish "
-            f"writing: {file_path.name} (expected ~{expected_size / 1024 / 1024:.0f} MB, "
-            f"timeout {timeout:.0f}s)"
-        )
-
-        while time.monotonic() - start < timeout:
-            if not file_path.exists():
-                logger.debug(
-                    f"[MATCH] Title {title_id} (Job {job_id}): file not yet on disk, "
-                    f"waiting... ({file_path.name})"
-                )
-                await asyncio.sleep(check_interval)
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title_id,
-                    TitleState.RIPPING.value,  # Fixed: Should be RIPPING while file is being written
-                    match_stage="waiting_for_file",
-                    match_progress=0.0,
-                    expected_size_bytes=expected_size,
-                    actual_size_bytes=0,
-                )
-                continue
-
-            try:
-                current_size = file_path.stat().st_size
-            except OSError as e:
-                logger.debug(
-                    f"[MATCH] Title {title_id} (Job {job_id}): cannot stat file ({e}), retrying..."
-                )
-                await asyncio.sleep(check_interval)
-                continue
-
-            if current_size > 0 and current_size == last_size:
-                stable_count += 1
-
-                # Check if size is close to expected (allow 5% tolerance for metadata overhead)
-                size_matches_expected = True
-                if expected_size > 0:
-                    size_ratio = current_size / expected_size
-                    # MakeMKV scan estimates are approximate; allow 15% tolerance
-                    size_matches_expected = size_ratio >= 0.85
-
-                logger.debug(
-                    f"[MATCH] Title {title_id} (Job {job_id}): file size stable "
-                    f"({current_size / 1024 / 1024:.0f} MB) — check {stable_count}/{required_stable}"
-                    + (
-                        f" — size {size_ratio * 100:.1f}% of expected {expected_size / 1024 / 1024:.0f} MB"
-                        if expected_size > 0
-                        else ""
-                    )
-                )
-
-                if stable_count >= required_stable and size_matches_expected:
-                    # Extra check on Windows: MakeMKV may still hold the file open
-                    # for writing even after size is stable, causing ffprobe EACCES.
-                    # Try opening for read; if denied, wait another cycle.
-                    try:
-                        with open(file_path, "rb") as _f:
-                            _f.read(1)
-                    except PermissionError:
-                        logger.debug(
-                            f"[MATCH] Title {title_id} (Job {job_id}): size stable but "
-                            f"file still locked ({file_path.name}) — waiting..."
-                        )
-                        stable_count = 0
-                        await asyncio.sleep(check_interval)
-                        continue
-                    logger.info(
-                        f"[MATCH] Title {title_id} (Job {job_id}): file ready "
-                        f"({current_size / 1024 / 1024:.0f} MB, stable for "
-                        f"{stable_count * check_interval:.0f}s): {file_path.name}"
-                    )
-                    return True
-                elif stable_count >= required_stable and not size_matches_expected:
-                    # Size is stable but doesn't match expected - file still being written
-                    logger.debug(
-                        f"[MATCH] Title {title_id} (Job {job_id}): file size stable but only "
-                        f"{current_size / 1024 / 1024:.0f} MB of expected "
-                        f"{expected_size / 1024 / 1024:.0f} MB ({size_ratio * 100:.1f}%) — still writing"
-                    )
-                    stable_count = 0  # Reset and keep waiting
-            else:
-                if stable_count > 0:
-                    logger.debug(
-                        f"[MATCH] Title {title_id} (Job {job_id}): file size changed "
-                        f"({last_size} -> {current_size}), resetting stability counter"
-                    )
-                stable_count = 0
-
-            last_size = current_size
-
-            # Broadcast wait progress
-            if expected_size > 0:
-                # Progress based on size (capped at 99%)
-                wait_progress = min(99.0, (current_size / expected_size) * 100.0)
-            else:
-                # Fallback: stable_count goes from 0 to 3 explicitly
-                wait_progress = min(99.0, (stable_count / required_stable) * 100.0)
-
-            await ws_manager.broadcast_title_update(
-                job_id,
-                title_id,
-                TitleState.RIPPING.value,  # Fixed: Should be RIPPING while file is being written
-                match_stage="waiting_for_file",
-                match_progress=wait_progress,
-                expected_size_bytes=expected_size,
-                actual_size_bytes=current_size,
-            )
-
-            await asyncio.sleep(check_interval)
-
-        elapsed = time.monotonic() - start
-        logger.warning(
-            f"[MATCH] Title {title_id} (Job {job_id}): timed out waiting for file "
-            f"after {elapsed:.0f}s: {file_path.name}"
-        )
-        return False
-
-    def _on_match_task_done(self, task: asyncio.Task, job_id: int, title_id: int) -> None:
-        """Handle matching task completion/failure."""
+    def _on_task_done(self, task: asyncio.Task, job_id: int) -> None:
+        """Callback for background tasks to log any unhandled exceptions."""
         if task.cancelled():
-            logger.warning(f"[MATCH] Title {title_id} (Job {job_id}): task cancelled")
-            asyncio.ensure_future(self._handle_match_failure(job_id, title_id, "Task cancelled"))
+            logger.info(f"Job {job_id} task was cancelled")
         elif exc := task.exception():
-            logger.error(
-                f"[MATCH] Title {title_id} (Job {job_id}): task failed: {exc}",
-                exc_info=exc,
-            )
-            asyncio.ensure_future(self._handle_match_failure(job_id, title_id, str(exc)))
-
-    async def _handle_match_failure(self, job_id: int, title_id: int, error: str) -> None:
-        """Clean up after a matching task fails unexpectedly."""
-        async with async_session() as session:
-            title = await session.get(DiscTitle, title_id)
-            active_states = (TitleState.PENDING, TitleState.RIPPING, TitleState.MATCHING)
-            if title and title.state in active_states:
-                title.state = TitleState.REVIEW
-                title.match_details = json.dumps(
-                    {"error": "matching_task_failed", "message": error}
-                )
-                session.add(title)
-                await session.commit()
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title_id,
-                    title.state.value,
-                    match_details=title.match_details,
-                )
-            await self._check_job_completion(session, job_id)
-
-    async def _try_discdb_assignment(self, job_id: int, title: "DiscTitle", session) -> bool:
-        """Try to assign episode info from TheDiscDB mappings, skipping fingerprinting.
-
-        Returns True if assignment was made, False to fall back to audio matching.
-        """
-        mappings = self._discdb_mappings.get(job_id)
-        if not mappings:
-            return False
-
-        # Find the mapping for this title index
-        mapping = None
-        for m in mappings:
-            if m.index == title.title_index:
-                mapping = m
-                break
-
-        if not mapping or not mapping.season or not mapping.episode:
-            return False
-
-        if mapping.title_type not in ("Episode", "MainMovie"):
-            return False
-
-        episode_code = f"S{mapping.season:02d}E{mapping.episode:02d}"
-        logger.info(
-            f"Job {job_id}: TheDiscDB pre-assigned title {title.title_index} "
-            f"→ {episode_code} ({mapping.episode_title!r}) — skipping audio matching"
-        )
-
-        title.matched_episode = episode_code
-        title.match_confidence = 0.99
-        title.match_details = f'{{"source": "discdb", "episode_title": "{mapping.episode_title}"}}'
-        title.state = TitleState.MATCHED
-        session.add(title)
-        await session.commit()
-
-        await ws_manager.broadcast_title_update(
-            job_id,
-            title.id,
-            TitleState.MATCHED.value,
-            matched_episode=episode_code,
-            match_confidence=0.99,
-        )
-
-        return True
-
-    async def _match_single_file(self, job_id: int, title_id: int, file_path: Path) -> None:
-        """Run matching for a single ripped file."""
-        logger.info(
-            f"[MATCH] Title {title_id} (Job {job_id}): match task started for {file_path.name}"
-        )
-
-        # 1. Wait for subtitles to be ready before matching
-        logger.info(
-            f"[MATCH] Title {title_id} (Job {job_id}): _match_single_file entered. "
-            f"subtitle_ready event exists: {job_id in self._subtitle_ready}"
-        )
-        if job_id in self._subtitle_ready:
-            logger.info(
-                f"[MATCH] Title {title_id} (Job {job_id}): waiting for subtitle download..."
-            )
-            try:
-                # Log before wait
-                logger.debug(
-                    f"[MATCH] Title {title_id} (Job {job_id}): entering wait_for(subtitle_ready)"
-                )
-                await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=300)
-                logger.info(f"[MATCH] Title {title_id} (Job {job_id}): subtitle event received")
-            except TimeoutError:
-                logger.warning(
-                    f"[MATCH] Title {title_id} (Job {job_id}): subtitle download timed out "
-                    f"after 300s"
-                )
-            except Exception as e:
-                logger.error(
-                    f"[MATCH] Title {title_id} (Job {job_id}): error waiting for subtitles: {e}"
-                )
-
-        # 1b. Check subtitle status from database - BLOCK matching if failed
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            subtitle_status = job.subtitle_status if job else None
-
-        # Gate matching based on subtitle status
-        if subtitle_status == "failed":
-            logger.warning(
-                f"[MATCH] Title {title_id} (Job {job_id}): subtitle download failed. "
-                f"No reference files available. Title needs manual episode assignment."
-            )
-            # Mark title as REVIEW — file ripped fine, just can't auto-match
-            async with async_session() as session:
-                title = await session.get(DiscTitle, title_id)
-                if title:
-                    title.state = TitleState.REVIEW
-                    title.match_confidence = 0.0
-                    title.match_details = json.dumps(
-                        {
-                            "error": "subtitle_download_failed",
-                            "message": "Subtitle download failed, cannot auto-match. Manual episode assignment needed.",
-                        }
-                    )
-                    session.add(title)
-                    await session.commit()
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title.id,
-                        title.state.value,
-                        matched_episode=None,
-                        match_confidence=0.0,
-                    )
-                    await self._check_job_completion(session, job_id)
-            return  # Exit early, don't proceed with matching
-
-        elif subtitle_status == "partial":
-            logger.warning(
-                f"[MATCH] Title {title_id} (Job {job_id}): subtitle download partially succeeded. "
-                f"Matching will proceed with available reference files."
-            )
-            # Continue with matching (some episodes have subtitles)
-
-        elif subtitle_status in ("completed", None):
-            logger.info(
-                f"[MATCH] Title {title_id} (Job {job_id}): subtitles ready, proceeding with matching"
-            )
-            # Continue normally
-
-        else:
-            logger.warning(
-                f"[MATCH] Title {title_id} (Job {job_id}): unknown subtitle status '{subtitle_status}', "
-                f"attempting match anyway"
-            )
-
-        # 2. Wait for the file to be fully written before matching (MOVED UP)
-        file_ready = await self._wait_for_file_ready(file_path, title_id, job_id)
-        if not file_ready:
-            logger.error(
-                f"[MATCH] Title {title_id} (Job {job_id}): file never became ready, "
-                f"skipping match for {file_path.name}"
-            )
-            async with async_session() as session:
-                title = await session.get(DiscTitle, title_id)
-                if title:
-                    title.state = TitleState.FAILED
-                    session.add(title)
-                    await session.commit()
-                await self._check_job_completion(session, job_id)
-            return
-
-        # 1c. Duration pre-filter: skip matching for tracks that don't match any
-        # expected episode runtime from TMDB (likely extras/bonus content)
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            title = await session.get(DiscTitle, title_id)
-            if job and title and job.detected_season:
-                try:
-                    if job_id not in self._episode_runtimes:
-                        from app.matcher.tmdb_client import (
-                            fetch_season_episode_runtimes,
-                            fetch_show_id,
-                        )
-
-                        show_id = await asyncio.to_thread(fetch_show_id, job.detected_title)
-                        if show_id:
-                            runtimes = await asyncio.to_thread(
-                                fetch_season_episode_runtimes, show_id, job.detected_season
-                            )
-                            self._episode_runtimes[job_id] = runtimes
-                        else:
-                            self._episode_runtimes[job_id] = []
-
-                    runtimes = self._episode_runtimes.get(job_id, [])
-                    if runtimes and title.duration_seconds:
-                        title_minutes = title.duration_seconds / 60
-                        tolerance = 5  # minutes
-                        matches_any = any(abs(title_minutes - rt) <= tolerance for rt in runtimes)
-                        if not matches_any:
-                            logger.info(
-                                f"[MATCH] Title {title_id} (Job {job_id}): duration {title_minutes:.0f}min "
-                                f"doesn't match any episode runtime {runtimes} (±{tolerance}min). "
-                                f"Detected as extra."
-                            )
-
-                            # Check extras policy
-                            from app.services.config_service import (
-                                get_config as get_db_config,
-                            )
-
-                            db_config = await get_db_config()
-                            extras_policy = db_config.extras_policy
-
-                            if extras_policy == "skip":
-                                logger.info(
-                                    f"[MATCH] Title {title_id}: extras policy is 'skip', discarding."
-                                )
-                                title.state = TitleState.COMPLETED
-                                title.is_extra = True
-                                title.match_details = json.dumps(
-                                    {
-                                        "auto_sorted": "extras",
-                                        "action": "skipped",
-                                        "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
-                                    }
-                                )
-                                session.add(title)
-                                await session.commit()
-                                await ws_manager.broadcast_title_update(
-                                    job_id,
-                                    title.id,
-                                    title.state.value,
-                                    is_extra=title.is_extra,
-                                    match_details=title.match_details,
-                                )
-                                await self._check_job_completion(session, job_id)
-                                return
-
-                            if extras_policy == "ask":
-                                logger.info(
-                                    f"[MATCH] Title {title_id}: extras policy is 'ask', sending to review."
-                                )
-                                title.state = TitleState.REVIEW
-                                title.is_extra = True
-                                title.match_details = json.dumps(
-                                    {
-                                        "auto_sorted": "extras",
-                                        "action": "review",
-                                        "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
-                                    }
-                                )
-                                session.add(title)
-                                await session.commit()
-                                await ws_manager.broadcast_title_update(
-                                    job_id,
-                                    title.id,
-                                    title.state.value,
-                                    is_extra=title.is_extra,
-                                    match_details=title.match_details,
-                                )
-                                await self._check_job_completion(session, job_id)
-                                return
-
-                            # Default: "keep" — organize to extras folder
-                            from app.core.organizer import organize_tv_extras
-
-                            # Count existing extras for this job to determine index
-                            extras_count = 0
-                            all_titles = await session.execute(
-                                select(DiscTitle).where(DiscTitle.job_id == job_id)
-                            )
-                            for t in all_titles.scalars():
-                                if t.match_details:
-                                    try:
-                                        details = json.loads(t.match_details)
-                                        if details.get("auto_sorted") == "extras":
-                                            extras_count += 1
-                                    except (json.JSONDecodeError, KeyError, TypeError):
-                                        pass
-
-                            extra_index = extras_count + 1
-
-                            org_result = await asyncio.to_thread(
-                                organize_tv_extras,
-                                file_path,
-                                job.detected_title,
-                                job.detected_season,
-                                None,  # library_path (uses default)
-                                job.disc_number,
-                                extra_index,
-                            )
-                            if org_result["success"]:
-                                title.state = TitleState.COMPLETED
-                                title.organized_from = file_path.name
-                                title.organized_to = (
-                                    str(org_result.get("final_path"))
-                                    if org_result.get("final_path")
-                                    else None
-                                )
-                                title.is_extra = True
-                                title.match_details = json.dumps(
-                                    {
-                                        "auto_sorted": "extras",
-                                        "action": "kept",
-                                        "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
-                                    }
-                                )
-                            else:
-                                title.state = TitleState.COMPLETED
-                                title.match_details = json.dumps(
-                                    {
-                                        "auto_sorted": "extras",
-                                        "action": "kept",
-                                        "organize_error": org_result["error"],
-                                    }
-                                )
-                                logger.warning(
-                                    f"[MATCH] Title {title_id}: extras organize failed: {org_result['error']}"
-                                )
-                            session.add(title)
-                            await session.commit()
-                            await ws_manager.broadcast_title_update(
-                                job_id,
-                                title.id,
-                                title.state.value,
-                                organized_from=title.organized_from,
-                                organized_to=title.organized_to,
-                                output_filename=title.output_filename,
-                                is_extra=title.is_extra,
-                                match_details=title.match_details,
-                            )
-                            await self._check_job_completion(session, job_id)
-                            return
-                except Exception as e:
-                    logger.warning(
-                        f"[MATCH] Title {title_id} (Job {job_id}): duration pre-filter failed: {e}. "
-                        f"Proceeding with matching normally."
-                    )
-
-        # (File ready check moved up to before duration pre-filter)
-
-        # 3. Acquire semaphore to limit concurrent matching (Whisper ASR is GPU-heavy)
-        if self._match_semaphore is not None:
-            logger.info(f"[MATCH] Title {title_id} (Job {job_id}): waiting for match semaphore...")
-            await self._match_semaphore.acquire()
-            logger.info(f"[MATCH] Title {title_id} (Job {job_id}): acquired match semaphore")
-
-        # 4. Transition title to MATCHING now that file is ready and slot acquired
-        async with async_session() as session:
-            title = await session.get(DiscTitle, title_id)
-            if title:
-                title.state = TitleState.MATCHING
-                session.add(title)
-                await session.commit()
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title.id,
-                    title.state.value,
-                    duration_seconds=title.duration_seconds,
-                    file_size_bytes=title.file_size_bytes,
-                )
-
-        # 5. Run matching
-        try:
-            logger.debug(
-                f"[MATCH] Title {title_id} (Job {job_id}): entering _match_single_file_inner"
-            )
-            await self._match_single_file_inner(job_id, title_id, file_path)
-            logger.debug(
-                f"[MATCH] Title {title_id} (Job {job_id}): returned from _match_single_file_inner"
-            )
-        except Exception as e:
-            logger.exception(
-                f"[MATCH] Title {title_id} (Job {job_id}): error in _match_single_file_inner: {e}"
-            )
-            raise  # Let _on_match_task_done trigger _handle_match_failure
-        finally:
-            if self._match_semaphore is not None:
-                self._match_semaphore.release()
-                logger.info(f"[MATCH] Title {title_id} (Job {job_id}): released match semaphore")
-
-    async def _match_single_file_inner(self, job_id: int, title_id: int, file_path: Path) -> None:
-        """Inner matching logic, called under the match semaphore."""
-
-        match_start = time.monotonic()
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            title = await session.get(DiscTitle, title_id)
-            if not job or not title:
-                logger.warning(
-                    f"[MATCH] Title {title_id} (Job {job_id}): DB record not found, aborting"
-                )
-                return
-
-            file_size_mb = 0
-            try:
-                file_size_mb = file_path.stat().st_size / 1024 / 1024
-            except OSError:
-                pass
-
-            logger.info(
-                f"[MATCH] Title {title_id} (Job {job_id}): starting episode matching — "
-                f"file={file_path.name} ({file_size_mb:.0f} MB), "
-                f"series={job.detected_title!r}, season={job.detected_season}"
-            )
-
-            try:
-                # Define progress callback
-                # Since matching runs in a thread, we must schedule the WebSocket update
-                # on the main event loop using run_coroutine_threadsafe.
-                loop = asyncio.get_running_loop()
-                # Bind json.dumps locally to avoid free-variable scoping issues
-                # when the callback runs in a worker thread (seen in production).
-                _json_dumps = json.dumps
-
-                def on_progress(stage: str, percent: float, vote_data: list | None = None):
-                    try:
-                        details = None
-                        if vote_data:
-                            # Build interim match_details with current standings
-                            # Include ALL candidates in runner_ups so the UI can
-                            # display the full voting leaderboard during matching.
-                            best = vote_data[0] if vote_data else None
-                            target = best.get("target_votes", 5) if best else 5
-                            details = _json_dumps(
-                                {
-                                    "score": best["score"] if best else 0,
-                                    "vote_count": best["vote_count"] if best else 0,
-                                    "target_votes": target,
-                                    "runner_ups": vote_data,
-                                }
-                            )
-                        coro = ws_manager.broadcast_title_update(
-                            job_id,
-                            title_id,
-                            TitleState.MATCHING.value,
-                            match_stage=stage,
-                            match_progress=percent,
-                            match_details=details,
-                        )
-                        asyncio.run_coroutine_threadsafe(coro, loop)
-                    except Exception as e:
-                        logger.warning(f"[MATCH] Title {title_id}: progress callback error: {e}")
-
-                # Run the episode matcher (Whisper ASR or subtitle matching)
-                logger.info(
-                    f"[MATCH] Title {title_id} (Job {job_id}): calling episode_curator.match_single_file for {file_path.name}"
-                )
-                result = await episode_curator.match_single_file(
-                    file_path,
-                    series_name=job.detected_title,
-                    season=job.detected_season,
-                    progress_callback=on_progress,
-                )
-                logger.info(
-                    f"[MATCH] Title {title_id} (Job {job_id}): episode_curator.match_single_file returned for {file_path.name}"
-                )
-
-                elapsed = time.monotonic() - match_start
-
-                # Update title with match result
-                title.matched_episode = result.episode_code
-                title.match_confidence = result.confidence
-
-                if result.needs_review:
-                    if result.episode_code:
-                        # Low-confidence match — still usable, mark as matched
-                        title.state = TitleState.MATCHED
-                    else:
-                        # No match found — needs human episode assignment
-                        title.state = TitleState.REVIEW
-
-                    logger.info(
-                        f"[MATCH] Title {title_id} (Job {job_id}): needs review — "
-                        f"episode={result.episode_code}, confidence={result.confidence:.2f}, "
-                        f"state={title.state.value}, elapsed={elapsed:.1f}s"
-                    )
-                else:
-                    title.state = TitleState.MATCHED
-                    logger.info(
-                        f"[MATCH] Title {title_id} (Job {job_id}): matched (deferred) — "
-                        f"episode={result.episode_code}, confidence={result.confidence:.2f}, "
-                        f"elapsed={elapsed:.1f}s"
-                    )
-
-                if result.match_details:
-                    try:
-                        title.match_details = json.dumps(result.match_details)
-                    except Exception as e:
-                        logger.error(f"Failed to dump match_details: {e}")
-
-                # Extract match stats for broadcast
-                matches_found = 1  # Primary match
-                matches_rejected = 0
-
-                if title.match_details:
-                    try:
-                        details = json.loads(title.match_details)
-                        runner_ups = details.get("runner_ups", [])
-                        matches_found += len(runner_ups)
-                        matches_rejected = len(
-                            [r for r in runner_ups if r.get("confidence", 0) < 0.5]
-                        )
-                    except (json.JSONDecodeError, KeyError, TypeError):
-                        pass  # No match details available
-
-                session.add(title)
-                await session.commit()
-
-                # Broadcast update
-                await event_broadcaster.broadcast_job_state_changed(job_id, job.state)
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title.id,
-                    title.state.value,
-                    matched_episode=title.matched_episode,
-                    match_confidence=title.match_confidence,
-                    duration_seconds=title.duration_seconds,
-                    file_size_bytes=title.file_size_bytes,
-                    matches_found=matches_found,
-                    matches_rejected=matches_rejected,
-                    match_details=title.match_details,
-                )
-
-                # DEFERRED ORGANIZATION: We wait for all titles to be matched.
-                # Logic moved to _finalize_disc_job.
-
-                # Check if ALL titles are done to update parent job
-                await self._check_job_completion(session, job_id)
-
-            except (MatchingError, OSError, ValueError):
-                elapsed = time.monotonic() - match_start
-                logger.exception(
-                    f"[MATCH] Title {title_id} (Job {job_id}): matching error after "
-                    f"{elapsed:.1f}s — {file_path.name}. Needs manual assignment."
-                )
-                title.state = TitleState.REVIEW
-                session.add(title)
-                await session.commit()
-                await self._check_job_completion(session, job_id)
-
-    async def _download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
-        """Download subtitles in background. Failure BLOCKS matching."""
-        from sqlalchemy import update
-
-        try:
-            # Set initial status — targeted update to avoid overwriting job state
-            async with async_session() as session:
-                await session.execute(
-                    update(DiscJob)
-                    .where(DiscJob.id == job_id)
-                    .values(subtitle_status="downloading")
-                )
-                await session.commit()
-
-            logger.info(f"Starting background subtitle download for {show_name} S{season}")
-            await ws_manager.broadcast_subtitle_event(job_id, "downloading", downloaded=0, total=0)
-
-            from app.matcher.testing_service import download_subtitles
-
-            # Run in thread as it might be blocking
-            result = await asyncio.to_thread(download_subtitles, show_name, season)
-
-            # Count successes/failures
-            downloaded = sum(
-                1 for ep in result["episodes"] if ep["status"] in ("downloaded", "cached")
-            )
-            failed = sum(1 for ep in result["episodes"] if ep["status"] in ("not_found", "failed"))
-            total = len(result["episodes"])
-
-            # Determine final status
-            status = "completed" if failed == 0 else ("partial" if downloaded > 0 else "failed")
-
-            error_msg = None
-            if status == "failed":
-                error_msg = "Subtitle download failed: No subtitles found"
-
-            logger.info(
-                f"Subtitle download complete for {show_name} S{season}: "
-                f"{status} ({downloaded} downloaded/cached, {failed} failed)"
-            )
-
-            # PERSIST STATUS — targeted update to avoid overwriting job state
-            async with async_session() as session:
-                update_values = {"subtitle_status": status}
-
-                # Update to canonical name if it changed
-                if result.get("show_name") and result["show_name"] != show_name:
-                    logger.info(f"Updating job {job_id} title to canonical: {result['show_name']}")
-                    update_values["detected_title"] = result["show_name"]
-
-                if error_msg:
-                    update_values["error_message"] = error_msg
-
-                await session.execute(
-                    update(DiscJob).where(DiscJob.id == job_id).values(**update_values)
-                )
-                await session.commit()
-
-            await ws_manager.broadcast_subtitle_event(
-                job_id, status, downloaded=downloaded, total=total, failed_count=failed
-            )
-
-        except ValueError as e:
-            logger.error(f"Subtitle download ValueError for {show_name} S{season}: {e}")
-            async with async_session() as session:
-                await session.execute(
-                    update(DiscJob)
-                    .where(DiscJob.id == job_id)
-                    .values(subtitle_status="failed", error_message=str(e))
-                )
-                await session.commit()
-            await ws_manager.broadcast_subtitle_event(job_id, "failed")
-
-        except Exception as e:
-            logger.exception(
-                f"Unexpected error in subtitle download for {show_name} S{season}: {e}"
-            )
-            async with async_session() as session:
-                await session.execute(
-                    update(DiscJob)
-                    .where(DiscJob.id == job_id)
-                    .values(subtitle_status="failed", error_message=f"Download error: {str(e)}")
-                )
-                await session.commit()
-            await ws_manager.broadcast_subtitle_event(job_id, "failed")
-
-        finally:
-            # ALWAYS set event (matching will check status before proceeding)
-            if job_id in self._subtitle_ready:
-                self._subtitle_ready[job_id].set()
-
-    async def cancel_job(self, job_id: int) -> None:
-        """Cancel a running job."""
-        if job_id in self._active_jobs:
-            self._active_jobs[job_id].cancel()
-            del self._active_jobs[job_id]
-
-        self._extractor.cancel(job_id)
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if job and job.state not in (JobState.COMPLETED, JobState.FAILED):
-                await state_machine.transition_to_failed(
-                    job, session, error_message="Cancelled by user"
-                )
-
-    async def apply_review(
-        self,
-        job_id: int,
-        title_id: int,
-        episode_code: str | None = None,
-        edition: str | None = None,
-    ) -> None:
-        """Apply a user's review decision for a title."""
-        from app.core.organizer import movie_organizer, tv_organizer
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                raise ValueError("Job not found")
-
-            title = await session.get(DiscTitle, title_id)
-            if not title or title.job_id != job_id:
-                raise ValueError("Title not found for this job")
-
-            if episode_code:
-                title.matched_episode = episode_code
-
-            if edition:
-                title.edition = edition
-
-            title.match_confidence = 1.0  # User-confirmed
-            session.add(title)
-            await session.commit()
-
-            # Handle Movie Workflow
-            if job.content_type == ContentType.MOVIE:
-                if episode_code == "skip":
-                    title.state = TitleState.FAILED
-                    session.add(title)
-                    await session.commit()
-                    return
-
-                # For movies, we organize the selected title immediately
-                # We assume the user selects the MAIN title(s) they want.
-
-                # Organize
-                if title.output_filename:
-                    source_file = Path(title.output_filename)
-                    if not source_file.exists():
-                        logger.info(
-                            f"Source file {source_file} not found. Triggering ripping for selected title."
-                        )
-
-                        # Set other titles to is_selected=False
-                        # The user selected 'title', so we ensure only this one is selected
-                        statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
-                        all_titles = (await session.execute(statement)).scalars().all()
-                        for t in all_titles:
-                            t.is_selected = t.id == title.id
-                            session.add(t)
-
-                        # Trigger ripping
-                        await session.commit()
-
-                        # We need to call start_ripping, but we are inside an async_session context.
-                        # start_ripping creates its own session. We should schedule it outside or handle it carefully.
-                        # JobManager methods usually handle their own sessions.
-                        # We can just update state here and call _run_ripping as a task?
-                        # Or better, return from here and call start_ripping?
-                        # But apply_review is atomic.
-
-                        # Let's update state to REVIEW_NEEDED -> RIPPING manually here?
-                        # start_ripping checks for IDLE/REVIEW_NEEDED.
-
-                        # Let's close this transaction and call start_ripping?
-                        # We can't easily do that inside the context manager.
-
-                        # Option: Update state to RIPPING here, then spawn the task.
-                        job.state = JobState.RIPPING
-                        job.updated_at = datetime.now(UTC)
-                        session.add(job)
-                        await session.commit()
-                        await event_broadcaster.broadcast_job_state_changed(job_id, job.state)
-
-                        # Spawn ripping task
-                        task = asyncio.create_task(self._run_ripping(job_id))
-                        task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
-                        self._active_jobs[job_id] = task
-                        return
-
-                    else:
-                        # File exists, proceed to organize (Post-Rip workflow)
-                        job.state = JobState.ORGANIZING
-                        await session.commit()
-                        await event_broadcaster.broadcast_job_state_changed(job_id, job.state)
-
-                        # Clean up unselected ripped files (Ambiguous Movie workflow)
-                        # If we ripped multiple versions, delete the ones not selected
-                        cleanup_statement = select(DiscTitle).where(
-                            DiscTitle.job_id == job_id,
-                            DiscTitle.id != title_id,
-                            DiscTitle.output_filename.isnot(None),
-                        )
-                        unselected_titles = (
-                            (await session.execute(cleanup_statement)).scalars().all()
-                        )
-
-                        for unselected in unselected_titles:
-                            try:
-                                p = Path(unselected.output_filename)
-                                if p.exists():
-                                    p.unlink()
-                                    logger.info(f"Deleted unselected file: {p}")
-
-                                unselected.state = TitleState.FAILED
-                                unselected.match_details = json.dumps(
-                                    {"reason": "Unselected by user"}
-                                )
-                                session.add(unselected)
-                            except Exception as e:
-                                logger.warning(
-                                    f"Failed to delete unselected file {unselected.output_filename}: {e}"
-                                )
-
-                        # Pass edition to organizer if supported, or append to title?
-                        # movie_organizer.organize signature: (file_path, volume_label, detected_title)
-                        # We might need to update movie_organizer to accept edition, OR append it to detected_title temporarily
-
-                        final_title = job.detected_title or job.volume_label
-                        if edition and edition.lower() not in final_title.lower():
-                            final_title = f"{final_title} {{edition-{edition}}}"
-
-                        org_result = await asyncio.to_thread(
-                            movie_organizer.organize,
-                            source_file,
-                            job.volume_label,
-                            final_title,
-                        )
-
-                        if org_result["success"]:
-                            title.state = TitleState.COMPLETED
-                            job.progress_percent = 100.0
-                            job.error_message = None
-                            job.final_path = str(org_result["main_file"])
-                            await state_machine.transition_to_completed(job, session)
-                            logger.info(f"Organized movie: {org_result['main_file']}")
-                        elif org_result.get("error_code") == "FILE_EXISTS":
-                            title.state = TitleState.REVIEW
-                            try:
-                                # Preserve existing details if JSON
-                                existing_details = (
-                                    json.loads(title.match_details) if title.match_details else {}
-                                )
-                                existing_details.update(
-                                    {"error": "file_exists", "message": str(org_result["error"])}
-                                )
-                                title.match_details = json.dumps(existing_details)
-                            except (json.JSONDecodeError, TypeError):
-                                # Fall back to creating new details JSON
-                                title.match_details = json.dumps(
-                                    {"error": "file_exists", "message": str(org_result["error"])}
-                                )
-
-                            await state_machine.transition_to_review(
-                                job, session, reason="File already exists in library"
-                            )
-                            logger.warning(
-                                f"Organization conflict for movie: {org_result['error']}"
-                            )
-                        else:
-                            title.state = TitleState.FAILED
-                            logger.error(f"Failed to organize movie: {org_result['error']}")
-                            await state_machine.transition_to_failed(
-                                job, session, error_message=org_result["error"]
-                            )
-
-                # Movie workflow complete — don't fall through to TV workflow
-                return
-
-            # Handle TV Workflow (Original Logic)
-            # Check if all titles for this job are now resolved
-            result = await session.execute(
-                select(DiscTitle).where(
-                    DiscTitle.job_id == job_id,
-                    DiscTitle.matched_episode.is_(None),
-                )
-            )
-            unresolved = result.scalars().all()
-
-            if not unresolved:
-                # All titles resolved - organize files to library
-                job.state = JobState.ORGANIZING
-                session.add(job)
-                await session.commit()
-                await ws_manager.broadcast_job_update(job_id, JobState.ORGANIZING.value)
-
-                # Get all resolved titles for this job
-                all_titles_result = await session.execute(
-                    select(DiscTitle).where(
-                        DiscTitle.job_id == job_id,
-                        DiscTitle.matched_episode.isnot(None),
-                    )
-                )
-                resolved_titles = all_titles_result.scalars().all()
-
-                # Organize each file
-                success_count = 0
-                conflict_count = 0
-
-                for disc_title in resolved_titles:
-                    if disc_title.output_filename and disc_title.matched_episode != "skip":
-                        source_file = Path(disc_title.output_filename)
-                        if source_file.exists():
-                            org_result = await asyncio.to_thread(
-                                tv_organizer.organize,
-                                source_file,
-                                job.detected_title or job.volume_label,
-                                disc_title.matched_episode,
-                            )
-                            if org_result["success"]:
-                                success_count += 1
-                                # Store organization tracking info
-                                disc_title.organized_from = source_file.name
-                                disc_title.organized_to = (
-                                    str(org_result.get("final_path"))
-                                    if org_result.get("final_path")
-                                    else None
-                                )
-                                disc_title.is_extra = False
-                                disc_title.state = TitleState.COMPLETED
-                                logger.info(f"Organized: {org_result['final_path']}")
-                            elif org_result.get("error_code") == "FILE_EXISTS":
-                                conflict_count += 1
-                                disc_title.state = TitleState.REVIEW
-                                try:
-                                    existing = (
-                                        json.loads(disc_title.match_details)
-                                        if disc_title.match_details
-                                        else {}
-                                    )
-                                    existing.update(
-                                        {
-                                            "error": "file_exists",
-                                            "message": str(org_result["error"]),
-                                        }
-                                    )
-                                    disc_title.match_details = json.dumps(existing)
-                                except (json.JSONDecodeError, TypeError):
-                                    # Fall back to creating new details JSON
-                                    disc_title.match_details = json.dumps(
-                                        {
-                                            "error": "file_exists",
-                                            "message": str(org_result["error"]),
-                                        }
-                                    )
-                                logger.warning(
-                                    f"Organization conflict for TV: {org_result['error']}"
-                                )
-                            else:
-                                logger.error(f"Failed to organize: {org_result['error']}")
-
-                            # Broadcast title update with organization result
-                            session.add(disc_title)
-                            await session.commit()
-                            await ws_manager.broadcast_title_update(
-                                job_id,
-                                disc_title.id,
-                                disc_title.state.value,
-                                matched_episode=disc_title.matched_episode,
-                                match_confidence=disc_title.match_confidence,
-                                organized_from=disc_title.organized_from,
-                                organized_to=disc_title.organized_to,
-                                output_filename=disc_title.output_filename,
-                                is_extra=disc_title.is_extra,
-                                match_details=disc_title.match_details,
-                            )
-                        else:
-                            logger.warning(f"Source file not found: {source_file}")
-
-                if conflict_count > 0:
-                    await state_machine.transition_to_review(
-                        job, session, reason=f"{conflict_count} files already exist in library"
-                    )
-                elif success_count > 0:
-                    job.progress_percent = 100.0
-                    job.error_message = None
-                    from app.services.config_service import get_config as get_db_config
-
-                    db_config = await get_db_config()
-                    job.final_path = str(
-                        Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
-                    )
-                    await state_machine.transition_to_completed(job, session)
-                else:
-                    await state_machine.transition_to_failed(
-                        job, session, error_message="Failed to organize files"
-                    )
-            else:
-                await session.commit()
-
-    async def process_matched_titles(self, job_id: int) -> dict:
-        """Process all matched titles for a job without waiting for unresolved ones.
-
-        Organizes titles that already have matches while leaving unresolved titles
-        in REVIEW_NEEDED state. Returns counts of processed, conflicted, and remaining titles.
-        """
-        from app.core.organizer import tv_organizer
-        from app.services.config_service import get_config as get_db_config
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                raise ValueError("Job not found")
-
-            # Query titles that have a match, are not skipped, and are not already terminal
-            result = await session.execute(
-                select(DiscTitle).where(
-                    DiscTitle.job_id == job_id,
-                    DiscTitle.matched_episode.isnot(None),
-                    DiscTitle.matched_episode != "skip",
-                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
-                )
-            )
-            matched_titles = result.scalars().all()
-
-            success_count = 0
-            conflict_count = 0
-
-            for disc_title in matched_titles:
-                if not disc_title.output_filename:
-                    continue
-
-                source_file = Path(disc_title.output_filename)
-                if not source_file.exists():
-                    logger.warning(f"Source file not found: {source_file}")
-                    continue
-
-                org_result = await asyncio.to_thread(
-                    tv_organizer.organize,
-                    source_file,
-                    job.detected_title or job.volume_label,
-                    disc_title.matched_episode,
-                )
-
-                if org_result["success"]:
-                    success_count += 1
-                    disc_title.organized_from = source_file.name
-                    disc_title.organized_to = (
-                        str(org_result.get("final_path")) if org_result.get("final_path") else None
-                    )
-                    disc_title.is_extra = disc_title.matched_episode == "extra"
-                    disc_title.state = TitleState.COMPLETED
-                    logger.info(f"Organized: {org_result['final_path']}")
-                elif org_result.get("error_code") == "FILE_EXISTS":
-                    conflict_count += 1
-                    disc_title.state = TitleState.REVIEW
-                    try:
-                        existing = (
-                            json.loads(disc_title.match_details) if disc_title.match_details else {}
-                        )
-                        existing.update(
-                            {
-                                "error": "file_exists",
-                                "message": str(org_result["error"]),
-                            }
-                        )
-                        disc_title.match_details = json.dumps(existing)
-                    except (json.JSONDecodeError, TypeError):
-                        disc_title.match_details = json.dumps(
-                            {
-                                "error": "file_exists",
-                                "message": str(org_result["error"]),
-                            }
-                        )
-                    logger.warning(f"Organization conflict for TV: {org_result['error']}")
-                else:
-                    logger.error(f"Failed to organize: {org_result['error']}")
-                    continue
-
-                session.add(disc_title)
-                await session.commit()
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    disc_title.id,
-                    disc_title.state.value,
-                    matched_episode=disc_title.matched_episode,
-                    match_confidence=disc_title.match_confidence,
-                    organized_from=disc_title.organized_from,
-                    organized_to=disc_title.organized_to,
-                    output_filename=disc_title.output_filename,
-                    is_extra=disc_title.is_extra,
-                    match_details=disc_title.match_details,
-                )
-
-            # Check if any unresolved titles remain
-            unresolved_result = await session.execute(
-                select(DiscTitle).where(
-                    DiscTitle.job_id == job_id,
-                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
-                    DiscTitle.matched_episode.is_(None),
-                )
-            )
-            unresolved = unresolved_result.scalars().all()
-
-            if not unresolved and conflict_count == 0:
-                job.progress_percent = 100.0
-                job.error_message = None
-                db_config = await get_db_config()
-                job.final_path = str(
-                    Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
-                )
-                await state_machine.transition_to_completed(job, session)
-            else:
-                # Keep in REVIEW_NEEDED — unresolved titles or conflicts remain
-                await session.commit()
-
-        return {
-            "organized": success_count,
-            "conflicts": conflict_count,
-            "unresolved": len(unresolved),
-        }
-
-    # --- Simulation Methods ---
-
-    async def simulate_disc_insert(self, params: dict) -> int:
-        """Simulate a disc insertion for testing purposes."""
-        from app.services.config_service import get_config as get_sim_config
-
-        drive_id = params.get("drive_id", "E:")
-        volume_label = params.get("volume_label", "SIMULATED_DISC")
-        content_type_str = params.get("content_type", "tv")
-
-        # Parse detected_title: remove season/disc suffix (e.g., "_S1D1", "_S01D01")
-        default_title = volume_label.replace("_", " ").title()
-        import re
-
-        # Remove season/disc patterns like "S1D1", "S01D01", etc.
-        default_title = re.sub(r"\s+S\d+D?\d*$", "", default_title, flags=re.IGNORECASE)
-        detected_title = params.get("detected_title", default_title)
-        detected_season = params.get("detected_season", 1)
-        simulate_ripping = params.get("simulate_ripping", False)
-        rip_speed_multiplier = params.get("rip_speed_multiplier", 10)
-        title_params = params.get("titles", [])
-
-        content_type = ContentType(content_type_str)
-
-        # Default titles if none provided
-        if not title_params:
-            if content_type == ContentType.TV:
-                title_params = [
-                    {"duration_seconds": 1320 + i * 60, "file_size_bytes": 1024 * 1024 * 1024}
-                    for i in range(8)
-                ]
-            else:
-                title_params = [
-                    {"duration_seconds": 7200, "file_size_bytes": 4 * 1024 * 1024 * 1024}
-                ]
-
-        async with async_session() as session:
-            # Create job
-            job = DiscJob(
-                drive_id=drive_id,
-                volume_label=volume_label,
-                content_type=content_type,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-                state=JobState.IDENTIFYING,
-                total_titles=len(title_params),
-                staging_path=str(
-                    Path((await get_sim_config()).staging_path)
-                    / f"sim_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-                ),
-            )
-            session.add(job)
-            await session.commit()
-            await session.refresh(job)
-
-            # Create titles
-            titles = []
-            for i, tp in enumerate(title_params):
-                title = DiscTitle(
-                    job_id=job.id,
-                    title_index=i,
-                    duration_seconds=tp.get("duration_seconds", 1320),
-                    file_size_bytes=tp.get("file_size_bytes", 1024 * 1024 * 1024),
-                    chapter_count=tp.get("chapter_count", 5),
-                )
-                session.add(title)
-                titles.append(title)
-            await session.commit()
-            for t in titles:
-                await session.refresh(t)
-
-            # Broadcast drive event
-            await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)
-
-            # Broadcast identifying
-            await ws_manager.broadcast_job_update(
-                job.id,
-                JobState.IDENTIFYING.value,
-                content_type=content_type.value,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-                total_titles=len(title_params),
-            )
-
-            # Short delay to simulate scanning
-            await asyncio.sleep(0.5)
-
-            # Broadcast titles discovered
-            title_list = build_title_list(titles)
-            await ws_manager.broadcast_titles_discovered(
-                job.id,
-                title_list,
-                content_type=content_type.value,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-            )
-
-            # Start subtitle download for TV content (needed for matching)
-            # Use simulated subtitle download since this is a simulation
-            if content_type == ContentType.TV and detected_title and detected_season:
-                self._subtitle_ready[job.id] = asyncio.Event()
-                self._subtitle_tasks[job.id] = asyncio.create_task(
-                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
-                )
-                logger.info(
-                    f"Job {job.id}: starting simulated subtitle download for {detected_title} S{detected_season}"
-                )
-
-            force_review = params.get("force_review_needed", False)
-            if force_review:
-                # Transition directly to review_needed (for E2E testing name prompt, etc.)
-                job.state = JobState.REVIEW_NEEDED
-                job.detected_title = None  # Clear title to trigger name prompt
-                job.review_reason = params.get("review_reason", "Disc label unreadable")
-                await session.commit()
-                await ws_manager.broadcast_job_update(
-                    job.id,
-                    JobState.REVIEW_NEEDED.value,
-                    content_type=content_type.value,
-                    detected_title=None,
-                    review_reason=job.review_reason,
-                    total_titles=len(title_params),
-                )
-            elif simulate_ripping:
-                # Start simulated ripping in background
-                task = asyncio.create_task(
-                    self._simulate_ripping(job.id, titles, rip_speed_multiplier, content_type)
-                )
-                task.add_done_callback(lambda t, jid=job.id: self._on_task_done(t, jid))
-                self._active_jobs[job.id] = task
-            else:
-                # Just move to ripping state
-                job.state = JobState.RIPPING
-                await session.commit()
-                await ws_manager.broadcast_job_update(
-                    job.id,
-                    JobState.RIPPING.value,
-                    content_type=content_type.value,
-                    detected_title=detected_title,
-                    detected_season=detected_season if content_type == ContentType.TV else None,
-                    total_titles=len(title_params),
-                )
-
-            return job.id
-
-    async def simulate_disc_insert_realistic(self, params: dict) -> int:
-        """
-        Simulate disc insertion using real MKV files from staging.
-        Uses 10-second ripping simulation per track with progress updates.
-        """
-
-        drive_id = params.get("drive_id", "E:")
-        volume_label = params.get("volume_label", "REAL_DATA_DISC")
-        content_type = ContentType(params.get("content_type", "tv"))
-        detected_title = params.get("detected_title")
-        detected_season = params.get("detected_season", 1)
-        title_params = params.get("titles", [])
-        staging_path = params.get("staging_path")
-        rip_speed_multiplier = params.get("rip_speed_multiplier", 1)
-
-        async with async_session() as session:
-            # Create DiscJob first (before broadcasting, so fetch finds it)
-            job = DiscJob(
-                drive_id=drive_id,
-                volume_label=volume_label,
-                content_type=content_type,
-                state=JobState.IDENTIFYING,
-                detected_title=detected_title,
-                detected_season=detected_season,
-                staging_path=staging_path,
-            )
-            session.add(job)
-            await session.commit()
-            await session.refresh(job)
-
-            # Broadcast drive event after job exists in DB
-            await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)
-
-            await ws_manager.broadcast_job_update(
-                job.id,
-                JobState.IDENTIFYING.value,
-                content_type=content_type.value,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-                total_titles=len(title_params),
-            )
-
-            # Create titles from real files
-            titles = []
-            for title_param in title_params:
-                title = DiscTitle(
-                    job_id=job.id,
-                    title_index=title_param["title_index"],
-                    duration_seconds=title_param["duration_seconds"],
-                    file_size_bytes=title_param["file_size_bytes"],
-                    chapter_count=title_param.get("chapter_count", 5),
-                    is_selected=True,
-                    output_filename=title_param.get("output_filename"),
-                    state=TitleState.PENDING,
-                )
-                session.add(title)
-                titles.append(title)
-
-            await session.commit()
-
-            # Move to ripping state
-            job.state = JobState.RIPPING
-            job.total_titles = len(titles)
-            await session.commit()
-            await ws_manager.broadcast_job_update(
-                job.id,
-                JobState.RIPPING.value,
-                content_type=content_type.value,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-                total_titles=len(titles),
-            )
-
-            # Refresh titles to get their IDs after commit
-            for t in titles:
-                await session.refresh(t)
-
-            # Broadcast titles discovered (must include id for frontend)
-            title_list = build_title_list(titles)
-            await ws_manager.broadcast_titles_discovered(
-                job.id,
-                title_list,
-                content_type=content_type.value,
-                detected_title=detected_title,
-                detected_season=detected_season if content_type == ContentType.TV else None,
-            )
-
-            # Start subtitle download for TV content
-            if content_type == ContentType.TV and detected_title and detected_season:
-                self._subtitle_ready[job.id] = asyncio.Event()
-                self._subtitle_tasks[job.id] = asyncio.create_task(
-                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
-                )
-                logger.info(
-                    f"Job {job.id}: starting simulated subtitle download for {detected_title} S{detected_season}"
-                )
-
-            # Start realistic ripping simulation
-            task = asyncio.create_task(
-                self._simulate_realistic_ripping(job.id, titles, content_type, rip_speed_multiplier)
-            )
-            self._active_jobs[job.id] = task
-
-            return job.id
-
-    async def _simulate_realistic_ripping(
-        self,
-        job_id: int,
-        titles: list[DiscTitle],
-        content_type: ContentType,
-        speed_multiplier: int = 1,
-    ) -> None:
-        """Simulate ripping with configurable speed per track and progress updates."""
-        async with async_session() as session:
-            for i, title in enumerate(titles):
-                logger.info(f"[SIMULATE] Job {job_id}: starting realistic rip of title {i}")
-
-                # Update title state to ripping
-                title_db = await session.get(DiscTitle, title.id)
-                if not title_db:
-                    continue
-
-                title_db.state = TitleState.RIPPING
-                title_bytes = title_db.file_size_bytes or 0
-                await session.commit()
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title_db.id,
-                    TitleState.RIPPING.value,
-                    duration_seconds=title_db.duration_seconds,
-                    file_size_bytes=title_db.file_size_bytes,
-                    expected_size_bytes=title_bytes,
-                    actual_size_bytes=0,
-                )
-
-                # Simulate ripping with progress updates (speed multiplier reduces time)
-                base_steps = 20  # 20 steps at 0.5s = 10 seconds base
-                steps = max(4, base_steps // max(1, speed_multiplier))
-                sleep_time = 0.5 / max(1, speed_multiplier)
-                step_size = title_bytes / steps if steps > 0 else 0
-                for step in range(steps + 1):
-                    await asyncio.sleep(sleep_time)
-
-                    # Update job progress
-                    job = await session.get(DiscJob, job_id)
-                    if job:
-                        job.progress_percent = ((i + (step / steps)) / len(titles)) * 100
-                        job.current_title = i + 1
-                        await session.commit()
-                        await ws_manager.broadcast_job_update(
-                            job_id,
-                            JobState.RIPPING.value,
-                            progress=job.progress_percent,
-                            current_title=i + 1,
-                        )
-
-                    # Per-track byte progress
-                    title_actual = int(step_size * step)
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title_db.id,
-                        TitleState.RIPPING.value,
-                        expected_size_bytes=title_bytes,
-                        actual_size_bytes=min(title_actual, title_bytes),
-                    )
-
-                # Mark title as done ripping — movies skip matching
-                post_rip_state = (
-                    TitleState.MATCHING if content_type == ContentType.TV else TitleState.MATCHED
-                )
-                title_db.state = post_rip_state
-                await session.commit()
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title_db.id,
-                    post_rip_state.value,
-                    duration_seconds=title_db.duration_seconds,
-                    file_size_bytes=title_db.file_size_bytes,
-                )
-
-                logger.info(f"[SIMULATE] Job {job_id}: completed realistic rip of title {i}")
-
-            # Move to matching
-            job = await session.get(DiscJob, job_id)
-            if content_type == ContentType.TV:
-                # Wait for subtitle download
-                if job_id in self._subtitle_ready:
-                    logger.info(f"[SIMULATE] Job {job_id}: waiting for subtitle download...")
-                    try:
-                        await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=30)
-                        logger.info(f"[SIMULATE] Job {job_id}: subtitle download complete")
-                        await session.refresh(job)
-                    except TimeoutError:
-                        logger.warning(f"[SIMULATE] Job {job_id}: subtitle download timed out")
-
-                job.state = JobState.MATCHING
-                await session.commit()
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.MATCHING)
-                # Use the real matching simulation with runner_ups
-                await self._simulate_matching(job_id, titles, session)
-            else:
-                job.state = JobState.ORGANIZING
-                await session.commit()
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.ORGANIZING)
-                await asyncio.sleep(0.5)
-                job.progress_percent = 100.0
-                # Transition all movie titles to COMPLETED before completing job
-                for title in titles:
-                    title_db = await session.get(DiscTitle, title.id)
-                    if title_db and title_db.state not in (
-                        TitleState.COMPLETED,
-                        TitleState.FAILED,
-                    ):
-                        title_db.state = TitleState.COMPLETED
-                        session.add(title_db)
-                await session.commit()
-                await state_machine.transition_to_completed(job, session)
-
-    async def _simulate_ripping(
-        self,
-        job_id: int,
-        titles: list[DiscTitle],
-        speed_multiplier: int,
-        content_type: ContentType,
-    ) -> None:
-        """Simulate the ripping process with realistic progress updates."""
-        import random
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                return
-
-            job.state = JobState.RIPPING
-            await session.commit()
-
-            total_bytes = sum(t.file_size_bytes for t in titles)
-            cumulative_bytes = 0
-
-            for i, title in enumerate(titles):
-                current_title = i + 1
-                title_bytes = title.file_size_bytes
-                steps = max(5, 20 // speed_multiplier)
-                step_size = title_bytes / steps
-
-                # Set title to RIPPING with expected size for per-track progress
-                title_db = await session.get(DiscTitle, title.id)
-                if title_db:
-                    title_db.state = TitleState.RIPPING
-                    await session.commit()
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title_db.id,
-                        TitleState.RIPPING.value,
-                        duration_seconds=title_db.duration_seconds,
-                        file_size_bytes=title_db.file_size_bytes,
-                        expected_size_bytes=title_bytes,
-                        actual_size_bytes=0,
-                    )
-
-                for step in range(steps):
-                    await asyncio.sleep(0.1 / speed_multiplier)
-                    cumulative_bytes += step_size
-                    pct = min((cumulative_bytes / total_bytes) * 100, 100)
-
-                    speed_val = random.uniform(3.0, 8.0)
-                    remaining = total_bytes - cumulative_bytes
-                    eta = int(remaining / (speed_val * 4.5 * 1024 * 1024)) if speed_val > 0 else 0
-
-                    await ws_manager.broadcast_job_update(
-                        job_id,
-                        JobState.RIPPING.value,
-                        progress=pct,
-                        speed=f"{speed_val:.1f}x ({speed_val * 4.5:.1f} M/s)",
-                        eta=eta,
-                        current_title=current_title,
-                        total_titles=len(titles),
-                    )
-
-                    # Per-track byte progress
-                    title_actual = int(step_size * (step + 1))
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title.id,
-                        TitleState.RIPPING.value,
-                        expected_size_bytes=title_bytes,
-                        actual_size_bytes=min(title_actual, title_bytes),
-                    )
-
-                # Title done — movies skip matching
-                title_db = await session.get(DiscTitle, title.id)
-                if title_db:
-                    title_db.output_filename = f"simulated_title_{title.title_index}.mkv"
-                    post_rip_state = (
-                        TitleState.MATCHING
-                        if content_type == ContentType.TV
-                        else TitleState.MATCHED
-                    )
-                    title_db.state = post_rip_state
-                    await session.commit()
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title_db.id,
-                        post_rip_state.value,
-                        duration_seconds=title_db.duration_seconds,
-                        file_size_bytes=title_db.file_size_bytes,
-                    )
-
-            # Move to matching
-            job = await session.get(DiscJob, job_id)
-            if content_type == ContentType.TV:
-                # Wait for subtitle download to complete before matching
-                if job_id in self._subtitle_ready:
-                    logger.info(f"[SIMULATE] Job {job_id}: waiting for subtitle download...")
-                    try:
-                        await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=10)
-                        logger.info(f"[SIMULATE] Job {job_id}: subtitle download complete")
-                        # Refresh job to get updated subtitle_status
-                        await session.refresh(job)
-                    except TimeoutError:
-                        logger.warning(f"[SIMULATE] Job {job_id}: subtitle download timed out")
-
-                job.state = JobState.MATCHING
-                await session.commit()
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.MATCHING)
-                # Simulate matching
-                await self._simulate_matching(job_id, titles, session)
-            else:
-                job.state = JobState.ORGANIZING
-                await session.commit()
-                await event_broadcaster.broadcast_job_state_changed(job_id, JobState.ORGANIZING)
-                await asyncio.sleep(0.5)
-                job.progress_percent = 100.0
-                # Transition all movie titles to COMPLETED before completing job
-                for title in titles:
-                    title_db = await session.get(DiscTitle, title.id)
-                    if title_db and title_db.state not in (
-                        TitleState.COMPLETED,
-                        TitleState.FAILED,
-                    ):
-                        title_db.state = TitleState.COMPLETED
-                        session.add(title_db)
-                await session.commit()
-                await state_machine.transition_to_completed(job, session)
-
-    async def _simulate_subtitle_download(self, job_id: int, total: int, show_name: str) -> None:
-        """Simulate subtitle download events. Fails completely for unknown shows."""
-        import random
-
-        from sqlalchemy import update
-
-        # Set initial status to "downloading" — targeted update to avoid overwriting state
-        async with async_session() as session:
-            await session.execute(
-                update(DiscJob).where(DiscJob.id == job_id).values(subtitle_status="downloading")
-            )
-            await session.commit()
-
-        # Simulate subtitle download progress
-        downloaded = 0
-        for _i in range(total):
-            await asyncio.sleep(0.2)
-            if random.random() > 0.1:
-                downloaded += 1
-            await ws_manager.broadcast_subtitle_event(
-                job_id, "downloading", downloaded=downloaded, total=total
-            )
-
-        failed = total - downloaded
-        status = "completed" if failed == 0 else "partial"
-
-        # PERSIST STATUS IN DATABASE — targeted update to avoid overwriting state
-        async with async_session() as session:
-            await session.execute(
-                update(DiscJob).where(DiscJob.id == job_id).values(subtitle_status=status)
-            )
-            await session.commit()
-
-        await ws_manager.broadcast_subtitle_event(
-            job_id, status, downloaded=downloaded, total=total, failed_count=failed
-        )
-
-        # Always set the event
-        if job_id in self._subtitle_ready:
-            self._subtitle_ready[job_id].set()
-
-    async def _simulate_matching(
-        self,
-        job_id: int,
-        titles: list[DiscTitle],
-        session: AsyncSession,
-    ) -> None:
-        """Simulate episode matching with random confidence levels."""
-        import random
-
-        # Check subtitle status - BLOCK matching if failed
-        job = await session.get(DiscJob, job_id)
-        subtitle_status = job.subtitle_status if job else None
-
-        if subtitle_status == "failed":
-            logger.error(
-                f"[SIMULATE] Job {job_id}: BLOCKING matching - subtitle download failed. "
-                f"Marking all titles as FAILED."
-            )
-            # Mark all titles as FAILED
-            for title in titles:
-                title_db = await session.get(DiscTitle, title.id)
-                if title_db:
-                    title_db.state = TitleState.FAILED
-                    title_db.match_confidence = 0.0
-                    title_db.match_details = json.dumps(
-                        {
-                            "error": "subtitle_download_failed",
-                            "message": job.error_message
-                            or "Subtitle download failed, cannot match without reference files",
-                        }
-                    )
-                    await session.commit()
-                    await ws_manager.broadcast_title_update(
-                        job_id,
-                        title_db.id,
-                        title_db.state.value,
-                        matched_episode=None,
-                        match_confidence=0.0,
-                    )
-            # Mark job as FAILED
-            await state_machine.transition_to_failed(
-                job,
-                session,
-                error_message="Subtitle download failed - cannot proceed with matching",
-            )
-            return
-
-        logger.info(
-            f"[SIMULATE] Job {job_id}: subtitle status '{subtitle_status}', proceeding with matching simulation"
-        )
-
-        needs_review = False
-        for i, title in enumerate(titles):
-            title_db = await session.get(DiscTitle, title.id)
-            if not title_db:
-                continue
-
-            # Phase 1: Simulate transcribing/matching progress
-            confidence = random.uniform(0.7, 1.0)
-            season = 1
-            job = await session.get(DiscJob, job_id)
-            if job and job.detected_season:
-                season = job.detected_season
-
-            episode_code = f"S{season:02d}E{(i + 1):02d}"
-
-            # Generate runner_ups upfront so we can show them during matching
-            runner_ups = []
-            num_candidates = random.randint(2, 4)
-            for j in range(num_candidates):
-                alt_episode = f"S{season:02d}E{(i + j + 1):02d}"
-                alt_score = confidence if j == 0 else random.uniform(0.3, confidence - 0.1)
-                runner_ups.append(
-                    {
-                        "episode": alt_episode,
-                        "score": alt_score,
-                        "vote_count": 0,
-                    }
-                )
-
-            # Simulate voting rounds — candidates accumulate votes
-            target_votes = 4
-            for vote_round in range(target_votes):
-                progress = ((vote_round + 1) / target_votes) * 100.0
-                # Increment votes for each candidate
-                for ru in runner_ups:
-                    if random.random() < ru["score"]:
-                        ru["vote_count"] = min(target_votes, ru["vote_count"] + 1)
-
-                interim_details = json.dumps(
-                    {
-                        "score": confidence,
-                        "vote_count": vote_round + 1,
-                        "target_votes": target_votes,
-                        "runner_ups": runner_ups,
-                    }
-                )
-                await ws_manager.broadcast_title_update(
-                    job_id,
-                    title_db.id,
-                    TitleState.MATCHING.value,
-                    match_stage="matching",
-                    match_progress=progress,
-                    match_details=interim_details,
-                )
-                await asyncio.sleep(0.4)
-
-            # Phase 2: Final match result
-            title_db.matched_episode = episode_code
-            title_db.match_confidence = confidence
-            title_db.match_details = json.dumps(
-                {
-                    "score": confidence,
-                    "vote_count": min(target_votes, int(confidence * target_votes)),
-                    "file_cov": random.uniform(0.6, 0.95),
-                    "runner_ups": runner_ups,
-                }
-            )
-
-            if confidence >= 0.6:
-                title_db.state = TitleState.COMPLETED
-            else:
-                title_db.state = TitleState.MATCHING
-                needs_review = True
-
-            await session.commit()
-            await ws_manager.broadcast_title_update(
-                job_id,
-                title_db.id,
-                title_db.state.value,
-                matched_episode=title_db.matched_episode,
-                match_confidence=title_db.match_confidence,
-                match_details=title_db.match_details,
-                duration_seconds=title_db.duration_seconds,
-                file_size_bytes=title_db.file_size_bytes,
-            )
-
-        job = await session.get(DiscJob, job_id)
-        if not job:
-            logger.error(f"[SIMULATE] Job {job_id}: could not load job for completion")
-            return
-
-        logger.info(
-            f"[SIMULATE] Job {job_id}: matching complete. "
-            f"needs_review={needs_review}, job.state={job.state.value}"
-        )
-
-        if needs_review:
-            await state_machine.transition_to_review(
-                job, session, reason="Some episodes have low confidence matches", broadcast=False
-            )
-            await ws_manager.broadcast_job_update(job_id, job.state.value, progress=0)
-        else:
-            job.progress_percent = 100.0
-            result = await state_machine.transition_to_completed(job, session)
-            logger.info(
-                f"[SIMULATE] Job {job_id}: transition_to_completed returned {result}, "
-                f"job.state={job.state.value}"
-            )
-
-    async def advance_job(self, job_id: int) -> str:
-        """Manually advance a job to the next state. Returns new state."""
-        state_flow = {
-            JobState.IDLE: JobState.IDENTIFYING,
-            JobState.IDENTIFYING: JobState.RIPPING,
-            JobState.RIPPING: JobState.MATCHING,
-            JobState.MATCHING: JobState.ORGANIZING,
-            JobState.ORGANIZING: JobState.COMPLETED,
-            JobState.REVIEW_NEEDED: JobState.RIPPING,
-        }
-
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            if not job:
-                raise ValueError(f"Job {job_id} not found")
-
-            next_state = state_flow.get(job.state)
-            if not next_state:
-                raise ValueError(f"Cannot advance from state: {job.state}")
-
-            job.state = next_state
-            job.updated_at = datetime.now(UTC)
-            if next_state == JobState.COMPLETED:
-                job.progress_percent = 100.0
-            await session.commit()
-
-            await ws_manager.broadcast_job_update(job_id, next_state.value)
-            return next_state.value
+            logger.error(f"Job {job_id} task failed with exception: {exc}", exc_info=exc)
 
     async def _cancel_jobs_for_drive(self, drive_letter: str) -> None:
         """Cancel jobs that need the disc; leave post-ripping jobs running."""
-        # Only cancel jobs in states that require the physical disc
-        # Note: RIPPING is excluded because MakeMKV might auto-eject at the end, causing a race condition.
-        # If the user manually ejects during ripping, MakeMKV will fail with an I/O error anyway.
         disc_required_states = [JobState.IDLE, JobState.IDENTIFYING]
         async with async_session() as session:
             result = await session.execute(
@@ -4289,6 +1154,12 @@ class JobManager:
                     f"Disc removed from {drive_letter} but no jobs need cancelling "
                     "(post-ripping jobs continue)"
                 )
+
+    # --- Convenience access for routes (subtitle download) ---
+
+    async def _download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
+        """Download subtitles — exposed for test routes."""
+        await self._matching.download_subtitles(job_id, show_name, season)
 
 
 # Singleton instance

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1,0 +1,853 @@
+"""Matching Coordinator - Episode matching, subtitle download, and DiscDB assignment.
+
+Extracted from JobManager to isolate matching concerns.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.core.curator import curator as episode_curator
+from app.core.errors import MatchingError
+from app.database import async_session
+from app.models import DiscJob
+from app.models.disc_job import DiscTitle, TitleState
+from app.services.event_broadcaster import EventBroadcaster
+from app.services.job_state_machine import JobStateMachine
+
+logger = logging.getLogger(__name__)
+
+
+class MatchingCoordinator:
+    """Coordinates episode matching: subtitle download, audio fingerprinting, DiscDB assignment."""
+
+    def __init__(
+        self,
+        event_broadcaster: EventBroadcaster,
+        state_machine: JobStateMachine,
+    ) -> None:
+        self._broadcaster = event_broadcaster
+        self._state_machine = state_machine
+
+        # Shared state (moved from JobManager)
+        self._discdb_mappings: dict[int, list] = {}
+        self._episode_runtimes: dict[int, list[int]] = {}
+        self._subtitle_ready: dict[int, asyncio.Event] = {}
+        self._subtitle_tasks: dict[int, asyncio.Task] = {}
+        self._match_semaphore: asyncio.Semaphore | None = None
+
+        # Cross-coordinator callback
+        self._check_job_completion: callable = None
+
+    def set_callbacks(self, *, check_job_completion) -> None:
+        """Set cross-coordinator callbacks."""
+        self._check_job_completion = check_job_completion
+
+    def init_semaphore(self, concurrency: int) -> None:
+        """Initialize the match semaphore with the given concurrency."""
+        self._match_semaphore = asyncio.Semaphore(concurrency)
+
+    def get_discdb_mappings(self, job_id: int) -> list:
+        """Get DiscDB mappings for a job."""
+        return self._discdb_mappings.get(job_id, [])
+
+    def set_discdb_mappings(self, job_id: int, mappings: list) -> None:
+        """Set DiscDB mappings for a job."""
+        self._discdb_mappings[job_id] = mappings
+
+    def start_subtitle_download(self, job_id: int, show_name: str, season: int) -> None:
+        """Start background subtitle download with tracking."""
+        self._subtitle_ready[job_id] = asyncio.Event()
+        self._subtitle_tasks[job_id] = asyncio.create_task(
+            self.download_subtitles(job_id, show_name, season)
+        )
+
+    async def try_discdb_assignment(self, job_id: int, title: "DiscTitle", session) -> bool:
+        """Try to assign episode info from TheDiscDB mappings, skipping fingerprinting.
+
+        Returns True if assignment was made, False to fall back to audio matching.
+        """
+        mappings = self._discdb_mappings.get(job_id)
+        if not mappings:
+            return False
+
+        # Find the mapping for this title index
+        mapping = None
+        for m in mappings:
+            if m.index == title.title_index:
+                mapping = m
+                break
+
+        if not mapping or not mapping.season or not mapping.episode:
+            return False
+
+        if mapping.title_type not in ("Episode", "MainMovie"):
+            return False
+
+        episode_code = f"S{mapping.season:02d}E{mapping.episode:02d}"
+        logger.info(
+            f"Job {job_id}: TheDiscDB pre-assigned title {title.title_index} "
+            f"→ {episode_code} ({mapping.episode_title!r}) — skipping audio matching"
+        )
+
+        title.matched_episode = episode_code
+        title.match_confidence = 0.99
+        title.match_details = f'{{"source": "discdb", "episode_title": "{mapping.episode_title}"}}'
+        title.state = TitleState.MATCHED
+        session.add(title)
+        await session.commit()
+
+        await ws_manager.broadcast_title_update(
+            job_id,
+            title.id,
+            TitleState.MATCHED.value,
+            matched_episode=episode_code,
+            match_confidence=0.99,
+        )
+
+        return True
+
+    async def match_single_file(self, job_id: int, title_id: int, file_path: Path) -> None:
+        """Run matching for a single ripped file."""
+        logger.info(
+            f"[MATCH] Title {title_id} (Job {job_id}): match task started for {file_path.name}"
+        )
+
+        # 1. Wait for subtitles to be ready before matching
+        logger.info(
+            f"[MATCH] Title {title_id} (Job {job_id}): _match_single_file entered. "
+            f"subtitle_ready event exists: {job_id in self._subtitle_ready}"
+        )
+        if job_id in self._subtitle_ready:
+            logger.info(
+                f"[MATCH] Title {title_id} (Job {job_id}): waiting for subtitle download..."
+            )
+            try:
+                logger.debug(
+                    f"[MATCH] Title {title_id} (Job {job_id}): entering wait_for(subtitle_ready)"
+                )
+                await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=300)
+                logger.info(f"[MATCH] Title {title_id} (Job {job_id}): subtitle event received")
+            except TimeoutError:
+                logger.warning(
+                    f"[MATCH] Title {title_id} (Job {job_id}): subtitle download timed out "
+                    f"after 300s"
+                )
+            except Exception as e:
+                logger.error(
+                    f"[MATCH] Title {title_id} (Job {job_id}): error waiting for subtitles: {e}"
+                )
+
+        # 1b. Check subtitle status from database - BLOCK matching if failed
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            subtitle_status = job.subtitle_status if job else None
+
+        # Gate matching based on subtitle status
+        if subtitle_status == "failed":
+            logger.warning(
+                f"[MATCH] Title {title_id} (Job {job_id}): subtitle download failed. "
+                f"No reference files available. Title needs manual episode assignment."
+            )
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                if title:
+                    title.state = TitleState.REVIEW
+                    title.match_confidence = 0.0
+                    title.match_details = json.dumps(
+                        {
+                            "error": "subtitle_download_failed",
+                            "message": "Subtitle download failed, cannot auto-match. Manual episode assignment needed.",
+                        }
+                    )
+                    session.add(title)
+                    await session.commit()
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title.id,
+                        title.state.value,
+                        matched_episode=None,
+                        match_confidence=0.0,
+                    )
+                    await self._check_job_completion(session, job_id)
+            return
+
+        elif subtitle_status == "partial":
+            logger.warning(
+                f"[MATCH] Title {title_id} (Job {job_id}): subtitle download partially succeeded. "
+                f"Matching will proceed with available reference files."
+            )
+
+        elif subtitle_status in ("completed", None):
+            logger.info(
+                f"[MATCH] Title {title_id} (Job {job_id}): subtitles ready, proceeding with matching"
+            )
+
+        else:
+            logger.warning(
+                f"[MATCH] Title {title_id} (Job {job_id}): unknown subtitle status '{subtitle_status}', "
+                f"attempting match anyway"
+            )
+
+        # 2. Wait for the file to be fully written before matching
+        file_ready = await self._wait_for_file_ready(file_path, title_id, job_id)
+        if not file_ready:
+            logger.error(
+                f"[MATCH] Title {title_id} (Job {job_id}): file never became ready, "
+                f"skipping match for {file_path.name}"
+            )
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                if title:
+                    title.state = TitleState.FAILED
+                    session.add(title)
+                    await session.commit()
+                await self._check_job_completion(session, job_id)
+            return
+
+        # 1c. Duration pre-filter
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            title = await session.get(DiscTitle, title_id)
+            if job and title and job.detected_season:
+                try:
+                    if job_id not in self._episode_runtimes:
+                        from app.matcher.tmdb_client import (
+                            fetch_season_episode_runtimes,
+                            fetch_show_id,
+                        )
+
+                        show_id = await asyncio.to_thread(fetch_show_id, job.detected_title)
+                        if show_id:
+                            runtimes = await asyncio.to_thread(
+                                fetch_season_episode_runtimes,
+                                show_id,
+                                job.detected_season,
+                            )
+                            self._episode_runtimes[job_id] = runtimes
+                        else:
+                            self._episode_runtimes[job_id] = []
+
+                    runtimes = self._episode_runtimes.get(job_id, [])
+                    if runtimes and title.duration_seconds:
+                        title_minutes = title.duration_seconds / 60
+                        tolerance = 5  # minutes
+                        matches_any = any(abs(title_minutes - rt) <= tolerance for rt in runtimes)
+                        if not matches_any:
+                            handled = await self._handle_extras(
+                                job_id,
+                                title_id,
+                                title,
+                                job,
+                                file_path,
+                                title_minutes,
+                                runtimes,
+                                session,
+                            )
+                            if handled:
+                                return
+                except Exception as e:
+                    logger.warning(
+                        f"[MATCH] Title {title_id} (Job {job_id}): duration pre-filter failed: {e}. "
+                        f"Proceeding with matching normally."
+                    )
+
+        # 3. Acquire semaphore to limit concurrent matching
+        if self._match_semaphore is not None:
+            logger.info(f"[MATCH] Title {title_id} (Job {job_id}): waiting for match semaphore...")
+            await self._match_semaphore.acquire()
+            logger.info(f"[MATCH] Title {title_id} (Job {job_id}): acquired match semaphore")
+
+        # 4. Transition title to MATCHING
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if title:
+                title.state = TitleState.MATCHING
+                session.add(title)
+                await session.commit()
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title.id,
+                    title.state.value,
+                    duration_seconds=title.duration_seconds,
+                    file_size_bytes=title.file_size_bytes,
+                )
+
+        # 5. Run matching
+        try:
+            logger.debug(
+                f"[MATCH] Title {title_id} (Job {job_id}): entering _match_single_file_inner"
+            )
+            await self._match_single_file_inner(job_id, title_id, file_path)
+            logger.debug(
+                f"[MATCH] Title {title_id} (Job {job_id}): returned from _match_single_file_inner"
+            )
+        except Exception as e:
+            logger.exception(
+                f"[MATCH] Title {title_id} (Job {job_id}): error in _match_single_file_inner: {e}"
+            )
+            raise
+        finally:
+            if self._match_semaphore is not None:
+                self._match_semaphore.release()
+                logger.info(f"[MATCH] Title {title_id} (Job {job_id}): released match semaphore")
+
+    async def _match_single_file_inner(self, job_id: int, title_id: int, file_path: Path) -> None:
+        """Inner matching logic, called under the match semaphore."""
+        match_start = time.monotonic()
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            title = await session.get(DiscTitle, title_id)
+            if not job or not title:
+                logger.warning(
+                    f"[MATCH] Title {title_id} (Job {job_id}): DB record not found, aborting"
+                )
+                return
+
+            file_size_mb = 0
+            try:
+                file_size_mb = file_path.stat().st_size / 1024 / 1024
+            except OSError:
+                pass
+
+            logger.info(
+                f"[MATCH] Title {title_id} (Job {job_id}): starting episode matching — "
+                f"file={file_path.name} ({file_size_mb:.0f} MB), "
+                f"series={job.detected_title!r}, season={job.detected_season}"
+            )
+
+            try:
+                # Define progress callback
+                loop = asyncio.get_running_loop()
+                _json_dumps = json.dumps
+
+                def on_progress(stage: str, percent: float, vote_data: list | None = None):
+                    try:
+                        details = None
+                        if vote_data:
+                            best = vote_data[0] if vote_data else None
+                            target = best.get("target_votes", 5) if best else 5
+                            details = _json_dumps(
+                                {
+                                    "score": best["score"] if best else 0,
+                                    "vote_count": best["vote_count"] if best else 0,
+                                    "target_votes": target,
+                                    "runner_ups": vote_data,
+                                }
+                            )
+                        coro = ws_manager.broadcast_title_update(
+                            job_id,
+                            title_id,
+                            TitleState.MATCHING.value,
+                            match_stage=stage,
+                            match_progress=percent,
+                            match_details=details,
+                        )
+                        asyncio.run_coroutine_threadsafe(coro, loop)
+                    except Exception as e:
+                        logger.warning(f"[MATCH] Title {title_id}: progress callback error: {e}")
+
+                # Run the episode matcher
+                logger.info(
+                    f"[MATCH] Title {title_id} (Job {job_id}): calling episode_curator.match_single_file for {file_path.name}"
+                )
+                result = await episode_curator.match_single_file(
+                    file_path,
+                    series_name=job.detected_title,
+                    season=job.detected_season,
+                    progress_callback=on_progress,
+                )
+                logger.info(
+                    f"[MATCH] Title {title_id} (Job {job_id}): episode_curator.match_single_file returned for {file_path.name}"
+                )
+
+                elapsed = time.monotonic() - match_start
+
+                # Update title with match result
+                title.matched_episode = result.episode_code
+                title.match_confidence = result.confidence
+
+                if result.needs_review:
+                    if result.episode_code:
+                        title.state = TitleState.MATCHED
+                    else:
+                        title.state = TitleState.REVIEW
+
+                    logger.info(
+                        f"[MATCH] Title {title_id} (Job {job_id}): needs review — "
+                        f"episode={result.episode_code}, confidence={result.confidence:.2f}, "
+                        f"state={title.state.value}, elapsed={elapsed:.1f}s"
+                    )
+                else:
+                    title.state = TitleState.MATCHED
+                    logger.info(
+                        f"[MATCH] Title {title_id} (Job {job_id}): matched (deferred) — "
+                        f"episode={result.episode_code}, confidence={result.confidence:.2f}, "
+                        f"elapsed={elapsed:.1f}s"
+                    )
+
+                if result.match_details:
+                    try:
+                        title.match_details = json.dumps(result.match_details)
+                    except Exception as e:
+                        logger.error(f"Failed to dump match_details: {e}")
+
+                # Extract match stats for broadcast
+                matches_found = 1
+                matches_rejected = 0
+
+                if title.match_details:
+                    try:
+                        details = json.loads(title.match_details)
+                        runner_ups = details.get("runner_ups", [])
+                        matches_found += len(runner_ups)
+                        matches_rejected = len(
+                            [r for r in runner_ups if r.get("confidence", 0) < 0.5]
+                        )
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        pass
+
+                session.add(title)
+                await session.commit()
+
+                # Broadcast update
+                await self._broadcaster.broadcast_job_state_changed(job_id, job.state)
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title.id,
+                    title.state.value,
+                    matched_episode=title.matched_episode,
+                    match_confidence=title.match_confidence,
+                    duration_seconds=title.duration_seconds,
+                    file_size_bytes=title.file_size_bytes,
+                    matches_found=matches_found,
+                    matches_rejected=matches_rejected,
+                    match_details=title.match_details,
+                )
+
+                # Check if ALL titles are done
+                await self._check_job_completion(session, job_id)
+
+            except (MatchingError, OSError, ValueError):
+                elapsed = time.monotonic() - match_start
+                logger.exception(
+                    f"[MATCH] Title {title_id} (Job {job_id}): matching error after "
+                    f"{elapsed:.1f}s — {file_path.name}. Needs manual assignment."
+                )
+                title.state = TitleState.REVIEW
+                session.add(title)
+                await session.commit()
+                await self._check_job_completion(session, job_id)
+
+    async def _handle_extras(
+        self,
+        job_id,
+        title_id,
+        title,
+        job,
+        file_path,
+        title_minutes,
+        runtimes,
+        session,
+    ):
+        """Handle extras based on policy. Returns True if title was handled."""
+        logger.info(
+            f"[MATCH] Title {title_id} (Job {job_id}): duration {title_minutes:.0f}min "
+            f"doesn't match any episode runtime {runtimes} (±5min). "
+            f"Detected as extra."
+        )
+
+        from app.services.config_service import get_config as get_db_config
+
+        db_config = await get_db_config()
+        extras_policy = db_config.extras_policy
+
+        if extras_policy == "skip":
+            logger.info(f"[MATCH] Title {title_id}: extras policy is 'skip', discarding.")
+            title.state = TitleState.COMPLETED
+            title.is_extra = True
+            title.match_details = json.dumps(
+                {
+                    "auto_sorted": "extras",
+                    "action": "skipped",
+                    "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
+                }
+            )
+            session.add(title)
+            await session.commit()
+            await ws_manager.broadcast_title_update(
+                job_id,
+                title.id,
+                title.state.value,
+                is_extra=title.is_extra,
+                match_details=title.match_details,
+            )
+            await self._check_job_completion(session, job_id)
+            return True
+
+        if extras_policy == "ask":
+            logger.info(f"[MATCH] Title {title_id}: extras policy is 'ask', sending to review.")
+            title.state = TitleState.REVIEW
+            title.is_extra = True
+            title.match_details = json.dumps(
+                {
+                    "auto_sorted": "extras",
+                    "action": "review",
+                    "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
+                }
+            )
+            session.add(title)
+            await session.commit()
+            await ws_manager.broadcast_title_update(
+                job_id,
+                title.id,
+                title.state.value,
+                is_extra=title.is_extra,
+                match_details=title.match_details,
+            )
+            await self._check_job_completion(session, job_id)
+            return True
+
+        # Default: "keep" — organize to extras folder
+        from app.core.organizer import organize_tv_extras
+
+        # Count existing extras for this job to determine index
+        extras_count = 0
+        all_titles = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id))
+        for t in all_titles.scalars():
+            if t.match_details:
+                try:
+                    details = json.loads(t.match_details)
+                    if details.get("auto_sorted") == "extras":
+                        extras_count += 1
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    pass
+
+        extra_index = extras_count + 1
+
+        org_result = await asyncio.to_thread(
+            organize_tv_extras,
+            file_path,
+            job.detected_title,
+            job.detected_season,
+            None,
+            job.disc_number,
+            extra_index,
+        )
+        if org_result["success"]:
+            title.state = TitleState.COMPLETED
+            title.organized_from = file_path.name
+            title.organized_to = (
+                str(org_result.get("final_path")) if org_result.get("final_path") else None
+            )
+            title.is_extra = True
+            title.match_details = json.dumps(
+                {
+                    "auto_sorted": "extras",
+                    "action": "kept",
+                    "reason": f"Duration {title_minutes:.0f}min doesn't match episode runtimes",
+                }
+            )
+        else:
+            title.state = TitleState.COMPLETED
+            title.match_details = json.dumps(
+                {
+                    "auto_sorted": "extras",
+                    "action": "kept",
+                    "organize_error": org_result["error"],
+                }
+            )
+            logger.warning(
+                f"[MATCH] Title {title_id}: extras organize failed: {org_result['error']}"
+            )
+        session.add(title)
+        await session.commit()
+        await ws_manager.broadcast_title_update(
+            job_id,
+            title.id,
+            title.state.value,
+            organized_from=title.organized_from,
+            organized_to=title.organized_to,
+            output_filename=title.output_filename,
+            is_extra=title.is_extra,
+            match_details=title.match_details,
+        )
+        await self._check_job_completion(session, job_id)
+        return True
+
+    async def _wait_for_file_ready(
+        self,
+        file_path: Path,
+        title_id: int,
+        job_id: int,
+        timeout: float | None = None,
+    ) -> bool:
+        """Wait until a ripped file is fully written and ready for processing."""
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        check_interval = config.ripping_file_poll_interval
+        required_stable = config.ripping_stability_checks
+
+        # Get expected size from DB
+        expected_size = 0
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if title and title.file_size_bytes:
+                expected_size = title.file_size_bytes
+
+        # Calculate dynamic timeout based on file size
+        if timeout is None:
+            if expected_size > 0:
+                base_timeout = (expected_size / (1024 * 1024)) * 2
+                timeout = max(config.ripping_file_ready_timeout, base_timeout)
+            else:
+                timeout = config.ripping_file_ready_timeout
+
+        last_size = -1
+        stable_count = 0
+        start = time.monotonic()
+
+        logger.info(
+            f"[MATCH] Title {title_id} (Job {job_id}): waiting for file to finish "
+            f"writing: {file_path.name} (expected ~{expected_size / 1024 / 1024:.0f} MB, "
+            f"timeout {timeout:.0f}s)"
+        )
+
+        while time.monotonic() - start < timeout:
+            if not file_path.exists():
+                logger.debug(
+                    f"[MATCH] Title {title_id} (Job {job_id}): file not yet on disk, "
+                    f"waiting... ({file_path.name})"
+                )
+                await asyncio.sleep(check_interval)
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title_id,
+                    TitleState.RIPPING.value,
+                    match_stage="waiting_for_file",
+                    match_progress=0.0,
+                    expected_size_bytes=expected_size,
+                    actual_size_bytes=0,
+                )
+                continue
+
+            try:
+                current_size = file_path.stat().st_size
+            except OSError as e:
+                logger.debug(
+                    f"[MATCH] Title {title_id} (Job {job_id}): cannot stat file ({e}), retrying..."
+                )
+                await asyncio.sleep(check_interval)
+                continue
+
+            if current_size > 0 and current_size == last_size:
+                stable_count += 1
+
+                size_matches_expected = True
+                if expected_size > 0:
+                    size_ratio = current_size / expected_size
+                    size_matches_expected = size_ratio >= 0.85
+
+                logger.debug(
+                    f"[MATCH] Title {title_id} (Job {job_id}): file size stable "
+                    f"({current_size / 1024 / 1024:.0f} MB) — check {stable_count}/{required_stable}"
+                    + (
+                        f" — size {size_ratio * 100:.1f}% of expected {expected_size / 1024 / 1024:.0f} MB"
+                        if expected_size > 0
+                        else ""
+                    )
+                )
+
+                if stable_count >= required_stable and size_matches_expected:
+                    try:
+                        with open(file_path, "rb") as _f:
+                            _f.read(1)
+                    except PermissionError:
+                        logger.debug(
+                            f"[MATCH] Title {title_id} (Job {job_id}): size stable but "
+                            f"file still locked ({file_path.name}) — waiting..."
+                        )
+                        stable_count = 0
+                        await asyncio.sleep(check_interval)
+                        continue
+                    logger.info(
+                        f"[MATCH] Title {title_id} (Job {job_id}): file ready "
+                        f"({current_size / 1024 / 1024:.0f} MB, stable for "
+                        f"{stable_count * check_interval:.0f}s): {file_path.name}"
+                    )
+                    return True
+                elif stable_count >= required_stable and not size_matches_expected:
+                    logger.debug(
+                        f"[MATCH] Title {title_id} (Job {job_id}): file size stable but only "
+                        f"{current_size / 1024 / 1024:.0f} MB of expected "
+                        f"{expected_size / 1024 / 1024:.0f} MB ({size_ratio * 100:.1f}%) — still writing"
+                    )
+                    stable_count = 0
+            else:
+                if stable_count > 0:
+                    logger.debug(
+                        f"[MATCH] Title {title_id} (Job {job_id}): file size changed "
+                        f"({last_size} -> {current_size}), resetting stability counter"
+                    )
+                stable_count = 0
+
+            last_size = current_size
+
+            # Broadcast wait progress
+            if expected_size > 0:
+                wait_progress = min(99.0, (current_size / expected_size) * 100.0)
+            else:
+                wait_progress = min(99.0, (stable_count / required_stable) * 100.0)
+
+            await ws_manager.broadcast_title_update(
+                job_id,
+                title_id,
+                TitleState.RIPPING.value,
+                match_stage="waiting_for_file",
+                match_progress=wait_progress,
+                expected_size_bytes=expected_size,
+                actual_size_bytes=current_size,
+            )
+
+            await asyncio.sleep(check_interval)
+
+        elapsed = time.monotonic() - start
+        logger.warning(
+            f"[MATCH] Title {title_id} (Job {job_id}): timed out waiting for file "
+            f"after {elapsed:.0f}s: {file_path.name}"
+        )
+        return False
+
+    def on_match_task_done(self, task: asyncio.Task, job_id: int, title_id: int) -> None:
+        """Handle matching task completion/failure."""
+        if task.cancelled():
+            logger.warning(f"[MATCH] Title {title_id} (Job {job_id}): task cancelled")
+            asyncio.ensure_future(self._handle_match_failure(job_id, title_id, "Task cancelled"))
+        elif exc := task.exception():
+            logger.error(
+                f"[MATCH] Title {title_id} (Job {job_id}): task failed: {exc}",
+                exc_info=exc,
+            )
+            asyncio.ensure_future(self._handle_match_failure(job_id, title_id, str(exc)))
+
+    async def _handle_match_failure(self, job_id: int, title_id: int, error: str) -> None:
+        """Clean up after a matching task fails unexpectedly."""
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            active_states = (
+                TitleState.PENDING,
+                TitleState.RIPPING,
+                TitleState.MATCHING,
+            )
+            if title and title.state in active_states:
+                title.state = TitleState.REVIEW
+                title.match_details = json.dumps(
+                    {"error": "matching_task_failed", "message": error}
+                )
+                session.add(title)
+                await session.commit()
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title_id,
+                    title.state.value,
+                    match_details=title.match_details,
+                )
+            await self._check_job_completion(session, job_id)
+
+    async def download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
+        """Download subtitles in background. Failure BLOCKS matching."""
+        from sqlalchemy import update
+
+        try:
+            async with async_session() as session:
+                await session.execute(
+                    update(DiscJob)
+                    .where(DiscJob.id == job_id)
+                    .values(subtitle_status="downloading")
+                )
+                await session.commit()
+
+            logger.info(f"Starting background subtitle download for {show_name} S{season}")
+            await ws_manager.broadcast_subtitle_event(job_id, "downloading", downloaded=0, total=0)
+
+            from app.matcher.testing_service import download_subtitles
+
+            result = await asyncio.to_thread(download_subtitles, show_name, season)
+
+            downloaded = sum(
+                1 for ep in result["episodes"] if ep["status"] in ("downloaded", "cached")
+            )
+            failed = sum(1 for ep in result["episodes"] if ep["status"] in ("not_found", "failed"))
+            total = len(result["episodes"])
+
+            status = "completed" if failed == 0 else ("partial" if downloaded > 0 else "failed")
+
+            error_msg = None
+            if status == "failed":
+                error_msg = "Subtitle download failed: No subtitles found"
+
+            logger.info(
+                f"Subtitle download complete for {show_name} S{season}: "
+                f"{status} ({downloaded} downloaded/cached, {failed} failed)"
+            )
+
+            async with async_session() as session:
+                update_values = {"subtitle_status": status}
+
+                if result.get("show_name") and result["show_name"] != show_name:
+                    logger.info(f"Updating job {job_id} title to canonical: {result['show_name']}")
+                    update_values["detected_title"] = result["show_name"]
+
+                if error_msg:
+                    update_values["error_message"] = error_msg
+
+                await session.execute(
+                    update(DiscJob).where(DiscJob.id == job_id).values(**update_values)
+                )
+                await session.commit()
+
+            await ws_manager.broadcast_subtitle_event(
+                job_id,
+                status,
+                downloaded=downloaded,
+                total=total,
+                failed_count=failed,
+            )
+
+        except ValueError as e:
+            logger.error(f"Subtitle download ValueError for {show_name} S{season}: {e}")
+            async with async_session() as session:
+                await session.execute(
+                    update(DiscJob)
+                    .where(DiscJob.id == job_id)
+                    .values(subtitle_status="failed", error_message=str(e))
+                )
+                await session.commit()
+            await ws_manager.broadcast_subtitle_event(job_id, "failed")
+
+        except Exception as e:
+            logger.exception(
+                f"Unexpected error in subtitle download for {show_name} S{season}: {e}"
+            )
+            async with async_session() as session:
+                await session.execute(
+                    update(DiscJob)
+                    .where(DiscJob.id == job_id)
+                    .values(
+                        subtitle_status="failed",
+                        error_message=f"Download error: {str(e)}",
+                    )
+                )
+                await session.commit()
+            await ws_manager.broadcast_subtitle_event(job_id, "failed")
+
+        finally:
+            if job_id in self._subtitle_ready:
+                self._subtitle_ready[job_id].set()

--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -1,0 +1,717 @@
+"""Simulation Service - Test/debug simulation endpoints.
+
+Extracted from JobManager to isolate simulation concerns.
+Only active when DEBUG=true.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.websocket import manager as ws_manager
+from app.database import async_session
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.event_broadcaster import EventBroadcaster
+from app.services.job_state_machine import JobStateMachine
+from app.services.ripping_helpers import build_title_list
+
+logger = logging.getLogger(__name__)
+
+
+class SimulationService:
+    """Handles all simulation methods for E2E testing."""
+
+    def __init__(
+        self,
+        event_broadcaster: EventBroadcaster,
+        state_machine: JobStateMachine,
+    ) -> None:
+        self._broadcaster = event_broadcaster
+        self._state_machine = state_machine
+
+        # Cross-coordinator references (set by JobManager)
+        self._subtitle_ready: dict = None
+        self._subtitle_tasks: dict = None
+        self._active_jobs: dict = None
+        self._on_task_done: callable = None
+
+    def set_callbacks(
+        self,
+        *,
+        subtitle_ready,
+        subtitle_tasks,
+        active_jobs,
+        on_task_done,
+    ) -> None:
+        """Set cross-coordinator references."""
+        self._subtitle_ready = subtitle_ready
+        self._subtitle_tasks = subtitle_tasks
+        self._active_jobs = active_jobs
+        self._on_task_done = on_task_done
+
+    async def simulate_disc_insert(self, params: dict) -> int:
+        """Simulate a disc insertion for testing purposes."""
+        from app.services.config_service import get_config as get_sim_config
+
+        drive_id = params.get("drive_id", "E:")
+        volume_label = params.get("volume_label", "SIMULATED_DISC")
+        content_type_str = params.get("content_type", "tv")
+
+        # Parse detected_title
+        default_title = volume_label.replace("_", " ").title()
+        default_title = re.sub(r"\s+S\d+D?\d*$", "", default_title, flags=re.IGNORECASE)
+        detected_title = params.get("detected_title", default_title)
+        detected_season = params.get("detected_season", 1)
+        simulate_ripping = params.get("simulate_ripping", False)
+        rip_speed_multiplier = params.get("rip_speed_multiplier", 10)
+        title_params = params.get("titles", [])
+
+        content_type = ContentType(content_type_str)
+
+        # Default titles if none provided
+        if not title_params:
+            if content_type == ContentType.TV:
+                title_params = [
+                    {
+                        "duration_seconds": 1320 + i * 60,
+                        "file_size_bytes": 1024 * 1024 * 1024,
+                    }
+                    for i in range(8)
+                ]
+            else:
+                title_params = [
+                    {
+                        "duration_seconds": 7200,
+                        "file_size_bytes": 4 * 1024 * 1024 * 1024,
+                    }
+                ]
+
+        async with async_session() as session:
+            job = DiscJob(
+                drive_id=drive_id,
+                volume_label=volume_label,
+                content_type=content_type,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+                state=JobState.IDENTIFYING,
+                total_titles=len(title_params),
+                staging_path=str(
+                    Path((await get_sim_config()).staging_path)
+                    / f"sim_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+                ),
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+
+            # Create titles
+            titles = []
+            for i, tp in enumerate(title_params):
+                title = DiscTitle(
+                    job_id=job.id,
+                    title_index=i,
+                    duration_seconds=tp.get("duration_seconds", 1320),
+                    file_size_bytes=tp.get("file_size_bytes", 1024 * 1024 * 1024),
+                    chapter_count=tp.get("chapter_count", 5),
+                )
+                session.add(title)
+                titles.append(title)
+            await session.commit()
+            for t in titles:
+                await session.refresh(t)
+
+            # Broadcast drive event
+            await self._broadcaster.broadcast_drive_inserted(drive_id, volume_label)
+
+            # Broadcast identifying
+            await ws_manager.broadcast_job_update(
+                job.id,
+                JobState.IDENTIFYING.value,
+                content_type=content_type.value,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+                total_titles=len(title_params),
+            )
+
+            await asyncio.sleep(0.5)
+
+            # Broadcast titles discovered
+            title_list = build_title_list(titles)
+            await ws_manager.broadcast_titles_discovered(
+                job.id,
+                title_list,
+                content_type=content_type.value,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+            )
+
+            # Start subtitle download for TV content
+            if content_type == ContentType.TV and detected_title and detected_season:
+                self._subtitle_ready[job.id] = asyncio.Event()
+                self._subtitle_tasks[job.id] = asyncio.create_task(
+                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
+                )
+                logger.info(
+                    f"Job {job.id}: starting simulated subtitle download for "
+                    f"{detected_title} S{detected_season}"
+                )
+
+            force_review = params.get("force_review_needed", False)
+            if force_review:
+                job.state = JobState.REVIEW_NEEDED
+                job.detected_title = None
+                job.review_reason = params.get("review_reason", "Disc label unreadable")
+                await session.commit()
+                await ws_manager.broadcast_job_update(
+                    job.id,
+                    JobState.REVIEW_NEEDED.value,
+                    content_type=content_type.value,
+                    detected_title=None,
+                    review_reason=job.review_reason,
+                    total_titles=len(title_params),
+                )
+            elif simulate_ripping:
+                task = asyncio.create_task(
+                    self._simulate_ripping(job.id, titles, rip_speed_multiplier, content_type)
+                )
+                task.add_done_callback(lambda t, jid=job.id: self._on_task_done(t, jid))
+                self._active_jobs[job.id] = task
+            else:
+                job.state = JobState.RIPPING
+                await session.commit()
+                await ws_manager.broadcast_job_update(
+                    job.id,
+                    JobState.RIPPING.value,
+                    content_type=content_type.value,
+                    detected_title=detected_title,
+                    detected_season=(detected_season if content_type == ContentType.TV else None),
+                    total_titles=len(title_params),
+                )
+
+            return job.id
+
+    async def simulate_disc_insert_realistic(self, params: dict) -> int:
+        """Simulate disc insertion using real MKV files from staging."""
+        drive_id = params.get("drive_id", "E:")
+        volume_label = params.get("volume_label", "REAL_DATA_DISC")
+        content_type = ContentType(params.get("content_type", "tv"))
+        detected_title = params.get("detected_title")
+        detected_season = params.get("detected_season", 1)
+        title_params = params.get("titles", [])
+        staging_path = params.get("staging_path")
+        rip_speed_multiplier = params.get("rip_speed_multiplier", 1)
+
+        async with async_session() as session:
+            job = DiscJob(
+                drive_id=drive_id,
+                volume_label=volume_label,
+                content_type=content_type,
+                state=JobState.IDENTIFYING,
+                detected_title=detected_title,
+                detected_season=detected_season,
+                staging_path=staging_path,
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+
+            await self._broadcaster.broadcast_drive_inserted(drive_id, volume_label)
+
+            await ws_manager.broadcast_job_update(
+                job.id,
+                JobState.IDENTIFYING.value,
+                content_type=content_type.value,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+                total_titles=len(title_params),
+            )
+
+            # Create titles from real files
+            titles = []
+            for title_param in title_params:
+                title = DiscTitle(
+                    job_id=job.id,
+                    title_index=title_param["title_index"],
+                    duration_seconds=title_param["duration_seconds"],
+                    file_size_bytes=title_param["file_size_bytes"],
+                    chapter_count=title_param.get("chapter_count", 5),
+                    is_selected=True,
+                    output_filename=title_param.get("output_filename"),
+                    state=TitleState.PENDING,
+                )
+                session.add(title)
+                titles.append(title)
+
+            await session.commit()
+
+            job.state = JobState.RIPPING
+            job.total_titles = len(titles)
+            await session.commit()
+            await ws_manager.broadcast_job_update(
+                job.id,
+                JobState.RIPPING.value,
+                content_type=content_type.value,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+                total_titles=len(titles),
+            )
+
+            for t in titles:
+                await session.refresh(t)
+
+            title_list = build_title_list(titles)
+            await ws_manager.broadcast_titles_discovered(
+                job.id,
+                title_list,
+                content_type=content_type.value,
+                detected_title=detected_title,
+                detected_season=(detected_season if content_type == ContentType.TV else None),
+            )
+
+            # Start subtitle download for TV content
+            if content_type == ContentType.TV and detected_title and detected_season:
+                self._subtitle_ready[job.id] = asyncio.Event()
+                self._subtitle_tasks[job.id] = asyncio.create_task(
+                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
+                )
+                logger.info(
+                    f"Job {job.id}: starting simulated subtitle download for "
+                    f"{detected_title} S{detected_season}"
+                )
+
+            task = asyncio.create_task(
+                self._simulate_realistic_ripping(job.id, titles, content_type, rip_speed_multiplier)
+            )
+            self._active_jobs[job.id] = task
+
+            return job.id
+
+    async def _simulate_realistic_ripping(
+        self,
+        job_id: int,
+        titles: list[DiscTitle],
+        content_type: ContentType,
+        speed_multiplier: int = 1,
+    ) -> None:
+        """Simulate ripping with configurable speed per track."""
+        async with async_session() as session:
+            for i, title in enumerate(titles):
+                logger.info(f"[SIMULATE] Job {job_id}: starting realistic rip of title {i}")
+
+                title_db = await session.get(DiscTitle, title.id)
+                if not title_db:
+                    continue
+
+                title_db.state = TitleState.RIPPING
+                title_bytes = title_db.file_size_bytes or 0
+                await session.commit()
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title_db.id,
+                    TitleState.RIPPING.value,
+                    duration_seconds=title_db.duration_seconds,
+                    file_size_bytes=title_db.file_size_bytes,
+                    expected_size_bytes=title_bytes,
+                    actual_size_bytes=0,
+                )
+
+                base_steps = 20
+                steps = max(4, base_steps // max(1, speed_multiplier))
+                sleep_time = 0.5 / max(1, speed_multiplier)
+                step_size = title_bytes / steps if steps > 0 else 0
+                for step in range(steps + 1):
+                    await asyncio.sleep(sleep_time)
+
+                    job = await session.get(DiscJob, job_id)
+                    if job:
+                        job.progress_percent = ((i + (step / steps)) / len(titles)) * 100
+                        job.current_title = i + 1
+                        await session.commit()
+                        await ws_manager.broadcast_job_update(
+                            job_id,
+                            JobState.RIPPING.value,
+                            progress=job.progress_percent,
+                            current_title=i + 1,
+                        )
+
+                    title_actual = int(step_size * step)
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title_db.id,
+                        TitleState.RIPPING.value,
+                        expected_size_bytes=title_bytes,
+                        actual_size_bytes=min(title_actual, title_bytes),
+                    )
+
+                post_rip_state = (
+                    TitleState.MATCHING if content_type == ContentType.TV else TitleState.MATCHED
+                )
+                title_db.state = post_rip_state
+                await session.commit()
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title_db.id,
+                    post_rip_state.value,
+                    duration_seconds=title_db.duration_seconds,
+                    file_size_bytes=title_db.file_size_bytes,
+                )
+
+                logger.info(f"[SIMULATE] Job {job_id}: completed realistic rip of title {i}")
+
+            # Move to matching
+            job = await session.get(DiscJob, job_id)
+            if content_type == ContentType.TV:
+                if job_id in self._subtitle_ready:
+                    logger.info(f"[SIMULATE] Job {job_id}: waiting for subtitle download...")
+                    try:
+                        await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=30)
+                        logger.info(f"[SIMULATE] Job {job_id}: subtitle download complete")
+                        await session.refresh(job)
+                    except TimeoutError:
+                        logger.warning(f"[SIMULATE] Job {job_id}: subtitle download timed out")
+
+                job.state = JobState.MATCHING
+                await session.commit()
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.MATCHING)
+                await self._simulate_matching(job_id, titles, session)
+            else:
+                job.state = JobState.ORGANIZING
+                await session.commit()
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.ORGANIZING)
+                await asyncio.sleep(0.5)
+                job.progress_percent = 100.0
+                for title in titles:
+                    title_db = await session.get(DiscTitle, title.id)
+                    if title_db and title_db.state not in (
+                        TitleState.COMPLETED,
+                        TitleState.FAILED,
+                    ):
+                        title_db.state = TitleState.COMPLETED
+                        session.add(title_db)
+                await session.commit()
+                await self._state_machine.transition_to_completed(job, session)
+
+    async def _simulate_ripping(
+        self,
+        job_id: int,
+        titles: list[DiscTitle],
+        speed_multiplier: int,
+        content_type: ContentType,
+    ) -> None:
+        """Simulate the ripping process with realistic progress updates."""
+        import random
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+
+            job.state = JobState.RIPPING
+            await session.commit()
+
+            total_bytes = sum(t.file_size_bytes for t in titles)
+            cumulative_bytes = 0
+
+            for i, title in enumerate(titles):
+                current_title = i + 1
+                title_bytes = title.file_size_bytes
+                steps = max(5, 20 // speed_multiplier)
+                step_size = title_bytes / steps
+
+                title_db = await session.get(DiscTitle, title.id)
+                if title_db:
+                    title_db.state = TitleState.RIPPING
+                    await session.commit()
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title_db.id,
+                        TitleState.RIPPING.value,
+                        duration_seconds=title_db.duration_seconds,
+                        file_size_bytes=title_db.file_size_bytes,
+                        expected_size_bytes=title_bytes,
+                        actual_size_bytes=0,
+                    )
+
+                for step in range(steps):
+                    await asyncio.sleep(0.1 / speed_multiplier)
+                    cumulative_bytes += step_size
+                    pct = min((cumulative_bytes / total_bytes) * 100, 100)
+
+                    speed_val = random.uniform(3.0, 8.0)
+                    remaining = total_bytes - cumulative_bytes
+                    eta = int(remaining / (speed_val * 4.5 * 1024 * 1024)) if speed_val > 0 else 0
+
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.RIPPING.value,
+                        progress=pct,
+                        speed=f"{speed_val:.1f}x ({speed_val * 4.5:.1f} M/s)",
+                        eta=eta,
+                        current_title=current_title,
+                        total_titles=len(titles),
+                    )
+
+                    title_actual = int(step_size * (step + 1))
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title.id,
+                        TitleState.RIPPING.value,
+                        expected_size_bytes=title_bytes,
+                        actual_size_bytes=min(title_actual, title_bytes),
+                    )
+
+                title_db = await session.get(DiscTitle, title.id)
+                if title_db:
+                    title_db.output_filename = f"simulated_title_{title.title_index}.mkv"
+                    post_rip_state = (
+                        TitleState.MATCHING
+                        if content_type == ContentType.TV
+                        else TitleState.MATCHED
+                    )
+                    title_db.state = post_rip_state
+                    await session.commit()
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title_db.id,
+                        post_rip_state.value,
+                        duration_seconds=title_db.duration_seconds,
+                        file_size_bytes=title_db.file_size_bytes,
+                    )
+
+            # Move to matching
+            job = await session.get(DiscJob, job_id)
+            if content_type == ContentType.TV:
+                if job_id in self._subtitle_ready:
+                    logger.info(f"[SIMULATE] Job {job_id}: waiting for subtitle download...")
+                    try:
+                        await asyncio.wait_for(self._subtitle_ready[job_id].wait(), timeout=10)
+                        logger.info(f"[SIMULATE] Job {job_id}: subtitle download complete")
+                        await session.refresh(job)
+                    except TimeoutError:
+                        logger.warning(f"[SIMULATE] Job {job_id}: subtitle download timed out")
+
+                job.state = JobState.MATCHING
+                await session.commit()
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.MATCHING)
+                await self._simulate_matching(job_id, titles, session)
+            else:
+                job.state = JobState.ORGANIZING
+                await session.commit()
+                await self._broadcaster.broadcast_job_state_changed(job_id, JobState.ORGANIZING)
+                await asyncio.sleep(0.5)
+                job.progress_percent = 100.0
+                for title in titles:
+                    title_db = await session.get(DiscTitle, title.id)
+                    if title_db and title_db.state not in (
+                        TitleState.COMPLETED,
+                        TitleState.FAILED,
+                    ):
+                        title_db.state = TitleState.COMPLETED
+                        session.add(title_db)
+                await session.commit()
+                await self._state_machine.transition_to_completed(job, session)
+
+    async def _simulate_subtitle_download(self, job_id: int, total: int, show_name: str) -> None:
+        """Simulate subtitle download events."""
+        import random
+
+        from sqlalchemy import update
+
+        async with async_session() as session:
+            await session.execute(
+                update(DiscJob).where(DiscJob.id == job_id).values(subtitle_status="downloading")
+            )
+            await session.commit()
+
+        downloaded = 0
+        for _i in range(total):
+            await asyncio.sleep(0.2)
+            if random.random() > 0.1:
+                downloaded += 1
+            await ws_manager.broadcast_subtitle_event(
+                job_id, "downloading", downloaded=downloaded, total=total
+            )
+
+        failed = total - downloaded
+        status = "completed" if failed == 0 else "partial"
+
+        async with async_session() as session:
+            await session.execute(
+                update(DiscJob).where(DiscJob.id == job_id).values(subtitle_status=status)
+            )
+            await session.commit()
+
+        await ws_manager.broadcast_subtitle_event(
+            job_id,
+            status,
+            downloaded=downloaded,
+            total=total,
+            failed_count=failed,
+        )
+
+        if job_id in self._subtitle_ready:
+            self._subtitle_ready[job_id].set()
+
+    async def _simulate_matching(
+        self,
+        job_id: int,
+        titles: list[DiscTitle],
+        session: AsyncSession,
+    ) -> None:
+        """Simulate episode matching with random confidence levels."""
+        import random
+
+        job = await session.get(DiscJob, job_id)
+        subtitle_status = job.subtitle_status if job else None
+
+        if subtitle_status == "failed":
+            logger.error(
+                f"[SIMULATE] Job {job_id}: BLOCKING matching - subtitle download failed. "
+                f"Marking all titles as FAILED."
+            )
+            for title in titles:
+                title_db = await session.get(DiscTitle, title.id)
+                if title_db:
+                    title_db.state = TitleState.FAILED
+                    title_db.match_confidence = 0.0
+                    title_db.match_details = json.dumps(
+                        {
+                            "error": "subtitle_download_failed",
+                            "message": (
+                                job.error_message
+                                or "Subtitle download failed, cannot match without reference files"
+                            ),
+                        }
+                    )
+                    await session.commit()
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title_db.id,
+                        title_db.state.value,
+                        matched_episode=None,
+                        match_confidence=0.0,
+                    )
+            await self._state_machine.transition_to_failed(
+                job,
+                session,
+                error_message="Subtitle download failed - cannot proceed with matching",
+            )
+            return
+
+        logger.info(
+            f"[SIMULATE] Job {job_id}: subtitle status '{subtitle_status}', "
+            f"proceeding with matching simulation"
+        )
+
+        needs_review = False
+        for i, title in enumerate(titles):
+            title_db = await session.get(DiscTitle, title.id)
+            if not title_db:
+                continue
+
+            confidence = random.uniform(0.7, 1.0)
+            season = 1
+            job = await session.get(DiscJob, job_id)
+            if job and job.detected_season:
+                season = job.detected_season
+
+            episode_code = f"S{season:02d}E{(i + 1):02d}"
+
+            runner_ups = []
+            num_candidates = random.randint(2, 4)
+            for j in range(num_candidates):
+                alt_episode = f"S{season:02d}E{(i + j + 1):02d}"
+                alt_score = confidence if j == 0 else random.uniform(0.3, confidence - 0.1)
+                runner_ups.append(
+                    {
+                        "episode": alt_episode,
+                        "score": alt_score,
+                        "vote_count": 0,
+                    }
+                )
+
+            target_votes = 4
+            for vote_round in range(target_votes):
+                progress = ((vote_round + 1) / target_votes) * 100.0
+                for ru in runner_ups:
+                    if random.random() < ru["score"]:
+                        ru["vote_count"] = min(target_votes, ru["vote_count"] + 1)
+
+                interim_details = json.dumps(
+                    {
+                        "score": confidence,
+                        "vote_count": vote_round + 1,
+                        "target_votes": target_votes,
+                        "runner_ups": runner_ups,
+                    }
+                )
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title_db.id,
+                    TitleState.MATCHING.value,
+                    match_stage="matching",
+                    match_progress=progress,
+                    match_details=interim_details,
+                )
+                await asyncio.sleep(0.4)
+
+            title_db.matched_episode = episode_code
+            title_db.match_confidence = confidence
+            title_db.match_details = json.dumps(
+                {
+                    "score": confidence,
+                    "vote_count": min(target_votes, int(confidence * target_votes)),
+                    "file_cov": random.uniform(0.6, 0.95),
+                    "runner_ups": runner_ups,
+                }
+            )
+
+            if confidence >= 0.6:
+                title_db.state = TitleState.COMPLETED
+            else:
+                title_db.state = TitleState.MATCHING
+                needs_review = True
+
+            await session.commit()
+            await ws_manager.broadcast_title_update(
+                job_id,
+                title_db.id,
+                title_db.state.value,
+                matched_episode=title_db.matched_episode,
+                match_confidence=title_db.match_confidence,
+                match_details=title_db.match_details,
+                duration_seconds=title_db.duration_seconds,
+                file_size_bytes=title_db.file_size_bytes,
+            )
+
+        job = await session.get(DiscJob, job_id)
+        if not job:
+            logger.error(f"[SIMULATE] Job {job_id}: could not load job for completion")
+            return
+
+        logger.info(
+            f"[SIMULATE] Job {job_id}: matching complete. "
+            f"needs_review={needs_review}, job.state={job.state.value}"
+        )
+
+        if needs_review:
+            await self._state_machine.transition_to_review(
+                job,
+                session,
+                reason="Some episodes have low confidence matches",
+                broadcast=False,
+            )
+            await ws_manager.broadcast_job_update(job_id, job.state.value, progress=0)
+        else:
+            job.progress_percent = 100.0
+            result = await self._state_machine.transition_to_completed(job, session)
+            logger.info(
+                f"[SIMULATE] Job {job_id}: transition_to_completed returned {result}, "
+                f"job.state={job.state.value}"
+            )

--- a/backend/tests/integration/test_movie_edition_workflow.py
+++ b/backend/tests/integration/test_movie_edition_workflow.py
@@ -44,12 +44,14 @@ def mock_db_session_factory(session):
 
 
 @pytest.mark.asyncio
+@patch("app.services.finalization_coordinator.async_session")
 @patch("app.services.job_manager.async_session")
 async def test_movie_edition_review_workflow(
-    mock_async_session, session, mock_db_session_factory, tmp_path
+    mock_async_session, mock_fc_session, session, mock_db_session_factory, tmp_path
 ):
-    # Patch async_session in job_manager
+    # Patch async_session in job_manager and finalization_coordinator
     mock_async_session.side_effect = mock_db_session_factory
+    mock_fc_session.side_effect = mock_db_session_factory
 
     # Create dummy files
     staging_dir = tmp_path / "staging"
@@ -131,9 +133,13 @@ async def test_movie_edition_review_workflow(
 
 
 @pytest.mark.asyncio
+@patch("app.services.finalization_coordinator.async_session")
 @patch("app.services.job_manager.async_session")
-async def test_movie_edition_skip_workflow(mock_async_session, session, mock_db_session_factory):
+async def test_movie_edition_skip_workflow(
+    mock_async_session, mock_fc_session, session, mock_db_session_factory
+):
     mock_async_session.side_effect = mock_db_session_factory
+    mock_fc_session.side_effect = mock_db_session_factory
     # Setup similar job
     job = DiscJob(
         drive_id="TEST_DRIVE_2",
@@ -168,10 +174,14 @@ async def test_movie_edition_skip_workflow(mock_async_session, session, mock_db_
 
 
 @pytest.mark.asyncio
+@patch("app.services.finalization_coordinator.async_session")
 @patch("app.services.job_manager.async_session")
-async def test_movie_edition_prerip_workflow(mock_async_session, session, mock_db_session_factory):
+async def test_movie_edition_prerip_workflow(
+    mock_async_session, mock_fc_session, session, mock_db_session_factory
+):
     """Test selecting an edition BEFORE ripping (files do not exist)."""
     mock_async_session.side_effect = mock_db_session_factory
+    mock_fc_session.side_effect = mock_db_session_factory
 
     # 1. Setup Job (REVIEW_NEEDED)
     job = DiscJob(
@@ -233,13 +243,20 @@ async def test_movie_edition_prerip_workflow(mock_async_session, session, mock_d
 
 
 @pytest.mark.asyncio
+@patch("app.services.finalization_coordinator.async_session")
 @patch("app.services.job_manager.async_session")
 @patch("app.core.organizer.movie_organizer")
 async def test_movie_ambiguous_rip_first_workflow(
-    mock_movie_organizer, mock_async_session, session, mock_db_session_factory, tmp_path
+    mock_movie_organizer,
+    mock_async_session,
+    mock_fc_session,
+    session,
+    mock_db_session_factory,
+    tmp_path,
 ):
     """Test 'Rip First, Review Later' workflow for ambiguous movies."""
     mock_async_session.side_effect = mock_db_session_factory
+    mock_fc_session.side_effect = mock_db_session_factory
 
     # Setup Logic
     # 1. Create Job and Titles (Simulating Post-Rip state with multiple files)

--- a/backend/tests/integration/test_simulation.py
+++ b/backend/tests/integration/test_simulation.py
@@ -203,7 +203,9 @@ async def test_on_title_ripped_transitions_to_ripping(client):
         patch(
             "app.api.websocket.manager.broadcast_title_update", new_callable=AsyncMock
         ) as mock_broadcast,
-        patch.object(job_manager, "_match_single_file", new_callable=AsyncMock) as mock_match,
+        patch.object(
+            job_manager._matching, "match_single_file", new_callable=AsyncMock
+        ) as mock_match,
     ):
         # Simulate MakeMKV completing title 1 (filename pattern: B1_t01.mkv)
         fake_path = Path("/staging/B1_t01.mkv")
@@ -269,7 +271,7 @@ async def test_on_title_ripped_maps_by_filename_index(client):
 
     with (
         patch("app.api.websocket.manager.broadcast_title_update", new_callable=AsyncMock),
-        patch.object(job_manager, "_match_single_file", new_callable=AsyncMock),
+        patch.object(job_manager._matching, "match_single_file", new_callable=AsyncMock),
     ):
         # Rip title index 3 (filename: title_t03.mkv)
         fake_path = Path("/staging/title_t03.mkv")

--- a/backend/tests/unit/test_staging_cleanup.py
+++ b/backend/tests/unit/test_staging_cleanup.py
@@ -92,67 +92,66 @@ class TestTerminalCallback:
 class TestCleanupPolicy:
     """Test that _on_job_terminal respects the configured policy."""
 
-    def _make_job_manager(self):
-        """Create a minimal JobManager with mocked dependencies."""
-        with (
-            patch("app.services.job_manager.DriveMonitor"),
-            patch("app.services.job_manager.MakeMKVExtractor"),
-            patch("app.services.job_manager.DiscAnalyst"),
-        ):
-            from app.services.job_manager import JobManager
+    def _make_cleanup_service(self):
+        """Create a CleanupService with mocked delete_staging."""
+        from app.services.cleanup_service import CleanupService
 
-            jm = JobManager()
-            jm._delete_staging = AsyncMock()
-            return jm
+        svc = CleanupService()
+        svc.delete_staging = AsyncMock()
+        return svc
 
     @pytest.mark.asyncio
     async def test_on_success_cleans_completed(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="on_success")
+        svc = self._make_cleanup_service()
+        config = MagicMock(staging_cleanup_policy="on_success", discdb_contributions_enabled=False)
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(1, JobState.COMPLETED)
-        jm._delete_staging.assert_awaited_once_with(1)
+            await svc.on_job_terminal(1, JobState.COMPLETED)
+        svc.delete_staging.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
     async def test_on_success_skips_failed(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="on_success")
+        svc = self._make_cleanup_service()
+        config = MagicMock(staging_cleanup_policy="on_success", discdb_contributions_enabled=False)
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(2, JobState.FAILED)
-        jm._delete_staging.assert_not_awaited()
+            await svc.on_job_terminal(2, JobState.FAILED)
+        svc.delete_staging.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_on_completion_cleans_completed(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="on_completion")
+        svc = self._make_cleanup_service()
+        config = MagicMock(
+            staging_cleanup_policy="on_completion", discdb_contributions_enabled=False
+        )
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(3, JobState.COMPLETED)
-        jm._delete_staging.assert_awaited_once_with(3)
+            await svc.on_job_terminal(3, JobState.COMPLETED)
+        svc.delete_staging.assert_awaited_once_with(3)
 
     @pytest.mark.asyncio
     async def test_on_completion_cleans_failed(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="on_completion")
+        svc = self._make_cleanup_service()
+        config = MagicMock(
+            staging_cleanup_policy="on_completion", discdb_contributions_enabled=False
+        )
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(4, JobState.FAILED)
-        jm._delete_staging.assert_awaited_once_with(4)
+            await svc.on_job_terminal(4, JobState.FAILED)
+        svc.delete_staging.assert_awaited_once_with(4)
 
     @pytest.mark.asyncio
     async def test_manual_never_cleans(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="manual")
+        svc = self._make_cleanup_service()
+        config = MagicMock(staging_cleanup_policy="manual", discdb_contributions_enabled=False)
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(5, JobState.COMPLETED)
-            await jm._on_job_terminal(6, JobState.FAILED)
-        jm._delete_staging.assert_not_awaited()
+            await svc.on_job_terminal(5, JobState.COMPLETED)
+            await svc.on_job_terminal(6, JobState.FAILED)
+        svc.delete_staging.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_after_days_defers_to_background(self):
-        jm = self._make_job_manager()
-        config = MagicMock(staging_cleanup_policy="after_days")
+        svc = self._make_cleanup_service()
+        config = MagicMock(staging_cleanup_policy="after_days", discdb_contributions_enabled=False)
         with patch("app.services.config_service.get_config", return_value=config):
-            await jm._on_job_terminal(7, JobState.COMPLETED)
-        jm._delete_staging.assert_not_awaited()
+            await svc.on_job_terminal(7, JobState.COMPLETED)
+        svc.delete_staging.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -179,14 +178,9 @@ class TestTimedCleanup:
         new_dir.mkdir()
         (new_dir / "title_0.mkv").write_text("fake")
 
-        with (
-            patch("app.services.job_manager.DriveMonitor"),
-            patch("app.services.job_manager.MakeMKVExtractor"),
-            patch("app.services.job_manager.DiscAnalyst"),
-        ):
-            from app.services.job_manager import JobManager
+        from app.services.cleanup_service import CleanupService
 
-            jm = JobManager()
+        svc = CleanupService()
 
         # Monkey-patch sleep: first call returns immediately (lets cleanup run),
         # second call cancels.
@@ -201,7 +195,7 @@ class TestTimedCleanup:
 
         with patch("asyncio.sleep", side_effect=mock_sleep):
             try:
-                await jm._run_timed_cleanup(str(tmp_path), max_age_days=7)
+                await svc.run_timed_cleanup(str(tmp_path), max_age_days=7)
             except asyncio.CancelledError:
                 pass
 
@@ -216,14 +210,9 @@ class TestTimedCleanup:
         old_time = time.time() - (30 * 86400)
         os.utime(other_dir, (old_time, old_time))
 
-        with (
-            patch("app.services.job_manager.DriveMonitor"),
-            patch("app.services.job_manager.MakeMKVExtractor"),
-            patch("app.services.job_manager.DiscAnalyst"),
-        ):
-            from app.services.job_manager import JobManager
+        from app.services.cleanup_service import CleanupService
 
-            jm = JobManager()
+        svc = CleanupService()
 
         call_count = 0
 
@@ -236,7 +225,7 @@ class TestTimedCleanup:
 
         with patch("asyncio.sleep", side_effect=mock_sleep):
             try:
-                await jm._run_timed_cleanup(str(tmp_path), max_age_days=7)
+                await svc.run_timed_cleanup(str(tmp_path), max_age_days=7)
             except asyncio.CancelledError:
                 pass
 


### PR DESCRIPTION
## Summary
Breaks up the monolithic `JobManager` (4,295 lines, 52 methods) into 5 focused coordinators + a thin orchestrator:

| Service | Lines | Responsibility |
|---|---|---|
| `job_manager.py` | 1,166 | Core orchestration, startup, drive events, ripping |
| `identification_coordinator.py` | 745 | Disc scanning, DiscDB/TMDB/AI lookup, classification |
| `matching_coordinator.py` | 853 | Episode matching, subtitles, file readiness, extras |
| `finalization_coordinator.py` | 721 | Conflict resolution, organization, review workflow |
| `cleanup_service.py` | 118 | Staging cleanup, timed cleanup, DiscDB export |
| `simulation_service.py` | 717 | All simulate_* methods for E2E testing |

**Design:** All coordinators use constructor injection. Cross-coordinator communication uses callbacks. Public API unchanged — no route changes needed.

Part of #58 (Priority 1: Break Up JobManager)

## Test plan
- [x] `uv run pytest tests/unit/` — 413 unit tests pass
- [x] `uv run ruff check app/services/` — clean
- [ ] Run full simulation workflow (insert disc → identify → rip → match → organize)
- [ ] Verify WebSocket events still broadcast correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)