### PR TITLE
fix(#106): gate REVIEW NEEDED button on review_needed state

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -360,6 +360,7 @@ function MainDashboard() {
                       disc.state === "error" ? "bg-red-400" :
                       disc.state === "ripping" ? "bg-magenta-400" :
                       disc.state === "scanning" ? "bg-cyan-400" :
+                      disc.state === "review_needed" ? "bg-yellow-400" :
                       disc.state === "matching" ? "bg-amber-400" :
                       "bg-slate-500"
                     }`} />

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -11,7 +11,7 @@ import { ActionButtons } from "./DiscCard/ActionButtons";
 import { useElapsedTime } from "../hooks/useElapsedTime";
 
 export type MediaType = "movie" | "tv" | "unknown";
-export type DiscState = "idle" | "scanning" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
+export type DiscState = "idle" | "scanning" | "review_needed" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
 export type TrackState = "pending" | "ripping" | "matching" | "matched" | "failed" | "completed";
 
 export interface MatchCandidate {
@@ -96,6 +96,7 @@ interface DiscCardProps {
 const stateColors = {
   idle: { from: "#64748b", to: "#94a3b8" },
   scanning: { from: "#06b6d4", to: "#22d3ee" }, // cyan
+  review_needed: { from: "#eab308", to: "#facc15" }, // yellow
   archiving_iso: { from: "#8b5cf6", to: "#a78bfa" },
   ripping: { from: "#ec4899", to: "#f472b6" }, // magenta
   matching: { from: "#f59e0b", to: "#fbbf24" }, // amber

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -221,7 +221,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   transition={{ duration: 3, repeat: Infinity }}
                 />
 
-                {/* State overlay icon */}
+                {/* State overlay icon — review_needed intentionally excluded: job is paused, not actively processing */}
                 {["scanning", "archiving_iso", "ripping", "matching", "organizing", "processing"].includes(disc.state) && (
                   <div className="absolute inset-0 flex items-center justify-center bg-black/30">
                     <motion.div

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -49,7 +49,7 @@ export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdenti
             )}
 
             {/* Review Button */}
-            {onReview && (
+            {onReview && state === 'review_needed' && (
                 <motion.button
                     initial={{ opacity: 0, scale: 0.8 }}
                     animate={{ opacity: 1, scale: 1 }}

--- a/frontend/src/app/components/StateIndicator.tsx
+++ b/frontend/src/app/components/StateIndicator.tsx
@@ -9,6 +9,7 @@ interface StateIndicatorProps {
 const stateConfig: Record<DiscState, { label: string; color: string; glow: string; icon: React.ElementType }> = {
   idle: { label: "IDLE", color: "text-slate-400", glow: "rgba(148, 163, 184, 0.5)", icon: Loader2 },
   scanning: { label: "SCANNING", color: "text-cyan-400", glow: "rgba(6, 182, 212, 0.8)", icon: Search },
+  review_needed: { label: "REVIEW NEEDED", color: "text-yellow-400", glow: "rgba(234, 179, 8, 0.8)", icon: AlertTriangle },
   archiving_iso: { label: "ARCHIVING", color: "text-purple-400", glow: "rgba(139, 92, 246, 0.8)", icon: Archive },
   ripping: { label: "RIPPING", color: "text-magenta-400", glow: "rgba(236, 72, 153, 0.8)", icon: Disc3 },
   matching: { label: "MATCHING", color: "text-amber-400", glow: "rgba(245, 158, 11, 0.8)", icon: Fingerprint },

--- a/frontend/src/types/__tests__/adapters.test.ts
+++ b/frontend/src/types/__tests__/adapters.test.ts
@@ -14,7 +14,7 @@ describe("mapJobStateToDiscState", () => {
   const cases: [JobState, string][] = [
     ["idle", "idle"],
     ["identifying", "scanning"],
-    ["review_needed", "scanning"],
+    ["review_needed", "review_needed"],
     ["ripping", "ripping"],
     ["matching", "matching"],
     ["organizing", "organizing"],

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -9,7 +9,7 @@ export function mapJobStateToDiscState(jobState: Job['state']): DiscState {
   const stateMap: Record<Job['state'], DiscState> = {
     'idle': 'idle',
     'identifying': 'scanning',
-    'review_needed': 'scanning',
+    'review_needed': 'review_needed',
     'ripping': 'ripping',
     'matching': 'matching',
     'organizing': 'organizing',


### PR DESCRIPTION
## Problem

The REVIEW NEEDED button was visible on a DiscCard while the job was still in the scanning/identifying phase. The root cause was in the adapter layer: both `'identifying'` and `'review_needed'` backend states were mapped to the same frontend string `'scanning'`, making it impossible for components to distinguish between the two.

## Fix

- `adapters.ts` — map `'review_needed'` to its own distinct `DiscState` value instead of `'scanning'`
- `DiscCard.tsx` — add `'review_needed'` to the `DiscState` type union and `stateColors` map (yellow)
- `StateIndicator.tsx` — add a `'review_needed'` entry to the state config (yellow, AlertTriangle icon, "REVIEW NEEDED" label)
- `ActionButtons.tsx` — gate the Review button on `state === 'review_needed'` in addition to `onReview` being set

## Test plan

- [ ] Simulate a TV disc insert — confirm the REVIEW NEEDED button does **not** appear while state is SCANNING
- [ ] Advance the job to `review_needed` state — confirm the button **does** appear
- [ ] Confirm `StateIndicator` shows "REVIEW NEEDED" in yellow when in that state

Closes #106