### PR TITLE
fix: correct DiscDB scan log URL to include /disc/ path segment

### DIFF
--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -97,13 +97,13 @@ async def submit_scan_log(
 ) -> bool:
     """Submit MakeMKV scan log as text/plain to TheDiscDB API.
 
-    POST {base_url}/api/engram/{content_hash}/logs/scan
+    POST {base_url}/api/engram/disc/{content_hash}/logs/scan
     """
     if not log_path.exists():
         logger.debug(f"No scan log at {log_path}, skipping submission")
         return False
 
-    url = f"{base_url.rstrip('/')}/api/engram/{content_hash}/logs/scan"
+    url = f"{base_url.rstrip('/')}/api/engram/disc/{content_hash}/logs/scan"
     log_text = log_path.read_text(encoding="utf-8", errors="replace")
 
     try:

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -197,8 +197,8 @@ class TestSubmitScanLog:
 
         assert result is True
 
-        # Verify content type
         call_kwargs = mock_client.post.call_args
+        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/disc/ABC123/logs/scan"
         assert call_kwargs.kwargs["headers"]["Content-Type"] == "text/plain"
 
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- The submitter posts MakeMKV scan logs to `/api/engram/{hash}/logs/scan`, but TheDiscDB''s endpoint is `/api/engram/disc/{hash}/logs/scan` ([correction from @lfoust on discussion #111](https://github.com/Jsakkos/engram/discussions/111#discussioncomment-16704914)). Without `/disc/`, every scan log submission 404s.
- Strengthens the existing scan-log unit test to assert the URL — the missing assertion is what let this regress to begin with.

## Test plan
- [x] `uv run pytest tests/unit/test_discdb_submitter.py` — all 10 tests pass
- [x] `uv run ruff check` / `ruff format --check` — clean
- [ ] Manual: re-run a real submission against the test endpoint after merge to confirm logs land on TheDiscDB''s side

🤖 Generated with [Claude Code](https://claude.com/claude-code)