### PR TITLE
fix: make Claude code-review workflow post review comments

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -28,9 +28,20 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request for code quality, correctness, and security.
             Follow the project conventions in CLAUDE.md.
             Focus on: bugs, race conditions in async code, WebSocket contract drift,
-            error-handling patterns (specific exceptions + exc_info=True), and adherence
-            to the JobState machine. Post findings as inline review comments.
-          claude_args: "--max-turns 5"
+            error-handling patterns (specific exceptions + exc_info=True), and
+            adherence to the JobState machine.
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) to flag specific lines of code.
+            Only post GitHub comments — do not submit review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## What

Fixes the `Code Review` GitHub Actions workflow so Claude actually posts review feedback on PRs.

## Why

The workflow ran on every PR but produced **no output** — the job exited 0 while posting zero reviews and zero comments (see [example run](https://github.com/Jsakkos/engram/actions/runs/26115227105) on PR #139, a green `✓ review in 33s` that did nothing).

The run's result JSON revealed the cause:

```
"num_turns": 5,                  // hit the --max-turns 5 cap
"permission_denials_count": 2,   // tried tools it wasn't allowed to use
"No buffered inline comments"    // nothing was posted
```

Two problems in `code-review.yml`:

1. **No `--allowedTools`** — the prompt told Claude to post inline review comments, but `claude_args` never granted the tools to do so (`mcp__github_inline_comment__create_inline_comment`, `gh pr comment`). Every post attempt was denied.
2. **`--max-turns 5` was far too low** — with 2 turns burned on denied calls, Claude ran out of budget (10s total) before reviewing anything.

## Changes

Aligned the review step with the official `anthropics/claude-code-action` "Automatic PR Code Review" example:

- Added `--allowedTools` granting the inline-comment MCP tool and `gh pr comment/diff/view`.
- Removed the `--max-turns 5` cap (the official example sets none; review turn count scales with PR size).
- Added `REPO`/`PR NUMBER` context to the prompt plus explicit instructions to use `gh pr comment` / `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) and post only via GitHub comments.

The engram-specific review focus (async race conditions, WebSocket contract drift, error-handling patterns, JobState machine) is preserved. `claude.yml` is unaffected.

## Verification

This PR's own `synchronize`/`opened` event exercises the fixed workflow — the Claude review run on this PR should now post comments instead of completing silently. After the run, the result JSON should show `permission_denials_count: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
