### PR TITLE
Ambient rip animation + bottom-anchored status bar

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   SvAtmosphere,
   SvTopBar,
   SvStatusBar,
+  SvRipAnimation,
   sv,
 } from "./components/synapse";
 import { DashboardSideRail } from "./components/DashboardSideRail";
@@ -326,7 +327,7 @@ function MainDashboard() {
             alignItems: "stretch",
           }}
         >
-        <div style={{ minWidth: 0 }}>
+        <div style={{ minWidth: 0, display: "flex", flexDirection: "column" }}>
         {filteredDiscs.length === 0 ? (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -470,6 +471,14 @@ function MainDashboard() {
             </AnimatePresence>
           </div>
         )}
+        {/* Falling-code animation — fills the slack below the active job
+            card while a rip is in progress (expanded view only). */}
+        <AnimatePresence>
+          {viewMode === "expanded" &&
+            filteredDiscs.some((d: DiscData) => d.state === "ripping") && (
+              <SvRipAnimation />
+            )}
+        </AnimatePresence>
         </div>
         {filteredDiscs.length > 0 && viewMode === "expanded" && (
           <DashboardSideRail jobs={jobs} titlesMap={titlesMap} />

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -310,7 +310,7 @@ function MainDashboard() {
       </AnimatePresence>
 
       {/* Main Content */}
-      <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-6 sm:py-8 pb-20 sm:pb-24 relative z-0">
+      <div className="max-w-[1600px] mx-auto px-4 sm:px-6 py-6 sm:py-8 pb-24 sm:pb-28 relative z-0">
         <div
           data-testid="sv-dashboard-grid"
           style={{

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -19,7 +19,6 @@ import {
   SvAtmosphere,
   SvTopBar,
   SvStatusBar,
-  SvRipAnimation,
   sv,
 } from "./components/synapse";
 import { DashboardSideRail } from "./components/DashboardSideRail";
@@ -117,7 +116,7 @@ function MainDashboard() {
   ];
 
   return (
-    <SvAtmosphere>
+    <SvAtmosphere ripActive={discsData.some((d) => d.state === "ripping")}>
       <SvTopBar
         isConnected={isConnected}
         version={__APP_VERSION__}
@@ -327,7 +326,7 @@ function MainDashboard() {
             alignItems: "stretch",
           }}
         >
-        <div style={{ minWidth: 0, display: "flex", flexDirection: "column" }}>
+        <div style={{ minWidth: 0 }}>
         {filteredDiscs.length === 0 ? (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -471,14 +470,6 @@ function MainDashboard() {
             </AnimatePresence>
           </div>
         )}
-        {/* Falling-code animation — fills the slack below the active job
-            card while a rip is in progress (expanded view only). */}
-        <AnimatePresence>
-          {viewMode === "expanded" &&
-            filteredDiscs.some((d: DiscData) => d.state === "ripping") && (
-              <SvRipAnimation />
-            )}
-        </AnimatePresence>
         </div>
         {filteredDiscs.length > 0 && viewMode === "expanded" && (
           <DashboardSideRail jobs={jobs} titlesMap={titlesMap} />

--- a/frontend/src/app/components/synapse/SvAtmosphere.tsx
+++ b/frontend/src/app/components/synapse/SvAtmosphere.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
+import { AnimatePresence } from "motion/react";
 import { sv } from "./tokens";
+import { SvRipAnimation } from "./SvRipAnimation";
 
 interface Props {
   children: ReactNode;
@@ -7,6 +9,8 @@ interface Props {
   scanlines?: boolean;
   /** Toggle the distant skyline silhouette. Default: true. */
   skyline?: boolean;
+  /** When true, render the ambient falling-code layer behind all content. */
+  ripActive?: boolean;
   className?: string;
   style?: CSSProperties;
 }
@@ -28,6 +32,7 @@ export function SvAtmosphere({
   children,
   scanlines = true,
   skyline = true,
+  ripActive = false,
   className,
   style,
 }: Props) {
@@ -158,6 +163,11 @@ export function SvAtmosphere({
           <rect width="1280" height="180" fill="url(#sv-skyline-fade)" opacity="0.6" />
         </svg>
       )}
+      {/* Ambient falling-code layer — sits above the atmosphere gradients
+          (z-index 0) but below the content (z-index 1). */}
+      <AnimatePresence>
+        {ripActive && <SvRipAnimation key="rip" />}
+      </AnimatePresence>
       <div style={content}>{children}</div>
     </div>
   );

--- a/frontend/src/app/components/synapse/SvRipAnimation.tsx
+++ b/frontend/src/app/components/synapse/SvRipAnimation.tsx
@@ -1,55 +1,37 @@
-import { useEffect, useState } from "react";
-import type { CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
 import { sv } from "./tokens";
-import { SvCorners } from "./SvCorners";
-import { SvLabel } from "./SvLabel";
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   SvRipAnimation — "C3 · Bitstream · Falling Code"
+   SvRipAnimation — "C3 · Bitstream · Falling Code" (ambient layer)
 
-   A live-animated panel that fills the empty space beneath the active job
-   card while a rip is in progress: a wide field of falling hex characters in
-   the Engram terminal aesthetic. Recreated from the design handoff at
-   docs/design_handoff_rip_animation/ (README.md + source/rip-anim.jsx).
+   A decorative full-viewport background layer of falling hex characters in
+   the Engram terminal aesthetic, shown behind all content while a rip is in
+   progress. Recreated from the design handoff at
+   docs/design_handoff_rip_animation/ and adapted from a bordered card into a
+   fixed ambient layer that fills the dashboard's negative space.
 
-   Decorative — every value (head positions, active columns, characters, the
-   readout text) is procedural, derived from a wall-clock timer and a hash
-   function. No real rip data is plumbed in.
+   Rendered to a <canvas> rather than DOM nodes: a viewport-sized field is
+   ~8k cells, far too many to re-render as React spans at 20fps. The canvas
+   redraws the whole field each tick with plain fillText calls.
 
-   The parent gates this on `state === 'ripping'` and unmounts it otherwise;
-   the 20fps timer's lifetime is therefore naturally bounded.
+   Fully procedural — head positions, active columns, and characters are
+   derived from a wall-clock timer and a hash function. No rip data is
+   plumbed in.
    ═══════════════════════════════════════════════════════════════════════════ */
 
-const COLS = 72; // evenly-spaced character columns (handoff spec)
-const ROWS = 12; // visible hex rows per column
-const FPS = 20; // animation tick rate
-const MIN_HEIGHT = 168; // floor height; grows to fill the column otherwise
+const FPS = 20; // redraw rate
+const COL_PX = 20; // column spacing
+const ROW_PX = 22; // row spacing
+const FONT_PX = 14;
 const HEX = "0123456789ABCDEF";
+const LAYER_OPACITY = 0.5; // ambient — quiet enough not to fight content
 
 /** Stable deterministic hash so the per-column "fill pattern" doesn't shimmer. */
 function hash(n: number): number {
   let x = (n * 374761393) ^ ((n >> 11) * 668265263);
   x = (x ^ (x >> 16)) >>> 0;
   return x / 0xffffffff;
-}
-
-/**
- * Elapsed-seconds clock driven by `setInterval`. Returns a frozen 0 when
- * `enabled` is false so callers can render a single static frame.
- */
-function useSvTime(fps: number, enabled: boolean): number {
-  const [now, setNow] = useState(0);
-  useEffect(() => {
-    if (!enabled) return;
-    const start = performance.now();
-    const id = setInterval(
-      () => setNow((performance.now() - start) / 1000),
-      1000 / fps,
-    );
-    return () => clearInterval(id);
-  }, [fps, enabled]);
-  return now;
 }
 
 /** Tracks the `prefers-reduced-motion` media query reactively. */
@@ -69,177 +51,132 @@ function usePrefersReducedMotion(): boolean {
 }
 
 /**
- * Decorative falling-code panel for the ripping state. Render gated on a
- * ripping job; wrap the call site in `<AnimatePresence>` for the exit fade.
+ * Draw one frame of the falling-code field. `t` is elapsed seconds; columns
+ * descend at per-column deterministic speeds with a bright head, a five-row
+ * fading trail, and a barely-visible background field.
  */
-export function SvRipAnimation() {
-  const reducedMotion = usePrefersReducedMotion();
-  const t = useSvTime(FPS, !reducedMotion);
+function drawField(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  t: number,
+) {
+  ctx.clearRect(0, 0, w, h);
+  ctx.font = `${FONT_PX}px ${sv.mono}`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
 
-  const shell: CSSProperties = {
-    position: "relative",
-    flex: 1,
-    minHeight: MIN_HEIGHT,
-    display: "flex",
-    flexDirection: "column",
-    overflow: "hidden",
-    border: `1px solid ${sv.lineMid}`,
-    background:
-      "linear-gradient(180deg, rgba(18,24,39,0.62), rgba(10,14,24,0.85))",
-    boxShadow: "inset 0 0 32px rgba(94,234,212,0.02)",
-  };
+  const cols = Math.ceil(w / COL_PX);
+  const rows = Math.ceil(h / ROW_PX) + 1;
+  const tick = Math.floor(t * 2); // chars refresh ~2 Hz
 
-  const header: CSSProperties = {
-    flexShrink: 0,
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
-    padding: "8px 14px",
-    borderBottom: `1px solid ${sv.line}`,
-    background: "rgba(5,7,12,0.4)",
-  };
+  for (let c = 0; c < cols; c++) {
+    const colSeed = c * 13.71;
+    const speed = 1.2 + hash(c + 99) * 1.6; // 1.2 – 2.8 rows/sec
+    const phase = hash(c + 5) * 4; // 0 – 4 sec offset
+    const head = ((t * speed + phase) % (rows + 4)) - 2; // -2 .. rows+2
+    const isActive = hash(c + 71) > 0.7; // ~30% magenta columns
+    const x = c * COL_PX + COL_PX / 2;
 
-  const body: CSSProperties = {
-    position: "relative",
-    flex: 1,
-    overflow: "hidden",
-  };
+    for (let r = 0; r < rows; r++) {
+      const d = head - r; // rows below the head
+      const onHead = d > -0.4 && d < 0.6;
+      const inTrail = d > 0 && d < 5;
 
-  const field: CSSProperties = {
-    position: "absolute",
-    inset: 0,
-    padding: "12px 10px",
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "stretch",
-    overflow: "hidden",
-  };
+      if (onHead) {
+        ctx.fillStyle = isActive ? sv.magentaHi : sv.cyanHi;
+        ctx.shadowColor = isActive ? sv.magenta : sv.cyan;
+        ctx.shadowBlur = 6;
+      } else if (inTrail) {
+        const fade = Math.max(0, 1 - d / 5);
+        ctx.fillStyle = isActive
+          ? `rgba(255,61,127,${fade * 0.65})`
+          : `rgba(94,234,212,${fade * 0.55})`;
+        ctx.shadowBlur = 0;
+      } else {
+        ctx.fillStyle = "rgba(74,83,105,0.18)";
+        ctx.shadowBlur = 0;
+      }
 
-  return (
-    <motion.div
-      style={shell}
-      data-testid="sv-rip-animation"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 8 }}
-      transition={{ duration: 0.3, ease: "easeOut" }}
-    >
-      <SvCorners color={sv.lineHi} />
-
-      {/* Header strip */}
-      <div style={header}>
-        <SvLabel color={sv.cyan}>Bitstream · Falling Code</SvLabel>
-        <SvLabel color={sv.inkFaint} noCaret>
-          Decode · Live · 0x00000000 → 0xFFFFFFFF
-        </SvLabel>
-      </div>
-
-      {/* Body — the falling code */}
-      <div style={body}>
-        <div style={field}>
-          {Array.from({ length: COLS }).map((_, c) => (
-            <RipColumn key={c} col={c} t={t} />
-          ))}
-        </div>
-      </div>
-
-      {/* Overlay readouts — positioned against the shell root */}
-      <div
-        style={{
-          position: "absolute",
-          top: 36,
-          left: 14,
-          padding: "4px 8px",
-          background: "rgba(5,7,12,0.7)",
-          border: `1px solid ${sv.line}`,
-          fontFamily: sv.mono,
-          fontSize: 9,
-          letterSpacing: "0.18em",
-          color: sv.magentaHi,
-          pointerEvents: "none",
-        }}
-      >
-        T00 · 0x4A8F · 23.0 MB/s
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          bottom: 8,
-          right: 14,
-          fontFamily: sv.mono,
-          fontSize: 9,
-          letterSpacing: "0.20em",
-          textTransform: "uppercase",
-          color: sv.inkFaint,
-          pointerEvents: "none",
-        }}
-      >
-        {COLS} Streams · Decoded
-      </div>
-    </motion.div>
-  );
+      const ch =
+        HEX[
+          Math.floor(Math.abs(Math.sin(colSeed + r * 1.7 + tick)) * 16) % 16
+        ];
+      ctx.fillText(ch, x, r * ROW_PX + ROW_PX / 2);
+    }
+  }
+  ctx.shadowBlur = 0;
 }
 
 /**
- * A single descending column: a bright head row trailed by five fading rows,
- * over a barely-visible background field. Speed and phase are per-column and
- * deterministic so the column positions never shimmer.
+ * Ambient falling-code background. Render gated on a ripping job; wrap the
+ * call site in `<AnimatePresence>` for the fade-out when ripping ends.
  */
-function RipColumn({ col, t }: { col: number; t: number }) {
-  const colSeed = col * 13.71;
-  const speed = 1.2 + hash(col + 99) * 1.6; // 1.2 – 2.8 rows/sec
-  const phase = hash(col + 5) * 4; // 0 – 4 sec offset
-  const head = ((t * speed + phase) % (ROWS + 4)) - 2; // -2 .. ROWS+2
-  const isActive = hash(col + 71) > 0.7; // ~30% magenta columns
+export function SvRipAnimation() {
+  const reducedMotion = usePrefersReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  const column: CSSProperties = {
-    flexShrink: 0,
-    width: `${100 / COLS}%`,
-    display: "flex",
-    flexDirection: "column",
-    fontFamily: sv.mono,
-    fontSize: 11,
-    lineHeight: "1.05em",
-    letterSpacing: "0.04em",
-    textAlign: "center",
-  };
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let raf = 0;
+    let lastDraw = 0;
+    const start = performance.now();
+
+    // Size the backing store to the device pixel ratio for crisp glyphs.
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      if (reducedMotion) drawField(ctx, w, h, 0);
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    if (reducedMotion) {
+      // Static single frame — no animation loop.
+      return () => window.removeEventListener("resize", resize);
+    }
+
+    const frame = (now: number) => {
+      if (now - lastDraw >= 1000 / FPS) {
+        lastDraw = now;
+        drawField(ctx, window.innerWidth, window.innerHeight, (now - start) / 1000);
+      }
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+    };
+  }, [reducedMotion]);
 
   return (
-    <div style={column}>
-      {Array.from({ length: ROWS }).map((_, r) => {
-        const d = head - r; // rows below the head
-        const onHead = d > -0.4 && d < 0.6;
-        const inTrail = d > 0 && d < 5;
-        // Deterministic per-cell char — refreshes ~2 Hz in place.
-        const ch =
-          HEX[
-            Math.floor(
-              Math.abs(Math.sin(colSeed + r * 1.7 + Math.floor(t * 2))) * 16,
-            ) % 16
-          ];
-
-        let color: string;
-        let weight = 400;
-        let glow = "none";
-        if (onHead) {
-          color = isActive ? sv.magentaHi : sv.cyanHi;
-          weight = 700;
-          glow = `0 0 6px ${isActive ? sv.magenta : sv.cyan}`;
-        } else if (inTrail) {
-          const fade = Math.max(0, 1 - d / 5);
-          color = isActive
-            ? `rgba(255,61,127,${fade * 0.65})`
-            : `rgba(94,234,212,${fade * 0.55})`;
-        } else {
-          color = "rgba(74,83,105,0.18)";
-        }
-
-        return (
-          <span key={r} style={{ color, fontWeight: weight, textShadow: glow }}>
-            {ch}
-          </span>
-        );
-      })}
-    </div>
+    <motion.div
+      data-testid="sv-rip-animation"
+      aria-hidden="true"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: "none",
+      }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: LAYER_OPACITY }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+    >
+      <canvas ref={canvasRef} style={{ display: "block" }} />
+    </motion.div>
   );
 }

--- a/frontend/src/app/components/synapse/SvRipAnimation.tsx
+++ b/frontend/src/app/components/synapse/SvRipAnimation.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from "react";
+import type { CSSProperties } from "react";
+import { motion } from "motion/react";
+import { sv } from "./tokens";
+import { SvCorners } from "./SvCorners";
+import { SvLabel } from "./SvLabel";
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   SvRipAnimation — "C3 · Bitstream · Falling Code"
+
+   A live-animated panel that fills the empty space beneath the active job
+   card while a rip is in progress: a wide field of falling hex characters in
+   the Engram terminal aesthetic. Recreated from the design handoff at
+   docs/design_handoff_rip_animation/ (README.md + source/rip-anim.jsx).
+
+   Decorative — every value (head positions, active columns, characters, the
+   readout text) is procedural, derived from a wall-clock timer and a hash
+   function. No real rip data is plumbed in.
+
+   The parent gates this on `state === 'ripping'` and unmounts it otherwise;
+   the 20fps timer's lifetime is therefore naturally bounded.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+const COLS = 72; // evenly-spaced character columns (handoff spec)
+const ROWS = 12; // visible hex rows per column
+const FPS = 20; // animation tick rate
+const MIN_HEIGHT = 168; // floor height; grows to fill the column otherwise
+const HEX = "0123456789ABCDEF";
+
+/** Stable deterministic hash so the per-column "fill pattern" doesn't shimmer. */
+function hash(n: number): number {
+  let x = (n * 374761393) ^ ((n >> 11) * 668265263);
+  x = (x ^ (x >> 16)) >>> 0;
+  return x / 0xffffffff;
+}
+
+/**
+ * Elapsed-seconds clock driven by `setInterval`. Returns a frozen 0 when
+ * `enabled` is false so callers can render a single static frame.
+ */
+function useSvTime(fps: number, enabled: boolean): number {
+  const [now, setNow] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    const start = performance.now();
+    const id = setInterval(
+      () => setNow((performance.now() - start) / 1000),
+      1000 / fps,
+    );
+    return () => clearInterval(id);
+  }, [fps, enabled]);
+  return now;
+}
+
+/** Tracks the `prefers-reduced-motion` media query reactively. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = () => setReduced(mq.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  return reduced;
+}
+
+/**
+ * Decorative falling-code panel for the ripping state. Render gated on a
+ * ripping job; wrap the call site in `<AnimatePresence>` for the exit fade.
+ */
+export function SvRipAnimation() {
+  const reducedMotion = usePrefersReducedMotion();
+  const t = useSvTime(FPS, !reducedMotion);
+
+  const shell: CSSProperties = {
+    position: "relative",
+    flex: 1,
+    minHeight: MIN_HEIGHT,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+    border: `1px solid ${sv.lineMid}`,
+    background:
+      "linear-gradient(180deg, rgba(18,24,39,0.62), rgba(10,14,24,0.85))",
+    boxShadow: "inset 0 0 32px rgba(94,234,212,0.02)",
+  };
+
+  const header: CSSProperties = {
+    flexShrink: 0,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: "8px 14px",
+    borderBottom: `1px solid ${sv.line}`,
+    background: "rgba(5,7,12,0.4)",
+  };
+
+  const body: CSSProperties = {
+    position: "relative",
+    flex: 1,
+    overflow: "hidden",
+  };
+
+  const field: CSSProperties = {
+    position: "absolute",
+    inset: 0,
+    padding: "12px 10px",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "stretch",
+    overflow: "hidden",
+  };
+
+  return (
+    <motion.div
+      style={shell}
+      data-testid="sv-rip-animation"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <SvCorners color={sv.lineHi} />
+
+      {/* Header strip */}
+      <div style={header}>
+        <SvLabel color={sv.cyan}>Bitstream · Falling Code</SvLabel>
+        <SvLabel color={sv.inkFaint} noCaret>
+          Decode · Live · 0x00000000 → 0xFFFFFFFF
+        </SvLabel>
+      </div>
+
+      {/* Body — the falling code */}
+      <div style={body}>
+        <div style={field}>
+          {Array.from({ length: COLS }).map((_, c) => (
+            <RipColumn key={c} col={c} t={t} />
+          ))}
+        </div>
+      </div>
+
+      {/* Overlay readouts — positioned against the shell root */}
+      <div
+        style={{
+          position: "absolute",
+          top: 36,
+          left: 14,
+          padding: "4px 8px",
+          background: "rgba(5,7,12,0.7)",
+          border: `1px solid ${sv.line}`,
+          fontFamily: sv.mono,
+          fontSize: 9,
+          letterSpacing: "0.18em",
+          color: sv.magentaHi,
+          pointerEvents: "none",
+        }}
+      >
+        T00 · 0x4A8F · 23.0 MB/s
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 8,
+          right: 14,
+          fontFamily: sv.mono,
+          fontSize: 9,
+          letterSpacing: "0.20em",
+          textTransform: "uppercase",
+          color: sv.inkFaint,
+          pointerEvents: "none",
+        }}
+      >
+        {COLS} Streams · Decoded
+      </div>
+    </motion.div>
+  );
+}
+
+/**
+ * A single descending column: a bright head row trailed by five fading rows,
+ * over a barely-visible background field. Speed and phase are per-column and
+ * deterministic so the column positions never shimmer.
+ */
+function RipColumn({ col, t }: { col: number; t: number }) {
+  const colSeed = col * 13.71;
+  const speed = 1.2 + hash(col + 99) * 1.6; // 1.2 – 2.8 rows/sec
+  const phase = hash(col + 5) * 4; // 0 – 4 sec offset
+  const head = ((t * speed + phase) % (ROWS + 4)) - 2; // -2 .. ROWS+2
+  const isActive = hash(col + 71) > 0.7; // ~30% magenta columns
+
+  const column: CSSProperties = {
+    flexShrink: 0,
+    width: `${100 / COLS}%`,
+    display: "flex",
+    flexDirection: "column",
+    fontFamily: sv.mono,
+    fontSize: 11,
+    lineHeight: "1.05em",
+    letterSpacing: "0.04em",
+    textAlign: "center",
+  };
+
+  return (
+    <div style={column}>
+      {Array.from({ length: ROWS }).map((_, r) => {
+        const d = head - r; // rows below the head
+        const onHead = d > -0.4 && d < 0.6;
+        const inTrail = d > 0 && d < 5;
+        // Deterministic per-cell char — refreshes ~2 Hz in place.
+        const ch =
+          HEX[
+            Math.floor(
+              Math.abs(Math.sin(colSeed + r * 1.7 + Math.floor(t * 2))) * 16,
+            ) % 16
+          ];
+
+        let color: string;
+        let weight = 400;
+        let glow = "none";
+        if (onHead) {
+          color = isActive ? sv.magentaHi : sv.cyanHi;
+          weight = 700;
+          glow = `0 0 6px ${isActive ? sv.magenta : sv.cyan}`;
+        } else if (inTrail) {
+          const fade = Math.max(0, 1 - d / 5);
+          color = isActive
+            ? `rgba(255,61,127,${fade * 0.65})`
+            : `rgba(94,234,212,${fade * 0.55})`;
+        } else {
+          color = "rgba(74,83,105,0.18)";
+        }
+
+        return (
+          <span key={r} style={{ color, fontWeight: weight, textShadow: glow }}>
+            {ch}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/app/components/synapse/SvStatusBar.tsx
+++ b/frontend/src/app/components/synapse/SvStatusBar.tsx
@@ -14,8 +14,12 @@ interface Props {
 }
 
 /**
- * Bottom status bar — fixed-height (36px) telemetry strip.
+ * Bottom status bar — fixed-height (44px) telemetry strip.
  * Layout: [active/archived counts + drive] [scrolling telemetry] [WS pill + version].
+ *
+ * `marginTop: auto` pins the bar to the bottom of `SvAtmosphere`'s flex
+ * column even when the page is shorter than the viewport; `position: sticky`
+ * keeps it docked while the page scrolls.
  */
 export function SvStatusBar({
   activeCount,
@@ -26,7 +30,7 @@ export function SvStatusBar({
   telemetry,
 }: Props) {
   const root: CSSProperties = {
-    height: 36,
+    height: 44,
     padding: "0 20px",
     display: "flex",
     alignItems: "center",
@@ -41,6 +45,7 @@ export function SvStatusBar({
     color: sv.inkDim,
     position: "sticky",
     bottom: 0,
+    marginTop: "auto",
     zIndex: 20,
   };
 

--- a/frontend/src/app/components/synapse/index.ts
+++ b/frontend/src/app/components/synapse/index.ts
@@ -28,6 +28,7 @@ export { SvDiscInsert } from "./SvDiscInsert";
 export type { DiscInsertPhase } from "./SvDiscInsert";
 export { SvPageHeader } from "./SvPageHeader";
 export { SvProgressBar } from "./SvProgressBar";
+export { SvRipAnimation } from "./SvRipAnimation";
 export { SvActionButton } from "./SvActionButton";
 export type { SvActionButtonTone, SvActionButtonSize } from "./SvActionButton";
 export { SvNotice } from "./SvNotice";


### PR DESCRIPTION
## Summary

Two dashboard UI changes from the `docs/design_handoff_rip_animation/` handoff.

### 1. Status bar — anchored to the window bottom + taller
`SvStatusBar` used `position: sticky; bottom: 0`, but as the last child of `SvAtmosphere`'s flex column it floated above dead space on pages shorter than the viewport (`sticky` only engages while scrolling). Added `margin-top: auto` so it absorbs the flex slack and docks at the true window bottom in all cases. Height raised 36px → 44px; main-content bottom padding bumped to clear the taller bar.

### 2. Rip animation — ambient falling-code background layer
Recreates the handoff's "C3 · Bitstream · Falling Code" design as a full-viewport ambient layer behind all dashboard content, gated on a job in the `ripping` state. It fills the dead negative space (side margins, area below the cards) rather than occupying a card panel.

- `SvRipAnimation` is a `<canvas>` renderer — a viewport-sized field is ~8k cells, far too many to re-render as React nodes at 20fps. Same procedural column logic from the handoff: per-column speed/phase, glowing head, five-row fading trail, ~30% magenta columns.
- Mounted in `SvAtmosphere` at `z-index: 0` (above the atmosphere gradients, below content) and `pointer-events: none`. Gated via a new `ripActive` prop fed from `discsData` in `App.tsx`.
- Honors `prefers-reduced-motion` (single static frame). Tuned subtle at 50% layer opacity.

The animation was first built as a bordered card panel, then converted to the ambient layer after a design review — hence the panel commit followed by the refactor commit.

## Verification
- `npm run build` (tsc + Vite) and `npm run lint` pass.
- Verified live at 2560×1440: status bar docks flush at the window bottom on short pages and stays pinned while scrolling; the ambient layer renders crisply, animates, fills the negative space, and sits behind the cards with clicks passing through.

## Visual regression baselines
The status-bar reposition changes the `dashboard-idle` snapshot. Baselines are chromium-on-Linux only and must be regenerated on a Linux runner — this is being done from this PR's CI run (a follow-up commit will land the regenerated `dashboard-idle-chromium-linux.png` once CI produces it). The `history-empty` baseline is unaffected (the history page has no status bar) and the ambient layer never appears in either baseline (both are idle/static pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)