### PR TITLE
fix(subtitles): restart subtitle download after re-identification

### DIFF
--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -46,6 +46,7 @@ class IdentificationCoordinator:
         self._get_discdb_mappings: callable = None
         self._set_discdb_mappings: callable = None
         self._start_subtitle_download: callable = None
+        self._restart_subtitle_download: callable = None
         self._try_discdb_assignment: callable = None
         self._match_single_file: callable = None
         self._on_match_task_done: callable = None
@@ -59,6 +60,7 @@ class IdentificationCoordinator:
         get_discdb_mappings,
         set_discdb_mappings,
         start_subtitle_download,
+        restart_subtitle_download,
         try_discdb_assignment,
         match_single_file,
         on_match_task_done,
@@ -70,6 +72,7 @@ class IdentificationCoordinator:
         self._get_discdb_mappings = get_discdb_mappings
         self._set_discdb_mappings = set_discdb_mappings
         self._start_subtitle_download = start_subtitle_download
+        self._restart_subtitle_download = restart_subtitle_download
         self._try_discdb_assignment = try_discdb_assignment
         self._match_single_file = match_single_file
         self._on_match_task_done = on_match_task_done
@@ -662,6 +665,22 @@ class IdentificationCoordinator:
             job.updated_at = datetime.now(UTC)
             await session.commit()
 
+            # Restart subtitle download with the corrected title. The original
+            # subtitle attempt likely failed against the unresolvable label,
+            # leaving subtitle_status="failed" and a stale `_subtitle_ready`
+            # event that would gate matching back into REVIEW.
+            should_restart_subtitles = (
+                job.content_type == ContentType.TV
+                and job.detected_title
+                and job.detected_season is not None
+                and self._restart_subtitle_download is not None
+            )
+            restart_args = (
+                (job_id, job.detected_title, job.detected_season)
+                if should_restart_subtitles
+                else None
+            )
+
             await ws_manager.broadcast_job_update(
                 job_id,
                 target_state.value,
@@ -674,6 +693,11 @@ class IdentificationCoordinator:
                 f"Job {job_id}: re-identified as '{job.detected_title}' "
                 f"({content_type_str}), transitioning to {target_state.value}"
             )
+
+        # Restart outside the session block: restart_subtitle_download opens its
+        # own session for cleanup and would deadlock on the same connection.
+        if restart_args is not None:
+            await self._restart_subtitle_download(*restart_args)
 
         return {"job_id": job_id, "has_ripped": has_ripped}
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -81,6 +81,7 @@ class JobManager:
             get_discdb_mappings=self._matching.get_discdb_mappings,
             set_discdb_mappings=self._matching.set_discdb_mappings,
             start_subtitle_download=self._matching.start_subtitle_download,
+            restart_subtitle_download=self._matching.restart_subtitle_download,
             try_discdb_assignment=self._matching.try_discdb_assignment,
             match_single_file=self._matching.match_single_file,
             on_match_task_done=self._matching.on_match_task_done,
@@ -523,6 +524,25 @@ class JobManager:
 
     async def rerun_matching(self, job_id: int, source_preference: str | None = None) -> None:
         """Re-run episode matching for all titles in a job."""
+        # If a previous subtitle download failed (e.g. unresolvable label that
+        # has since been corrected via re-identification), give the user a
+        # recovery path: retry subtitles when they hit "Re-match all".
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            needs_subtitle_retry = (
+                job is not None
+                and job.content_type == ContentType.TV
+                and job.subtitle_status == "failed"
+                and job.detected_title
+                and job.detected_season is not None
+            )
+            retry_args = (
+                (job_id, job.detected_title, job.detected_season) if needs_subtitle_retry else None
+            )
+
+        if retry_args is not None:
+            await self._matching.restart_subtitle_download(*retry_args)
+
         await self._rerun_matching(job_id, source_preference)
 
     async def rematch_single_title(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -72,6 +72,47 @@ class MatchingCoordinator:
             self.download_subtitles(job_id, show_name, season)
         )
 
