### PR TITLE
fix: unblock Build Subtitle Cache workflow + better show selection

### DIFF
--- a/.github/workflows/build-subtitle-cache.yml
+++ b/.github/workflows/build-subtitle-cache.yml
@@ -42,6 +42,19 @@ jobs:
         working-directory: backend
         run: uv sync --no-install-project
 
+      # Persist harvested SRTs across runs so repeat builds only scrape shows
+      # /episodes not already on disk (download_subtitles() reuses cached files).
+      # The key is unique per run (cache entries are immutable once written);
+      # restore-keys pulls in the most recent prior cache. SRTs are plain text
+      # and stay on the runner only — they are never added to the release tarball.
+      - name: Restore harvested-subtitle cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.engram/cache/data
+          key: subtitle-srt-${{ github.run_id }}
+          restore-keys: |
+            subtitle-srt-
+
       - name: Build subtitle cache
         working-directory: backend
         env:
@@ -49,7 +62,9 @@ jobs:
           OPENSUBTITLES_API_KEY: ${{ secrets.OPENSUBTITLES_API_KEY }}
           OPENSUBTITLES_USERNAME: ${{ secrets.OPENSUBTITLES_USERNAME }}
           OPENSUBTITLES_PASSWORD: ${{ secrets.OPENSUBTITLES_PASSWORD }}
-        run: uv run python scripts/build_subtitle_cache.py --limit ${{ inputs.limit }}
+        # --keep-srt preserves the harvested SRTs for the cache step above;
+        # they are excluded from the published tarball regardless.
+        run: uv run python scripts/build_subtitle_cache.py --limit ${{ inputs.limit }} --keep-srt
 
       - name: Publish to GitHub Release
         uses: softprops/action-gh-release@v3

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -432,6 +432,53 @@ def fetch_popular_shows(page: int = 1) -> list[dict]:
         return []
 
 
+def fetch_shows_by_vote_count(page: int = 1) -> list[dict]:
+    """
+    Fetch TV shows ranked by total accumulated TMDB votes (descending).
+
+    Unlike ``/tv/popular`` (a rolling, recency-biased activity score), this
+    ranks by lifetime ``vote_count`` — a stable proxy for broadly-watched,
+    established shows. Used to seed the precomputed subtitle cache so the
+    selection is representative and reproducible across builds.
+
+    Args:
+        page (int): Page number (default: 1)
+
+    Returns:
+        list[dict]: List of show objects (id, name, etc.)
+    """
+    from app.services.config_service import get_config_sync
+
+    config = get_config_sync()
+    if not config.tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return []
+
+    api_key = config.tmdb_api_key.strip()
+    url = "https://api.themoviedb.org/3/discover/tv"
+
+    headers = {}
+    params = {"language": "en-US", "page": page, "sort_by": "vote_count.desc"}
+
+    if len(api_key) > 40:
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        params["api_key"] = api_key
+
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            logger.error(f"HTTP Error {response.status_code}: {response.text}")
+            raise e
+
+        return response.json().get("results", [])
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch shows by vote count: {e}")
+        return []
+
+
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_season_details(show_id: str, season_number: int) -> int:
     """

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -47,6 +47,23 @@ from app.matcher.vectorizer_config import (
 _VALID_STATUSES = {"cached", "downloaded"}
 
 
+def _ensure_db_schema() -> None:
+    """Create DB tables — the standalone script has no app lifespan to do it.
+
+    The running app creates the schema in ``database.init_db()``. This script
+    runs without that lifespan, so a fresh ``engram.db`` (e.g. on a CI runner)
+    has no tables. ``create_all`` is idempotent, so this is safe against an
+    existing dev database too.
+    """
+    from sqlmodel import SQLModel
+
+    # Importing app.database registers AppConfig/DiscJob on SQLModel.metadata.
+    import app.database  # noqa: F401
+    from app.services.config_service import _get_sync_engine
+
+    SQLModel.metadata.create_all(_get_sync_engine())
+
+
 def _bootstrap_config_from_env() -> None:
     """Populate the AppConfig DB row with credentials from env vars (for CI)."""
     env_map = {
@@ -160,6 +177,7 @@ def main() -> int:
     parser.add_argument("--keep-srt", action="store_true", help="Do not delete harvested SRT files")
     args = parser.parse_args()
 
+    _ensure_db_schema()
     _bootstrap_config_from_env()
 
     from app.services.config_service import get_config_sync

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -1,6 +1,6 @@
 """Build the precomputed subtitle-vector cache shipped with Engram.
 
-Harvests subtitles for the most popular TV shows, reduces each episode to a
+Harvests subtitles for the most-voted TV shows on TMDB, reduces each episode to a
 HASHED TF-IDF vector (no readable vocabulary -- see app/matcher/vectorizer_config),
 discards the raw SRT, and packages the vectors into a `.tar.gz` plus a manifest
 for hosting on GitHub Releases.
