### PR TITLE
Ship a pre-built subtitle-vector cache with scraping fallback

### DIFF
--- a/.github/workflows/build-subtitle-cache.yml
+++ b/.github/workflows/build-subtitle-cache.yml
@@ -1,0 +1,64 @@
+name: Build Subtitle Cache
+
+# Manually triggered. Harvesting subtitles for ~300 shows takes a long time and
+# hits rate-limited third-party scrapers, so this must NOT run on every release.
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Number of popular TV shows to include"
+        default: "300"
+      cache_tag:
+        description: "Release tag to publish the cache to"
+        default: "subtitle-cache-v1"
+
+permissions:
+  contents: write
+
+# See ci.yml for context on the Node 24 opt-in.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: build-subtitle-cache
+  cancel-in-progress: false
+
+jobs:
+  build-cache:
+    name: Build & publish subtitle-vector cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        working-directory: backend
+        run: uv sync --no-install-project
+
+      - name: Build subtitle cache
+        working-directory: backend
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          OPENSUBTITLES_API_KEY: ${{ secrets.OPENSUBTITLES_API_KEY }}
+          OPENSUBTITLES_USERNAME: ${{ secrets.OPENSUBTITLES_USERNAME }}
+          OPENSUBTITLES_PASSWORD: ${{ secrets.OPENSUBTITLES_PASSWORD }}
+        run: uv run python scripts/build_subtitle_cache.py --limit ${{ inputs.limit }}
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.cache_tag }}
+          name: Subtitle Cache (${{ inputs.cache_tag }})
+          body: >
+            Precomputed subtitle-matching cache (hashed TF-IDF vectors).
+            Downloaded automatically by Engram on first run.
+          files: |
+            backend/engram-subtitle-cache.tar.gz
+            backend/manifest.json

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -46,5 +46,10 @@ class Settings(BaseSettings):
     # CORS (comma-separated origins, or leave empty for dev defaults)
     cors_origins: str = ""
 
+    # Precomputed subtitle-vector cache: base URL of the GitHub Release that hosts
+    # the artifact. The format-version tag and filenames are appended at runtime.
+    # Overridable (e.g. to point at a test release) via the env var of the same name.
+    precomputed_cache_base_url: str = "https://github.com/jsakkos/engram/releases/download"
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,10 +91,22 @@ async def lifespan(app: FastAPI):
     await job_manager.start()
     logger.info("Job manager started")
 
+    # Download/refresh the precomputed subtitle-vector cache in the background.
+    # Fire-and-forget: a slow or failed download must never block startup, and
+    # subtitle scraping remains the fallback until the cache lands.
+    import asyncio
+
+    from app.services.precomputed_cache_service import ensure_precomputed_cache
+
+    app.state.precomputed_cache_task = asyncio.create_task(ensure_precomputed_cache())
+
     yield
 
     # Shutdown
     logger.info("Shutting down Engram Backend...")
+    cache_task = getattr(app.state, "precomputed_cache_task", None)
+    if cache_task and not cache_task.done():
+        cache_task.cancel()
     await job_manager.stop()
     logger.info("Shutdown complete")
 

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -1,3 +1,4 @@
+import json
 import re
 import subprocess
 import tempfile
@@ -10,6 +11,7 @@ import numpy as np
 from loguru import logger
 from rich import print
 from rich.console import Console
+from scipy.sparse import load_npz as scipy_load_npz
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity as sklearn_cosine_similarity
 
@@ -142,8 +144,28 @@ class TfidfMatcher:
     def __init__(self):
         self.vectorizer = None
         self.ref_matrix = None
-        self.ref_file_order = []  # ordered list of reference file paths
+        self.ref_file_order = []  # ordered list of reference file paths (or episode codes)
         self._prepared = False