+    async def restart_subtitle_download(self, job_id: int, show_name: str, season: int) -> None:
+        """Cancel any in-flight subtitle download and start a fresh one.
+
+        Used after re-identification corrects the show title. Resets the
+        in-memory event/task pair, clears stale `subtitle_status` and
+        subtitle-related error_message in the DB, then kicks off a new download.
+        """
+        from sqlalchemy import update
+
+        # Cancel a stale or in-flight task. Awaiting cancellation prevents the
+        # old task's DB write from racing past the new one.
+        old_task = self._subtitle_tasks.get(job_id)
+        if old_task is not None and not old_task.done():
+            old_task.cancel()
+            try:
+                await old_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if job is None:
+                return
+            update_values: dict = {"subtitle_status": None}
+            # Only wipe error_message if it came from the subtitle pipeline.
+            if job.error_message and (
+                job.error_message.startswith("Subtitle download")
+                or job.error_message.startswith("Download error")
+            ):
+                update_values["error_message"] = None
+            await session.execute(
+                update(DiscJob).where(DiscJob.id == job_id).values(**update_values)
+            )
+            await session.commit()
+
+        # Clear the persistent UI banner immediately; the new task will emit
+        # progress events as it runs.
+        await ws_manager.broadcast_subtitle_event(job_id, "downloading", downloaded=0, total=0)
+
+        self.start_subtitle_download(job_id, show_name, season)
+
     async def try_discdb_assignment(self, job_id: int, title: "DiscTitle", session) -> bool:
         """Try to assign episode info from TheDiscDB mappings, skipping fingerprinting.
 

--- a/backend/tests/integration/test_subtitle_restart.py
+++ b/backend/tests/integration/test_subtitle_restart.py
@@ -1,0 +1,258 @@
+"""Integration tests for subtitle download restart on re-identification.
+
+Regression test for the bug where re-identifying a TV disc with a corrected
+title left subtitle download in a stuck "failed" state, gating matching back
+into REVIEW.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import text
+
+from app.api.websocket import manager as ws_manager
+from app.database import async_session, init_db
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType
+from app.services.event_broadcaster import EventBroadcaster
+from app.services.job_state_machine import JobStateMachine
+from app.services.matching_coordinator import MatchingCoordinator
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+def matching_coordinator():
+    broadcaster = EventBroadcaster(ws_manager)
+    state_machine = JobStateMachine(broadcaster)
+    return MatchingCoordinator(broadcaster, state_machine)
+
+
+async def _seed_failed_subtitle_job(matching: MatchingCoordinator) -> int:
+    """Create a job mid-way through a failed subtitle attempt.
+
+    Mirrors the state left behind when initial subtitle download fails:
+    DB has `subtitle_status="failed"` + subtitle-prefixed error_message,
+    and the in-memory `_subtitle_ready` event has been set() by the
+    download task's finally block.
+    """
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="STRANGENEWWORLDS",
+            drive_id="E:",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Star Trek: Strange New Worlds",
+            detected_season=3,
+            subtitle_status="failed",
+            error_message="Subtitle download failed: No subtitles found",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    # Simulate the stale event from the prior failed download — set in the
+    # finally block at matching_coordinator.py:957-958 regardless of outcome.
+    stale_event = asyncio.Event()
+    stale_event.set()
+    matching._subtitle_ready[job_id] = stale_event
+
+    # And a stale finished task reference, mimicking a completed-but-failed task.
+    async def _no_op():
+        return None
+
+    stale_task = asyncio.create_task(_no_op())
+    await stale_task
+    matching._subtitle_tasks[job_id] = stale_task
+
+    return job_id
+
+
+@pytest.mark.asyncio
+async def test_restart_clears_failed_state_and_starts_new_task(matching_coordinator):
+    job_id = await _seed_failed_subtitle_job(matching_coordinator)
+    stale_event = matching_coordinator._subtitle_ready[job_id]
+    stale_task = matching_coordinator._subtitle_tasks[job_id]
+
+    # Stub the actual download so the test stays offline. The new task will
+    # await this and write subtitle_status="completed" to the DB.
+    async def fake_download(self, jid, show_name, season):
+        # Capture the show_name the new task was started with.
+        fake_download.last_args = (jid, show_name, season)
+        from sqlalchemy import update
+
+        async with async_session() as s:
+            await s.execute(
+                update(DiscJob).where(DiscJob.id == jid).values(subtitle_status="completed")
+            )
+            await s.commit()
+        # Mirror the real download_subtitles `finally` behavior.
+        if jid in self._subtitle_ready:
+            self._subtitle_ready[jid].set()
+
+    with patch.object(MatchingCoordinator, "download_subtitles", fake_download):
+        await matching_coordinator.restart_subtitle_download(
+            job_id, "Star Trek: Strange New Worlds", 3
+        )
+        # Let the freshly-spawned task run.
+        await matching_coordinator._subtitle_tasks[job_id]
+
+    # In-memory state was reset (event/task replaced, not the same instances).
+    assert matching_coordinator._subtitle_ready[job_id] is not stale_event
+    assert matching_coordinator._subtitle_tasks[job_id] is not stale_task
+
+    # The new task was started with the corrected show name.
+    assert fake_download.last_args == (job_id, "Star Trek: Strange New Worlds", 3)
+
+    # DB state was cleared then updated by the new task.
+    async with async_session() as session:
+        job = await session.get(DiscJob, job_id)
+        assert job.subtitle_status == "completed"
+        assert job.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_restart_cancels_inflight_task(matching_coordinator):
+    """A still-running stale task must be cancelled before the new one starts."""
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="BOGUS",
+            drive_id="E:",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Some Show",
+            detected_season=1,
+            subtitle_status="downloading",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    started = asyncio.Event()
+
+    async def long_running():
+        started.set()
+        await asyncio.sleep(60)
+
+    matching_coordinator._subtitle_ready[job_id] = asyncio.Event()
+    stale_task = asyncio.create_task(long_running())
+    matching_coordinator._subtitle_tasks[job_id] = stale_task
+
+    # Make sure the stale task has actually started running (entered the sleep)
+    # before we trigger restart, so cancellation lands at a real await point.
+    await started.wait()
+
+    async def fake_download(self, jid, show_name, season):
+        return None
+
+    with patch.object(MatchingCoordinator, "download_subtitles", fake_download):
+        await matching_coordinator.restart_subtitle_download(job_id, "Some Show", 1)
+
+    assert stale_task.cancelled(), "stale in-flight subtitle task must be cancelled"
+    # And it should not be the same task as the new one in the dict.
+    assert matching_coordinator._subtitle_tasks[job_id] is not stale_task
+
+
+@pytest.mark.asyncio
+async def test_restart_preserves_non_subtitle_error_message(matching_coordinator):
+    """error_message from non-subtitle sources (e.g. matching) must not be wiped."""
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="BOGUS",
+            drive_id="E:",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Some Show",
+            detected_season=1,
+            subtitle_status="failed",
+            error_message="Matching failed: ambiguous results",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    async def fake_download(self, jid, show_name, season):
+        return None
+
+    with patch.object(MatchingCoordinator, "download_subtitles", fake_download):
+        await matching_coordinator.restart_subtitle_download(job_id, "Some Show", 1)
+
+    async with async_session() as session:
+        job = await session.get(DiscJob, job_id)
+        assert job.subtitle_status is None
+        # Non-subtitle error preserved.
+        assert job.error_message == "Matching failed: ambiguous results"
+
+
+@pytest.mark.asyncio
+async def test_rerun_matching_retries_subtitles_when_failed():
+    """JobManager.rerun_matching should restart subtitles for stuck TV jobs."""
+    from app.services.job_manager import job_manager
+
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="STRANGENEWWORLDS",
+            drive_id="E:",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Star Trek: Strange New Worlds",
+            detected_season=3,
+            subtitle_status="failed",
+            error_message="Subtitle download failed: No subtitles found",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    with (
+        patch.object(
+            job_manager._matching, "restart_subtitle_download", new_callable=AsyncMock
+        ) as mock_restart,
+        patch.object(job_manager, "_rerun_matching", new_callable=AsyncMock),
+    ):
+        await job_manager.rerun_matching(job_id)
+
+    mock_restart.assert_awaited_once_with(job_id, "Star Trek: Strange New Worlds", 3)
+
+
+@pytest.mark.asyncio
+async def test_rerun_matching_skips_subtitle_retry_when_completed():
+    """rerun_matching should NOT trigger subtitle retry if subtitles already succeeded."""
+    from app.services.job_manager import job_manager
+
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="GOODSHOW",
+            drive_id="E:",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Good Show",
+            detected_season=1,
+            subtitle_status="completed",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    with (
+        patch.object(
+            job_manager._matching, "restart_subtitle_download", new_callable=AsyncMock
+        ) as mock_restart,
+        patch.object(job_manager, "_rerun_matching", new_callable=AsyncMock),
+    ):
+        await job_manager.rerun_matching(job_id)
+
+    mock_restart.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Re-identifying a TV disc with a corrected title left subtitle download stuck in `failed` state, gating matching back into REVIEW with a persistent `SUBTITLE DOWNLOAD FAILED` banner. Re-match all didn't recover.
- Added `MatchingCoordinator.restart_subtitle_download()` that cancels-and-awaits any stale task, clears subtitle-prefixed DB state, broadcasts a fresh `downloading` event, then spawns a new download with the corrected title.
- Wired into `IdentificationCoordinator.re_identify()` (pre-rip + post-rip branches) and defensively into `JobManager.rerun_matching()` so already-broken jobs recover via Re-match all.