@@ -34,7 +34,11 @@ from scipy import sparse
 from app.matcher.episode_identification import SubtitleCache
 from app.matcher.subtitle_utils import sanitize_filename
 from app.matcher.testing_service import download_subtitles
-from app.matcher.tmdb_client import fetch_popular_shows, fetch_show_details, fetch_show_id
+from app.matcher.tmdb_client import (
+    fetch_show_details,
+    fetch_show_id,
+    fetch_shows_by_vote_count,
+)
 from app.matcher.vectorizer_config import (
     CACHE_FORMAT_VERSION,
     HASHING_N_FEATURES,
@@ -98,13 +102,15 @@ def _select_shows(args) -> list[dict]:
         names = [s.strip() for s in args.shows.split(",") if s.strip()]
         candidates = [{"name": n, "id": fetch_show_id(n)} for n in names]
     else:
+        # Discover returns shows already ranked by vote_count desc; iterating
+        # pages in order and deduping preserves that ranking (dict is ordered).
         seen: dict[int, dict] = {}
         for page in range(1, args.pages + 1):
-            for show in fetch_popular_shows(page):
+            for show in fetch_shows_by_vote_count(page):
                 if show.get("id") and show["id"] not in seen:
                     seen[show["id"]] = show
             time.sleep(args.sleep)
-        ranked = sorted(seen.values(), key=lambda s: s.get("popularity", 0), reverse=True)
+        ranked = list(seen.values())
         candidates = [{"name": s["name"], "id": s["id"]} for s in ranked[: args.limit]]
 
     shows = []
@@ -159,8 +165,10 @@ def _harvest_show(show: dict, args) -> list[tuple[int, str, Path]]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Build the Engram subtitle-vector cache")
-    parser.add_argument("--limit", type=int, default=300, help="Number of popular shows")
-    parser.add_argument("--pages", type=int, default=15, help="TMDB popular pages to scan")
+    parser.add_argument(
+        "--limit", type=int, default=300, help="Number of shows (top by TMDB vote count)"
+    )
+    parser.add_argument("--pages", type=int, default=15, help="TMDB discover pages to scan")
     parser.add_argument(
         "--shows", type=str, default="", help="Comma-separated show names (overrides popular)"
     )


### PR DESCRIPTION
## Summary

The `Build Subtitle Cache` workflow added in #140 crashed on its first
dispatch. This PR unblocks it, adds caching so repeat runs aren't full
re-scrapes, and switches the show-selection source to something
representative of what users actually rip.

Verified end-to-end: a `limit=5` dispatch on this branch
([run 26074248424](https://github.com/Jsakkos/engram/actions/runs/26074248424))
ran green — bootstrapped config, harvested 226 episodes, built a 5.1 MB
cache, and published it to the `subtitle-cache-v1` release.

## 1. Fix: create DB schema in the build script

The workflow failed with `sqlite3.OperationalError: no such table: app_config`.
`build_subtitle_cache.py` runs standalone — it has none of the FastAPI
lifespan startup, so `database.init_db()` (which calls
`SQLModel.metadata.create_all`) never runs. On a CI runner there is no
committed DB, so `_bootstrap_config_from_env()` queried `AppConfig`
against a table-less `engram.db` and crashed before any work began.

Added `_ensure_db_schema()`, called at the top of `main()`, which runs
`create_all` on the sync engine. Idempotent, so safe for local runs too.

## 2. Cache harvested subtitles across runs

Scraping SRTs from rate-limited sources is the slow part — the
verification run took ~25 min for just 5 shows. Added an `actions/cache`
step for the SRT data dir (`~/.engram/cache/data`) and pass `--keep-srt`
so harvested files survive to be cached. `download_subtitles()` already
treats on-disk files as `status="cached"` and skips them, so repeat runs
only scrape what's new. SRTs stay on the runner — the published tarball
is built from precomputed vectors and never includes raw SRT.

## 3. Seed from TMDB vote count, not `/tv/popular`

`/tv/popular` ranks by a rolling, recency-decaying activity score, so a
build surfaces whatever is mid-season now (much of it streaming-only,
no disc release) and misses the catalog staples that fill disc
collections. Added `fetch_shows_by_vote_count()` using `/discover/tv`
with `sort_by=vote_count.desc` — a monotonic lifetime total, a stable
proxy for broadly-watched established shows, and reproducible across
builds. No new credentials: same TMDB token, same result shape.

## Note

The failed run showed the three `OPENSUBTITLES_*` repo secrets are empty.
This does not crash the build — `download_subtitles()` uses Addic7ed
first and only falls back to the OpenSubtitles REST API when all three
are set — but setting them would improve cache coverage.

## Test plan

- [x] `ruff check` passes
- [x] Schema fix reproduced against a fresh empty DB
- [x] `limit=5` workflow dispatch on this branch ran green end-to-end
- [x] `fetch_shows_by_vote_count()` verified against the live TMDB API
- [ ] Re-dispatch to confirm the SRT cache restores on a second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
