### PR TITLE
fix: migrate stale DB schema in build_subtitle_cache script

### DIFF
--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -52,20 +52,22 @@ _VALID_STATUSES = {"cached", "downloaded"}
 
 
 def _ensure_db_schema() -> None:
-    """Create DB tables — the standalone script has no app lifespan to do it.
+    """Create and migrate the DB schema via the app's canonical ``init_db()``.
 
-    The running app creates the schema in ``database.init_db()``. This script
-    runs without that lifespan, so a fresh ``engram.db`` (e.g. on a CI runner)
-    has no tables. ``create_all`` is idempotent, so this is safe against an
-    existing dev database too.
+    The standalone script runs without the FastAPI lifespan that normally
+    calls ``database.init_db()``. A fresh ``engram.db`` (e.g. a CI runner)
+    needs its tables created; a pre-existing dev database needs any
+    recently-added columns applied. ``create_all`` alone does the former but
+    never the latter, so an older local ``engram.db`` ends up missing newer
+    columns such as ``app_config.precomputed_cache_enabled``. Delegating to
+    ``init_db()`` runs the same create-all + ``_add_missing_columns`` +
+    Alembic migration path the running app uses on startup.
     """
-    from sqlmodel import SQLModel
+    import asyncio
 
-    # Importing app.database registers AppConfig/DiscJob on SQLModel.metadata.
-    import app.database  # noqa: F401
-    from app.services.config_service import _get_sync_engine
+    from app.database import init_db
 
-    SQLModel.metadata.create_all(_get_sync_engine())
+    asyncio.run(init_db())
 
 
 def _bootstrap_config_from_env() -> None:


### PR DESCRIPTION
## What

`scripts/build_subtitle_cache.py` failed locally with:

```
sqlite3.OperationalError: no such column: app_config.precomputed_cache_enabled
```

`_ensure_db_schema()` bootstrapped the DB with only `SQLModel.metadata.create_all()`. `create_all()` issues `CREATE TABLE IF NOT EXISTS` — it creates missing tables but **never adds columns to tables that already exist**.

- **Fresh CI runner:** no `engram.db`, so `create_all` builds today's full schema → works.
- **Pre-existing local `engram.db`** (from an older app version): `create_all` is a no-op, leaving the stale `app_config` table missing newer columns like `precomputed_cache_enabled` → query fails.

The running app never hits this because `init_db()` also runs `_add_missing_columns()` (ALTER TABLE ADD COLUMN), Alembic, and `_migrate_app_config()`. The script reimplemented only the weakest layer.

## Fix

`_ensure_db_schema()` now delegates to the app's canonical `init_db()` instead of hand-rolling a parallel schema path. The script runs the exact same migration path as app startup, so it can no longer drift behind the app schema.

## Why CI didn't catch it

Schema-drift bugs need a pre-existing old DB to surface; a clean-checkout CI runner has none by construction. The migration logic itself is already covered (`tests/unit/test_database_migration.py`) — the gap was a duplicated schema path in the script that bypassed it. This change removes the duplication, eliminating the bug class rather than detecting it.

## Testing

Re-ran `uv run python scripts/build_subtitle_cache.py --limit 1 --keep-srt` against the stale local DB:
- Applied the pending Alembic migration (`9b793042b934 → f3a9c1e7b204`)
- Got past `get_config_sync()` into subtitle harvesting
- Verified `app_config.precomputed_cache_enabled` now present in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
