### PR TITLE
fix: make frozen build errors visible with run.py entry point

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -177,31 +177,14 @@ else:
 
 
 if __name__ == "__main__":
-    import threading
-    import webbrowser
-
+    # For frozen builds, use run.py instead — it wraps ALL imports
+    # in error handling so crashes are always visible.
     import uvicorn
 
-    is_frozen = getattr(sys, "frozen", False)
-
-    if is_frozen:
-        # Open browser after a short delay to let the server bind the port
-        url = f"http://{settings.host}:{settings.port}"
-        threading.Timer(1.5, webbrowser.open, args=[url]).start()
-
-    try:
-        uvicorn.run(
-            app,
-            host=settings.host,
-            port=settings.port,
-            # reload is incompatible with passing app object directly
-            # and also incompatible with frozen PyInstaller bundles
-            reload=False if is_frozen else settings.debug,
-            factory=False,
-        )
-    except Exception as e:
-        logger.error(f"Fatal error: {e}", exc_info=True)
-        if is_frozen:
-            print(f"\nFatal error: {e}")
-            input("Press Enter to exit...")
-            sys.exit(1)
+    uvicorn.run(
+        app,
+        host=settings.host,
+        port=settings.port,
+        reload=settings.debug,
+        factory=False,
+    )

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -45,14 +45,25 @@ third_party_hidden = [
     "sklearn.neighbors._partition_nodes",
     # Logging
     "loguru",
+    "rich",
+    "rich.console",
+    "rich.text",
     # HTTP client
     "httpx",
     "httpcore",
+    "requests",
+    # Database migrations (optional at runtime, but declared dependency)
+    "alembic",
+    "alembic.config",
+    "alembic.command",
+    "alembic.runtime",
+    "alembic.runtime.migration",
+    "mako",
+    "mako.template",
     # Other
     "chardet",
     "rapidfuzz",
     "psutil",
-    "beautifulsoup4",
     "bs4",
 ]
 
@@ -71,7 +82,7 @@ datas += collect_data_files("faster_whisper")
 datas += collect_data_files("ctranslate2")
 
 a = Analysis(
-    ["app/main.py"],
+    ["run.py"],
     pathex=[],
     binaries=[],
     datas=datas,

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,44 @@
+"""Engram entry point for PyInstaller frozen builds.
+
+Wraps the entire import and startup sequence in error handling so that
+any crash — including module-level import errors — keeps the console
+window open with a visible traceback.
+"""
+
+import sys
+import traceback
+
+try:
+    import threading
+    import webbrowser
+
+    import uvicorn
+
+    from app.main import app, settings
+
+    is_frozen = getattr(sys, "frozen", False)
+
+    if is_frozen:
+        # Open browser after a short delay to let the server bind the port
+        url = f"http://{settings.host}:{settings.port}"
+        threading.Timer(1.5, webbrowser.open, args=[url]).start()
+
+    uvicorn.run(
+        app,
+        host=settings.host,
+        port=settings.port,
+        # reload is incompatible with frozen PyInstaller bundles
+        reload=False if is_frozen else settings.debug,
+        factory=False,
+    )
+except KeyboardInterrupt:
+    pass  # Normal Ctrl+C shutdown
+except SystemExit as exc:
+    sys.exit(exc.code)  # Preserve original exit code
+except BaseException as exc:
+    traceback.print_exc()
+    if getattr(sys, "frozen", False):
+        print(f"\nFatal error: {exc}")
+        print("Check ~/.engram/engram.log for details")
+        input("Press Enter to exit...")
+    sys.exit(1)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.4.5"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes the v0.5.0 build regression reported in #57 where the Windows frozen build crashes silently — errors flash in the console and disappear before the user can read them.

- **New `run.py` entry point**: Wraps the entire import + startup sequence in error handling so any crash (including module-level `ImportError`) keeps the console open with a full traceback
- **Updated `engram.spec`**: Entry point changed from `app/main.py` to `run.py`; added missing hidden imports for v0.5.0 deps (`alembic`, `rich`, `mako`, `requests`); removed dead `beautifulsoup4` entry
- **Simplified `main.py` `__main__` block**: Frozen builds use `run.py`; dev usage (`python app/main.py`) still works

## Test plan

- [ ] `uv run ruff check` passes
- [ ] `uv run pytest tests/unit/` passes (287/288, 1 pre-existing)
- [ ] `uv run python run.py` starts the server correctly
- [ ] PyInstaller build succeeds: `uv run pyinstaller engram.spec`
- [ ] Frozen exe shows traceback on crash instead of silently closing
- [ ] Normal Ctrl+C shutdown exits cleanly (no "Fatal error" message)

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)