### PR TITLE
fix(exe): blank white page on Windows — corrupted CSS MIME type

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,15 +5,6 @@ import os
 import sys
 from contextlib import asynccontextmanager
 
-# Override any incorrect Windows Registry MIME type mappings before StaticFiles is mounted.
-# Python's mimetypes module reads from HKEY_CLASSES_ROOT on Windows, which can be corrupted
-# by certain software installs (old Node.js, some IDEs). Browsers silently refuse to apply
-# stylesheets served with a non-"text/css" Content-Type, producing a blank white page.
-mimetypes.add_type("text/css", ".css")
-mimetypes.add_type("application/javascript", ".js")
-mimetypes.add_type("application/javascript", ".mjs")
-mimetypes.add_type("image/svg+xml", ".svg")
-
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
@@ -26,6 +17,15 @@ from app.config import settings
 from app.core.logging import setup_logging
 from app.database import init_db
 from app.services import job_manager
+
+# Override any incorrect Windows Registry MIME type mappings before StaticFiles is mounted.
+# Python's mimetypes module reads from HKEY_CLASSES_ROOT on Windows, which can be corrupted
+# by certain software installs (old Node.js, some IDEs). Browsers silently refuse to apply
+# stylesheets served with a non-"text/css" Content-Type, producing a blank white page.
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("image/svg+xml", ".svg")
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,18 @@
 """FastAPI application entry point for Engram."""
 
+import mimetypes
 import os
 import sys
 from contextlib import asynccontextmanager