+        self._precomputed = False  # True when loaded from the shipped vector cache
+        self._idf = None  # global IDF array, only set in precomputed mode
+
+    def load_precomputed(self, ref_matrix, ref_episode_codes, idf_array) -> None:
+        """Load a precomputed hashed TF-IDF cache instead of fitting from SRT.
+
+        Args:
+            ref_matrix: scipy CSR matrix, one L2-normalized TF-IDF row per episode.
+            ref_episode_codes: episode codes ("S01E03"), aligned to matrix rows.
+            idf_array: global IDF array used to project queries into the same space.
+        """
+        self.ref_matrix = ref_matrix
+        self.ref_file_order = list(ref_episode_codes)
+        self._idf = idf_array
+        self._precomputed = True
+        self._prepared = True
+        logger.info(
+            f"TF-IDF loaded from precomputed cache: {len(self.ref_file_order)} episodes, "
+            f"{self.ref_matrix.shape[1]} features"
+        )
 
     def prepare(self, reference_files, subtitle_cache: SubtitleCache):
         """
@@ -186,7 +208,12 @@ class TfidfMatcher:
         if not self._prepared:
             raise RuntimeError("TfidfMatcher.prepare() must be called before match()")
 
-        q_vec = self.vectorizer.transform([query_text])
+        if self._precomputed:
+            from app.matcher.vectorizer_config import transform_query
+
+            q_vec = transform_query(query_text, self._idf)
+        else:
+            q_vec = self.vectorizer.transform([query_text])
         sims = sklearn_cosine_similarity(q_vec, self.ref_matrix)[0]
 
         results = list(zip(self.ref_file_order, sims.tolist(), strict=False))
@@ -320,6 +347,9 @@ class EpisodeMatcher:
         self.audio_chunks = {}
         # Store reference files to avoid repeated glob operations
         self.reference_files_cache = {}
+        # Precomputed subtitle-vector cache (lazily loaded; False once known-absent)
+        self._precomputed_manifest = None
+        self._precomputed_idf = None
         # Ranked voting parameters
         self.min_vote_count = min_vote_count
         self.match_threshold = match_threshold
@@ -432,6 +462,96 @@ class EpisodeMatcher:
         except Exception as e:
             logger.error(f"Error loading reference chunk from {srt_file}: {e}")
             return ""
+
+    def _load_precomputed_manifest(self):
+        """Load and validate the precomputed-cache manifest once. Returns dict or None.
+
+        A missing, unreadable, or version/config-mismatched manifest is treated as
+        "no cache" -- the caller falls back to subtitle scraping.
+        """
+        if self._precomputed_manifest is not None:
+            return self._precomputed_manifest or None
+
+        from app.matcher.vectorizer_config import (
+            CACHE_FORMAT_VERSION,
+            vectorizer_config_hash,
+        )
+
+        manifest_path = self.cache_dir / "precomputed" / "manifest.json"
+        if not manifest_path.exists():
+            self._precomputed_manifest = False
+            return None
+
+        try:
+            with open(manifest_path, encoding="utf-8") as fh:
+                manifest = json.load(fh)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(f"Precomputed cache manifest unreadable ({e}); using scraping")
+            self._precomputed_manifest = False
+            return None
+
+        if manifest.get("cache_format_version") != CACHE_FORMAT_VERSION:
+            logger.warning(
+                f"Precomputed cache format mismatch "
+                f"(manifest={manifest.get('cache_format_version')}, code={CACHE_FORMAT_VERSION}); "
+                f"ignoring cache"
+            )
+            self._precomputed_manifest = False
+            return None
+        if manifest.get("vectorizer_config_hash") != vectorizer_config_hash():
+            logger.warning("Precomputed cache vectorizer-config mismatch; ignoring cache")
+            self._precomputed_manifest = False
+            return None
+
+        self._precomputed_manifest = manifest
+        return manifest
+
+    def _load_precomputed_season(self, season_number):
+        """Load precomputed hashed TF-IDF vectors for this show/season.
+
+        Returns (ref_matrix, episode_codes, idf_array) when the shipped cache
+        covers the show+season, otherwise None (caller falls back to scraping).
+        """
+        manifest = self._load_precomputed_manifest()
+        if not manifest:
+            return None
+
+        show_entry = manifest.get("shows", {}).get(self.show_name)
+        if not show_entry or season_number not in show_entry.get("seasons", []):
+            return None
+
+        precomputed_dir = self.cache_dir / "precomputed"
+        show_dir = precomputed_dir / sanitize_filename(self.show_name)
+        npz_path = show_dir / f"S{season_number:02d}.npz"
+        index_path = show_dir / f"S{season_number:02d}.index.json"
+        if not npz_path.exists() or not index_path.exists():
+            logger.warning(
+                f"Precomputed cache lists {self.show_name} S{season_number:02d} "
+                f"but its files are missing; using scraping"
+            )
+            return None
+
+        try:
+            if self._precomputed_idf is None:
+                self._precomputed_idf = np.load(precomputed_dir / "idf.npy")
+            ref_matrix = scipy_load_npz(npz_path)
+            with open(index_path, encoding="utf-8") as fh:
+                episode_codes = json.load(fh)
+        except (OSError, ValueError) as e:
+            logger.warning(
+                f"Failed to load precomputed cache for {self.show_name} "
+                f"S{season_number:02d} ({e}); using scraping"
+            )
+            return None
+
+        if ref_matrix.shape[0] != len(episode_codes):
+            logger.warning(
+                f"Precomputed cache row/index mismatch for {self.show_name} "
+                f"S{season_number:02d}; using scraping"
+            )
+            return None
+
+        return ref_matrix, episode_codes, self._precomputed_idf
 
     def get_reference_files(self, season_number):
         """Get reference subtitle files with caching."""
@@ -697,17 +817,29 @@ class EpisodeMatcher:
             if progress_callback:
                 progress_callback("analyzing", 0.0)
 
-            # 1. Get Reference Files
-            reference_files = self.get_reference_files(season_number)
-            if not reference_files:
-                reference_dir = self.cache_dir / "data" / sanitize_filename(self.show_name)
-                logger.error(
-                    f"No reference subtitle files found for '{self.show_name}' season {season_number}. "
-                    f"Expected directory: {reference_dir}. "
-                    f"This usually means subtitle download failed. "
-                    f"Check subtitle download status and retry if needed."
+            # 1. Get References - shipped precomputed vectors, else scraped SRT
+            precomputed = self._load_precomputed_season(season_number)
+            using_precomputed = precomputed is not None
+
+            if using_precomputed:
+                ref_matrix, ref_episode_codes, idf_array = precomputed
+                reference_files = []  # no SRT files on disk in precomputed mode
+                logger.info(
+                    f"[Matcher] using precomputed subtitle-vector cache for "
+                    f"'{self.show_name}' season {season_number} "
+                    f"({len(ref_episode_codes)} episodes)"
                 )
-                return None
+            else:
+                reference_files = self.get_reference_files(season_number)
+                if not reference_files:
+                    reference_dir = self.cache_dir / "data" / sanitize_filename(self.show_name)
+                    logger.error(
+                        f"No reference subtitle files found for '{self.show_name}' "
+                        f"season {season_number}. Expected directory: {reference_dir}. "
+                        f"This usually means subtitle download failed. "
+                        f"Check subtitle download status and retry if needed."
+                    )
+                    return None
 
             if progress_callback:
                 progress_callback("analyzing", 5.0)
@@ -719,26 +851,31 @@ class EpisodeMatcher:
                 logger.error(f"Failed to get video duration for {video_file}: {e}")
                 return None
 
-            # 3. Get Reference Durations
-            ref_durations = {}
-            for rf in reference_files:
-                try:
-                    content = self.subtitle_cache.get_subtitle_content(rf)
-                    ref_durations[str(rf)] = SubtitleReader.get_duration(content)
-                except Exception as e:
-                    logger.warning(f"Could not get duration for reference {rf}: {e}")
-                    ref_durations[str(rf)] = 0.0
-
-            # 4. Initialize Coverages
+            # 3. Initialize Coverages
             coverages = {}
-            for rf in reference_files:
-                ref_dur = ref_durations.get(str(rf), video_duration)
-                # If ref duration is missing, assume same as video for penalty-free matching (fallback)
-                if ref_dur == 0:
-                    ref_dur = video_duration
+            if using_precomputed:
+                # No SRT durations are shipped; assume reference duration == video
+                # duration for penalty-free coverage (same as the ref_dur==0 fallback).
+                for code in ref_episode_codes:
+                    coverages[code] = MatchCoverage(code, video_duration, video_duration)
+            else:
+                ref_durations = {}
+                for rf in reference_files:
+                    try:
+                        content = self.subtitle_cache.get_subtitle_content(rf)
+                        ref_durations[str(rf)] = SubtitleReader.get_duration(content)
+                    except Exception as e:
+                        logger.warning(f"Could not get duration for reference {rf}: {e}")
+                        ref_durations[str(rf)] = 0.0
 
-                ep_name = Path(rf).stem
-                coverages[str(rf)] = MatchCoverage(ep_name, ref_dur, video_duration)
+                for rf in reference_files:
+                    ref_dur = ref_durations.get(str(rf), video_duration)
+                    # Missing ref duration -> assume video duration for penalty-free matching
+                    if ref_dur == 0:
+                        ref_dur = video_duration
+
+                    ep_name = Path(rf).stem
+                    coverages[str(rf)] = MatchCoverage(ep_name, ref_dur, video_duration)
 
             # 5. Scan Chunks - Evenly Spaced Strategy
             # Distribute scan points evenly across the episode (after skipping intro)
@@ -780,7 +917,10 @@ class EpisodeMatcher:
                 if progress_callback:
                     progress_callback("preparing_model", 10.0)
                 self.tfidf_matcher = TfidfMatcher()
-                self.tfidf_matcher.prepare(reference_files, self.subtitle_cache)
+                if using_precomputed:
+                    self.tfidf_matcher.load_precomputed(ref_matrix, ref_episode_codes, idf_array)
+                else:
+                    self.tfidf_matcher.prepare(reference_files, self.subtitle_cache)
 
             logger.info(
                 f"Scanning {len(scan_points)} chunks using {model_config['name']} + TF-IDF matching "

--- a/backend/app/matcher/vectorizer_config.py
+++ b/backend/app/matcher/vectorizer_config.py
@@ -1,0 +1,117 @@
+"""Shared, stateless vectorizer config for the precomputed subtitle cache.
+
+This module is the single source of truth for the hashed TF-IDF feature space.
+It is imported by BOTH the offline build script (scripts/build_subtitle_cache.py)
+and the runtime matcher (episode_identification.py) so the two can never drift.
+
+The shipped cache contains HASHED TF-IDF vectors only. ``HashingVectorizer`` is
+stateless -- no vocabulary is stored or distributed -- so the published artifact
+is a non-invertible statistical fingerprint rather than verbatim subtitle text.
+A single global IDF array is fit once at build time and shipped alongside it.
+"""
+
+import hashlib
+import json
+
+import numpy as np
+from scipy import sparse
+from sklearn.feature_extraction.text import HashingVectorizer
+from sklearn.preprocessing import normalize as _sk_normalize
+
+# Bump whenever VECTORIZER_PARAMS, HASHING_N_FEATURES, SUBLINEAR_TF, the artifact
+# layout, or the subtitle-cleaning function changes. A mismatch between this value
+# and a cache manifest invalidates the cache (runtime falls back to scraping).
+CACHE_FORMAT_VERSION = "1"
+
+HASHING_N_FEATURES = 2**18
+
+# Frozen HashingVectorizer params. ``alternate_sign=False`` keeps token counts
+# non-negative (required for the TF-IDF transform); ``norm=None`` defers
+# normalization so sublinear TF + IDF weighting + the final L2 norm are applied
+# explicitly and identically at build time and at query time.
+VECTORIZER_PARAMS: dict = {
+    "analyzer": "word",
+    "ngram_range": (1, 2),
+    "n_features": HASHING_N_FEATURES,
+    "alternate_sign": False,
+    "norm": None,
+}
+
+# Matches the original TfidfVectorizer config used by the scraped (fallback) path.
+SUBLINEAR_TF = True
+
+
+def build_hashing_vectorizer() -> HashingVectorizer:
+    """Return a HashingVectorizer with the frozen, shared config."""
+    return HashingVectorizer(**VECTORIZER_PARAMS)
+
+
+def vectorizer_config_hash() -> str:
+    """Stable sha256 of the frozen config, embedded in the cache manifest.
+
+    Recomputed at runtime; any divergence from the manifest's stored value means
+    the cache was built with an incompatible config and must not be used.
+    """
+    payload = json.dumps(
+        {
+            "format": CACHE_FORMAT_VERSION,
+            "n_features": HASHING_N_FEATURES,
+            "params": {
+                k: (list(v) if isinstance(v, tuple) else v)
+                for k, v in sorted(VECTORIZER_PARAMS.items())
+            },
+            "sublinear_tf": SUBLINEAR_TF,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def compute_idf(count_matrix) -> np.ndarray:
+    """Compute the global smoothed IDF array from a hashed term-count matrix.
+
+    Uses the same smoothed formula as ``sklearn``'s TfidfTransformer
+    (``smooth_idf=True``): ``idf(t) = ln((1 + n) / (1 + df(t))) + 1``.
+
+    Args:
+        count_matrix: sparse matrix (rows = documents) of raw hashed term counts.
+
+    Returns:
+        1-D float32 array of length ``HASHING_N_FEATURES``.
+    """
+    count_matrix = sparse.csr_matrix(count_matrix)
+    n_docs = count_matrix.shape[0]
+    df = np.asarray((count_matrix > 0).sum(axis=0)).ravel().astype(np.float64)
+    idf = np.log((1.0 + n_docs) / (1.0 + df)) + 1.0
+    return idf.astype(np.float32)
+
+
+def apply_tfidf(counts, idf_array):
+    """Convert a hashed term-count matrix into L2-normalized TF-IDF rows.
+
+    Build time and query time both route through this function, so reference
+    vectors and query vectors always land in the identical feature space.
+
+    Args:
+        counts: sparse matrix of raw hashed term counts (rows = documents).
+        idf_array: 1-D IDF array of length ``HASHING_N_FEATURES``.
+
+    Returns:
+        L2-normalized CSR matrix.
+    """
+    counts = sparse.csr_matrix(counts, dtype=np.float64, copy=True)
+    if SUBLINEAR_TF and counts.nnz:
+        counts.data = 1.0 + np.log(counts.data)
+    idf_row = np.asarray(idf_array, dtype=np.float64).reshape(1, -1)
+    weighted = sparse.csr_matrix(counts.multiply(idf_row))
+    return _sk_normalize(weighted, norm="l2", copy=False)
+
+
+def transform_query(text: str, idf_array):
+    """Transform raw query text into a 1xN L2-normalized TF-IDF vector.
+
+    Stateless: relies only on the frozen HashingVectorizer config and the shipped
+    global IDF array, so it reproduces the build-time feature space exactly.
+    """
+    counts = build_hashing_vectorizer().transform([text or ""])
+    return apply_tfidf(counts, idf_array)

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -4,6 +4,7 @@ This model stores user-configurable settings that persist across restarts
 and can be modified via the UI.
 """
 
