### PR TITLE
Remove unimplemented "Enable transcoding" setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,6 @@ Components use updated settings
 - **Paths**: `staging_path`, `library_movies_path`, `library_tv_path`, `makemkv_path`, `ffmpeg_path`
 - **API Keys**: `makemkv_key`, `tmdb_api_key` (redacted in responses)
 - **Matching**: `max_concurrent_matches` (default: 3), threshold constants in Analyst
-- **Transcoding**: `transcoding_enabled` (default: false)
 - **Conflict resolution**: `conflict_resolution_default` ("skip" | "overwrite" | "ask")
 
 ### Configuration Validation

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -171,7 +171,6 @@ class ConfigResponse(BaseModel):
     staging_path: str
     library_movies_path: str
     library_tv_path: str
-    transcoding_enabled: bool
     tmdb_api_key: str
     max_concurrent_matches: int
     ffmpeg_path: str
@@ -227,7 +226,6 @@ class ConfigUpdate(BaseModel):
     staging_path: str | None = None
     library_movies_path: str | None = None
     library_tv_path: str | None = None
-    transcoding_enabled: bool | None = None
     tmdb_api_key: str | None = None
     max_concurrent_matches: int | None = None
     ffmpeg_path: str | None = None
@@ -770,7 +768,6 @@ async def get_config() -> ConfigResponse:
         staging_path=config.staging_path,
         library_movies_path=config.library_movies_path,
         library_tv_path=config.library_tv_path,
-        transcoding_enabled=config.transcoding_enabled,
         tmdb_api_key="***" if config.tmdb_api_key else "",  # Redacted
         max_concurrent_matches=config.max_concurrent_matches,
         ffmpeg_path=config.ffmpeg_path,