## Root cause

Three layers got out of sync after re-identification:

| Layer | Stale state |
|---|---|
| DB | `subtitle_status="failed"` + subtitle-prefixed `error_message` |
| In-memory event | `_subtitle_ready[job_id]` stuck `set()` (set in `finally` on every download outcome — `matching_coordinator.py:957-958`) |
| In-memory task | `_subtitle_tasks[job_id]` reference still pointing at the failed task |

Matching gates on all three (`matching_coordinator.py:228-280`), so titles kept getting pushed back to REVIEW with `error: subtitle_download_failed`.

## Test plan
- [x] `uv run pytest backend/tests/integration/test_subtitle_restart.py` — 5 new regression tests pass (cleanup, cancellation, non-subtitle error preservation, rerun_matching retry-when-failed, rerun_matching skip-when-completed)
- [x] `uv run pytest backend/tests/integration/test_subtitle_workflow.py backend/tests/integration/test_re_identify.py backend/tests/integration/test_workflow.py backend/tests/integration/test_rematch.py backend/tests/integration/test_simulation.py backend/tests/unit/test_rematch.py` — 49 related tests pass
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [ ] Manual smoke test: insert disc with bogus label → re-identify with valid show → verify subtitle banner clears and `subtitle_status` transitions to `downloading` → `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)