+from sqlalchemy import text
 from sqlmodel import Field, SQLModel
 
 
@@ -26,6 +27,13 @@ class AppConfig(SQLModel, table=True):
     # Episode Matcher Settings
     subtitles_cache_path: str = "~/.engram/cache"
     matcher_min_confidence: float = 0.6
+
+    # Precomputed subtitle-vector cache (downloaded from GitHub Releases on first run).
+    # server_default="1" so the column is added enabled for pre-existing databases.
+    precomputed_cache_enabled: bool = Field(
+        default=True, sa_column_kwargs={"server_default": text("1")}
+    )
+    precomputed_cache_version: str = ""  # content version of the installed cache
 
     # TMDB API (for show metadata)
     tmdb_api_key: str = ""

--- a/backend/app/services/precomputed_cache_service.py
+++ b/backend/app/services/precomputed_cache_service.py
@@ -1,0 +1,164 @@
+"""Fetch-on-first-run for the precomputed subtitle-vector cache.
+
+On startup the app downloads a hashed TF-IDF cache -- covering the most popular
+TV shows -- from a GitHub Release and extracts it into the subtitle cache
+directory. The matcher then uses these vectors instead of scraping subtitles.
+
+This is strictly best-effort: any failure (offline, 404, checksum mismatch,
+disk error) is logged and swallowed. Subtitle scraping remains the functional
+fallback for every show, and startup must never fail because of this.
+"""
+
+import hashlib
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import httpx
+from loguru import logger
+
+from app.config import settings
+from app.matcher.vectorizer_config import CACHE_FORMAT_VERSION
+
+_CACHE_TAG = f"subtitle-cache-v{CACHE_FORMAT_VERSION}"
+_MANIFEST_NAME = "manifest.json"
+_TARBALL_NAME = "engram-subtitle-cache.tar.gz"
+_MANIFEST_TIMEOUT = 30.0
+_DOWNLOAD_TIMEOUT = 600.0
+
+
+def _release_url(filename: str) -> str:
+    base = settings.precomputed_cache_base_url.rstrip("/")
+    return f"{base}/{_CACHE_TAG}/{filename}"
+
+
+async def ensure_precomputed_cache() -> None:
+    """Download/refresh the precomputed subtitle cache if needed. Never raises."""
+    try:
+        await _ensure_precomputed_cache_inner()
+    except Exception as e:  # defensive: this must never break startup
+        logger.warning(f"Precomputed cache check failed ({e}); subtitle scraping still works")
+
+
+async def _ensure_precomputed_cache_inner() -> None:
+    from app.services.config_service import get_config, update_config
+
+    config = await get_config()
+    if not config.precomputed_cache_enabled:
+        logger.info("Precomputed subtitle cache disabled in config; skipping")
+        return
+
+    cache_dir = Path(config.subtitles_cache_path).expanduser()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    precomputed_dir = cache_dir / "precomputed"
+
+    local_manifest = _read_local_manifest(precomputed_dir)
+
+    remote_manifest = await _fetch_remote_manifest()
+    if remote_manifest is None:
+        logger.info("Precomputed cache: remote manifest unavailable (offline?); skipping")
+        return
+
+    remote_format = remote_manifest.get("cache_format_version")
+    remote_content = remote_manifest.get("content_version", "")
+    if remote_format != CACHE_FORMAT_VERSION:
+        logger.info(
+            f"Precomputed cache: remote format {remote_format!r} is not supported "
+            f"version {CACHE_FORMAT_VERSION!r}; skipping"
+        )
+        return
+
+    up_to_date = (
+        local_manifest is not None
+        and local_manifest.get("cache_format_version") == CACHE_FORMAT_VERSION
+        and remote_content != ""
+        and config.precomputed_cache_version == remote_content
+    )
+    if up_to_date:
+        logger.info(f"Precomputed subtitle cache up to date (version {remote_content})")
+        return
+
+    logger.info(
+        f"Downloading precomputed subtitle cache (version {remote_content or 'unknown'})..."
+    )
+    if await _download_and_extract(remote_manifest, cache_dir, precomputed_dir):
+        await update_config(precomputed_cache_version=remote_content)
+        logger.info(
+            f"Precomputed subtitle cache installed ({len(remote_manifest.get('shows', {}))} shows)"
+        )
+
+
+def _read_local_manifest(precomputed_dir: Path) -> dict | None:
+    try:
+        with open(precomputed_dir / _MANIFEST_NAME, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+async def _fetch_remote_manifest() -> dict | None:
+    try:
+        async with httpx.AsyncClient(timeout=_MANIFEST_TIMEOUT, follow_redirects=True) as client:
+            resp = await client.get(_release_url(_MANIFEST_NAME))
+            resp.raise_for_status()
+            return resp.json()
+    except (httpx.HTTPError, json.JSONDecodeError) as e:
+        logger.debug(f"Precomputed cache manifest fetch failed: {e}")
+        return None
+
+
+async def _download_and_extract(
+    remote_manifest: dict, cache_dir: Path, precomputed_dir: Path
+) -> bool:
+    expected_sha = remote_manifest.get("tarball_sha256", "")
+    tarball_path = cache_dir / f".{_TARBALL_NAME}.download"
+    staging_dir = cache_dir / ".precomputed_staging"
+
+    try:
+        sha = hashlib.sha256()
+        with open(tarball_path, "wb") as fh:
+            async with httpx.AsyncClient(
+                timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True
+            ) as client:
+                async with client.stream("GET", _release_url(_TARBALL_NAME)) as resp:
+                    resp.raise_for_status()
+                    async for chunk in resp.aiter_bytes():
+                        fh.write(chunk)
+                        sha.update(chunk)
+
+        if expected_sha and sha.hexdigest() != expected_sha:
+            logger.warning("Precomputed cache: tarball checksum mismatch; discarding download")
+            return False
+
+        # Extract into a staging dir, then atomically swap it into place.
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            _safe_extractall(tar, staging_dir)
+
+        extracted = staging_dir / "precomputed"
+        if not (extracted / _MANIFEST_NAME).exists():
+            logger.warning("Precomputed cache: extracted archive missing manifest; aborting")
+            return False
+
+        shutil.rmtree(precomputed_dir, ignore_errors=True)
+        shutil.move(str(extracted), str(precomputed_dir))
+        return True
+    except (httpx.HTTPError, OSError, tarfile.TarError) as e:
+        logger.warning(f"Precomputed cache download/extract failed ({e}); using scraping")
+        return False
+    finally:
+        tarball_path.unlink(missing_ok=True)
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+def _safe_extractall(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract a tar archive, rejecting members that escape the destination."""
+    dest = dest.resolve()
+    for member in tar.getmembers():
+        target = (dest / member.name).resolve()
+        if not str(target).startswith(str(dest)):
+            raise tarfile.TarError(f"unsafe path in archive: {member.name}")
+    tar.extractall(dest)

--- a/backend/app/services/precomputed_cache_service.py
+++ b/backend/app/services/precomputed_cache_service.py
@@ -136,7 +136,9 @@ async def _download_and_extract(
             shutil.rmtree(staging_dir, ignore_errors=True)
         staging_dir.mkdir(parents=True, exist_ok=True)
         with tarfile.open(tarball_path, "r:gz") as tar:
-            _safe_extractall(tar, staging_dir)
+            # filter="data" (Python 3.11.4+) rejects members that escape the
+            # destination -- path traversal, absolute paths, unsafe links.
+            tar.extractall(staging_dir, filter="data")
 
         extracted = staging_dir / "precomputed"
         if not (extracted / _MANIFEST_NAME).exists():
@@ -152,13 +154,3 @@ async def _download_and_extract(
     finally:
         tarball_path.unlink(missing_ok=True)
         shutil.rmtree(staging_dir, ignore_errors=True)
-
-
-def _safe_extractall(tar: tarfile.TarFile, dest: Path) -> None:
-    """Extract a tar archive, rejecting members that escape the destination."""
-    dest = dest.resolve()
-    for member in tar.getmembers():
-        target = (dest / member.name).resolve()
-        if not str(target).startswith(str(dest)):
-            raise tarfile.TarError(f"unsafe path in archive: {member.name}")
-    tar.extractall(dest)

--- a/backend/scripts/ab_accuracy.py
+++ b/backend/scripts/ab_accuracy.py
@@ -1,0 +1,187 @@
+"""A/B accuracy comparison: scraped TF-IDF path vs. precomputed-vector cache.
+
+Runs scripts/test_matching_accuracy.py twice against the same ground-truth
+videos -- once with the precomputed cache absent (baseline: scraped SRT ->
+TF-IDF) and once with it present (precomputed hashed-vector path) -- then
+diffs accuracy, per-episode correctness, and timing.
+
+EpisodeMatcher auto-selects the precomputed path whenever
+``CACHE_DIR/precomputed/`` covers the show/season, so the only thing this
+script toggles between runs is the presence of that directory.
+
+Usage (from backend/):
+    uv run python scripts/ab_accuracy.py --precomputed /path/to/precomputed
+    uv run python scripts/ab_accuracy.py --precomputed cache.tar.gz --show "The Expanse"
+
+``--precomputed`` accepts either an extracted ``precomputed/`` directory or the
+``engram-subtitle-cache.tar.gz`` produced by build_subtitle_cache.py. It must
+cover the shows under test, otherwise run B silently falls back to scraping and
+the comparison is meaningless.
+
+Exit code is non-zero if the precomputed path regresses accuracy beyond
+``--tolerance`` (default 2 percentage points).
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+_scripts_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(_scripts_dir))
+
+from test_matching_accuracy import CACHE_DIR  # noqa: E402
+
+
+def _resolve_precomputed(src: Path, workdir: Path) -> Path:
+    """Return a path to a ``precomputed/`` directory, extracting a tarball if needed."""
+    if src.is_dir():
+        if src.name == "precomputed":
+            return src
+        inner = src / "precomputed"
+        if inner.is_dir():
+            return inner
+        raise SystemExit(f"No 'precomputed/' directory found in {src}")
+    if src.is_file() and (src.suffix == ".gz" or tarfile.is_tarfile(src)):
+        with tarfile.open(src) as tar:
+            tar.extractall(workdir, filter="data")
+        inner = workdir / "precomputed"
+        if not inner.is_dir():
+            raise SystemExit(f"Tarball {src} has no top-level 'precomputed/' directory")
+        return inner
+    raise SystemExit(f"--precomputed must be an existing directory or .tar.gz: {src}")
+
+
+def _run_accuracy(passthrough: list[str], label: str) -> dict:
+    """Run test_matching_accuracy.py as a subprocess; stream output; return its result JSON."""
+    print(f"\n{'#' * 70}\n#  {label}\n{'#' * 70}", flush=True)
+    cmd = [sys.executable, str(_scripts_dir / "test_matching_accuracy.py"), *passthrough]
+    results_path: str | None = None
+
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+    )
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        if "Results saved to:" in line:
+            results_path = line.split("Results saved to:", 1)[1].strip()
+    proc.wait()
+
+    if proc.returncode != 0:
+        raise SystemExit(f"accuracy run failed (exit {proc.returncode})")
+    if not results_path:
+        raise SystemExit("accuracy run did not report a results file")
+    return json.loads(Path(results_path).read_text())
+
+
+def _report(baseline: dict, precomputed: dict, tolerance: float) -> int:
+    """Print the A/B comparison; return a non-zero exit code on regression."""
+
+    def _row(label: str, a: str, b: str) -> None:
+        print(f"  {label:<22}{a:>16}{b:>16}")
+
+    a_acc = baseline.get("accuracy", 0.0)
+    b_acc = precomputed.get("accuracy", 0.0)
+
+    print(f"\n{'=' * 60}\n  A/B ACCURACY COMPARISON\n{'=' * 60}")
+    _row("metric", "baseline", "precomputed")
+    _row("accuracy", f"{a_acc * 100:.1f}%", f"{b_acc * 100:.1f}%")
+    _row(
+        "correct/total",
+        f"{baseline.get('correct')}/{baseline.get('total')}",
+        f"{precomputed.get('correct')}/{precomputed.get('total')}",
+    )
+    _row(
+        "avg time/episode",
+        f"{baseline.get('avg_time_sec')}s",
+        f"{precomputed.get('avg_time_sec')}s",
+    )
+
+    a_eps = {e["label"]: e for e in baseline.get("episodes", [])}
+    b_eps = {e["label"]: e for e in precomputed.get("episodes", [])}
+    disagreements = [
+        (label, a_eps[label]["correct"], b_eps[label]["correct"])
+        for label in sorted(a_eps.keys() & b_eps.keys())
+        if a_eps[label]["correct"] != b_eps[label]["correct"]
+    ]
+    if disagreements:
+        print("\n  Episodes where the two paths disagree:")
+        for label, a_ok, b_ok in disagreements:
+            print(
+                f"    {label}: baseline={'OK' if a_ok else 'X'}  "
+                f"precomputed={'OK' if b_ok else 'X'}"
+            )
+    else:
+        print("\n  Both paths agree on every episode.")
+
+    delta = b_acc - a_acc
+    print(f"\n  Accuracy delta (precomputed - baseline): {delta * 100:+.1f} pp")
+    if delta < -tolerance:
+        print(f"  REGRESSION: precomputed is more than {tolerance * 100:.0f} pp worse.")
+        return 1
+    print(f"  OK: precomputed is within the {tolerance * 100:.0f} pp tolerance.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="A/B accuracy: scraped vs. precomputed")
+    parser.add_argument(
+        "--precomputed",
+        required=True,
+        help="Path to a precomputed/ directory or engram-subtitle-cache.tar.gz",
+    )
+    parser.add_argument("--show", default=None, help="Limit to one show (partial name match)")
+    parser.add_argument("--subset", type=int, default=0, help="Test only N random episodes")
+    parser.add_argument("--model", default="small", help="Whisper model size")
+    parser.add_argument("--device", default=None, help="Force device (cpu/cuda)")
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.02,
+        help="Max accuracy drop (fraction) before flagging a regression",
+    )
+    args = parser.parse_args()
+
+    passthrough: list[str] = []
+    if args.show:
+        passthrough += ["--show", args.show]
+    if args.subset:
+        passthrough += ["--subset", str(args.subset)]
+    passthrough += ["--model", args.model]
+    if args.device:
+        passthrough += ["--device", args.device]
+
+    live = CACHE_DIR / "precomputed"
+    stash = CACHE_DIR / "precomputed.ab-stash"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        src = _resolve_precomputed(Path(args.precomputed).expanduser().resolve(), Path(tmp))
+
+        # Stash any installed precomputed cache so run A cannot see it.
+        if live.exists():
+            shutil.rmtree(stash, ignore_errors=True)
+            shutil.move(str(live), str(stash))
+        try:
+            baseline = _run_accuracy(passthrough, "A: BASELINE (scraped SRT -> TF-IDF)")
+
+            CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src, live)
+            try:
+                precomputed = _run_accuracy(passthrough, "B: PRECOMPUTED (hashed-vector cache)")
+            finally:
+                shutil.rmtree(live, ignore_errors=True)
+        finally:
+            # Restore the user's original cache state.
+            if stash.exists():
+                shutil.move(str(stash), str(live))
+
+    return _report(baseline, precomputed, args.tolerance)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -1,0 +1,284 @@
+"""Build the precomputed subtitle-vector cache shipped with Engram.
+
+Harvests subtitles for the most popular TV shows, reduces each episode to a
+HASHED TF-IDF vector (no readable vocabulary -- see app/matcher/vectorizer_config),
+discards the raw SRT, and packages the vectors into a `.tar.gz` plus a manifest
+for hosting on GitHub Releases.
+
+Usage (from backend/):
+    uv run python scripts/build_subtitle_cache.py --limit 300
+    uv run python scripts/build_subtitle_cache.py --shows "The Expanse,Arrested Development"
+
+TMDB / OpenSubtitles credentials are read from the AppConfig DB row; in CI they
+are bootstrapped from the env vars TMDB_API_KEY, OPENSUBTITLES_API_KEY,
+OPENSUBTITLES_USERNAME, OPENSUBTITLES_PASSWORD.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import numpy as np
+from loguru import logger
+from scipy import sparse
+
+from app.matcher.episode_identification import SubtitleCache
+from app.matcher.subtitle_utils import sanitize_filename
+from app.matcher.testing_service import download_subtitles
+from app.matcher.tmdb_client import fetch_popular_shows, fetch_show_details, fetch_show_id
+from app.matcher.vectorizer_config import (
+    CACHE_FORMAT_VERSION,
+    HASHING_N_FEATURES,
+    apply_tfidf,
+    build_hashing_vectorizer,
+    compute_idf,
+    vectorizer_config_hash,
+)
+
+_VALID_STATUSES = {"cached", "downloaded"}
+
+
+def _bootstrap_config_from_env() -> None:
+    """Populate the AppConfig DB row with credentials from env vars (for CI)."""
+    env_map = {
+        "tmdb_api_key": "TMDB_API_KEY",
+        "opensubtitles_api_key": "OPENSUBTITLES_API_KEY",
+        "opensubtitles_username": "OPENSUBTITLES_USERNAME",
+        "opensubtitles_password": "OPENSUBTITLES_PASSWORD",
+    }
+    updates = {field: os.environ[env] for field, env in env_map.items() if os.environ.get(env)}
+    if not updates:
+        return
+
+    from sqlmodel import Session, select
+
+    from app.models.app_config import AppConfig
+    from app.services.config_service import _get_sync_engine
+
+    with Session(_get_sync_engine()) as session:
+        config = session.exec(select(AppConfig).limit(1)).first()
+        if config is None:
+            config = AppConfig()
+            session.add(config)
+        for field, value in updates.items():
+            setattr(config, field, value)
+        session.commit()
+    logger.info(f"Bootstrapped config from env: {sorted(updates)}")
+
+
+def _select_shows(args) -> list[dict]:
+    """Return [{name, tmdb_id, seasons}] for the shows to cache."""
+    if args.shows:
+        names = [s.strip() for s in args.shows.split(",") if s.strip()]
+        candidates = [{"name": n, "id": fetch_show_id(n)} for n in names]
+    else:
+        seen: dict[int, dict] = {}
+        for page in range(1, args.pages + 1):
+            for show in fetch_popular_shows(page):
+                if show.get("id") and show["id"] not in seen:
+                    seen[show["id"]] = show
+            time.sleep(args.sleep)
+        ranked = sorted(seen.values(), key=lambda s: s.get("popularity", 0), reverse=True)
+        candidates = [{"name": s["name"], "id": s["id"]} for s in ranked[: args.limit]]
+
+    shows = []
+    for cand in candidates:
+        if not cand["id"]:
+            logger.warning(f"Skipping '{cand['name']}': not found on TMDB")
+            continue
+        details = fetch_show_details(cand["id"])
+        if not details:
+            logger.warning(f"Skipping '{cand['name']}': could not fetch TMDB details")
+            continue
+        shows.append(
+            {
+                "name": details.get("name", cand["name"]),
+                "tmdb_id": cand["id"],
+                "seasons": details.get("number_of_seasons", 0),
+            }
+        )
+        time.sleep(args.sleep)
+    return shows
+
+
+def _harvest_show(show: dict, args) -> list[tuple[int, str, Path]]:
+    """Download subtitles for every season. Returns [(season, episode_code, srt_path)]."""
+    harvested: list[tuple[int, str, Path]] = []
+    canonical = show["name"]
+    for season in range(1, show["seasons"] + 1):
+        try:
+            result = download_subtitles(canonical, season)
+        except Exception as e:
+            logger.warning(f"  {canonical} S{season:02d}: harvest failed ({e})")
+            continue
+
+        episodes = [
+            ep for ep in result["episodes"] if ep["status"] in _VALID_STATUSES and ep.get("path")
+        ]
+        total = result.get("total_episodes", 0) or len(result["episodes"])
+        ratio = len(episodes) / total if total else 0.0
+        if ratio < args.min_episodes_ratio:
+            logger.info(
+                f"  {canonical} S{season:02d}: {len(episodes)}/{total} episodes "
+                f"({ratio:.0%}) below threshold {args.min_episodes_ratio:.0%}; skipping season"
+            )
+            continue
+
+        for ep in episodes:
+            harvested.append((season, ep["code"], Path(ep["path"])))
+        logger.info(f"  {canonical} S{season:02d}: {len(episodes)}/{total} episodes")
+        time.sleep(args.sleep)
+    return harvested
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the Engram subtitle-vector cache")
+    parser.add_argument("--limit", type=int, default=300, help="Number of popular shows")
+    parser.add_argument("--pages", type=int, default=15, help="TMDB popular pages to scan")
+    parser.add_argument(
+        "--shows", type=str, default="", help="Comma-separated show names (overrides popular)"
+    )
+    parser.add_argument(
+        "--min-episodes-ratio", type=float, default=0.6, help="Min episode coverage per season"
+    )
+    parser.add_argument("--sleep", type=float, default=1.0, help="Seconds between API/scrape calls")
+    parser.add_argument(
+        "--output", type=str, default="engram-subtitle-cache.tar.gz", help="Output tarball path"
+    )
+    parser.add_argument(
+        "--content-version", type=str, default="", help="Cache content version (default: today)"
+    )
+    parser.add_argument("--keep-srt", action="store_true", help="Do not delete harvested SRT files")
+    args = parser.parse_args()
+
+    _bootstrap_config_from_env()
+
+    from app.services.config_service import get_config_sync
+
+    cache_dir = Path(get_config_sync().subtitles_cache_path).expanduser()
+    precomputed_dir = cache_dir / "precomputed"
+    if precomputed_dir.exists():
+        shutil.rmtree(precomputed_dir)
+    precomputed_dir.mkdir(parents=True, exist_ok=True)
+
+    content_version = args.content_version or datetime.date.today().isoformat()
+
+    shows = _select_shows(args)
+    logger.info(f"Selected {len(shows)} shows for the cache")
+
+    # --- Harvest SRT + extract cleaned full text per episode -------------------
+    subtitle_cache = SubtitleCache()
+    # blocks: list of (show_name, season, [episode_codes], count_csr)
+    blocks: list[tuple[str, int, list[str], object]] = []
+    hv = build_hashing_vectorizer()
+    manifest_shows: dict[str, dict] = {}
+
+    for idx, show in enumerate(shows, 1):
+        logger.info(f"[{idx}/{len(shows)}] {show['name']} (TMDB {show['tmdb_id']})")
+        harvested = _harvest_show(show, args)
+        if not harvested:
+            logger.warning(f"  {show['name']}: no usable seasons; omitting from cache")
+            continue
+
+        by_season: dict[int, list[tuple[str, Path]]] = {}
+        for season, code, path in harvested:
+            by_season.setdefault(season, []).append((code, path))
+
+        show_seasons: list[int] = []
+        episode_counts: dict[str, int] = {}
+        for season in sorted(by_season):
+            episodes = sorted(by_season[season], key=lambda x: x[0])
+            texts, codes = [], []
+            for code, path in episodes:
+                text = subtitle_cache.get_full_text(str(path))
+                if text:
+                    texts.append(text)
+                    codes.append(code)
+            if not texts:
+                continue
+            counts = hv.transform(texts)  # raw hashed term counts
+            blocks.append((show["name"], season, codes, counts))
+            show_seasons.append(season)
+            episode_counts[str(season)] = len(codes)
+
+        if show_seasons:
+            manifest_shows[show["name"]] = {
+                "tmdb_id": show["tmdb_id"],
+                "seasons": show_seasons,
+                "episode_counts": episode_counts,
+            }
+
+    if not blocks:
+        logger.error("No subtitles harvested; nothing to build")
+        return 1
+
+    # --- Fit one global IDF across the whole corpus ----------------------------
+    all_counts = sparse.vstack([b[3] for b in blocks], format="csr")
+    idf = compute_idf(all_counts)
+    np.save(precomputed_dir / "idf.npy", idf)
+    logger.info(f"Global IDF fit over {all_counts.shape[0]} episodes")
+
+    # --- Write per-(show, season) L2-normalized TF-IDF matrices ----------------
+    for show_name, season, codes, counts in blocks:
+        show_dir = precomputed_dir / sanitize_filename(show_name)
+        show_dir.mkdir(parents=True, exist_ok=True)
+        tfidf = apply_tfidf(counts, idf)
+        sparse.save_npz(show_dir / f"S{season:02d}.npz", tfidf)
+        with open(show_dir / f"S{season:02d}.index.json", "w", encoding="utf-8") as fh:
+            json.dump(codes, fh)
+
+    # --- In-tarball manifest (read by the matcher) -----------------------------
+    manifest = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "vectorizer_config_hash": vectorizer_config_hash(),
+        "content_version": content_version,
+        "built_at": datetime.datetime.now(datetime.UTC).isoformat(),
+        "n_features": HASHING_N_FEATURES,
+        "shows": manifest_shows,
+    }
+    with open(precomputed_dir / "manifest.json", "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+    # --- Package + checksum ----------------------------------------------------
+    output_path = Path(args.output).resolve()
+    with tarfile.open(output_path, "w:gz") as tar:
+        tar.add(precomputed_dir, arcname="precomputed")
+
+    sha = hashlib.sha256()
+    with open(output_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            sha.update(chunk)
+
+    # Release-asset manifest = in-tar manifest + the tarball checksum.
+    release_manifest = dict(manifest, tarball_sha256=sha.hexdigest())
+    release_manifest_path = output_path.with_name("manifest.json")
+    with open(release_manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(release_manifest, fh, indent=2)
+
+    if not args.keep_srt:
+        data_dir = cache_dir / "data"
+        if data_dir.exists():
+            shutil.rmtree(data_dir)
+            logger.info("Deleted harvested SRT files (not shipped)")
+
+    total_episodes = sum(len(c) for _, _, c, _ in blocks)
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+    logger.info(
+        f"Built cache: {len(manifest_shows)} shows, {total_episodes} episodes, "
+        f"{size_mb:.1f} MB -> {output_path}"
+    )
+    logger.info(f"Release manifest -> {release_manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/unit/test_precomputed_cache.py
+++ b/backend/tests/unit/test_precomputed_cache.py
@@ -1,0 +1,127 @@
+"""Unit tests for the precomputed subtitle-vector cache.
+
+Covers the shared vectorizer config, TfidfMatcher precomputed mode, and the
+EpisodeMatcher cache loader (including format/config-mismatch fallback).
+"""
+
+import json
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from app.matcher.episode_identification import EpisodeMatcher, TfidfMatcher
+from app.matcher.vectorizer_config import (
+    CACHE_FORMAT_VERSION,
+    apply_tfidf,
+    build_hashing_vectorizer,
+    compute_idf,
+    transform_query,
+    vectorizer_config_hash,
+)
+
+_DOCS = [
+    "detective solves the murder in the old mansion at midnight",
+    "the spaceship crew explores a distant alien planet",
+    "a chef cooks an elaborate pasta dinner in a small kitchen",
+]
+
+
+def _build_refs(docs=_DOCS):
+    """Return (ref_matrix, idf) for a small corpus."""
+    counts = build_hashing_vectorizer().transform(docs)
+    idf = compute_idf(counts)
+    return apply_tfidf(counts, idf), idf
+
+
+class TestVectorizerConfig:
+    def test_config_hash_is_stable(self):
+        assert vectorizer_config_hash() == vectorizer_config_hash()
+
+    def test_transform_query_is_deterministic(self):
+        _, idf = _build_refs()
+        v1 = transform_query("the alien planet", idf)
+        v2 = transform_query("the alien planet", idf)
+        assert (v1 != v2).nnz == 0
+
+    def test_apply_tfidf_rows_are_l2_normalized(self):
+        ref, _ = _build_refs()
+        norms = np.sqrt(np.asarray(ref.multiply(ref).sum(axis=1)).ravel())
+        # Every non-empty row is unit length.
+        assert np.allclose(norms, 1.0, atol=1e-6)
+
+    def test_compute_idf_length_matches_feature_space(self):
+        _, idf = _build_refs()
+        assert idf.shape[0] == build_hashing_vectorizer().n_features
+
+
+class TestTfidfMatcherPrecomputed:
+    def test_load_precomputed_match_picks_correct_episode(self):
+        ref, idf = _build_refs()
+        matcher = TfidfMatcher()
+        matcher.load_precomputed(ref, ["S01E01", "S01E02", "S01E03"], idf)
+
+        results = matcher.match("the crew explores a far away planet")
+        assert results[0][0] == "S01E02"
+        assert results[0][1] > results[1][1]
+
+    def test_match_before_load_raises(self):
+        with pytest.raises(RuntimeError):
+            TfidfMatcher().match("anything")
+
+
+class TestEpisodeMatcherCacheLoader:
+    def _write_cache(self, tmp_path, manifest_overrides=None):
+        """Write a minimal valid precomputed cache under tmp_path. Returns the show name."""
+        show = "Test Show"
+        precomputed = tmp_path / "precomputed"
+        show_dir = precomputed / show  # sanitize_filename("Test Show") == "Test Show"
+        show_dir.mkdir(parents=True)
+
+        ref, idf = _build_refs()
+        np.save(precomputed / "idf.npy", idf)
+        sparse.save_npz(show_dir / "S01.npz", ref)
+        (show_dir / "S01.index.json").write_text(json.dumps(["S01E01", "S01E02", "S01E03"]))
+
+        manifest = {
+            "cache_format_version": CACHE_FORMAT_VERSION,
+            "vectorizer_config_hash": vectorizer_config_hash(),
+            "content_version": "test",
+            "shows": {show: {"tmdb_id": 1, "seasons": [1]}},
+        }
+        manifest.update(manifest_overrides or {})
+        (precomputed / "manifest.json").write_text(json.dumps(manifest))
+        return show
+
+    def test_loads_valid_cache(self, tmp_path):
+        show = self._write_cache(tmp_path)
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=show)
+        loaded = matcher._load_precomputed_season(1)
+        assert loaded is not None
+        ref_matrix, codes, idf = loaded
+        assert ref_matrix.shape[0] == 3
+        assert codes == ["S01E01", "S01E02", "S01E03"]
+
+    def test_missing_manifest_returns_none(self, tmp_path):
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="Test Show")
+        assert matcher._load_precomputed_season(1) is None
+
+    def test_format_version_mismatch_falls_back(self, tmp_path):
+        show = self._write_cache(tmp_path, {"cache_format_version": "999"})
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=show)
+        assert matcher._load_precomputed_season(1) is None
+
+    def test_config_hash_mismatch_falls_back(self, tmp_path):
+        show = self._write_cache(tmp_path, {"vectorizer_config_hash": "tampered"})
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=show)
+        assert matcher._load_precomputed_season(1) is None
+
+    def test_uncovered_season_returns_none(self, tmp_path):
+        show = self._write_cache(tmp_path)
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=show)
+        assert matcher._load_precomputed_season(2) is None
+
+    def test_unknown_show_returns_none(self, tmp_path):
+        self._write_cache(tmp_path)
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="Other Show")
+        assert matcher._load_precomputed_season(1) is None

--- a/backend/tests/unit/test_precomputed_cache_service.py
+++ b/backend/tests/unit/test_precomputed_cache_service.py
@@ -1,0 +1,267 @@
+"""Tests for the precomputed-cache fetch-on-first-run service.
+
+Exercises ``ensure_precomputed_cache()`` end to end against a real localhost
+HTTP server: download -> checksum -> extract -> install, plus the offline,
+disabled, checksum-mismatch, format-mismatch, and up-to-date paths. The
+happy-path test also confirms an installed cache loads through EpisodeMatcher
+and matches the correct episode.
+
+No external network is used -- the artifact is served from a loopback port.
+"""
+
+import hashlib
+import json
+import socket
+import tarfile
+import threading
+from contextlib import contextmanager
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+import app.services.config_service as config_service
+from app.config import settings
+from app.matcher.episode_identification import EpisodeMatcher, TfidfMatcher
+from app.matcher.vectorizer_config import (
+    CACHE_FORMAT_VERSION,
+    HASHING_N_FEATURES,
+    apply_tfidf,
+    build_hashing_vectorizer,
+    compute_idf,
+    vectorizer_config_hash,
+)
+from app.services.precomputed_cache_service import (
+    _CACHE_TAG,
+    _MANIFEST_NAME,
+    _TARBALL_NAME,
+    ensure_precomputed_cache,
+)
+
+_SHOW = "Test Show"  # sanitize_filename("Test Show") == "Test Show"
+_CODES = ["S01E01", "S01E02", "S01E03"]
+_DOCS = [
+    "detective solves the murder in the old mansion at midnight",
+    "the spaceship crew explores a distant alien planet",
+    "a chef cooks an elaborate pasta dinner in a small kitchen",
+]
+_CONTENT_VERSION = "2026-05-19"
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    def log_message(self, *args):  # silence per-request stderr logging
+        pass
+
+
+@contextmanager
+def _http_server(directory):
+    """Serve ``directory`` over HTTP on a loopback port for the duration of the block."""
+    handler = partial(_QuietHandler, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _free_port() -> int:
+    """Return a port with nothing listening on it (for the offline path)."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_precomputed_tree(root) -> dict:
+    """Write a valid ``precomputed/`` tree under ``root``; return its in-tar manifest."""
+    precomputed = root / "precomputed"
+    show_dir = precomputed / _SHOW
+    show_dir.mkdir(parents=True)
+
+    counts = build_hashing_vectorizer().transform(_DOCS)
+    idf = compute_idf(counts)
+    np.save(precomputed / "idf.npy", idf)
+    sparse.save_npz(show_dir / "S01.npz", apply_tfidf(counts, idf))
+    (show_dir / "S01.index.json").write_text(json.dumps(_CODES))
+
+    manifest = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "vectorizer_config_hash": vectorizer_config_hash(),
+        "content_version": _CONTENT_VERSION,
+        "n_features": HASHING_N_FEATURES,
+        "shows": {_SHOW: {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}},
+    }
+    (precomputed / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def _publish(release_dir, build_dir, *, manifest_overrides=None, corrupt_sha=False) -> None:
+    """Build a cache tarball + release manifest into ``release_dir/<tag>/``."""
+    manifest = _build_precomputed_tree(build_dir)
+    tag_dir = release_dir / _CACHE_TAG
+    tag_dir.mkdir(parents=True, exist_ok=True)
+
+    tarball = tag_dir / _TARBALL_NAME
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(build_dir / "precomputed", arcname="precomputed")
+
+    sha = "0" * 64 if corrupt_sha else hashlib.sha256(tarball.read_bytes()).hexdigest()
+    release_manifest = dict(manifest, tarball_sha256=sha)
+    release_manifest.update(manifest_overrides or {})
+    (tag_dir / _MANIFEST_NAME).write_text(json.dumps(release_manifest, indent=2))
+
+
+def _fake_config(cache_dir, *, enabled=True, installed_version=""):
+    return SimpleNamespace(
+        precomputed_cache_enabled=enabled,
+        subtitles_cache_path=str(cache_dir),
+        precomputed_cache_version=installed_version,
+    )
+
+
+@pytest.fixture
+def patched_config(monkeypatch):
+    """Patch config_service.get_config/update_config; yield (set_config, recorded_updates)."""
+    state = {"config": None}
+    updates: dict = {}
+
+    async def fake_get_config():
+        return state["config"]
+
+    async def fake_update_config(**kwargs):
+        updates.update(kwargs)
+
+    monkeypatch.setattr(config_service, "get_config", fake_get_config)
+    monkeypatch.setattr(config_service, "update_config", fake_update_config)
+    return state.__setitem__, updates
+
+
+def _set(set_config, cfg):
+    set_config("config", cfg)
+
+
+async def test_disabled_skips_download(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+    _set(set_config, _fake_config(cache_dir, enabled=False))
+    monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{_free_port()}")
+
+    await ensure_precomputed_cache()  # must not raise
+
+    assert not (cache_dir / "precomputed").exists()
+    assert updates == {}
+
+
+async def test_offline_is_silent(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+    _set(set_config, _fake_config(cache_dir))
+    # Nothing is listening on this port -> connection refused.
+    monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{_free_port()}")
+
+    await ensure_precomputed_cache()  # must not raise
+
+    assert not (cache_dir / "precomputed").exists()
+    assert updates == {}
+
+
+async def test_happy_path_installs_and_matches(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+    _set(set_config, _fake_config(cache_dir))
+    _publish(tmp_path / "release", tmp_path / "build")
+
+    with _http_server(tmp_path / "release") as port:
+        monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{port}")
+        await ensure_precomputed_cache()
+
+    precomputed = cache_dir / "precomputed"
+    assert (precomputed / _MANIFEST_NAME).exists()
+    assert (precomputed / "idf.npy").exists()
+    assert (precomputed / _SHOW / "S01.npz").exists()
+    assert updates.get("precomputed_cache_version") == _CONTENT_VERSION
+
+    # End to end: the installed cache loads and matches through the matcher.
+    matcher = EpisodeMatcher(cache_dir=cache_dir, show_name=_SHOW)
+    loaded = matcher._load_precomputed_season(1)
+    assert loaded is not None
+    tfidf = TfidfMatcher()
+    tfidf.load_precomputed(*loaded)
+    results = tfidf.match("the crew explores a far away planet")
+    assert results[0][0] == "S01E02"
+
+
+async def test_checksum_mismatch_aborts_install(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+    _set(set_config, _fake_config(cache_dir))
+    _publish(tmp_path / "release", tmp_path / "build", corrupt_sha=True)
+
+    with _http_server(tmp_path / "release") as port:
+        monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{port}")
+        await ensure_precomputed_cache()
+
+    assert not (cache_dir / "precomputed").exists()
+    assert updates == {}
+
+
+async def test_format_version_mismatch_skips(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+    _set(set_config, _fake_config(cache_dir))
+    _publish(
+        tmp_path / "release",
+        tmp_path / "build",
+        manifest_overrides={"cache_format_version": "999"},
+    )
+
+    with _http_server(tmp_path / "release") as port:
+        monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{port}")
+        await ensure_precomputed_cache()
+
+    assert not (cache_dir / "precomputed").exists()
+    assert updates == {}
+
+
+async def test_up_to_date_skips_redownload(tmp_path, monkeypatch, patched_config):
+    set_config, updates = patched_config
+    cache_dir = tmp_path / "cache"
+
+    # A local cache is already installed at the current content version.
+    precomputed = cache_dir / "precomputed"
+    precomputed.mkdir(parents=True)
+    local_manifest = precomputed / _MANIFEST_NAME
+    local_manifest.write_text(
+        json.dumps(
+            {"cache_format_version": CACHE_FORMAT_VERSION, "content_version": _CONTENT_VERSION}
+        )
+    )
+    _set(set_config, _fake_config(cache_dir, installed_version=_CONTENT_VERSION))
+
+    # Publish only a manifest, no tarball: a download attempt would fail, so
+    # reaching this without error proves the up-to-date check short-circuits.
+    tag_dir = tmp_path / "release" / _CACHE_TAG
+    tag_dir.mkdir(parents=True)
+    (tag_dir / _MANIFEST_NAME).write_text(
+        json.dumps(
+            {
+                "cache_format_version": CACHE_FORMAT_VERSION,
+                "content_version": _CONTENT_VERSION,
+                "tarball_sha256": "0" * 64,
+            }
+        )
+    )
+
+    with _http_server(tmp_path / "release") as port:
+        monkeypatch.setattr(settings, "precomputed_cache_base_url", f"http://127.0.0.1:{port}")
+        await ensure_precomputed_cache()
+
+    # Local cache untouched; nothing re-downloaded.
+    assert list(precomputed.iterdir()) == [local_manifest]
+    assert updates == {}


### PR DESCRIPTION
## Summary

Ships a pre-built subtitle-matching cache covering the most popular TV shows, so episode matching works instantly with no network calls. The existing subtitle scraping remains the fallback for any show not in the cache.

The cache contains **hashed TF-IDF vectors only** — never raw subtitle text. `TfidfMatcher` already reduces each episode to a TF-IDF vector and matches via cosine similarity, so the shipped artifact stores those vectors directly, built with a `HashingVectorizer` (no stored vocabulary). The result is a non-invertible statistical fingerprint — far more defensible to host on GitHub than verbatim copyrighted SRT — conceptually similar to the audio fingerprints Engram already uses.

**Chunked-ASR matching is fully preserved.** The ~10-chunk scan loop in `identify_episode()` matches each 30s transcribed chunk against full-episode vectors exactly as before — the precomputed vectors serve that path identically. The only code precomputed mode can't serve is `_try_match_with_model` (chunk-vs-time-slice matching), which is dead legacy code with zero call sites.

## What's included

- **`app/matcher/vectorizer_config.py`** (new) — single source of truth for the frozen hashed TF-IDF config, shared by the build script and runtime so they cannot drift. Includes a config hash embedded in the cache manifest for versioning.
- **`app/matcher/episode_identification.py`** — `TfidfMatcher` gains a precomputed mode (`load_precomputed`); `EpisodeMatcher` loads shipped vectors via `_load_precomputed_season()` when the show/season is covered, otherwise scrapes SRT and fits TF-IDF exactly as before. A format/config-hash mismatch silently falls back to scraping.
- **`app/services/precomputed_cache_service.py`** (new) — best-effort fetch-on-first-run, triggered as a background task from the FastAPI lifespan. Verifies the tarball checksum, extracts atomically. Any failure (offline, 404, checksum mismatch) is logged and swallowed — startup never fails and scraping still works.
- **`scripts/build_subtitle_cache.py`** (new) — picks the top-N shows from TMDB `/tv/popular`, harvests subtitles (reusing the existing downloader), fits one global IDF, writes per-show/season vector matrices, **discards the raw SRT**, and packages a `.tar.gz` + manifest.
- **`.github/workflows/build-subtitle-cache.yml`** (new) — manual `workflow_dispatch` job that builds and publishes the cache to a dedicated `subtitle-cache-v{N}` release tag (decoupled from app releases).
- **`AppConfig`** — `precomputed_cache_enabled` (server_default so existing databases get the cache enabled) and `precomputed_cache_version`.

## Cache format versioning

`CACHE_FORMAT_VERSION` + a config hash are embedded in the manifest and validated both at download time and when the matcher loads the cache. Any mismatch silently degrades to scraping — it never crashes.

## Test plan

- [x] 12 new unit tests (`test_precomputed_cache.py`) — vectorizer determinism, L2 normalization, precomputed match correctness, and cache-loader fallback on missing/format-mismatch/config-mismatch/uncovered-season
- [x] Full unit suite green (536 passed) + migration verified: existing databases get the cache enabled
- [ ] Accuracy A/B against `ground_truth.json` (precomputed vs. scraped TF-IDF path)
- [ ] End-to-end: build a small artifact, host on a test release, confirm download → extract → match on first run
- [ ] Offline test: app starts cleanly, scraping fallback works

## Notes

- Requires repo secrets `TMDB_API_KEY`, `OPENSUBTITLES_API_KEY`, `OPENSUBTITLES_USERNAME`, `OPENSUBTITLES_PASSWORD` for the build workflow.
- The `~300` show cutoff is tunable via `--limit`; finalize it from the first build's artifact-size/popularity data.

https://claude.ai/code/session_01BCtoFCo4cjKerBoRbHWBVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCtoFCo4cjKerBoRbHWBVV)_