+
+# Override any incorrect Windows Registry MIME type mappings before StaticFiles is mounted.
+# Python's mimetypes module reads from HKEY_CLASSES_ROOT on Windows, which can be corrupted
+# by certain software installs (old Node.js, some IDEs). Browsers silently refuse to apply
+# stylesheets served with a non-"text/css" Content-Type, producing a blank white page.
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("image/svg+xml", ".svg")
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.5.4"
+version = "0.5.5"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/integration/test_static_files.py
+++ b/backend/tests/integration/test_static_files.py
@@ -1,0 +1,88 @@
+"""Integration tests for static file serving MIME types (Issue #110).
+
+Verifies that CSS/JS/SVG assets are served with the correct Content-Type
+headers even when the Windows Registry MIME mappings are corrupted.
+"""
+
+import mimetypes
+
+import pytest
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture()
+def static_root(tmp_path):
+    """Create a minimal static directory with one file per asset type."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "styles.css").write_text("body { background: #0b1120; }")
+    (assets / "bundle.js").write_text("console.log('engram');")
+    (assets / "icon.svg").write_text("<svg></svg>")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def restore_mime_types():
+    """Save and restore mimetypes state around each test."""
+    mimetypes.init()
+    saved = dict(mimetypes.types_map)
+    yield
+    mimetypes.types_map.clear()
+    mimetypes.types_map.update(saved)
+
+
+async def _make_app(static_root):
+    app = FastAPI()
+    app.mount("/assets", StaticFiles(directory=str(static_root / "assets")), name="assets")
+    return app
+
+
+async def test_css_served_with_correct_content_type(static_root):
+    """CSS must be served as text/css so browsers apply the stylesheet."""
+    mimetypes.add_type("text/css", ".css")
+    app = await _make_app(static_root)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/assets/styles.css")
+
+    assert response.status_code == 200
+    assert "text/css" in response.headers["content-type"]
+
+
+async def test_js_served_with_correct_content_type(static_root):
+    """JS must be served as application/javascript so browsers execute the module."""
+    mimetypes.add_type("application/javascript", ".js")
+    app = await _make_app(static_root)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/assets/bundle.js")
+
+    assert response.status_code == 200
+    assert "javascript" in response.headers["content-type"]
+
+
+async def test_svg_served_with_correct_content_type(static_root):
+    """SVG must be served as image/svg+xml."""
+    mimetypes.add_type("image/svg+xml", ".svg")
+    app = await _make_app(static_root)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/assets/icon.svg")
+
+    assert response.status_code == 200
+    assert "svg" in response.headers["content-type"]
+
+
+async def test_corrupted_registry_causes_wrong_css_content_type(static_root):
+    """Demonstrates the bug: corrupted Registry → CSS served as text/plain."""
+    mimetypes.types_map[".css"] = "text/plain"
+    app = await _make_app(static_root)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/assets/styles.css")
+
+    assert response.status_code == 200
+    # Without the fix, CSS is rejected by browsers (they see text/plain)
+    assert "text/plain" in response.headers["content-type"]

--- a/backend/tests/unit/test_mime_types.py
+++ b/backend/tests/unit/test_mime_types.py
@@ -1,0 +1,67 @@
+"""Unit tests for MIME type registration at startup (Issue #110).
+
+On Windows, mimetypes reads Content-Type mappings from HKEY_CLASSES_ROOT.
+Certain software (old Node.js, some IDEs) corrupts the .css entry to
+text/plain. Browsers silently refuse to apply CSS with a non-CSS Content-Type,
+producing a blank white page even though React renders successfully.
+
+The fix in app/main.py calls mimetypes.add_type() before StaticFiles mounts
+to override any bad Registry values.
+"""
+
+import mimetypes
+
+import pytest
+
+
+class TestMimeTypeRegistration:
+    @pytest.fixture(autouse=True)
+    def restore_mime_types(self):
+        """Save and restore mimetypes.types_map so tests don't leak into each other."""
+        mimetypes.init()
+        saved = dict(mimetypes.types_map)
+        yield
+        mimetypes.types_map.clear()
+        mimetypes.types_map.update(saved)
+
+    def test_add_type_overrides_corrupted_css_registry(self):
+        """mimetypes.add_type() must override a bad Windows Registry value for .css."""
+        mimetypes.types_map[".css"] = "text/plain"
+        assert mimetypes.guess_type("style.css")[0] == "text/plain"  # confirm corruption
+
+        mimetypes.add_type("text/css", ".css")
+
+        assert mimetypes.guess_type("style.css")[0] == "text/css"
+
+    def test_add_type_overrides_corrupted_js_registry(self):
+        """mimetypes.add_type() must override a bad Windows Registry value for .js."""
+        mimetypes.types_map[".js"] = "text/plain"
+
+        mimetypes.add_type("application/javascript", ".js")
+
+        assert mimetypes.guess_type("bundle.js")[0] == "application/javascript"
+
+    def test_all_critical_types_fixed_after_corruption(self):
+        """Applying the same registrations as app/main.py fixes all critical types."""
+        mimetypes.types_map.update(
+            {".css": "text/plain", ".js": "text/plain", ".mjs": "text/plain", ".svg": "text/plain"}
+        )
+
+        mimetypes.add_type("text/css", ".css")
+        mimetypes.add_type("application/javascript", ".js")
+        mimetypes.add_type("application/javascript", ".mjs")
+        mimetypes.add_type("image/svg+xml", ".svg")
+
+        assert mimetypes.guess_type("styles.css")[0] == "text/css"
+        assert mimetypes.guess_type("bundle.js")[0] == "application/javascript"
+        assert mimetypes.guess_type("bundle.mjs")[0] == "application/javascript"
+        assert mimetypes.guess_type("icon.svg")[0] == "image/svg+xml"
+
+    def test_app_main_registers_types_on_import(self):
+        """Importing app.main leaves all critical MIME types correctly set."""
+        import app.main  # noqa: F401 — imported for side effects
+
+        assert mimetypes.guess_type("styles.css")[0] == "text/css"
+        assert mimetypes.guess_type("bundle.js")[0] == "application/javascript"
+        assert mimetypes.guess_type("bundle.mjs")[0] == "application/javascript"
+        assert mimetypes.guess_type("icon.svg")[0] == "image/svg+xml"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Engram - Glass-Box automation for disc ripping" />
     <title>Engram - Media Archival Platform</title>
+    <style>body { background: #0b1120; color: #e2e8f0; }</style>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,48 @@
-import { StrictMode } from "react";
+import { Component, type ErrorInfo, type ReactNode, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./app/App.tsx";
 import "./styles/index.css";
 
+class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Engram render error:", error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      const err = this.state.error as Error;
+      return (
+        <div style={{ fontFamily: "monospace", padding: "2rem", color: "#e2e8f0" }}>
+          <h2 style={{ color: "#f87171" }}>Engram failed to load</h2>
+          <p style={{ color: "#94a3b8" }}>
+            Check the browser console (F12) for details and report this at{" "}
+            <a href="https://github.com/Jsakkos/engram/issues" style={{ color: "#22d3ee" }}>
+              github.com/Jsakkos/engram/issues
+            </a>
+          </p>
+          <pre style={{ background: "#1e293b", padding: "1rem", borderRadius: "0.5rem", overflowX: "auto", color: "#f87171" }}>
+            {err.message}
+          </pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Problem

On certain Windows 10 machines, launching `engram.exe` opens a browser tab that is completely white. Assets are served with HTTP 200/304, React mounts, and SVG images are requested — but all styling is absent, leaving a blank white page. Running from source works fine.

## Root Cause

Python's `mimetypes` module on Windows reads `Content-Type` mappings from `HKEY_CLASSES_ROOT` in the Windows Registry. Certain software (old Node.js installers, some IDEs) corrupt the `.css` entry from `text/css` to `text/plain`. Starlette's `StaticFiles` calls `mimetypes.guess_type()` to set `Content-Type`, so if `.css` is misconfigured the stylesheet is served with `Content-Type: text/plain`. Modern browsers **silently refuse to apply CSS served with a non-CSS Content-Type** ([MIME sniffing spec](https://mimesniff.spec.whatwg.org/)). The page renders — React works — but all Tailwind styles are stripped away.

Vite's dev server sets Content-Type from its own bundled database and never touches the Registry, which is why running from source works.

## Fix

Three-layer defense:

1. **`backend/app/main.py`** — `mimetypes.add_type()` for `.css`, `.js`, `.mjs`, `.svg` at module load, before `StaticFiles` mounts. This overrides any bad Registry values permanently for the process lifetime.
2. **`frontend/index.html`** — inline `<style>body { background: #0b1120; color: #e2e8f0; }</style>` so the page is never pure white even if the external stylesheet fails.
3. **`frontend/src/main.tsx`** — `ErrorBoundary` wrapper so React render errors produce a legible message rather than a blank page.

## Test Plan

- [ ] Verify backend unit tests pass (`uv run pytest tests/unit/ --ignore=tests/unit/test_coverage_improvements.py`)
- [ ] Build exe and test on a Windows machine with `reg add "HKCR\.css" /v "Content Type" /t REG_SZ /d "text/plain" /f` applied — page should now display the dark theme correctly
- [ ] Revert Registry change and confirm normal operation

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)