### PR TITLE
feat: add accessibility improvements to core components

### DIFF
--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -127,6 +127,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
         exit={{ opacity: 0, y: -20 }}
         onHoverStart={() => setIsHovered(true)}
         onHoverEnd={() => setIsHovered(false)}
+        aria-label={`${disc.title} — ${disc.state}`}
         className="relative overflow-hidden rounded-lg bg-navy-800/80 border border-cyan-500/20 shadow-2xl"
         style={{
           boxShadow: `0 0 15px rgba(6, 182, 212, 0.15), 0 0 30px rgba(236, 72, 153, 0.05), inset 0 0 20px rgba(6, 182, 212, 0.05)`,
@@ -195,7 +196,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                 {posterUrl ? (
                   <img
                     src={posterUrl}
-                    alt={disc.title}
+                    alt={`Poster for ${disc.title}`}
                     className="w-full h-full object-cover"
                     onError={(e) => {
                       // Fallback to disc icon on error

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -25,6 +25,7 @@ export function ActionButtons({ state, isHovered, onCancel, onReview }: ActionBu
                     onClick={onCancel}
                     className="p-2 border-2 border-red-500/50 bg-navy-900/80 text-red-400 hover:bg-red-500/20 hover:border-red-500 transition-all"
                     title="Cancel Job"
+                    aria-label="Cancel job"
                     style={{ boxShadow: "0 0 10px rgba(239, 68, 68, 0.3)" }}
                 >
                     <X className="w-4 h-4" />
@@ -39,6 +40,7 @@ export function ActionButtons({ state, isHovered, onCancel, onReview }: ActionBu
                     onClick={onReview}
                     className="px-4 py-2 border-2 border-yellow-500 bg-navy-900/80 text-yellow-400 hover:bg-yellow-500/20 hover:border-yellow-400 transition-all font-mono font-bold text-xs uppercase tracking-wider flex items-center gap-2"
                     style={{ boxShadow: "0 0 15px rgba(234, 179, 8, 0.5)" }}
+                    aria-label="Review needed — open review queue"
                 >
                     <AlertTriangle className="w-4 h-4" />
                     <span>REVIEW NEEDED</span>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -746,8 +746,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                         </div>
 
                         <div className="form-group">
-                            <label>Naming Convention</label>
+                            <label htmlFor="namingConvention">Naming Convention</label>
                             <select
+                                id="namingConvention"
                                 value={
                                     config.namingSeasonFormat === 'Season {season:02d}' &&
                                     config.namingEpisodeFormat === '{show} - S{season:02d}E{episode:02d}'
@@ -843,11 +844,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     };
 
     return (
-        <div className="modal-overlay" onClick={onClose}>
+        <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="wizard-title">
             <div className="modal wizard-modal" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header">
-                    <h2 className="modal-title">Setup Wizard</h2>
-                    <button className="modal-close" onClick={onClose}>&times;</button>
+                    <h2 className="modal-title" id="wizard-title">Setup Wizard</h2>
+                    <button className="modal-close" onClick={onClose} aria-label="Close setup wizard">&times;</button>
                 </div>
 
                 <div className={`wizard-progress ${!isOnboarding ? 'tabs-mode' : ''}`}>
@@ -856,6 +857,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             key={s}
                             className={`progress-step ${s === step ? 'active' : ''} ${s < step || !isOnboarding ? 'completed' : ''} ${!isOnboarding ? 'clickable' : ''}`}
                             onClick={() => !isOnboarding && setStep(s)}
+                            role={!isOnboarding ? 'button' : undefined}
+                            tabIndex={!isOnboarding ? 0 : undefined}
+                            onKeyDown={!isOnboarding ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setStep(s); } } : undefined}
+                            aria-label={`Step ${s}: ${s === 1 ? 'Paths' : s === 2 ? 'Tools' : s === 3 ? 'TMDB' : 'Preferences'}${s === step ? ' (current)' : ''}`}
+                            aria-current={s === step ? 'step' : undefined}
                         >
                             <span className="step-number">{!isOnboarding ? (s === step ? '●' : '○') : (s < step ? '✓' : s)}</span>
                             <span className="step-label">

--- a/frontend/src/components/NamePromptModal.tsx
+++ b/frontend/src/components/NamePromptModal.tsx
@@ -40,6 +40,10 @@ export default function NamePromptModal({ job, onSubmit, onCancel }: NamePromptM
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onKeyDown={handleKeyDown}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="name-prompt-title"
+            aria-describedby="name-prompt-description"
         >
             {/* Backdrop */}
             <motion.div
@@ -119,6 +123,7 @@ export default function NamePromptModal({ job, onSubmit, onCancel }: NamePromptM
                         </motion.div>
                         <div>
                             <h2
+                                id="name-prompt-title"
                                 className="font-mono font-bold text-lg tracking-[0.2em] uppercase text-cyan-300"
                                 style={{ textShadow: '0 0 10px rgba(6,182,212,0.6)' }}
                             >
@@ -143,7 +148,7 @@ export default function NamePromptModal({ job, onSubmit, onCancel }: NamePromptM
                             style={{ filter: 'drop-shadow(0 0 4px rgba(234,179,8,0.6))' }}
                         />
                         <div className="space-y-1.5 min-w-0">
-                            <p className="font-mono text-xs text-yellow-300/80 uppercase tracking-wider">
+                            <p id="name-prompt-description" className="font-mono text-xs text-yellow-300/80 uppercase tracking-wider">
                                 Disc label cannot be read automatically
                             </p>
                             <code
@@ -169,6 +174,7 @@ export default function NamePromptModal({ job, onSubmit, onCancel }: NamePromptM
                             value={title}
                             onChange={(e) => setTitle(e.target.value)}
                             placeholder="e.g. The Italian Job"
+                            aria-required="true"
                             className="w-full bg-navy-800 border-2 border-cyan-500/30 text-cyan-300 font-mono text-sm px-3 py-2.5 placeholder:text-cyan-800 focus:outline-none focus:border-cyan-500 transition-colors"
                             style={{
                                 boxShadow: title

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -258,6 +258,7 @@ function ReviewQueue() {
                             <button
                                 onClick={() => navigate('/')}
                                 className="px-3 py-2 font-mono font-bold text-sm uppercase tracking-wider border-2 bg-navy-900 text-slate-400 border-slate-700 hover:border-cyan-500/50 hover:text-cyan-400 transition-all"
+                                aria-label="Back to dashboard"
                             >
                                 <ArrowLeft className="w-4 h-4" />
                             </button>
@@ -324,6 +325,7 @@ function ReviewQueue() {
                                             value={selectedEditions[title.id] || ''}
                                             onChange={(e) => handleEditionChange(title.id, e.target.value)}
                                             className="w-full px-3 py-1.5 text-sm font-mono bg-navy-800 border border-slate-700 text-slate-300 placeholder-slate-600 focus:border-cyan-500/50 focus:outline-none"
+                                            aria-label={`Edition tag for title ${title.title_index}`}
                                         />
                                     </div>
 
@@ -380,6 +382,7 @@ function ReviewQueue() {
                             <button
                                 onClick={() => navigate('/')}
                                 className="px-3 py-2 font-mono font-bold text-sm uppercase tracking-wider border-2 bg-navy-900 text-slate-400 border-slate-700 hover:border-cyan-500/50 hover:text-cyan-400 transition-all"
+                                aria-label="Back to dashboard"
                             >
                                 <ArrowLeft className="w-4 h-4" />
                             </button>
@@ -581,6 +584,8 @@ function TVTitleRow({
                     <button
                         onClick={() => onToggleExpand(title.id)}
                         className="text-slate-600 hover:text-cyan-400 transition-colors"
+                        aria-expanded={isExpanded}
+                        aria-label={isExpanded ? `Collapse details for title ${title.title_index}` : `Expand details for title ${title.title_index}`}
                     >
                         {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                     </button>
@@ -647,11 +652,13 @@ function TVTitleRow({
                             onChange={(e) => setSeason(Math.max(1, Math.min(20, parseInt(e.target.value) || 1)))}
                             className="w-10 bg-slate-800 border border-slate-600 rounded px-1 py-1 text-xs text-center font-mono text-slate-200"
                             title="Season number"
+                            aria-label="Season number"
                         />
                         <select
                             value={selectedEpisode}
                             onChange={(e) => onEpisodeChange(title.id, e.target.value)}
                             className="flex-1 px-2 py-1.5 text-xs font-mono bg-navy-800 border border-slate-700 text-slate-300 focus:border-cyan-500/50 focus:outline-none"
+                            aria-label={`Episode assignment for title ${title.title_index}`}
                         >
                             <option value="">Select episode...</option>
                             {title.matched_episode && (


### PR DESCRIPTION
## Summary
Add ARIA attributes and keyboard handlers to core interactive components:

- **DiscCard**: `aria-label` on action buttons, descriptive `alt` text for poster images
- **ReviewQueue**: `aria-expanded` on expand/collapse toggles, `aria-label` on episode selects and inputs
- **ConfigWizard**: `role="dialog"` + `aria-modal`, keyboard-navigable step indicators, label-input associations
- **NamePromptModal**: `role="dialog"` + `aria-modal`, `aria-describedby` for descriptions, `aria-required` on inputs

Part of #58 (Accessibility recommendations)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes with 0 warnings
- [ ] Tab through DiscCard, ReviewQueue, ConfigWizard — verify focus visible and keyboard operable
- [ ] Screen reader spot-check on DiscCard action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)