@@ -1384,7 +1381,6 @@ async def generate_bug_report(
         "staging_path": str(config.staging_path).replace(_HOME_PATH, "~"),
         "library_movies_path": str(config.library_movies_path).replace(_HOME_PATH, "~"),
         "library_tv_path": str(config.library_tv_path).replace(_HOME_PATH, "~"),
-        "transcoding_enabled": config.transcoding_enabled,
         "max_concurrent_matches": config.max_concurrent_matches,
         "conflict_resolution_default": config.conflict_resolution_default,
         "extras_policy": config.extras_policy,

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -23,9 +23,6 @@ class AppConfig(SQLModel, table=True):
     library_movies_path: str = ""
     library_tv_path: str = ""
 
-    # Feature Flags
-    transcoding_enabled: bool = False
-
     # Episode Matcher Settings
     subtitles_cache_path: str = "~/.engram/cache"
     matcher_min_confidence: float = 0.6

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -52,7 +52,6 @@ class DiscJob(SQLModel, table=True):
     content_type: ContentType = ContentType.UNKNOWN
     detected_title: str | None = None  # e.g., "The Office"
     detected_season: int | None = None
-    is_transcoding_enabled: bool = False
 
     # Classification metadata (persisted from DiscAnalysisResult)
     classification_confidence: float = Field(

--- a/backend/migrations/versions/f3a9c1e7b204_drop_disc_jobs_is_transcoding_enabled.py
+++ b/backend/migrations/versions/f3a9c1e7b204_drop_disc_jobs_is_transcoding_enabled.py
@@ -1,0 +1,30 @@
+"""drop disc_jobs.is_transcoding_enabled
+
+Revision ID: f3a9c1e7b204
+Revises: 9b793042b934
+Create Date: 2026-05-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a9c1e7b204"
+down_revision: str | Sequence[str] | None = "9b793042b934"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("is_transcoding_enabled")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("is_transcoding_enabled", sa.Boolean(), nullable=True))

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -87,7 +87,6 @@ async def integration_config(async_session):
         staging_path="/tmp/integration-staging",
         library_movies_path="/tmp/integration-movies",
         library_tv_path="/tmp/integration-tv",
-        transcoding_enabled=False,
         tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.integration_test_token",
         max_concurrent_matches=2,
         ffmpeg_path="/usr/bin/ffmpeg",

--- a/backend/tests/integration/test_error_recovery.py
+++ b/backend/tests/integration/test_error_recovery.py
@@ -40,7 +40,6 @@ async def test_config():
             staging_path="/tmp/staging",
             library_movies_path="/media/movies",
             library_tv_path="/media/tv",
-            transcoding_enabled=False,
             tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.test",
             max_concurrent_matches=2,
             ffmpeg_path="/usr/bin/ffmpeg",

--- a/backend/tests/integration/test_title_state_broadcast.py
+++ b/backend/tests/integration/test_title_state_broadcast.py
@@ -42,7 +42,6 @@ async def test_config():
             staging_path="/tmp/staging",
             library_movies_path="/media/movies",
             library_tv_path="/media/tv",
-            transcoding_enabled=False,
             tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.test",
             max_concurrent_matches=2,
             ffmpeg_path="/usr/bin/ffmpeg",

--- a/backend/tests/integration/test_websocket_e2e.py
+++ b/backend/tests/integration/test_websocket_e2e.py
@@ -41,7 +41,6 @@ async def test_config():
             staging_path="/tmp/staging",
             library_movies_path="/media/movies",
             library_tv_path="/media/tv",
-            transcoding_enabled=False,
             tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.test",
             max_concurrent_matches=2,
             ffmpeg_path="/usr/bin/ffmpeg",

--- a/backend/tests/integration/test_workflow.py
+++ b/backend/tests/integration/test_workflow.py
@@ -44,7 +44,6 @@ async def test_config():
             staging_path="/tmp/staging",
             library_movies_path="/media/movies",
             library_tv_path="/media/tv",
-            transcoding_enabled=False,
             tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.test_jwt_token",
             max_concurrent_matches=2,
             ffmpeg_path="/usr/bin/ffmpeg",

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -30,7 +30,6 @@ async def _seed_config(
             staging_path=staging_path,
             library_movies_path="/media/movies",
             library_tv_path="/media/tv",
-            transcoding_enabled=False,
             tmdb_api_key=tmdb_api_key,
             max_concurrent_matches=4,
             ffmpeg_path="/usr/bin/ffmpeg",
@@ -171,7 +170,6 @@ class TestConfigEndpoints:
         assert config["makemkv_path"] == "/usr/bin/makemkvcon"
         assert config["staging_path"] == "/tmp/staging"
         assert config["library_movies_path"] == "/media/movies"
-        assert config["transcoding_enabled"] is False
 
     async def test_get_config_creates_default_when_empty(self, client):
         response = await client.get("/api/config")
@@ -181,7 +179,6 @@ class TestConfigEndpoints:
         await _seed_config()
         update_data = {
             "staging_path": "/new/staging/path",
-            "transcoding_enabled": True,
             "max_concurrent_matches": 8,
         }
         response = await client.put("/api/config", json=update_data)
@@ -190,7 +187,6 @@ class TestConfigEndpoints:
         verify = await client.get("/api/config")
         config = verify.json()
         assert config["staging_path"] == "/new/staging/path"
-        assert config["transcoding_enabled"] is True
         assert config["max_concurrent_matches"] == 8
 
     async def test_update_config_with_new_api_keys(self, client):

--- a/backend/tests/unit/test_database_migration.py
+++ b/backend/tests/unit/test_database_migration.py
@@ -108,8 +108,8 @@ class TestSchemaMigration:
                     "INSERT INTO disc_jobs (drive_id, volume_label, state, content_type, "
                     "current_speed, eta_seconds, progress_percent, current_title, total_titles, "
                     "subtitles_downloaded, subtitles_total, subtitles_failed, disc_number, "
-                    "is_transcoding_enabled, created_at, updated_at) VALUES "
-                    "('E:', 'TEST', 'ripping', 'tv', '0', 0, 0, 0, 0, 0, 0, 0, 1, 0, "
+                    "created_at, updated_at) VALUES "
+                    "('E:', 'TEST', 'ripping', 'tv', '0', 0, 0, 0, 0, 0, 0, 0, 1, "
                     "datetime('now'), datetime('now'))"
                 )
             )
@@ -208,7 +208,6 @@ class TestSchemaMigration:
                             content_type VARCHAR DEFAULT 'unknown',
                             detected_title VARCHAR,
                             detected_season INTEGER,
-                            is_transcoding_enabled BOOLEAN DEFAULT 0,
                             staging_path VARCHAR,
                             final_path VARCHAR,
                             state VARCHAR DEFAULT 'idle',

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -122,12 +122,12 @@ class TestConfigurationValidation:
     def test_boolean_flags_validation(self):
         """Test boolean configuration flags."""
         config = AppConfig(
-            transcoding_enabled=True,
+            ai_identification_enabled=True,
         )
-        assert config.transcoding_enabled is True
+        assert config.ai_identification_enabled is True
 
-        config2 = AppConfig(transcoding_enabled=False)
-        assert config2.transcoding_enabled is False
+        config2 = AppConfig(ai_identification_enabled=False)
+        assert config2.ai_identification_enabled is False
 
     def test_conflict_resolution_values(self):
         """Test conflict_resolution_default has valid values."""
@@ -244,8 +244,8 @@ class TestDefaultValues:
         assert config.max_concurrent_matches is not None
         assert config.max_concurrent_matches > 0
 
-        assert config.transcoding_enabled is not None
-        assert isinstance(config.transcoding_enabled, bool)
+        assert config.ai_identification_enabled is not None
+        assert isinstance(config.ai_identification_enabled, bool)
 
         assert config.conflict_resolution_default is not None
         assert config.conflict_resolution_default in ["ask", "skip", "rename", "overwrite"]

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -82,7 +82,6 @@ Configuration is resolved in this priority order:
 | Field | Description | Default |
 |-------|-------------|---------|
 | `max_concurrent_matches` | Parallel episode matching jobs | `3` |
-| `transcoding_enabled` | Enable post-rip transcoding | `false` |
 | `conflict_resolution_default` | File conflict handling | `"skip"` |
 
 The `conflict_resolution_default` field accepts one of three values:

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -14,7 +14,6 @@ interface ConfigData {
     makemkvKey: string;
     libraryMoviesPath: string;
     libraryTvPath: string;
-    transcodingEnabled: boolean;
     tmdbApiKey: string;
     maxConcurrentMatches: number;
     ffmpegPath: string;
@@ -61,7 +60,6 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         makemkvKey: '',
         libraryMoviesPath: '',
         libraryTvPath: '',
-        transcodingEnabled: false,
         tmdbApiKey: '',
         maxConcurrentMatches: 2,
         ffmpegPath: '',
@@ -118,7 +116,6 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     makemkvKey: data.makemkv_key === '***' ? '' : (data.makemkv_key || ''),
                     libraryMoviesPath: data.library_movies_path || '',
                     libraryTvPath: data.library_tv_path || '',
-                    transcodingEnabled: data.transcoding_enabled || false,
                     tmdbApiKey: data.tmdb_api_key === '***' ? '' : (data.tmdb_api_key || ''),
                     maxConcurrentMatches: data.max_concurrent_matches ?? 2,
                     ffmpegPath: data.ffmpeg_path || '',
@@ -213,7 +210,6 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     makemkv_key: config.makemkvKey,
                     library_movies_path: config.libraryMoviesPath,
                     library_tv_path: config.libraryTvPath,
-                    transcoding_enabled: config.transcodingEnabled,
                     tmdb_api_key: config.tmdbApiKey,
                     max_concurrent_matches: config.maxConcurrentMatches,
                     ffmpeg_path: config.ffmpegPath,
@@ -594,22 +590,6 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             Configure additional options for your workflow.
                         </p>
 
-                        <div className="form-group checkbox-group">
-                            <label className="checkbox-label">
-                                <input
-                                    type="checkbox"
-                                    checked={config.transcodingEnabled}
-                                    onChange={(e) => handleInputChange('transcodingEnabled', e.target.checked)}
-                                />
-                                <span className="checkbox-text">
-                                    <strong>Enable Transcoding</strong>
-                                    <span className="checkbox-hint">
-                                        Compress files after ripping using HandBrake (slower, smaller files)
-                                    </span>
-                                </span>
-                            </label>
-                        </div>
-
                         {FEATURES.DISCDB && (
                             <div className="form-group checkbox-group">
                                 <label className="checkbox-label">
@@ -904,8 +884,6 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 <dd>{config.makemkvKey ? 'New key entered' : (savedKeys.makemkv ? 'Configured' : 'Not set')}</dd>
                                 <dt>TMDB Token:</dt>
                                 <dd>{config.tmdbApiKey ? 'New token entered' : (savedKeys.tmdb ? 'Configured' : 'Not set')}</dd>
-                                <dt>Transcoding:</dt>
-                                <dd>{config.transcodingEnabled ? 'Enabled' : 'Disabled (Passthrough)'}</dd>
                             </dl>
                         </div>
                     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -156,6 +156,5 @@ export interface Config {
     staging_path: string;
     library_movies_path: string;
     library_tv_path: string;
-    transcoding_enabled: boolean;
     tmdb_api_key: string;
 }


### PR DESCRIPTION
## What

Removes the "Enable Transcoding" option from settings. It was never implemented — no transcoding logic exists anywhere in the codebase, so the flag only persisted to the database and was never read.

## Why

The toggle misled users into thinking transcoding was supported. There are no plans to implement it, so the dead feature is removed entirely rather than left as unused scaffolding.

## Changes

- **Models**: drop `AppConfig.transcoding_enabled` and `DiscJob.is_transcoding_enabled`
- **API**: remove transcoding from the config request/response models and the diagnostics report
- **Frontend**: remove the ConfigWizard "Enable Transcoding" checkbox, the config summary row, the `ConfigData`/`Config` type fields, and load/save mapping
- **Migration**: new Alembic migration drops the `disc_jobs.is_transcoding_enabled` column. `app_config` needs no migration — `_migrate_app_config()` rebuilds that table from model metadata and restores by column-name intersection, so the dropped field simply falls away
- **Tests/docs**: updated accordingly; the boolean-flag validation tests were repointed to `ai_identification_enabled` so they still exercise a real flag

## Reviewer notes

- The Alembic baseline migration is a no-op (tables come from `create_all`), so fresh DBs get `stamp head` and never run the new `upgrade()`. It only executes on existing DBs that predate it — exactly the ones that have the column to drop.
- Config wizard Step 4 ("Preferences") now opens directly with the gated TheDiscDB toggle; it renders fine without the transcoding checkbox.

## Verification

- Backend `ruff check`: passed
- Backend tests: 607 passed
- Frontend `npm run build` (tsc + vite) and `npm run lint`: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
