### PR TITLE
OpenSubtitles API audit + TMDB intra-run cache + rich progress

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,6 @@
 """Unified Media Automator Backend."""
 
-__version__ = "0.1.0"
+# Keep in sync with pyproject.toml [project].version. Surfaced as the
+# User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
+# stale value here misidentifies the app to upstream services.
+__version__ = "0.6.0"

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -47,11 +47,22 @@ except ImportError:
 # Catch only the failure modes that are actually retryable. Catching bare
 # Exception would silently retry programming bugs (AttributeError,
 # TypeError) inside the callable — those should surface immediately.
+#
+# Notable omissions:
+#
+# - ``OSError`` is the parent of ``FileNotFoundError`` and ``PermissionError``,
+#   which ``client.download_and_save`` can raise when the staging directory
+#   does not exist or is unwritable. Those are misconfiguration bugs, not
+#   transient errors — retrying for ~35s and burning download quota only
+#   delays the failure. Genuinely transient OS-level network failures
+#   already come through as ``requests.ConnectionError`` (a subclass of
+#   ``RequestException``).
+# - ``TimeoutError`` is a subclass of ``OSError`` since Python 3.3 and was
+#   therefore redundant with the dropped ``OSError`` entry; ``requests``
+#   timeouts come through as ``requests.Timeout`` (a ``RequestException``).
 _RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     OpenSubtitlesException,
     requests.RequestException,
-    OSError,
-    TimeoutError,
 )
 
 # Cap any single sleep at 5 minutes. Protects against a misbehaving server

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -87,6 +87,18 @@ def os_api_call(
 ) -> _T:
     """Invoke an OpenSubtitles API method with consistent 429-aware backoff.
 
+    .. warning::
+
+       This function calls ``time.sleep`` (up to ``_RETRY_AFTER_CAP_SECONDS``,
+       300s by default). Calling it directly from an ``async`` coroutine
+       blocks the event loop for the entire backoff window. Async callers
+       must wrap the call in ``asyncio.to_thread(os_api_call, ...)`` or
+       ``loop.run_in_executor(None, ...)``. The current callers
+       (``testing_service._get_os_client`` and
+       ``subtitle_provider._search_with_retry``/``_download_with_retry``)
+       are all reached via ``asyncio.to_thread`` in
+       ``matching_coordinator``, so this is safe today.
+
     Args:
         callable_: An ``opensubtitlescom.OpenSubtitles`` bound method
             (e.g. ``client.login``, ``client.search``, ``client.download_and_save``).

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -27,7 +27,28 @@ parameters.
 
 import time
 
+import requests
 from loguru import logger
+
+try:
+    from opensubtitlescom.exceptions import OpenSubtitlesException
+except ImportError:
+    # Library not installed in this environment; define a stand-in so the
+    # retry tuple still type-checks. The actual call sites guard against
+    # ImportError at a higher level (see testing_service._get_os_client).
+    class OpenSubtitlesException(Exception):  # type: ignore[no-redef]
+        pass
+
+
+# Catch only the failure modes that are actually retryable. Catching bare
+# Exception would silently retry programming bugs (AttributeError,
+# TypeError) inside the callable — those should surface immediately.
+_RETRYABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    OpenSubtitlesException,
+    requests.RequestException,
+    OSError,
+    TimeoutError,
+)
 
 # Cap any single sleep at 5 minutes. Protects against a misbehaving server
 # (or a stray ``Retry-After: 999999``) hanging a long build run.
@@ -80,18 +101,28 @@ def os_api_call(
     for attempt in range(max_attempts):
         try:
             return callable_(*args, **kwargs)
-        except Exception as exc:
+        except _RETRYABLE_EXCEPTIONS as exc:
             if attempt == max_attempts - 1:
                 raise
             retry_after = _parse_retry_after(exc)
             sleep_for = retry_after if retry_after is not None else delay
             is_rate_limit = "429" in str(exc) or retry_after is not None
             source = "Retry-After" if retry_after is not None else "exponential"
+            # CLAUDE.md: always log exceptions with exc_info=True for full
+            # tracebacks. Skip the trace for expected 429s so the log stays
+            # readable (the rate-limit case is fully described by the message).
             logger.warning(
                 f"OS API attempt {attempt + 1}/{max_attempts} failed "
                 f"({'rate limited' if is_rate_limit else exc}); "
-                f"sleeping {sleep_for:.1f}s ({source})"
+                f"sleeping {sleep_for:.1f}s ({source})",
+                exc_info=not is_rate_limit,
             )
             time.sleep(sleep_for)
             if retry_after is None:
                 delay *= 2
+    # Unreachable in normal control flow — the final attempt either returns
+    # or re-raises inside the loop. This explicit guard silences static
+    # analyzers that warn about implicit None fall-through, and protects
+    # against a future caller passing max_attempts=0 (which would otherwise
+    # silently return None).
+    raise RuntimeError(f"os_api_call: max_attempts must be >= 1, got {max_attempts}")

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -97,6 +97,13 @@ def os_api_call(
     Raises:
         The original exception, after the final attempt has exhausted.
     """
+    # Precondition check at function entry rather than as a fall-through
+    # guard at the bottom — surfaces a bad caller (e.g., ``max_attempts=0``)
+    # immediately, before any argument-marshalling, and removes the implicit-
+    # None code path entirely so static analyzers stop flagging it.
+    if max_attempts < 1:
+        raise ValueError(f"os_api_call: max_attempts must be >= 1, got {max_attempts}")
+
     delay = base_delay
     for attempt in range(max_attempts):
         try:
@@ -108,9 +115,11 @@ def os_api_call(
             sleep_for = retry_after if retry_after is not None else delay
             is_rate_limit = "429" in str(exc) or retry_after is not None
             source = "Retry-After" if retry_after is not None else "exponential"
-            # CLAUDE.md: always log exceptions with exc_info=True for full
-            # tracebacks. Skip the trace for expected 429s so the log stays
-            # readable (the rate-limit case is fully described by the message).
+            # CLAUDE.md normally requires ``exc_info=True`` inside except
+            # blocks, but for expected 429 responses the rate-limit case is
+            # fully described by the log message — adding a stack frame for
+            # every retry makes long build logs unreadable. This is a
+            # conscious, documented deviation; keep it.
             logger.warning(
                 f"OS API attempt {attempt + 1}/{max_attempts} failed "
                 f"({'rate limited' if is_rate_limit else exc}); "
@@ -120,9 +129,3 @@ def os_api_call(
             time.sleep(sleep_for)
             if retry_after is None:
                 delay *= 2
-    # Unreachable in normal control flow — the final attempt either returns
-    # or re-raises inside the loop. This explicit guard silences static
-    # analyzers that warn about implicit None fall-through, and protects
-    # against a future caller passing max_attempts=0 (which would otherwise
-    # silently return None).
-    raise RuntimeError(f"os_api_call: max_attempts must be >= 1, got {max_attempts}")

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -1,0 +1,97 @@
+"""Unified retry/backoff helper for opensubtitlescom calls.
+
+The OpenSubtitles best-practices doc requires honoring the ``Retry-After``
+response header on 429 responses. Unfortunately the installed library
+(``opensubtitlescom``) wraps ``requests.HTTPError`` into a bare
+``OpenSubtitlesException(str(http_err))`` in ``send_api`` and discards the
+response object, so we cannot read the header in practice today.
+
+This helper:
+
+1. Honors ``Retry-After`` defensively via ``getattr(exc, "response", None)``,
+   in case a future library version preserves the response (then we
+   automatically benefit with no further changes).
+2. Falls back to capped exponential backoff (5s, 10s, 20s, 40s by default)
+   when the header is not available — which is the current real-world path.
+3. Detects rate limiting via substring match on the exception (``"429" in
+   str(exc)``), matching what the rest of the codebase does, so the warning
+   log lines correctly identify rate limits vs. transient network errors.
+
+All three OpenSubtitles call sites (``client.login``, ``client.search``,
+``client.download_and_save``) route through this helper for consistent
+behavior — before this helper, login used an inline loop in
+``testing_service.py`` while search/download used a generic
+``retry_with_backoff`` decorator in ``subtitle_provider.py`` with different
+parameters.
+"""
+
+import time
+
+from loguru import logger
+
+# Cap any single sleep at 5 minutes. Protects against a misbehaving server
+# (or a stray ``Retry-After: 999999``) hanging a long build run.
+_RETRY_AFTER_CAP_SECONDS = 300.0
+
+
+def _parse_retry_after(exc: Exception) -> float | None:
+    """Extract Retry-After (seconds) from an exception's response, if present.
+
+    Returns the clamped delay in seconds, or None if the exception does not
+    carry a usable response/header (the common case with the current
+    ``opensubtitlescom`` release — see module docstring).
+    """
+    response = getattr(exc, "response", None)
+    if response is None or not hasattr(response, "headers"):
+        return None
+    raw = response.headers.get("Retry-After")
+    if raw is None:
+        return None
+    try:
+        return min(float(raw), _RETRY_AFTER_CAP_SECONDS)
+    except (TypeError, ValueError):
+        return None
+
+
+def os_api_call(
+    callable_,
+    *args,
+    max_attempts: int = 4,
+    base_delay: float = 5.0,
+    **kwargs,
+):
+    """Invoke an OpenSubtitles API method with consistent 429-aware backoff.
+
+    Args:
+        callable_: An ``opensubtitlescom.OpenSubtitles`` bound method
+            (e.g. ``client.login``, ``client.search``, ``client.download_and_save``).
+        *args, **kwargs: Forwarded to ``callable_``.
+        max_attempts: Total attempts including the first. Default 4.
+        base_delay: Initial backoff in seconds for the exponential fallback.
+            Doubles each subsequent attempt. Default 5.0.
+
+    Returns:
+        Whatever ``callable_`` returns on success.
+
+    Raises:
+        The original exception, after the final attempt has exhausted.
+    """
+    delay = base_delay
+    for attempt in range(max_attempts):
+        try:
+            return callable_(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_attempts - 1:
+                raise
+            retry_after = _parse_retry_after(exc)
+            sleep_for = retry_after if retry_after is not None else delay
+            is_rate_limit = "429" in str(exc) or retry_after is not None
+            source = "Retry-After" if retry_after is not None else "exponential"
+            logger.warning(
+                f"OS API attempt {attempt + 1}/{max_attempts} failed "
+                f"({'rate limited' if is_rate_limit else exc}); "
+                f"sleeping {sleep_for:.1f}s ({source})"
+            )
+            time.sleep(sleep_for)
+            if retry_after is None:
+                delay *= 2

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -101,20 +101,21 @@ def os_api_call(
     Raises:
         The original exception, after the final attempt has exhausted.
     """
-    # Precondition check at function entry rather than as a fall-through
-    # guard at the bottom — surfaces a bad caller (e.g., ``max_attempts=0``)
-    # immediately, before any argument-marshalling, and removes the implicit-
-    # None code path entirely so static analyzers stop flagging it.
+    # Precondition check at function entry — surfaces a bad caller
+    # (e.g., ``max_attempts=0``) immediately, before any argument-marshalling.
     if max_attempts < 1:
         raise ValueError(f"os_api_call: max_attempts must be >= 1, got {max_attempts}")
 
+    # Structure: do (max_attempts - 1) retry-with-sleep attempts, then ONE
+    # final attempt outside the loop. The final attempt either returns its
+    # result or lets the exception bubble — neither requires a sentinel
+    # return at the bottom, so static analyzers don't flag a mixed-returns
+    # fall-through.
     delay = base_delay
-    for attempt in range(max_attempts):
+    for attempt in range(max_attempts - 1):
         try:
             return callable_(*args, **kwargs)
         except _RETRYABLE_EXCEPTIONS as exc:
-            if attempt == max_attempts - 1:
-                raise
             retry_after = _parse_retry_after(exc)
             sleep_for = retry_after if retry_after is not None else delay
             is_rate_limit = "429" in str(exc) or retry_after is not None
@@ -133,3 +134,6 @@ def os_api_call(
             time.sleep(sleep_for)
             if retry_after is None:
                 delay *= 2
+
+    # Final attempt: succeed or raise. No sleep follows; no fall-through.
+    return callable_(*args, **kwargs)

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -26,9 +26,13 @@ parameters.
 """
 
 import time
+from collections.abc import Callable
+from typing import TypeVar
 
 import requests
 from loguru import logger
+
+_T = TypeVar("_T")
 
 try:
     from opensubtitlescom.exceptions import OpenSubtitlesException
@@ -75,12 +79,12 @@ def _parse_retry_after(exc: Exception) -> float | None:
 
 
 def os_api_call(
-    callable_,
+    callable_: Callable[..., _T],
     *args,
     max_attempts: int = 4,
     base_delay: float = 5.0,
     **kwargs,
-):
+) -> _T:
     """Invoke an OpenSubtitles API method with consistent 429-aware backoff.
 
     Args:

--- a/backend/app/matcher/os_api_retry.py
+++ b/backend/app/matcher/os_api_retry.py
@@ -156,7 +156,13 @@ def os_api_call(
             )
             time.sleep(sleep_for)
             if retry_after is None:
-                delay *= 2
+                # Cap the exponential growth using the same ceiling the
+                # Retry-After path uses, so both branches share a single
+                # documented maximum. Current call sites (max_attempts <= 6)
+                # never approach the cap, but a future caller with a larger
+                # max_attempts shouldn't be able to schedule multi-hour
+                # sleeps by accident.
+                delay = min(delay * 2, _RETRY_AFTER_CAP_SECONDS)
 
     # Final attempt: succeed or raise. No sleep follows; no fall-through.
     return callable_(*args, **kwargs)

--- a/backend/app/matcher/subtitle_provider.py
+++ b/backend/app/matcher/subtitle_provider.py
@@ -1,57 +1,19 @@
 import abc
 import re
 import shutil
-import time
-from collections.abc import Callable
-from functools import wraps
 from pathlib import Path
-from typing import Any, TypeVar
 
 from loguru import logger
 
 from app.matcher.config_manager import get_config_manager
 from app.matcher.models import EpisodeInfo, SubtitleFile
+from app.matcher.os_api_retry import os_api_call
 from app.matcher.subtitle_utils import sanitize_filename
 
-F = TypeVar("F", bound=Callable[..., Any])
-
-
-def retry_with_backoff(
-    max_retries: int = 3,
-    base_delay: float = 1.0,
-    max_delay: float = 60.0,
-    backoff_factor: float = 2.0,
-) -> Callable[[F], F]:
-    """Decorator for retrying operations with exponential backoff."""
-
-    def decorator(func: F) -> F:
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            last_exception = None
-            delay = base_delay
-
-            for attempt in range(max_retries + 1):
-                try:
-                    return func(*args, **kwargs)
-                except Exception as e:
-                    last_exception = e
-                    if attempt == max_retries:
-                        logger.error(
-                            f"Max retries ({max_retries}) exceeded for {func.__name__}: {e}"
-                        )
-                        raise e
-
-                    logger.warning(
-                        f"Attempt {attempt + 1}/{max_retries + 1} failed for {func.__name__}: {e}, retrying in {delay:.1f}s..."
-                    )
-                    time.sleep(delay)
-                    delay = min(delay * backoff_factor, max_delay)
-
-            raise last_exception
-
-        return wrapper  # type: ignore
-
-    return decorator
+# NOTE: This module previously defined a generic ``retry_with_backoff``
+# decorator that was only used here, with hardcoded parameters that differed
+# from the inline login retry in ``testing_service.py``. Both call sites now
+# route through ``os_api_retry.os_api_call`` for consistent 429 handling.
 
 
 def parse_season_episode(filename: str) -> EpisodeInfo | None:
@@ -210,7 +172,15 @@ class OpenSubtitlesProvider(SubtitleProvider):
                 self.client = None
                 return
 
-            user_agent = getattr(self.config, "open_subtitles_user_agent", "Oz 1.0.0")
+            # OS best-practices: User-Agent must be "AppName vX.Y.Z". The prior
+            # "Oz 1.0.0" placeholder was a leftover from upstream and silently
+            # misidentified the app. Override via config only if a deployment
+            # has registered a custom UA with OpenSubtitles.
+            from app import __version__
+
+            user_agent = (
+                getattr(self.config, "open_subtitles_user_agent", None) or f"Engram v{__version__}"
+            )
             self.client = OpenSubtitlesClient(user_agent, api_key)
             username = getattr(self.config, "open_subtitles_username", None)
             password = getattr(self.config, "open_subtitles_password", None)
@@ -223,7 +193,6 @@ class OpenSubtitlesProvider(SubtitleProvider):
             logger.error(f"Failed to initialize OpenSubtitles: {e}")
             self.client = None
 
-    @retry_with_backoff(max_retries=3, base_delay=1.0)
     def _search_with_retry(
         self,
         query: str | None = None,
@@ -232,7 +201,7 @@ class OpenSubtitlesProvider(SubtitleProvider):
         season_number: int | None = None,
         type: str | None = None,
     ):
-        """Search for subtitles with retry logic."""
+        """Search for subtitles with 429-aware retry."""
         if not self.client:
             raise RuntimeError("OpenSubtitles client not initialized")
 
@@ -247,23 +216,29 @@ class OpenSubtitlesProvider(SubtitleProvider):
             signal.alarm(self.network_timeout)
 
         try:
-            return self.client.search(
+            # Original retry cadence: 4 attempts, 1s base delay (1, 2, 4, 8).
+            # Tight schedule — sufficient for transient network errors; a
+            # genuine 429 still gets four chances.
+            return os_api_call(
+                self.client.search,
                 query=query,
                 languages=languages,
                 parent_tmdb_id=parent_tmdb_id,
                 season_number=season_number,
                 type=type,
+                max_attempts=4,
+                base_delay=1.0,
             )
         finally:
             if hasattr(signal, "SIGALRM"):
                 signal.alarm(0)  # Cancel the alarm
 
-    @retry_with_backoff(max_retries=5, base_delay=3.0)
     def _download_with_retry(self, subtitle):
-        """Download subtitle file with retry logic.
+        """Download subtitle file with 429-aware retry.
 
-        Uses 5 retries with 3s base delay to handle rate limit issues,
-        as the OpenSubtitles download quota can be buggy.
+        Uses 6 attempts with 3s base delay (3, 6, 12, 24, 48, ...) — generous
+        because the OpenSubtitles download quota check can be flaky and we'd
+        rather wait than burn the daily quota on transient failures.
         """
         if not self.client:
             raise RuntimeError("OpenSubtitles client not initialized")
@@ -279,7 +254,12 @@ class OpenSubtitlesProvider(SubtitleProvider):
             signal.alarm(self.network_timeout)
 
         try:
-            return self.client.download_and_save(subtitle)
+            return os_api_call(
+                self.client.download_and_save,
+                subtitle,
+                max_attempts=6,
+                base_delay=3.0,
+            )
         finally:
             if hasattr(signal, "SIGALRM"):
                 signal.alarm(0)  # Cancel the alarm

--- a/backend/app/matcher/subtitle_provider.py
+++ b/backend/app/matcher/subtitle_provider.py
@@ -194,7 +194,10 @@ class OpenSubtitlesProvider(SubtitleProvider):
             else:
                 logger.debug("Initialized OpenSubtitles (no login)")
         except Exception as e:
-            logger.error(f"Failed to initialize OpenSubtitles: {e}")
+            # CLAUDE.md: always log with exc_info=True inside except blocks.
+            # A bare str(e) hides AttributeError / ImportError surprises that
+            # may sneak through ``os_api_call``'s retry loop.
+            logger.error(f"Failed to initialize OpenSubtitles: {e}", exc_info=True)
             self.client = None
 
     def _search_with_retry(
@@ -220,9 +223,10 @@ class OpenSubtitlesProvider(SubtitleProvider):
             signal.alarm(self.network_timeout)
 
         try:
-            # Original retry cadence: 4 attempts, 1s base delay (1, 2, 4, 8).
-            # Tight schedule — sufficient for transient network errors; a
-            # genuine 429 still gets four chances.
+            # Retry cadence: 4 attempts with 1s base delay → 3 sleeps of
+            # 1s, 2s, 4s (the 4th attempt re-raises without sleeping). Tight
+            # schedule — sufficient for transient network errors; a genuine
+            # 429 still gets four chances.
             return os_api_call(
                 self.client.search,
                 query=query,
@@ -240,9 +244,10 @@ class OpenSubtitlesProvider(SubtitleProvider):
     def _download_with_retry(self, subtitle):
         """Download subtitle file with 429-aware retry.
 
-        Uses 6 attempts with 3s base delay (3, 6, 12, 24, 48, ...) — generous
-        because the OpenSubtitles download quota check can be flaky and we'd
-        rather wait than burn the daily quota on transient failures.
+        Uses 6 attempts with 3s base delay → 5 sleeps of 3s, 6s, 12s, 24s, 48s
+        (the 6th attempt re-raises without sleeping). Generous because the
+        OpenSubtitles download quota check can be flaky and we'd rather wait
+        than burn the daily quota on transient failures.
         """
         if not self.client:
             raise RuntimeError("OpenSubtitles client not initialized")

--- a/backend/app/matcher/subtitle_provider.py
+++ b/backend/app/matcher/subtitle_provider.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from app import __version__
 from app.matcher.config_manager import get_config_manager
 from app.matcher.models import EpisodeInfo, SubtitleFile
 from app.matcher.os_api_retry import os_api_call
@@ -14,6 +15,12 @@ from app.matcher.subtitle_utils import sanitize_filename
 # decorator that was only used here, with hardcoded parameters that differed
 # from the inline login retry in ``testing_service.py``. Both call sites now
 # route through ``os_api_retry.os_api_call`` for consistent 429 handling.
+
+# OpenSubtitles best-practices require the User-Agent be in the form
+# "AppName vX.Y.Z". Mirrors testing_service._USER_AGENT — kept separate
+# only to avoid a cross-module import dependency between two matcher
+# files that share a parent module.
+_USER_AGENT = f"Engram v{__version__}"
 
 
 def parse_season_episode(filename: str) -> EpisodeInfo | None:
@@ -172,15 +179,11 @@ class OpenSubtitlesProvider(SubtitleProvider):
                 self.client = None
                 return
 
-            # OS best-practices: User-Agent must be "AppName vX.Y.Z". The prior
-            # "Oz 1.0.0" placeholder was a leftover from upstream and silently
-            # misidentified the app. Override via config only if a deployment
-            # has registered a custom UA with OpenSubtitles.
-            from app import __version__
-
-            user_agent = (
-                getattr(self.config, "open_subtitles_user_agent", None) or f"Engram v{__version__}"
-            )
+            # OS best-practices: User-Agent must be "AppName vX.Y.Z". The
+            # prior "Oz 1.0.0" placeholder was a leftover from upstream and
+            # silently misidentified the app. Override via config only if a
+            # deployment has registered a custom UA with OpenSubtitles.
+            user_agent = getattr(self.config, "open_subtitles_user_agent", None) or _USER_AGENT
             self.client = OpenSubtitlesClient(user_agent, api_key)
             username = getattr(self.config, "open_subtitles_username", None)
             password = getattr(self.config, "open_subtitles_password", None)

--- a/backend/app/matcher/subtitle_provider.py
+++ b/backend/app/matcher/subtitle_provider.py
@@ -185,7 +185,11 @@ class OpenSubtitlesProvider(SubtitleProvider):
             username = getattr(self.config, "open_subtitles_username", None)
             password = getattr(self.config, "open_subtitles_password", None)
             if username and password:
-                self.client.login(username, password)
+                # Route through os_api_call so a transient 429 here gets the
+                # same retry treatment as login/search/download elsewhere —
+                # otherwise a single rate-limit response silently disables
+                # the entire provider for the rest of the job.
+                os_api_call(self.client.login, username, password)
                 logger.debug("Logged in to OpenSubtitles")
             else:
                 logger.debug("Initialized OpenSubtitles (no login)")

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -7,6 +7,7 @@ Provides three independent operations that can be called from CLI or API:
 """
 
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -98,6 +99,13 @@ class _OSState:
 
 
 _OS = _OSState()
+# Guards _get_os_client's check-then-login window. Two coroutines on the
+# FastAPI side (or two threads via asyncio.to_thread) can otherwise both
+# observe _OS.client is None and both call client.login(), consuming two
+# /login quota slots and racing on the assignment to _OS.client.
+# threading.Lock works in both sync and asyncio.to_thread contexts; we
+# don't need an asyncio.Lock because the login itself is sync.
+_OS_LOGIN_LOCK = threading.Lock()
 
 
 def _snapshot_os_quota(client) -> None:
@@ -144,49 +152,58 @@ def _get_os_client(config) -> object | None:
 
     Logs in once (with 429-aware backoff) and reuses the token across all
     seasons/shows. Returns None on persistent failure so callers fall back to
-    scrapers.
+    scrapers. Thread-safe via ``_OS_LOGIN_LOCK``: concurrent callers wait on
+    the lock and observe the resulting client on the second check.
     """
+    # Fast path (no lock): a logged-in client with a fresh token.
     if _OS.failed:
         return None
-
     if _OS.client is not None and (time.monotonic() - _OS.login_time) < _OS_TOKEN_MAX_AGE:
         return _OS.client
 
-    try:
-        from opensubtitlescom import OpenSubtitles as _OSApi
-    except ImportError:
-        logger.warning("opensubtitlescom package not installed — skipping API path")
-        _OS.failed = True
-        return None
+    with _OS_LOGIN_LOCK:
+        # Double-check after acquiring the lock — another thread may have
+        # completed the login (or flipped `failed`) while we were waiting.
+        if _OS.failed:
+            return None
+        if _OS.client is not None and (time.monotonic() - _OS.login_time) < _OS_TOKEN_MAX_AGE:
+            return _OS.client
 
-    client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
-    try:
-        login_response = os_api_call(
-            client.login,
-            config.opensubtitles_username,
-            config.opensubtitles_password,
-        )
-    except Exception as e:
-        logger.warning(
-            f"OpenSubtitles API login failed after retries ({e}); "
-            "using scrapers for the rest of this run",
-            exc_info=True,
-        )
-        _OS.failed = True
-        return None
+        try:
+            from opensubtitlescom import OpenSubtitles as _OSApi
+        except ImportError:
+            logger.warning("opensubtitlescom package not installed — skipping API path")
+            _OS.failed = True
+            return None
 
-    try:
-        remaining = login_response["user"]["allowed_downloads"]
-        logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
-    except (KeyError, TypeError):
-        logger.info("OpenSubtitles API login OK")
-    _OS.client = client
-    _OS.login_time = time.monotonic()
-    # Seed the quota snapshot from the login response — gives the build
-    # script's final summary a starting baseline even if no downloads happen
-    # this run (e.g., the whole cache is already populated).
-    _snapshot_os_quota(client)
-    return client
+        client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
+        try:
+            login_response = os_api_call(
+                client.login,
+                config.opensubtitles_username,
+                config.opensubtitles_password,
+            )
+        except Exception as e:
+            logger.warning(
+                f"OpenSubtitles API login failed after retries ({e}); "
+                "using scrapers for the rest of this run",
+                exc_info=True,
+            )
+            _OS.failed = True
+            return None
+
+        try:
+            remaining = login_response["user"]["allowed_downloads"]
+            logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
+        except (KeyError, TypeError):
+            logger.info("OpenSubtitles API login OK")
+        _OS.client = client
+        _OS.login_time = time.monotonic()
+        # Seed the quota snapshot from the login response — gives the build
+        # script's final summary a starting baseline even if no downloads
+        # happen this run (e.g., the whole cache is already populated).
+        _snapshot_os_quota(client)
+        return client
 
 
 def download_subtitles(show_name: str, season: int) -> dict:

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -120,12 +120,18 @@ def _snapshot_os_quota(client) -> None:
             return
         remaining_int = int(remaining)
         _OS.last_quota = {"remaining": remaining_int, "as_of": time.monotonic()}
-        # Log on first read and whenever quota has dropped by >= 10 from the
-        # *last logged value* (not the previous snapshot). Comparing against
-        # the previous snapshot would silently swallow slow drips: dropping
-        # 5-per-season for 20 seasons would never cross the threshold from
-        # snapshot to snapshot.
-        if _OS.last_logged_remaining is None or _OS.last_logged_remaining - remaining_int >= 10:
+        # Log on first read, on a drop of >= 10 from the last LOGGED value
+        # (not the previous snapshot — slow drips of 5-per-season would
+        # never cross a snapshot-to-snapshot threshold), AND on any refill.
+        # The refill branch matters at midnight: when the daily quota
+        # resets (e.g. 50 -> 1000), the "drop" check sees 50 - 1000 = -950,
+        # never >= 10, so without it the log line would go silent for the
+        # rest of the run even though the counter is healthy.
+        if (
+            _OS.last_logged_remaining is None
+            or _OS.last_logged_remaining - remaining_int >= 10
+            or remaining_int > _OS.last_logged_remaining
+        ):
             logger.info(f"OS API quota: {remaining_int} downloads remaining today")
             _OS.last_logged_remaining = remaining_int
     except Exception as exc:

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -8,6 +8,7 @@ Provides three independent operations that can be called from CLI or API:
 
 import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from loguru import logger
@@ -16,6 +17,7 @@ from app import __version__
 from app.matcher.addic7ed_client import Addic7edClient
 from app.matcher.asr_provider import get_asr_provider
 from app.matcher.opensubtitles_scraper import OpenSubtitlesClient
+from app.matcher.os_api_retry import os_api_call
 from app.matcher.srt_utils import extract_audio_chunk, get_video_duration
 from app.matcher.subtitle_provider import LocalSubtitleProvider
 from app.matcher.subtitle_utils import sanitize_filename
@@ -65,26 +67,37 @@ def is_valid_srt_file(file_path: Path) -> bool:
         return False
 
 
-# --- Cached OpenSubtitles API client ---------------------------------------
+# --- Cached OpenSubtitles API client + quota state -------------------------
 # The OpenSubtitles bearer token is valid ~24h and is meant to be reused.
 # `download_subtitles()` is called once per season; logging in each time
 # hammers the `/login` endpoint (throttled harder than data endpoints) and
 # triggers 429s long before the daily download quota is touched. We log in
-# once per process and reuse the client.
-_OS_CLIENT: object | None = None
-_OS_CLIENT_LOGIN_TIME: float = 0.0
-_OS_CLIENT_FAILED: bool = False
+# once per process and reuse the client. Quota tracking lives alongside
+# because the library updates ``client.user_downloads_remaining`` as a side
+# effect of ``login()``, ``user_info()``, and ``download()`` — reading the
+# attribute is free, no extra API call.
+#
+# All this state lives on a single ``_OS`` dataclass instance instead of
+# loose module globals. ``global`` declarations confuse static analyzers
+# (CodeQL flagged the writes as "unused global variable" because it does
+# not track read-then-write-across-calls through the ``global`` keyword);
+# attribute access on a single object reads as a plain "is referenced" and
+# also reduces top-of-module noise.
 _OS_TOKEN_MAX_AGE: float = 12 * 60 * 60  # re-login after 12h, well within 24h
 
-# --- Daily download quota tracking ------------------------------------------
-# The opensubtitlescom library updates ``client.user_downloads_remaining`` as
-# a side effect of ``login()``, ``user_info()``, and ``download()`` (see
-# .venv/.../opensubtitlescom/opensubtitles.py:105,124,305). Reading the
-# attribute is free — no extra API call — so we snapshot it after each season
-# bulk-download and surface the latest value via ``get_last_quota()`` for the
-# build script's final summary.
-_OS_LAST_QUOTA: dict | None = None
-_OS_LAST_LOGGED_REMAINING: int | None = None
+
+@dataclass
+class _OSState:
+    """Process-wide OpenSubtitles API client + quota state."""
+
+    client: object | None = None
+    login_time: float = 0.0
+    failed: bool = False
+    last_quota: dict | None = None
+    last_logged_remaining: int | None = None
+
+
+_OS = _OSState()
 
 
 def _snapshot_os_quota(client) -> None:
@@ -93,21 +106,20 @@ def _snapshot_os_quota(client) -> None:
     Called after each season's API download block. Non-fatal on any error —
     the quota counter is informational only.
     """
-    global _OS_LAST_QUOTA, _OS_LAST_LOGGED_REMAINING
     try:
         remaining = getattr(client, "user_downloads_remaining", None)
         if remaining is None:
             return
         remaining_int = int(remaining)
-        _OS_LAST_QUOTA = {"remaining": remaining_int, "as_of": time.monotonic()}
+        _OS.last_quota = {"remaining": remaining_int, "as_of": time.monotonic()}
         # Log on first read and whenever quota has dropped by >= 10 from the
         # *last logged value* (not the previous snapshot). Comparing against
         # the previous snapshot would silently swallow slow drips: dropping
         # 5-per-season for 20 seasons would never cross the threshold from
         # snapshot to snapshot.
-        if _OS_LAST_LOGGED_REMAINING is None or _OS_LAST_LOGGED_REMAINING - remaining_int >= 10:
+        if _OS.last_logged_remaining is None or _OS.last_logged_remaining - remaining_int >= 10:
             logger.info(f"OS API quota: {remaining_int} downloads remaining today")
-            _OS_LAST_LOGGED_REMAINING = remaining_int
+            _OS.last_logged_remaining = remaining_int
     except Exception as exc:
         logger.debug(f"Could not snapshot OS quota (non-fatal): {exc}")
 
@@ -119,7 +131,7 @@ def get_last_quota() -> dict | None:
     call has succeeded yet this process. Used by the build script's final
     summary so the user sees "downloads remaining today" at the end of a run.
     """
-    return _OS_LAST_QUOTA
+    return _OS.last_quota
 
 
 def _get_os_client(config) -> object | None:
@@ -129,22 +141,18 @@ def _get_os_client(config) -> object | None:
     seasons/shows. Returns None on persistent failure so callers fall back to
     scrapers.
     """
-    global _OS_CLIENT, _OS_CLIENT_LOGIN_TIME, _OS_CLIENT_FAILED
-
-    if _OS_CLIENT_FAILED:
+    if _OS.failed:
         return None
 
-    if _OS_CLIENT is not None and (time.monotonic() - _OS_CLIENT_LOGIN_TIME) < _OS_TOKEN_MAX_AGE:
-        return _OS_CLIENT
+    if _OS.client is not None and (time.monotonic() - _OS.login_time) < _OS_TOKEN_MAX_AGE:
+        return _OS.client
 
     try:
         from opensubtitlescom import OpenSubtitles as _OSApi
     except ImportError:
         logger.warning("opensubtitlescom package not installed — skipping API path")
-        _OS_CLIENT_FAILED = True
+        _OS.failed = True
         return None
-
-    from app.matcher.os_api_retry import os_api_call
 
     client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
     try:
@@ -156,9 +164,10 @@ def _get_os_client(config) -> object | None:
     except Exception as e:
         logger.warning(
             f"OpenSubtitles API login failed after retries ({e}); "
-            "using scrapers for the rest of this run"
+            "using scrapers for the rest of this run",
+            exc_info=True,
         )
-        _OS_CLIENT_FAILED = True
+        _OS.failed = True
         return None
 
     try:
@@ -166,8 +175,8 @@ def _get_os_client(config) -> object | None:
         logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
     except (KeyError, TypeError):
         logger.info("OpenSubtitles API login OK")
-    _OS_CLIENT = client
-    _OS_CLIENT_LOGIN_TIME = time.monotonic()
+    _OS.client = client
+    _OS.login_time = time.monotonic()
     # Seed the quota snapshot from the login response — gives the build
     # script's final summary a starting baseline even if no downloads happen
     # this run (e.g., the whole cache is already populated).

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from app import __version__
 from app.matcher.addic7ed_client import Addic7edClient
 from app.matcher.asr_provider import get_asr_provider
 from app.matcher.opensubtitles_scraper import OpenSubtitlesClient
@@ -19,6 +20,12 @@ from app.matcher.srt_utils import extract_audio_chunk, get_video_duration
 from app.matcher.subtitle_provider import LocalSubtitleProvider
 from app.matcher.subtitle_utils import sanitize_filename
 from app.matcher.tmdb_client import fetch_season_details, fetch_show_details, fetch_show_id
+
+# OpenSubtitles best-practices require the User-Agent be in the form
+# "AppName vX.Y.Z". A bare "Engram" (or worse, the upstream library default)
+# misidentifies us to OS and risks being lumped in with unidentified clients
+# for rate-limit purposes. __version__ is sourced from app/__init__.py.
+_USER_AGENT = f"Engram v{__version__}"
 
 
 def is_valid_srt_file(file_path: Path) -> bool:
@@ -69,6 +76,51 @@ _OS_CLIENT_LOGIN_TIME: float = 0.0
 _OS_CLIENT_FAILED: bool = False
 _OS_TOKEN_MAX_AGE: float = 12 * 60 * 60  # re-login after 12h, well within 24h
 
+# --- Daily download quota tracking ------------------------------------------
+# The opensubtitlescom library updates ``client.user_downloads_remaining`` as
+# a side effect of ``login()``, ``user_info()``, and ``download()`` (see
+# .venv/.../opensubtitlescom/opensubtitles.py:105,124,305). Reading the
+# attribute is free — no extra API call — so we snapshot it after each season
+# bulk-download and surface the latest value via ``get_last_quota()`` for the
+# build script's final summary.
+_OS_LAST_QUOTA: dict | None = None
+_OS_LAST_LOGGED_REMAINING: int | None = None
+
+
+def _snapshot_os_quota(client) -> None:
+    """Read ``client.user_downloads_remaining`` and stash it for later display.
+
+    Called after each season's API download block. Non-fatal on any error —
+    the quota counter is informational only.
+    """
+    global _OS_LAST_QUOTA, _OS_LAST_LOGGED_REMAINING
+    try:
+        remaining = getattr(client, "user_downloads_remaining", None)
+        if remaining is None:
+            return
+        remaining_int = int(remaining)
+        _OS_LAST_QUOTA = {"remaining": remaining_int, "as_of": time.monotonic()}
+        # Log on first read and whenever quota has dropped by >= 10 from the
+        # *last logged value* (not the previous snapshot). Comparing against
+        # the previous snapshot would silently swallow slow drips: dropping
+        # 5-per-season for 20 seasons would never cross the threshold from
+        # snapshot to snapshot.
+        if _OS_LAST_LOGGED_REMAINING is None or _OS_LAST_LOGGED_REMAINING - remaining_int >= 10:
+            logger.info(f"OS API quota: {remaining_int} downloads remaining today")
+            _OS_LAST_LOGGED_REMAINING = remaining_int
+    except Exception as exc:
+        logger.debug(f"Could not snapshot OS quota (non-fatal): {exc}")
+
+
+def get_last_quota() -> dict | None:
+    """Public read-only accessor for the most recent OS download-quota snapshot.
+
+    Returns a dict ``{"remaining": int, "as_of": float}`` or None if no API
+    call has succeeded yet this process. Used by the build script's final
+    summary so the user sees "downloads remaining today" at the end of a run.
+    """
+    return _OS_LAST_QUOTA
+
 
 def _get_os_client(config) -> object | None:
     """Return a logged-in OpenSubtitles client, cached for the process.
@@ -92,38 +144,35 @@ def _get_os_client(config) -> object | None:
         _OS_CLIENT_FAILED = True
         return None
 
-    delay = 5.0
-    for attempt in range(4):
-        try:
-            client = _OSApi("Engram", config.opensubtitles_api_key)
-            login_response = client.login(
-                config.opensubtitles_username, config.opensubtitles_password
-            )
-            try:
-                remaining = login_response["user"]["allowed_downloads"]
-                logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
-            except (KeyError, TypeError):
-                logger.info("OpenSubtitles API login OK")
-            _OS_CLIENT = client
-            _OS_CLIENT_LOGIN_TIME = time.monotonic()
-            return client
-        except Exception as e:
-            is_rate_limit = "429" in str(e)
-            if attempt == 3:
-                logger.warning(
-                    f"OpenSubtitles API login failed after retries ({e}); "
-                    "using scrapers for the rest of this run"
-                )
-                _OS_CLIENT_FAILED = True
-                return None
-            logger.warning(
-                f"OpenSubtitles API login attempt {attempt + 1}/4 failed "
-                f"({'rate limited' if is_rate_limit else e}), retrying in {delay:.0f}s..."
-            )
-            time.sleep(delay)
-            delay *= 2
+    from app.matcher.os_api_retry import os_api_call
 
-    return None
+    client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
+    try:
+        login_response = os_api_call(
+            client.login,
+            config.opensubtitles_username,
+            config.opensubtitles_password,
+        )
+    except Exception as e:
+        logger.warning(
+            f"OpenSubtitles API login failed after retries ({e}); "
+            "using scrapers for the rest of this run"
+        )
+        _OS_CLIENT_FAILED = True
+        return None
+
+    try:
+        remaining = login_response["user"]["allowed_downloads"]
+        logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
+    except (KeyError, TypeError):
+        logger.info("OpenSubtitles API login OK")
+    _OS_CLIENT = client
+    _OS_CLIENT_LOGIN_TIME = time.monotonic()
+    # Seed the quota snapshot from the login response — gives the build
+    # script's final summary a starting baseline even if no downloads happen
+    # this run (e.g., the whole cache is already populated).
+    _snapshot_os_quota(client)
+    return client
 
 
 def download_subtitles(show_name: str, season: int) -> dict:
@@ -233,6 +282,10 @@ def download_subtitles(show_name: str, season: int) -> dict:
                     f"OpenSubtitles API: {len(api_srt_map)}/{episode_count} subtitles "
                     f"for {canonical_show_name} S{season:02d}"
                 )
+                # Snapshot the daily download quota — the library has updated
+                # `user_downloads_remaining` for free as a side effect of the
+                # download_and_save() calls above.
+                _snapshot_os_quota(_os_client)
             except Exception as e:
                 logger.warning(f"OpenSubtitles API failed ({e}), falling back to scrapers")
 

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -270,11 +270,20 @@ def download_subtitles(show_name: str, season: int) -> dict:
             try:
                 import shutil
 
-                response = _os_client.search(
+                # Route search/download through os_api_call so a transient
+                # 429 anywhere in the bulk-download path retries with the
+                # same backoff used by subtitle_provider.py — without this
+                # wrapping, the 12+ hour build script would fall through to
+                # the legacy scrapers on the very first rate-limit response
+                # at any of ~1800 season call sites.
+                response = os_api_call(
+                    _os_client.search,
                     parent_tmdb_id=show_id,
                     season_number=season,
                     languages="en",
                     type="episode",
+                    max_attempts=4,
+                    base_delay=1.0,
                 )
                 seen_api_eps: set[int] = set()
                 for subtitle in response.data or []:
@@ -284,7 +293,17 @@ def download_subtitles(show_name: str, season: int) -> dict:
                         episode_code_api = f"S{season:02d}E{ep_num:02d}"
                         srt_target = series_cache_dir / f"{safe_show_name} - {episode_code_api}.srt"
                         if not srt_target.exists():
-                            srt_file = _os_client.download_and_save(subtitle)
+                            # Shorter cadence on download than on search — a
+                            # 429 on download usually means the daily quota
+                            # is exhausted (not the per-minute limit), and
+                            # retrying same-day for 90s+ doesn't help; we'd
+                            # rather fall back to scrapers and move on.
+                            srt_file = os_api_call(
+                                _os_client.download_and_save,
+                                subtitle,
+                                max_attempts=2,
+                                base_delay=5.0,
+                            )
                             if srt_file and is_valid_srt_file(Path(srt_file)):
                                 shutil.move(str(srt_file), srt_target)
                                 api_srt_map[ep_num] = srt_target
@@ -301,7 +320,10 @@ def download_subtitles(show_name: str, season: int) -> dict:
                 # download_and_save() calls above.
                 _snapshot_os_quota(_os_client)
             except Exception as e:
-                logger.warning(f"OpenSubtitles API failed ({e}), falling back to scrapers")
+                logger.warning(
+                    f"OpenSubtitles API failed ({e}), falling back to scrapers",
+                    exc_info=True,
+                )
 
     # Initialize scraper clients (used as fallback when API is unavailable or misses episodes)
     addic7ed_client = Addic7edClient()

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -176,8 +176,13 @@ def _get_os_client(config) -> object | None:
             _OS.failed = True
             return None
 
-        client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
+        # Construct AND login inside the same try so a malformed config
+        # (e.g., missing opensubtitles_api_key attribute → AttributeError)
+        # is caught and gracefully degraded to scrapers, matching the
+        # original pre-refactor contract. Constructing outside the try
+        # would propagate that AttributeError to the caller unhandled.
         try:
+            client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
             login_response = os_api_call(
                 client.login,
                 config.opensubtitles_username,

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -121,7 +121,12 @@ def _snapshot_os_quota(client) -> None:
             logger.info(f"OS API quota: {remaining_int} downloads remaining today")
             _OS.last_logged_remaining = remaining_int
     except Exception as exc:
-        logger.debug(f"Could not snapshot OS quota (non-fatal): {exc}")
+        # exc_info=True per CLAUDE.md. The quota path is best-effort, so
+        # this stays at DEBUG (won't spam production logs), but if a
+        # programming error sneaks in (e.g., an unexpected client shape →
+        # AttributeError) the traceback is the only thing that lets us
+        # diagnose it.
+        logger.debug(f"Could not snapshot OS quota (non-fatal): {exc}", exc_info=True)
 
 
 def get_last_quota() -> dict | None:

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -588,17 +588,15 @@ def _fetch_season_details_cached(show_id: str, season_number: int) -> int:
         params["api_key"] = tmdb_api_key
 
     # Let RequestException propagate so @retry_network_operation retries
-    # AND lru_cache doesn't cache 0 on transient failure. KeyError is kept
-    # as a return-0 path because malformed JSON isn't network-retryable —
-    # caching 0 there is correct (the response is structurally wrong).
+    # AND lru_cache doesn't cache 0 on transient failure. The previous
+    # KeyError fallback branch was unreachable — ``dict.get("episodes", [])``
+    # never raises KeyError; a missing key just returns the [] default and
+    # ``len([])`` is 0, so the structurally-malformed-response path lands
+    # at the same return-0 outcome without a dead except clause.
     response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
     season_data = response.json()
-    try:
-        return len(season_data.get("episodes", []))
-    except KeyError:
-        logger.error(f"Missing 'episodes' key in response JSON data for Season {season_number}")
-        return 0
+    return len(season_data.get("episodes", []))
 
 
 @retry_network_operation(max_retries=3, base_delay=1.0)

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -259,14 +259,20 @@ def fetch_show_id(show_name: str) -> str | None:
     is configured. Caching the ``None`` early-return would poison the cache
     on the common first-boot path (user starts Engram, then sets the TMDB
     key in ConfigWizard — later calls would keep returning the cached None
-    until process restart).
+    until process restart). Also catches post-retry RequestException so a
+    transient TMDB failure surfaces as None (preserving the external
+    contract) without being cached by @lru_cache as a permanent None.
     """
     from app.services.config_service import get_config_sync
 
     if not get_config_sync().tmdb_api_key:
         logger.warning("TMDB API key not configured in Engram settings")
         return None
-    return _fetch_show_id_cached(show_name)
+    try:
+        return _fetch_show_id_cached(show_name)
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch show ID for '{show_name}': {e}", exc_info=True)
+        return None
 
 
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
@@ -311,41 +317,46 @@ def _fetch_show_id_cached(show_name: str) -> str | None:
     else:
         params["api_key"] = api_key
 
+    # raise_for_status() turns non-200 responses (429/5xx, etc.) into
+    # HTTPError so @retry_network_operation can retry. Previously a 429
+    # silently fell through ``if response.status_code == 200:`` and the
+    # function eventually returned None — which @lru_cache would then
+    # permanently store for the show name, silently disabling TMDB
+    # lookups for that show until process restart.
     response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
 
-    results = []
-    if response.status_code == 200:
-        results = response.json().get("results", [])
-        logger.debug(f"TMDB search for '{show_name}': {len(results)} results")
+    results = response.json().get("results", [])
+    logger.debug(f"TMDB search for '{show_name}': {len(results)} results")
 
-        if results:
-            logger.debug(
-                f"Top result: {results[0].get('name')} ({results[0].get('first_air_date')}) ID: {results[0].get('id')}"
-            )
-            # ... (logging)
-            best_match = results[0]
-            logger.info(
-                f"Matched '{show_name}' to TMDB: '{best_match['name']}' (ID: {best_match['id']})"
-            )
-            return str(best_match["id"])
+    if results:
+        logger.debug(
+            f"Top result: {results[0].get('name')} ({results[0].get('first_air_date')}) ID: {results[0].get('id')}"
+        )
+        # ... (logging)
+        best_match = results[0]
+        logger.info(
+            f"Matched '{show_name}' to TMDB: '{best_match['name']}' (ID: {best_match['id']})"
+        )
+        return str(best_match["id"])
 
-        # Try common variations if exact match fails
-        for variation in variations:
-            if variation != show_name and variation:  # Skip if same or empty
-                variation_params = params.copy()
-                variation_params["query"] = variation
+    # Try common variations if exact match fails
+    for variation in variations:
+        if variation != show_name and variation:  # Skip if same or empty
+            variation_params = params.copy()
+            variation_params["query"] = variation
 
-                response = requests.get(url, headers=headers, params=variation_params, timeout=30)
-                if response.status_code == 200:
-                    results = response.json().get("results", [])
-                    if results:
-                        best_match = results[0]
-                        # ... (logging)
-                        logger.info(
-                            f"Matched '{show_name}' (via '{variation}') to TMDB: "
-                            f"'{best_match['name']}' (ID: {best_match['id']})"
-                        )
-                        return str(best_match["id"])
+            response = requests.get(url, headers=headers, params=variation_params, timeout=30)
+            response.raise_for_status()
+            results = response.json().get("results", [])
+            if results:
+                best_match = results[0]
+                # ... (logging)
+                logger.info(
+                    f"Matched '{show_name}' (via '{variation}') to TMDB: "
+                    f"'{best_match['name']}' (ID: {best_match['id']})"
+                )
+                return str(best_match["id"])
 
     # Fallback: Fuzzy match against popular shows
     # This handles cases like "Southpark" -> "South Park" (missing spaces)
@@ -384,7 +395,10 @@ def _fetch_show_id_cached(show_name: str) -> str | None:
     logger.warning(
         f"Could not find show '{show_name}' on TMDB (tried {num_variations} variations). API Key valid: {bool(api_key)}"
     )
-    if not results and response.status_code == 200:
+    # Reaching here means every requests.get() returned 200 (any non-200
+    # would have raised via raise_for_status() above) but no variation
+    # yielded a match — log the last response body for diagnostics.
+    if not results:
         logger.debug(f"TMDB Response: {response.text[:500]}")
     return None
 

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -267,8 +267,13 @@ def fetch_show_id(show_name: str) -> str | None:
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def _fetch_show_id_cached(show_name: str) -> str | None:
     """Cached implementation. Caller (the ``fetch_show_id`` wrapper)
-    guarantees an API key is present; the defensive ``if not api_key``
-    branch below is unreachable in normal flow.
+    guarantees an API key is present.
+
+    The api_key check below ``raise``s rather than returning ``None`` so a
+    misuse (e.g., a test calling the cached function directly without
+    mocking the config) fails loudly instead of caching ``None`` keyed on
+    the show name — which is exactly the failure mode the inner/outer
+    split was designed to prevent.
     """
     # Try to get API key from Engram settings first, then fallback to matcher config
     from app.services.config_service import get_config_sync
@@ -277,8 +282,10 @@ def _fetch_show_id_cached(show_name: str) -> str | None:
     api_key = config.tmdb_api_key
 
     if not api_key:
-        logger.warning("TMDB API key not configured in Engram settings")
-        return None
+        raise RuntimeError(
+            "_fetch_show_id_cached called without a TMDB API key; "
+            "use the public fetch_show_id wrapper which short-circuits the no-key path"
+        )
 
     logger.debug(
         f"Searching TMDB for '{show_name}' using API key ending in ...{api_key[-4:] if len(api_key) > 4 else '****'}"
@@ -392,16 +399,25 @@ def fetch_show_details(show_id: int) -> dict | None:
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def _fetch_show_details_cached(show_id: int) -> dict | None:
-    """Cached implementation. Caller guarantees the API key is present;
-    the defensive branch below is unreachable in normal flow."""
+    """Cached implementation. Caller guarantees the API key is present.
+
+    Returns a shallow copy of the TMDB response so a caller who mutates
+    the returned dict (e.g., ``details["name"] = "override"``) doesn't
+    silently corrupt the cached entry for every subsequent caller in this
+    process. The shallow copy is cheap (TMDB show payloads are flat dicts
+    with strings/numbers); nested mutation of ``seasons``/``genres`` lists
+    can still poison the cache, but that's not a current usage pattern.
+    """
     from app.services.config_service import get_config_sync
 
     config = get_config_sync()
     api_key = config.tmdb_api_key
 
     if not api_key:
-        logger.warning("TMDB API key not configured")
-        return None
+        raise RuntimeError(
+            "_fetch_show_details_cached called without a TMDB API key; "
+            "use the public fetch_show_details wrapper"
+        )
 
     url = f"https://api.themoviedb.org/3/tv/{show_id}"
 
@@ -416,9 +432,9 @@ def _fetch_show_details_cached(show_id: int) -> dict | None:
     try:
         response = requests.get(url, headers=headers, params=params, timeout=30)
         response.raise_for_status()
-        return response.json()
+        return {**response.json()}
     except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to fetch show details for ID {show_id}: {e}")
+        logger.error(f"Failed to fetch show details for ID {show_id}: {e}", exc_info=True)
         return None
 
 
@@ -539,8 +555,10 @@ def _fetch_season_details_cached(show_id: str, season_number: int) -> int:
     tmdb_api_key = config.tmdb_api_key
 
     if not tmdb_api_key:
-        logger.warning("TMDB API key not configured")
-        return 0
+        raise RuntimeError(
+            "_fetch_season_details_cached called without a TMDB API key; "
+            "use the public fetch_season_details wrapper"
+        )
 
     url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_number}"
 

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -2,12 +2,26 @@
 import re
 import time
 from collections.abc import Callable
-from functools import wraps
+from functools import lru_cache, wraps
 from threading import Lock
 from typing import Any, TypeVar
 
 import requests
 from loguru import logger
+
+# In-process cache for TMDB lookups. The build script calls
+# fetch_show_id/fetch_show_details for every show during selection AND again
+# inside download_subtitles() for every season — a 300-show, 5-season run
+# would otherwise burn ~1800 TMDB requests on data that doesn't change within
+# a single run. The cache key is (function, *args), and all three wrapped
+# functions take only hashable primitives (str, int).
+#
+# Caveat: this cache persists for the lifetime of the Python process. If the
+# TMDB API key is rotated mid-process, callers must explicitly invoke the
+# corresponding .cache_clear(). Tests that mutate config between assertions
+# must do the same. In practice, the FastAPI process restarts on config
+# changes and standalone scripts exit when done — both safe.
+_TMDB_LRU_MAXSIZE = 4096
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -231,6 +245,7 @@ def generate_name_variations(name: str) -> list[str]:
     return variations
 
 
+@lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_show_id(show_name: str) -> str | None:
     """
@@ -348,6 +363,7 @@ def fetch_show_id(show_name: str) -> str | None:
     return None
 
 
+@lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_show_details(show_id: int) -> dict | None:
     """
@@ -479,6 +495,7 @@ def fetch_shows_by_vote_count(page: int = 1) -> list[dict]:
         return []
 
 
+@lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_season_details(show_id: str, season_number: int) -> int:
     """

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -1,4 +1,5 @@
 # tmdb_client.py
+import copy
 import re
 import time
 from collections.abc import Callable
@@ -41,13 +42,18 @@ def retry_network_operation(max_retries: int = 3, base_delay: float = 1.0) -> Ca
                 except (requests.RequestException, ConnectionError, TimeoutError) as e:
                     last_exception = e
                     if attempt == max_retries:
+                        # exc_info=True per CLAUDE.md — preserves the
+                        # __cause__/__context__ chain pointing at the root
+                        # network failure, which a bare str(e) discards.
                         logger.error(
-                            f"Max retries ({max_retries}) exceeded for {func.__name__}: {e}"
+                            f"Max retries ({max_retries}) exceeded for {func.__name__}: {e}",
+                            exc_info=True,
                         )
                         raise e
 
                     logger.warning(
-                        f"Network retry {attempt + 1}/{max_retries + 1} for {func.__name__}: {e}"
+                        f"Network retry {attempt + 1}/{max_retries + 1} for {func.__name__}: {e}",
+                        exc_info=True,
                     )
                     time.sleep(delay)
                     delay = min(delay * 2, 30)  # Cap at 30 seconds
@@ -392,6 +398,13 @@ def fetch_show_details(show_id: int) -> dict | None:
     ``@retry_network_operation`` can see it AND so a transient failure isn't
     cached by ``@lru_cache``. ``lru_cache`` does not cache exceptions; only
     successful return values get stored.
+
+    Returns a ``deepcopy`` of the cached dict on every call so a caller
+    mutating any nested field can't corrupt the cached entry for every
+    subsequent caller. Doing the copy in the wrapper (rather than inside
+    the cached function) means cache HITS get a fresh copy too — copying
+    inside the cached function would only deep-copy the one-time miss and
+    then permanently return the same deep-copied object on hits.
     """
     from app.services.config_service import get_config_sync
 
@@ -399,10 +412,11 @@ def fetch_show_details(show_id: int) -> dict | None:
         logger.warning("TMDB API key not configured")
         return None
     try:
-        return _fetch_show_details_cached(show_id)
+        cached = _fetch_show_details_cached(show_id)
     except requests.exceptions.RequestException as e:
         logger.error(f"Failed to fetch show details for ID {show_id}: {e}", exc_info=True)
         return None
+    return copy.deepcopy(cached) if cached is not None else None
 
 
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
@@ -410,12 +424,12 @@ def fetch_show_details(show_id: int) -> dict | None:
 def _fetch_show_details_cached(show_id: int) -> dict | None:
     """Cached implementation. Caller guarantees the API key is present.
 
-    Returns a shallow copy of the TMDB response so a caller who mutates
-    the returned dict (e.g., ``details["name"] = "override"``) doesn't
-    silently corrupt the cached entry for every subsequent caller in this
-    process. The shallow copy is cheap (TMDB show payloads are flat dicts
-    with strings/numbers); nested mutation of ``seasons``/``genres`` lists
-    can still poison the cache, but that's not a current usage pattern.
+    Returns ``response.json()`` directly. Mutation protection lives in
+    the public ``fetch_show_details`` wrapper, which does a ``deepcopy``
+    on every call so cache hits also get a fresh, independent object.
+    Deep-copying here would protect only the rare cache-miss path while
+    permanently caching the same deep-copied object that subsequent
+    cache hits would all alias.
     """
     from app.services.config_service import get_config_sync
 
@@ -444,7 +458,7 @@ def _fetch_show_details_cached(show_id: int) -> dict | None:
     # surfaces None to satisfy the original contract.
     response = requests.get(url, headers=headers, params=params, timeout=30)
     response.raise_for_status()
-    return {**response.json()}
+    return response.json()
 
 
 @retry_network_operation(max_retries=3, base_delay=1.0)

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -387,13 +387,22 @@ def fetch_show_details(show_id: int) -> dict | None:
     """Public entry; short-circuits without caching when API key absent.
 
     See ``fetch_show_id`` docstring for rationale on the no-cache early-return.
+    Network failures are caught HERE (not inside ``_fetch_show_details_cached``)
+    so an exhausted-retries exception doesn't get swallowed before
+    ``@retry_network_operation`` can see it AND so a transient failure isn't
+    cached by ``@lru_cache``. ``lru_cache`` does not cache exceptions; only
+    successful return values get stored.
     """
     from app.services.config_service import get_config_sync
 
     if not get_config_sync().tmdb_api_key:
         logger.warning("TMDB API key not configured")
         return None
-    return _fetch_show_details_cached(show_id)
+    try:
+        return _fetch_show_details_cached(show_id)
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch show details for ID {show_id}: {e}", exc_info=True)
+        return None
 
 
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
@@ -429,13 +438,13 @@ def _fetch_show_details_cached(show_id: int) -> dict | None:
     else:
         params["api_key"] = api_key
 
-    try:
-        response = requests.get(url, headers=headers, params=params, timeout=30)
-        response.raise_for_status()
-        return {**response.json()}
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to fetch show details for ID {show_id}: {e}", exc_info=True)
-        return None
+    # Let RequestException propagate so @retry_network_operation can retry
+    # AND lru_cache does not cache a sentinel-None on transient failures.
+    # Caller (the public wrapper) catches the post-retry exception and
+    # surfaces None to satisfy the original contract.
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+    return {**response.json()}
 
 
 @retry_network_operation(max_retries=3, base_delay=1.0)
@@ -533,15 +542,24 @@ def fetch_season_details(show_id: str, season_number: int) -> int:
     """Public entry; short-circuits without caching when API key absent.
 
     Returns 0 (not None) for the no-key path, matching the original
-    contract — callers check ``if episode_count == 0``. See ``fetch_show_id``
-    for rationale on bypassing the cache.
+    contract — callers check ``if episode_count == 0``. Also catches the
+    post-retry RequestException so a transient network failure doesn't get
+    cached as ``0`` by ``@lru_cache`` (which would silently treat a season
+    as empty for the rest of the process — a 12h build with no recovery).
     """
     from app.services.config_service import get_config_sync
 
     if not get_config_sync().tmdb_api_key:
         logger.warning("TMDB API key not configured")
         return 0
-    return _fetch_season_details_cached(show_id, season_number)
+    try:
+        return _fetch_season_details_cached(show_id, season_number)
+    except requests.exceptions.RequestException as e:
+        logger.error(
+            f"Failed to fetch season details for Season {season_number}: {e}",
+            exc_info=True,
+        )
+        return 0
 
 
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
@@ -569,15 +587,15 @@ def _fetch_season_details_cached(show_id: str, season_number: int) -> int:
     else:
         params["api_key"] = tmdb_api_key
 
+    # Let RequestException propagate so @retry_network_operation retries
+    # AND lru_cache doesn't cache 0 on transient failure. KeyError is kept
+    # as a return-0 path because malformed JSON isn't network-retryable —
+    # caching 0 there is correct (the response is structurally wrong).
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+    season_data = response.json()
     try:
-        response = requests.get(url, headers=headers, params=params, timeout=30)
-        response.raise_for_status()
-        season_data = response.json()
-        total_episodes = len(season_data.get("episodes", []))
-        return total_episodes
-    except requests.exceptions.RequestException as e:
-        logger.error(f"Failed to fetch season details for Season {season_number}: {e}")
-        return 0
+        return len(season_data.get("episodes", []))
     except KeyError:
         logger.error(f"Missing 'episodes' key in response JSON data for Season {season_number}")
         return 0

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -17,11 +17,15 @@ from loguru import logger
 # a single run. The cache key is (function, *args), and all three wrapped
 # functions take only hashable primitives (str, int).
 #
-# Caveat: this cache persists for the lifetime of the Python process. If the
-# TMDB API key is rotated mid-process, callers must explicitly invoke the
-# corresponding .cache_clear(). Tests that mutate config between assertions
-# must do the same. In practice, the FastAPI process restarts on config
-# changes and standalone scripts exit when done — both safe.
+# Cache lifetime: this cache persists for the lifetime of the Python process.
+# The FastAPI server does NOT restart on config changes (PUT /api/config just
+# writes the DB row), so a key rotation via ConfigWizard would otherwise leave
+# stale entries — successful lookups made with the now-revoked key — in the
+# cache until process restart. ``config_service.update_config`` calls
+# ``clear_caches()`` whenever ``tmdb_api_key`` is in the updated fields to
+# handle this; tests that mutate config between assertions should do the
+# same (the ``_clear_tmdb_caches`` autouse fixture in test_tmdb_client.py
+# is the canonical pattern).
 _TMDB_LRU_MAXSIZE = 4096
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -51,9 +51,14 @@ def retry_network_operation(max_retries: int = 3, base_delay: float = 1.0) -> Ca
                         )
                         raise e
 
+                    # Intentionally NO ``exc_info=True`` here — emitting a
+                    # full stack trace on every retry attempt produces N
+                    # tracebacks per failure, which buries the rest of the
+                    # log on a 300-show build run. The terminal error log
+                    # above keeps the traceback for the failure that
+                    # actually sticks.
                     logger.warning(
-                        f"Network retry {attempt + 1}/{max_retries + 1} for {func.__name__}: {e}",
-                        exc_info=True,
+                        f"Network retry {attempt + 1}/{max_retries + 1} for {func.__name__}: {e}"
                     )
                     time.sleep(delay)
                     delay = min(delay * 2, 30)  # Cap at 30 seconds
@@ -270,7 +275,14 @@ def fetch_show_id(show_name: str) -> str | None:
         return None
     try:
         return _fetch_show_id_cached(show_name)
-    except requests.exceptions.RequestException as e:
+    # Match retry_network_operation's retry set exactly — it catches
+    # all three of (RequestException, ConnectionError, TimeoutError),
+    # the last two being Python builtins. After retries exhaust, the
+    # ORIGINAL exception is re-raised unchanged, so the catch here
+    # must cover the same set or a builtin ConnectionError (e.g., a
+    # socket-level DNS failure that requests didn't wrap) escapes
+    # the contract.
+    except (requests.exceptions.RequestException, ConnectionError, TimeoutError) as e:
         logger.error(f"Failed to fetch show ID for '{show_name}': {e}", exc_info=True)
         return None
 
@@ -427,7 +439,9 @@ def fetch_show_details(show_id: int) -> dict | None:
         return None
     try:
         cached = _fetch_show_details_cached(show_id)
-    except requests.exceptions.RequestException as e:
+    # See fetch_show_id wrapper for why the catch widens to match the
+    # retry decorator's tuple (RequestException + builtin Connection/Timeout).
+    except (requests.exceptions.RequestException, ConnectionError, TimeoutError) as e:
         logger.error(f"Failed to fetch show details for ID {show_id}: {e}", exc_info=True)
         return None
     return copy.deepcopy(cached) if cached is not None else None
@@ -582,7 +596,9 @@ def fetch_season_details(show_id: str, season_number: int) -> int:
         return 0
     try:
         return _fetch_season_details_cached(show_id, season_number)
-    except requests.exceptions.RequestException as e:
+    # See fetch_show_id wrapper for why the catch widens to match the
+    # retry decorator's tuple (RequestException + builtin Connection/Timeout).
+    except (requests.exceptions.RequestException, ConnectionError, TimeoutError) as e:
         logger.error(
             f"Failed to fetch season details for Season {season_number}: {e}",
             exc_info=True,

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -245,17 +245,30 @@ def generate_name_variations(name: str) -> list[str]:
     return variations
 
 
+def fetch_show_id(show_name: str) -> str | None:
+    """Fetch the TMDb ID for a given show name with fuzzy fallback.
+
+    Public entry point. The actual TMDB call is in ``_fetch_show_id_cached``;
+    this wrapper short-circuits BEFORE consulting the cache when no API key
+    is configured. Caching the ``None`` early-return would poison the cache
+    on the common first-boot path (user starts Engram, then sets the TMDB
+    key in ConfigWizard — later calls would keep returning the cached None
+    until process restart).
+    """
+    from app.services.config_service import get_config_sync
+
+    if not get_config_sync().tmdb_api_key:
+        logger.warning("TMDB API key not configured in Engram settings")
+        return None
+    return _fetch_show_id_cached(show_name)
+
+
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
-def fetch_show_id(show_name: str) -> str | None:
-    """
-    Fetch the TMDb ID for a given show name with fuzzy fallback.
-
-    Args:
-        show_name (str): The name of the show.
-
-    Returns:
-        str: The TMDb ID of the show, or None if not found.
+def _fetch_show_id_cached(show_name: str) -> str | None:
+    """Cached implementation. Caller (the ``fetch_show_id`` wrapper)
+    guarantees an API key is present; the defensive ``if not api_key``
+    branch below is unreachable in normal flow.
     """
     # Try to get API key from Engram settings first, then fallback to matcher config
     from app.services.config_service import get_config_sync
@@ -363,19 +376,24 @@ def fetch_show_id(show_name: str) -> str | None:
     return None
 
 
+def fetch_show_details(show_id: int) -> dict | None:
+    """Public entry; short-circuits without caching when API key absent.
+
+    See ``fetch_show_id`` docstring for rationale on the no-cache early-return.
+    """
+    from app.services.config_service import get_config_sync
+
+    if not get_config_sync().tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return None
+    return _fetch_show_details_cached(show_id)
+
+
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
-def fetch_show_details(show_id: int) -> dict | None:
-    """
-    Fetch show details from TMDB by ID.
-
-    Args:
-        show_id: The TMDB show ID
-
-    Returns:
-        dict: Show details including 'name', 'number_of_seasons', etc.
-        None: If request fails or API key not configured
-    """
+def _fetch_show_details_cached(show_id: int) -> dict | None:
+    """Cached implementation. Caller guarantees the API key is present;
+    the defensive branch below is unreachable in normal flow."""
     from app.services.config_service import get_config_sync
 
     config = get_config_sync()
@@ -495,19 +513,25 @@ def fetch_shows_by_vote_count(page: int = 1) -> list[dict]:
         return []
 
 
+def fetch_season_details(show_id: str, season_number: int) -> int:
+    """Public entry; short-circuits without caching when API key absent.
+
+    Returns 0 (not None) for the no-key path, matching the original
+    contract — callers check ``if episode_count == 0``. See ``fetch_show_id``
+    for rationale on bypassing the cache.
+    """
+    from app.services.config_service import get_config_sync
+
+    if not get_config_sync().tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return 0
+    return _fetch_season_details_cached(show_id, season_number)
+
+
 @lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
 @retry_network_operation(max_retries=3, base_delay=1.0)
-def fetch_season_details(show_id: str, season_number: int) -> int:
-    """
-    Fetch the total number of episodes for a given show and season from the TMDb API.
-
-    Args:
-        show_id (str): The ID of the show on TMDb.
-        season_number (int): The season number to fetch details for.
-
-    Returns:
-        int: The total number of episodes in the season, or 0 if the API request failed.
-    """
+def _fetch_season_details_cached(show_id: str, season_number: int) -> int:
+    """Cached implementation. Caller guarantees the API key is present."""
     logger.info(f"Fetching season details for Season {season_number}...")
     from app.services.config_service import get_config_sync
 
@@ -684,3 +708,16 @@ def fetch_movie_id(movie_name: str) -> str | None:
 
     logger.warning(f"Could not find movie '{movie_name}' on TMDB")
     return None
+
+
+def clear_caches() -> None:
+    """Clear all in-process TMDB LRU caches.
+
+    Test fixtures call this to prevent one test's mocked ``requests.get``
+    results from leaking into another test. Production callers may use it
+    after a TMDB API key rotation to drop any results fetched with the old
+    credentials.
+    """
+    _fetch_show_id_cached.cache_clear()
+    _fetch_show_details_cached.cache_clear()
+    _fetch_season_details_cached.cache_clear()

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -124,6 +124,17 @@ async def update_config(**kwargs) -> AppConfig:
         # Ensure paths exist
         await ensure_paths_exist(config)
 
+        # If the TMDB key was rotated, blow away any results fetched with
+        # the old key. The TMDB ``@lru_cache``-wrapped fetchers cache by
+        # the function arguments alone (not the key), so a rotation
+        # would silently keep returning stale results — including
+        # successful lookups made with a now-revoked key — until process
+        # restart. ConfigWizard is the common rotation entry point.
+        if "tmdb_api_key" in kwargs:
+            from app.matcher.tmdb_client import clear_caches
+
+            clear_caches()
+
         logger.info(f"Updated configuration: {list(kwargs.keys())}")
         return config
 

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -355,7 +355,7 @@ def main() -> int:
             delta_dls = tally.downloaded - tally_snapshot[1]
             delta_nf = tally.not_found - tally_snapshot[2]
             console.log(
-                f"[green]✓[/] {show['name']} — "
+                f"[green]OK[/] {show['name']} — "
                 f"{delta_hits + delta_dls}/{delta_hits + delta_dls + delta_nf} episodes "
                 f"({delta_hits} cached, {delta_dls} new, {delta_nf} missing) "
                 f"in {int(time.monotonic() - show_start)}s"

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -23,17 +23,27 @@ import shutil
 import sys
 import tarfile
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import numpy as np
 from loguru import logger
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 from scipy import sparse
 
 from app.matcher.episode_identification import SubtitleCache
 from app.matcher.subtitle_utils import sanitize_filename
-from app.matcher.testing_service import download_subtitles
+from app.matcher.testing_service import download_subtitles, get_last_quota
 from app.matcher.tmdb_client import (
     fetch_show_details,
     fetch_show_id,
@@ -49,6 +59,32 @@ from app.matcher.vectorizer_config import (
 )
 
 _VALID_STATUSES = {"cached", "downloaded"}
+
+
+@dataclass
+class RunTally:
+    """Running counters for the build run, surfaced in the final summary.
+
+    Mutated in place by ``_harvest_show`` so per-show progress can be
+    rendered without changing call-site semantics.
+    """
+
+    downloaded: int = 0
+    cache_hits: int = 0
+    not_found: int = 0
+    seasons_done: int = 0
+    seasons_skipped_below_threshold: int = 0
+    seasons_failed: int = 0
+    start_time: float = field(default_factory=time.monotonic)
+
+    def elapsed_str(self) -> str:
+        secs = int(time.monotonic() - self.start_time)
+        return f"{secs // 3600}:{(secs % 3600) // 60:02d}:{secs % 60:02d}"
+
+    @property
+    def cache_hit_rate(self) -> float:
+        denom = self.cache_hits + self.downloaded
+        return self.cache_hits / denom if denom else 0.0
 
 
 def _ensure_db_schema() -> None:
@@ -135,8 +171,20 @@ def _select_shows(args) -> list[dict]:
     return shows
 
 
-def _harvest_show(show: dict, args) -> list[tuple[int, str, Path]]:
-    """Download subtitles for every season. Returns [(season, episode_code, srt_path)]."""
+def _harvest_show(
+    show: dict,
+    args,
+    tally: RunTally,
+    on_season_done=None,
+) -> list[tuple[int, str, Path]]:
+    """Download subtitles for every season. Returns [(season, episode_code, srt_path)].
+
+    Mutates ``tally`` in place with per-status counts so the caller can render
+    progress without re-walking the episode lists. ``on_season_done``, if
+    given, is invoked after each season finishes (success, skip, or fail) so
+    the caller can advance a Progress bar without coupling to its
+    implementation.
+    """
     harvested: list[tuple[int, str, Path]] = []
     canonical = show["name"]
     for season in range(1, show["seasons"] + 1):
@@ -144,7 +192,21 @@ def _harvest_show(show: dict, args) -> list[tuple[int, str, Path]]:
             result = download_subtitles(canonical, season)
         except Exception as e:
             logger.warning(f"  {canonical} S{season:02d}: harvest failed ({e})")
+            tally.seasons_failed += 1
+            if on_season_done is not None:
+                on_season_done()
             continue
+
+        # Tally every episode (including failures) so the running totals
+        # match what actually happened, not what we chose to keep.
+        for ep in result["episodes"]:
+            status = ep.get("status")
+            if status == "cached":
+                tally.cache_hits += 1
+            elif status == "downloaded":
+                tally.downloaded += 1
+            elif status == "not_found":
+                tally.not_found += 1
 
         episodes = [
             ep for ep in result["episodes"] if ep["status"] in _VALID_STATUSES and ep.get("path")
@@ -156,11 +218,17 @@ def _harvest_show(show: dict, args) -> list[tuple[int, str, Path]]:
                 f"  {canonical} S{season:02d}: {len(episodes)}/{total} episodes "
                 f"({ratio:.0%}) below threshold {args.min_episodes_ratio:.0%}; skipping season"
             )
+            tally.seasons_skipped_below_threshold += 1
+            if on_season_done is not None:
+                on_season_done()
             continue
 
         for ep in episodes:
             harvested.append((season, ep["code"], Path(ep["path"])))
         logger.info(f"  {canonical} S{season:02d}: {len(episodes)}/{total} episodes")
+        tally.seasons_done += 1
+        if on_season_done is not None:
+            on_season_done()
         time.sleep(args.sleep)
     return harvested
 
@@ -244,41 +312,86 @@ def main() -> int:
     blocks: list[tuple[str, int, list[str], object]] = []
     hv = build_hashing_vectorizer()
     manifest_shows: dict[str, dict] = {}
+    tally = RunTally()
 
-    for idx, show in enumerate(shows, 1):
-        logger.info(f"[{idx}/{len(shows)}] {show['name']} (TMDB {show['tmdb_id']})")
-        harvested = _harvest_show(show, args)
-        if not harvested:
-            logger.warning(f"  {show['name']}: no usable seasons; omitting from cache")
-            continue
+    # Rich Console auto-detects TTY: in a local terminal we get a live
+    # updating progress bar; under GitHub Actions (no TTY) it degrades to
+    # one log line per console.log() call and the bar updates are
+    # effectively no-ops — exactly the shape that's readable in CI logs.
+    console = Console()
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        console=console,
+        transient=False,
+    ) as progress:
+        shows_task = progress.add_task("Building cache", total=len(shows))
+        for idx, show in enumerate(shows, 1):
+            show_start = time.monotonic()
+            tally_snapshot = (tally.cache_hits, tally.downloaded, tally.not_found)
+            season_task = progress.add_task(
+                f"  {show['name']}",
+                total=show["seasons"],
+                transient=True,
+            )
 
-        by_season: dict[int, list[tuple[str, Path]]] = {}
-        for season, code, path in harvested:
-            by_season.setdefault(season, []).append((code, path))
+            logger.info(f"[{idx}/{len(shows)}] {show['name']} (TMDB {show['tmdb_id']})")
+            # Bind season_task via default arg so the closure captures THIS
+            # iteration's task id, not the loop variable (B023).
+            harvested = _harvest_show(
+                show,
+                args,
+                tally,
+                on_season_done=lambda task=season_task: progress.advance(task),
+            )
+            progress.remove_task(season_task)
+            progress.advance(shows_task)
 
-        show_seasons: list[int] = []
-        episode_counts: dict[str, int] = {}
-        for season in sorted(by_season):
-            episodes = sorted(by_season[season], key=lambda x: x[0])
-            texts, codes = [], []
-            for code, path in episodes:
-                text = subtitle_cache.get_full_text(str(path))
-                if text:
-                    texts.append(text)
-                    codes.append(code)
-            if not texts:
+            # Per-show summary — show what we did this iteration.
+            delta_hits = tally.cache_hits - tally_snapshot[0]
+            delta_dls = tally.downloaded - tally_snapshot[1]
+            delta_nf = tally.not_found - tally_snapshot[2]
+            console.log(
+                f"[green]✓[/] {show['name']} — "
+                f"{delta_hits + delta_dls}/{delta_hits + delta_dls + delta_nf} episodes "
+                f"({delta_hits} cached, {delta_dls} new, {delta_nf} missing) "
+                f"in {int(time.monotonic() - show_start)}s"
+            )
+
+            if not harvested:
+                logger.warning(f"  {show['name']}: no usable seasons; omitting from cache")
                 continue
-            counts = hv.transform(texts)  # raw hashed term counts
-            blocks.append((show["name"], season, codes, counts))
-            show_seasons.append(season)
-            episode_counts[str(season)] = len(codes)
 
-        if show_seasons:
-            manifest_shows[show["name"]] = {
-                "tmdb_id": show["tmdb_id"],
-                "seasons": show_seasons,
-                "episode_counts": episode_counts,
-            }
+            by_season: dict[int, list[tuple[str, Path]]] = {}
+            for season, code, path in harvested:
+                by_season.setdefault(season, []).append((code, path))
+
+            show_seasons: list[int] = []
+            episode_counts: dict[str, int] = {}
+            for season in sorted(by_season):
+                episodes = sorted(by_season[season], key=lambda x: x[0])
+                texts, codes = [], []
+                for code, path in episodes:
+                    text = subtitle_cache.get_full_text(str(path))
+                    if text:
+                        texts.append(text)
+                        codes.append(code)
+                if not texts:
+                    continue
+                counts = hv.transform(texts)  # raw hashed term counts
+                blocks.append((show["name"], season, codes, counts))
+                show_seasons.append(season)
+                episode_counts[str(season)] = len(codes)
+
+            if show_seasons:
+                manifest_shows[show["name"]] = {
+                    "tmdb_id": show["tmdb_id"],
+                    "seasons": show_seasons,
+                    "episode_counts": episode_counts,
+                }
 
     if not blocks:
         logger.error("No subtitles harvested; nothing to build")
@@ -340,6 +453,27 @@ def main() -> int:
         f"{size_mb:.1f} MB -> {output_path}"
     )
     logger.info(f"Release manifest -> {release_manifest_path}")
+
+    # --- Final summary --------------------------------------------------------
+    # Single block readable in CI logs. ``console`` was created above in the
+    # Progress context but stays usable after the ``with`` exits.
+    quota = get_last_quota()
+    quota_str = f"{quota['remaining']}" if quota and quota.get("remaining") is not None else "n/a"
+    console.log(
+        "[bold]Final summary[/]: "
+        f"{len(manifest_shows)} shows, {total_episodes} episodes packaged "
+        f"({size_mb:.1f} MB)\n"
+        f"  episodes seen:    {tally.cache_hits + tally.downloaded + tally.not_found}\n"
+        f"  cache hits:       {tally.cache_hits}\n"
+        f"  new downloads:    {tally.downloaded}\n"
+        f"  not found:        {tally.not_found}\n"
+        f"  cache hit rate:   {tally.cache_hit_rate:.0%}\n"
+        f"  seasons OK:       {tally.seasons_done}\n"
+        f"  seasons skipped:  {tally.seasons_skipped_below_threshold} (below coverage threshold)\n"
+        f"  seasons failed:   {tally.seasons_failed}\n"
+        f"  elapsed:          {tally.elapsed_str()}\n"
+        f"  OS quota left:    {quota_str} downloads today"
+    )
     return 0
 
 

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -191,7 +191,11 @@ def _harvest_show(
         try:
             result = download_subtitles(canonical, season)
         except Exception as e:
-            logger.warning(f"  {canonical} S{season:02d}: harvest failed ({e})")
+            # exc_info=True per CLAUDE.md: the warning string alone (often
+            # just "429 Too Many Requests") doesn't say which provider in
+            # the OS/TMDB retry chain raised — the traceback is the only
+            # signal for diagnosing flaky seasons after the fact.
+            logger.warning(f"  {canonical} S{season:02d}: harvest failed ({e})", exc_info=True)
             tally.seasons_failed += 1
             if on_season_done is not None:
                 on_season_done()
@@ -350,6 +354,17 @@ def main() -> int:
             progress.remove_task(season_task)
             progress.advance(shows_task)
 
+            if not harvested:
+                # All seasons either failed or fell below the coverage
+                # threshold — emit a yellow SKIP banner instead of the green
+                # OK banner so the log line matches what actually happened.
+                console.log(
+                    f"[yellow]SKIP[/] {show['name']} — no usable seasons "
+                    f"(omitted from cache) in {int(time.monotonic() - show_start)}s"
+                )
+                logger.warning(f"  {show['name']}: no usable seasons; omitting from cache")
+                continue
+
             # Per-show summary — show what we did this iteration.
             delta_hits = tally.cache_hits - tally_snapshot[0]
             delta_dls = tally.downloaded - tally_snapshot[1]
@@ -360,10 +375,6 @@ def main() -> int:
                 f"({delta_hits} cached, {delta_dls} new, {delta_nf} missing) "
                 f"in {int(time.monotonic() - show_start)}s"
             )
-
-            if not harvested:
-                logger.warning(f"  {show['name']}: no usable seasons; omitting from cache")
-                continue
 
             by_season: dict[int, list[tuple[str, Path]]] = {}
             for season, code, path in harvested:

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -336,10 +336,15 @@ def main() -> int:
         for idx, show in enumerate(shows, 1):
             show_start = time.monotonic()
             tally_snapshot = (tally.cache_hits, tally.downloaded, tally.not_found)
+            # `transient` is a Progress() constructor argument that makes
+            # the whole bar vanish on exit, not a per-task option — passing
+            # it here is silently stored as task metadata and has no visual
+            # effect. The per-show task is removed cleanly by the
+            # `progress.remove_task(season_task)` call below after the
+            # show finishes.
             season_task = progress.add_task(
                 f"  {show['name']}",
                 total=show["seasons"],
-                transient=True,
             )
 
             logger.info(f"[{idx}/{len(shows)}] {show['name']} (TMDB {show['tmdb_id']})")

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -1,0 +1,168 @@
+"""Unit tests for build_subtitle_cache helpers.
+
+The build script is a long-running entry point that's hard to test end-to-end
+without burning a real OpenSubtitles quota — these tests cover the pure
+helpers (RunTally) and the _harvest_show contract (mutates tally in place,
+calls on_season_done).
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_build_module():
+    """Import scripts/build_subtitle_cache.py without polluting sys.modules.
+
+    The script lives outside the importable backend/app/ tree (it uses
+    ``sys.path.insert`` to find app/), so we load it by file path. This
+    keeps the test setup honest about what the script's structure is.
+    """
+    backend_root = Path(__file__).parent.parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "build_subtitle_cache",
+        backend_root / "scripts" / "build_subtitle_cache.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_subtitle_cache"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def bsc():
+    return _load_build_module()
+
+
+@pytest.mark.unit
+class TestRunTally:
+    def test_initial_state(self, bsc):
+        tally = bsc.RunTally()
+        assert tally.downloaded == 0
+        assert tally.cache_hits == 0
+        assert tally.not_found == 0
+        assert tally.cache_hit_rate == 0.0
+
+    def test_cache_hit_rate(self, bsc):
+        tally = bsc.RunTally()
+        tally.cache_hits = 30
+        tally.downloaded = 10
+        # 30 hits / (30 + 10) = 75%
+        assert tally.cache_hit_rate == 0.75
+
+    def test_elapsed_str_format(self, bsc):
+        tally = bsc.RunTally()
+        # Right after construction this is "0:00:00" or close to it; just
+        # assert the shape rather than the exact value.
+        elapsed = tally.elapsed_str()
+        assert elapsed.count(":") == 2
+
+
+@pytest.mark.unit
+class TestHarvestShowAccumulatesTally:
+    """`_harvest_show` is the only place that calls download_subtitles, and
+    it's responsible for translating per-episode statuses back into the
+    RunTally fields the final summary reports. A regression here would mean
+    the user sees zeros at the end of a real run."""
+
+    def test_per_status_counts_accumulated(self, bsc):
+        """One season with mixed cached / downloaded / not_found episodes —
+        each must increment the matching tally field."""
+
+        def fake_download(show_name, season):
+            return {
+                "show_name": show_name,
+                "season": season,
+                "total_episodes": 4,
+                "episodes": [
+                    {
+                        "code": "S01E01",
+                        "status": "cached",
+                        "path": "/tmp/x.srt",
+                        "source": "cache",
+                    },
+                    {
+                        "code": "S01E02",
+                        "status": "downloaded",
+                        "path": "/tmp/x.srt",
+                        "source": "opensubtitles_api",
+                    },
+                    {
+                        "code": "S01E03",
+                        "status": "downloaded",
+                        "path": "/tmp/x.srt",
+                        "source": "addic7ed",
+                    },
+                    {"code": "S01E04", "status": "not_found", "path": None, "source": None},
+                ],
+                "cache_dir": "/tmp",
+            }
+
+        tally = bsc.RunTally()
+        show = {"name": "X", "tmdb_id": 1, "seasons": 1}
+        args = type("Args", (), {"min_episodes_ratio": 0.5, "sleep": 0})()
+
+        with patch.object(bsc, "download_subtitles", side_effect=fake_download):
+            bsc._harvest_show(show, args, tally)
+
+        assert tally.cache_hits == 1
+        assert tally.downloaded == 2
+        assert tally.not_found == 1
+        assert tally.seasons_done == 1
+
+    def test_on_season_done_called_on_success_skip_and_fail(self, bsc):
+        """The progress-bar advance hook must fire for every season —
+        otherwise the bar stalls on shows with mixed outcomes."""
+
+        def downloads(show_name, season):
+            # 3 seasons → success / below-threshold / exception
+            if season == 1:
+                return {
+                    "show_name": show_name,
+                    "season": 1,
+                    "total_episodes": 1,
+                    "episodes": [
+                        {
+                            "code": "S01E01",
+                            "status": "downloaded",
+                            "path": "/tmp/x.srt",
+                            "source": "addic7ed",
+                        }
+                    ],
+                    "cache_dir": "/tmp",
+                }
+            if season == 2:
+                return {
+                    "show_name": show_name,
+                    "season": 2,
+                    "total_episodes": 4,
+                    "episodes": [
+                        {
+                            "code": "S02E01",
+                            "status": "downloaded",
+                            "path": "/tmp/x.srt",
+                            "source": "addic7ed",
+                        },
+                        {"code": "S02E02", "status": "not_found", "path": None, "source": None},
+                        {"code": "S02E03", "status": "not_found", "path": None, "source": None},
+                        {"code": "S02E04", "status": "not_found", "path": None, "source": None},
+                    ],
+                    "cache_dir": "/tmp",
+                }
+            raise RuntimeError("boom")
+
+        tally = bsc.RunTally()
+        show = {"name": "X", "tmdb_id": 1, "seasons": 3}
+        args = type("Args", (), {"min_episodes_ratio": 0.5, "sleep": 0})()
+        calls = []
+
+        with patch.object(bsc, "download_subtitles", side_effect=downloads):
+            bsc._harvest_show(show, args, tally, on_season_done=lambda: calls.append(None))
+
+        assert len(calls) == 3, "on_season_done must fire once per season"
+        assert tally.seasons_done == 1
+        assert tally.seasons_skipped_below_threshold == 1
+        assert tally.seasons_failed == 1

--- a/backend/tests/unit/test_config_service.py
+++ b/backend/tests/unit/test_config_service.py
@@ -80,6 +80,40 @@ class TestUpdateConfig:
         updated = await update_config(staging_path="/brand-new")
         assert updated.staging_path == "/brand-new"
 
+    async def test_tmdb_key_rotation_clears_tmdb_caches(self, monkeypatch):
+        """Rotating ``tmdb_api_key`` must drop any cached lookups made
+        with the old key — otherwise a revoked or replaced key would
+        keep returning stale results until process restart.
+        """
+        from app.matcher import tmdb_client
+
+        called = {"count": 0}
+
+        def fake_clear():
+            called["count"] += 1
+
+        monkeypatch.setattr(tmdb_client, "clear_caches", fake_clear)
+
+        await update_config(tmdb_api_key="eyJrotated_key")
+        assert called["count"] == 1, "TMDB key rotation must call clear_caches()"
+
+    async def test_non_tmdb_update_does_not_clear_caches(self, monkeypatch):
+        """A staging-path update should NOT touch the TMDB cache —
+        clear_caches() is expensive enough that we only call it on
+        rotations that could invalidate the cache.
+        """
+        from app.matcher import tmdb_client
+
+        called = {"count": 0}
+
+        def fake_clear():
+            called["count"] += 1
+
+        monkeypatch.setattr(tmdb_client, "clear_caches", fake_clear)
+
+        await update_config(staging_path="/changed/path")
+        assert called["count"] == 0, "non-TMDB update must not clear TMDB caches"
+
 
 class TestEnsurePathsExist:
     """Tests for ensure_paths_exist()."""

--- a/backend/tests/unit/test_os_api_retry.py
+++ b/backend/tests/unit/test_os_api_retry.py
@@ -9,8 +9,18 @@ cap clamps a runaway header value.
 from unittest.mock import Mock, patch
 
 import pytest
+from opensubtitlescom.exceptions import OpenSubtitlesException
 
 from app.matcher.os_api_retry import _RETRY_AFTER_CAP_SECONDS, _parse_retry_after, os_api_call
+
+
+# All test exceptions inherit from OpenSubtitlesException so they match the
+# narrowed _RETRYABLE_EXCEPTIONS tuple — the helper deliberately does NOT
+# retry on bare Exception (would silently retry programming bugs in the
+# wrapped callable). Tests exercise the real contract: the OS library wraps
+# every request error in OpenSubtitlesException before raising.
+class _FakeOSError(OpenSubtitlesException):
+    pass
 
 
 @pytest.mark.unit
@@ -27,11 +37,7 @@ class TestOsApiCall:
     def test_honors_retry_after_header_when_present(self):
         """When the exception carries a Retry-After header, sleep for that long
         (clamped) and skip the exponential schedule."""
-
-        class FakeHTTPError(Exception):
-            pass
-
-        first_exc = FakeHTTPError("429 rate limited")
+        first_exc = _FakeOSError("429 rate limited")
         first_exc.response = Mock()
         first_exc.response.headers = {"Retry-After": "7"}
 
@@ -49,9 +55,9 @@ class TestOsApiCall:
         capped exponential 5, 10, 20, ..."""
         callable_ = Mock(
             side_effect=[
-                RuntimeError("transient 1"),
-                RuntimeError("transient 2"),
-                RuntimeError("transient 3"),
+                _FakeOSError("transient 1"),
+                _FakeOSError("transient 2"),
+                _FakeOSError("transient 3"),
                 "ok",
             ]
         )
@@ -65,21 +71,17 @@ class TestOsApiCall:
     def test_reraises_after_max_attempts(self):
         """After exhausting attempts the original exception bubbles up so
         callers (e.g., _get_os_client) can latch the failure state."""
-        boom = RuntimeError("persistent failure")
+        boom = _FakeOSError("persistent failure")
         callable_ = Mock(side_effect=boom)
 
         with patch("app.matcher.os_api_retry.time.sleep"):
-            with pytest.raises(RuntimeError, match="persistent failure"):
+            with pytest.raises(_FakeOSError, match="persistent failure"):
                 os_api_call(callable_, max_attempts=3, base_delay=1.0)
         assert callable_.call_count == 3
 
     def test_retry_after_capped_at_300s(self):
         """A bogus header like ``Retry-After: 99999`` must not hang a build."""
-
-        class FakeHTTPError(Exception):
-            pass
-
-        bad = FakeHTTPError("429")
+        bad = _FakeOSError("429")
         bad.response = Mock()
         bad.response.headers = {"Retry-After": "99999"}
 
@@ -93,11 +95,7 @@ class TestOsApiCall:
     def test_retry_after_nonnumeric_falls_back_to_exponential(self):
         """A garbage value in Retry-After must not crash; fall back to the
         exponential schedule."""
-
-        class FakeHTTPError(Exception):
-            pass
-
-        bad = FakeHTTPError("429")
+        bad = _FakeOSError("429")
         bad.response = Mock()
         bad.response.headers = {"Retry-After": "not-a-number"}
 
@@ -111,12 +109,27 @@ class TestOsApiCall:
     def test_no_response_attribute_skips_header_path(self):
         """Today's opensubtitlescom wraps exceptions without preserving the
         response — the helper must still work and use exponential backoff."""
-        callable_ = Mock(side_effect=[RuntimeError("bare exception"), "ok"])
+        callable_ = Mock(side_effect=[_FakeOSError("bare exception"), "ok"])
 
         with patch("app.matcher.os_api_retry.time.sleep") as sleep:
             os_api_call(callable_, max_attempts=4, base_delay=5.0)
 
         sleep.assert_called_once_with(5.0)
+
+    def test_non_retryable_exception_propagates_immediately(self):
+        """A bug in the wrapped callable (TypeError, AttributeError, ...)
+        must surface on the first attempt — not be silently retried. This
+        is the whole point of narrowing the retry tuple."""
+        callable_ = Mock(side_effect=TypeError("programming error"))
+
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            with pytest.raises(TypeError, match="programming error"):
+                os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        # No retries, no sleeps — the helper let the exception bubble out
+        # of the first attempt.
+        assert callable_.call_count == 1
+        sleep.assert_not_called()
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_os_api_retry.py
+++ b/backend/tests/unit/test_os_api_retry.py
@@ -131,6 +131,16 @@ class TestOsApiCall:
         assert callable_.call_count == 1
         sleep.assert_not_called()
 
+    def test_zero_max_attempts_raises_immediately(self):
+        """Precondition check fires before the callable is even invoked.
+
+        Catches caller bugs early instead of silently returning None.
+        """
+        callable_ = Mock()
+        with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+            os_api_call(callable_, max_attempts=0)
+        callable_.assert_not_called()
+
 
 @pytest.mark.unit
 class TestParseRetryAfter:

--- a/backend/tests/unit/test_os_api_retry.py
+++ b/backend/tests/unit/test_os_api_retry.py
@@ -1,0 +1,145 @@
+"""Unit tests for the unified OpenSubtitles retry helper.
+
+Validates the contract that all three OS API call sites
+(login/search/download) depend on: Retry-After header honored when present,
+capped exponential fallback when absent, max-attempts re-raises, and the
+cap clamps a runaway header value.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.matcher.os_api_retry import _RETRY_AFTER_CAP_SECONDS, _parse_retry_after, os_api_call
+
+
+@pytest.mark.unit
+class TestOsApiCall:
+    """Behavioral contract for ``os_api_call``."""
+
+    def test_returns_callable_result_on_first_success(self):
+        """Happy path: no retry, just return what the callable returned."""
+        callable_ = Mock(return_value="hello")
+        result = os_api_call(callable_, "arg", kw="kw")
+        assert result == "hello"
+        callable_.assert_called_once_with("arg", kw="kw")
+
+    def test_honors_retry_after_header_when_present(self):
+        """When the exception carries a Retry-After header, sleep for that long
+        (clamped) and skip the exponential schedule."""
+
+        class FakeHTTPError(Exception):
+            pass
+
+        first_exc = FakeHTTPError("429 rate limited")
+        first_exc.response = Mock()
+        first_exc.response.headers = {"Retry-After": "7"}
+
+        callable_ = Mock(side_effect=[first_exc, "ok"])
+
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            result = os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        assert result == "ok"
+        # Server said wait 7s — we honored it instead of using base_delay=5.
+        sleep.assert_called_once_with(7.0)
+
+    def test_exponential_fallback_when_no_retry_after(self):
+        """No Retry-After (the normal case with the current library) →
+        capped exponential 5, 10, 20, ..."""
+        callable_ = Mock(
+            side_effect=[
+                RuntimeError("transient 1"),
+                RuntimeError("transient 2"),
+                RuntimeError("transient 3"),
+                "ok",
+            ]
+        )
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            result = os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        assert result == "ok"
+        # 3 failures means 3 sleeps: 5s, 10s, 20s. The 4th attempt succeeds.
+        assert [call.args[0] for call in sleep.call_args_list] == [5.0, 10.0, 20.0]
+
+    def test_reraises_after_max_attempts(self):
+        """After exhausting attempts the original exception bubbles up so
+        callers (e.g., _get_os_client) can latch the failure state."""
+        boom = RuntimeError("persistent failure")
+        callable_ = Mock(side_effect=boom)
+
+        with patch("app.matcher.os_api_retry.time.sleep"):
+            with pytest.raises(RuntimeError, match="persistent failure"):
+                os_api_call(callable_, max_attempts=3, base_delay=1.0)
+        assert callable_.call_count == 3
+
+    def test_retry_after_capped_at_300s(self):
+        """A bogus header like ``Retry-After: 99999`` must not hang a build."""
+
+        class FakeHTTPError(Exception):
+            pass
+
+        bad = FakeHTTPError("429")
+        bad.response = Mock()
+        bad.response.headers = {"Retry-After": "99999"}
+
+        callable_ = Mock(side_effect=[bad, "ok"])
+
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        sleep.assert_called_once_with(_RETRY_AFTER_CAP_SECONDS)
+
+    def test_retry_after_nonnumeric_falls_back_to_exponential(self):
+        """A garbage value in Retry-After must not crash; fall back to the
+        exponential schedule."""
+
+        class FakeHTTPError(Exception):
+            pass
+
+        bad = FakeHTTPError("429")
+        bad.response = Mock()
+        bad.response.headers = {"Retry-After": "not-a-number"}
+
+        callable_ = Mock(side_effect=[bad, "ok"])
+
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        sleep.assert_called_once_with(5.0)
+
+    def test_no_response_attribute_skips_header_path(self):
+        """Today's opensubtitlescom wraps exceptions without preserving the
+        response — the helper must still work and use exponential backoff."""
+        callable_ = Mock(side_effect=[RuntimeError("bare exception"), "ok"])
+
+        with patch("app.matcher.os_api_retry.time.sleep") as sleep:
+            os_api_call(callable_, max_attempts=4, base_delay=5.0)
+
+        sleep.assert_called_once_with(5.0)
+
+
+@pytest.mark.unit
+class TestParseRetryAfter:
+    """Direct tests for the header parser, since it has its own failure modes."""
+
+    def test_returns_none_when_no_response(self):
+        assert _parse_retry_after(RuntimeError("bare")) is None
+
+    def test_returns_none_when_header_missing(self):
+        exc = RuntimeError("429")
+        exc.response = Mock()
+        exc.response.headers = {}
+        assert _parse_retry_after(exc) is None
+
+    def test_clamps_to_cap(self):
+        exc = RuntimeError("429")
+        exc.response = Mock()
+        exc.response.headers = {"Retry-After": "1000000"}
+        assert _parse_retry_after(exc) == _RETRY_AFTER_CAP_SECONDS
+
+    def test_parses_float_seconds(self):
+        exc = RuntimeError("429")
+        exc.response = Mock()
+        exc.response.headers = {"Retry-After": "12.5"}
+        assert _parse_retry_after(exc) == 12.5

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -411,9 +411,13 @@ class TestQuotaSnapshot:
     cheapest way to surface the daily quota — no extra /infos/user request."""
 
     def setup_method(self):
-        # Reset module-scope state so tests don't bleed into each other.
-        testing_service._OS.last_quota = None
-        testing_service._OS.last_logged_remaining = None
+        # Fully replace the dataclass so tests don't bleed into each other.
+        # Resetting only `last_quota` + `last_logged_remaining` left
+        # `failed` / `client` / `login_time` carrying values from previous
+        # tests, silently exercising the wrong code path inside
+        # `_get_os_client`'s short-circuit and making `get_last_quota()`
+        # return None for the wrong reason.
+        testing_service._OS = testing_service._OSState()
 
     def test_snapshot_records_remaining_from_client_attribute(self):
         client = Mock()

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -4,6 +4,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+# Use the module-level import (`testing_service.X`) for everything in this
+# file. Mixing `import as` with `from … import …` of the same module
+# triggers CodeQL's duplicate-import-style warning and makes refactors that
+# rename symbols harder to follow.
+from app.matcher import testing_service
 from app.matcher.testing_service import download_subtitles
 
 
@@ -392,13 +397,12 @@ class TestUserAgent:
 
     def test_user_agent_constant_matches_version(self):
         from app import __version__
-        from app.matcher.testing_service import _USER_AGENT
 
-        assert _USER_AGENT == f"Engram v{__version__}"
+        assert testing_service._USER_AGENT == f"Engram v{__version__}"
         # Must satisfy the OS "AppName vX.Y.Z" pattern.
         import re
 
-        assert re.match(r"^Engram v\d+\.\d+\.\d+$", _USER_AGENT)
+        assert re.match(r"^Engram v\d+\.\d+\.\d+$", testing_service._USER_AGENT)
 
 
 @pytest.mark.unit
@@ -408,49 +412,41 @@ class TestQuotaSnapshot:
 
     def setup_method(self):
         # Reset module-scope state so tests don't bleed into each other.
-        import app.matcher.testing_service as ts
-
-        ts._OS_LAST_QUOTA = None
-        ts._OS_LAST_LOGGED_REMAINING = None
+        testing_service._OS.last_quota = None
+        testing_service._OS.last_logged_remaining = None
 
     def test_snapshot_records_remaining_from_client_attribute(self):
-        from app.matcher.testing_service import _snapshot_os_quota, get_last_quota
-
         client = Mock()
         client.user_downloads_remaining = 87
-        _snapshot_os_quota(client)
-        snap = get_last_quota()
+        testing_service._snapshot_os_quota(client)
+        snap = testing_service.get_last_quota()
         assert snap is not None
         assert snap["remaining"] == 87
         assert "as_of" in snap
 
     def test_snapshot_handles_missing_attribute_gracefully(self):
         """If the library version doesn't expose the attribute, we no-op."""
-        from app.matcher.testing_service import _snapshot_os_quota, get_last_quota
-
         client = Mock(spec=[])  # spec=[] → no attributes
-        _snapshot_os_quota(client)
-        assert get_last_quota() is None
+        testing_service._snapshot_os_quota(client)
+        assert testing_service.get_last_quota() is None
 
     def test_snapshot_logs_only_on_drop_of_ten_or_more(self):
         """Spammy log noise is the failure mode; one line per season would
         bury everything else. We log on the first read and on big drops only."""
-        from app.matcher.testing_service import _snapshot_os_quota
-
         client = Mock()
         client.user_downloads_remaining = 100
 
         with patch("app.matcher.testing_service.logger") as log:
-            _snapshot_os_quota(client)  # first read → logs
+            testing_service._snapshot_os_quota(client)  # first read → logs
             assert log.info.call_count == 1
 
             # Tiny drop (8) → no log.
             client.user_downloads_remaining = 92
-            _snapshot_os_quota(client)
+            testing_service._snapshot_os_quota(client)
             assert log.info.call_count == 1
 
             # Bigger drop crossing the 10-unit threshold from the LAST logged
             # value (100) → logs.
             client.user_downloads_remaining = 88
-            _snapshot_os_quota(client)
+            testing_service._snapshot_os_quota(client)
             assert log.info.call_count == 2

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -454,3 +454,26 @@ class TestQuotaSnapshot:
             client.user_downloads_remaining = 88
             testing_service._snapshot_os_quota(client)
             assert log.info.call_count == 2
+
+    def test_snapshot_logs_on_quota_refill_at_midnight(self):
+        """A 12-hour build crossing midnight would otherwise silence quota
+        logs forever: when daily quota resets (e.g. 50 -> 1000), the
+        "drop" check sees a negative diff and never fires. The refill
+        branch keeps visibility live across the boundary."""
+        client = Mock()
+        client.user_downloads_remaining = 50
+
+        with patch("app.matcher.testing_service.logger") as log:
+            testing_service._snapshot_os_quota(client)  # first read → logs
+            assert log.info.call_count == 1
+
+            # Midnight reset: quota jumps from 50 to 1000.
+            client.user_downloads_remaining = 1000
+            testing_service._snapshot_os_quota(client)
+            assert log.info.call_count == 2, "refill must trigger a log"
+
+            # And the next ~50-drop after the refill should still log
+            # normally against the new baseline.
+            client.user_downloads_remaining = 988
+            testing_service._snapshot_os_quota(client)
+            assert log.info.call_count == 3, "post-refill drops still log"

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -381,3 +381,76 @@ class TestSubtitleFilenameFormat:
         cache_path = tmp_path / "data" / "The Office"
         assert (cache_path / "The Office - S01E01.srt").exists()
         assert (cache_path / "The Office - S01E02.srt").exists()
+
+
+@pytest.mark.unit
+class TestUserAgent:
+    """The User-Agent string sent to OpenSubtitles must include the app
+    version per their best-practices doc; the prior placeholder ``"Engram"``
+    (no version) and ``"Oz 1.0.0"`` (wrong app name) were both
+    non-compliant."""
+
+    def test_user_agent_constant_matches_version(self):
+        from app import __version__
+        from app.matcher.testing_service import _USER_AGENT
+
+        assert _USER_AGENT == f"Engram v{__version__}"
+        # Must satisfy the OS "AppName vX.Y.Z" pattern.
+        import re
+
+        assert re.match(r"^Engram v\d+\.\d+\.\d+$", _USER_AGENT)
+
+
+@pytest.mark.unit
+class TestQuotaSnapshot:
+    """Reading ``client.user_downloads_remaining`` after API activity is the
+    cheapest way to surface the daily quota — no extra /infos/user request."""
+
+    def setup_method(self):
+        # Reset module-scope state so tests don't bleed into each other.
+        import app.matcher.testing_service as ts
+
+        ts._OS_LAST_QUOTA = None
+        ts._OS_LAST_LOGGED_REMAINING = None
+
+    def test_snapshot_records_remaining_from_client_attribute(self):
+        from app.matcher.testing_service import _snapshot_os_quota, get_last_quota
+
+        client = Mock()
+        client.user_downloads_remaining = 87
+        _snapshot_os_quota(client)
+        snap = get_last_quota()
+        assert snap is not None
+        assert snap["remaining"] == 87
+        assert "as_of" in snap
+
+    def test_snapshot_handles_missing_attribute_gracefully(self):
+        """If the library version doesn't expose the attribute, we no-op."""
+        from app.matcher.testing_service import _snapshot_os_quota, get_last_quota
+
+        client = Mock(spec=[])  # spec=[] → no attributes
+        _snapshot_os_quota(client)
+        assert get_last_quota() is None
+
+    def test_snapshot_logs_only_on_drop_of_ten_or_more(self):
+        """Spammy log noise is the failure mode; one line per season would
+        bury everything else. We log on the first read and on big drops only."""
+        from app.matcher.testing_service import _snapshot_os_quota
+
+        client = Mock()
+        client.user_downloads_remaining = 100
+
+        with patch("app.matcher.testing_service.logger") as log:
+            _snapshot_os_quota(client)  # first read → logs
+            assert log.info.call_count == 1
+
+            # Tiny drop (8) → no log.
+            client.user_downloads_remaining = 92
+            _snapshot_os_quota(client)
+            assert log.info.call_count == 1
+
+            # Bigger drop crossing the 10-unit threshold from the LAST logged
+            # value (100) → logs.
+            client.user_downloads_remaining = 88
+            _snapshot_os_quota(client)
+            assert log.info.call_count == 2

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -9,6 +9,7 @@ from app.matcher.tmdb_client import (
     _fetch_show_id_cached,
     clear_caches,
     fetch_season_details,
+    fetch_show_details,
     fetch_show_id,
 )
 from tests.fixtures.tmdb_responses import (
@@ -119,6 +120,40 @@ class TestLruCache:
                 _fetch_show_id_cached("Show")
         # Confirm the exception didn't leak into the cache.
         assert _fetch_show_id_cached.cache_info().currsize == 0
+
+    def test_fetch_show_details_returns_independent_dict_per_call(self):
+        """Cache-poisoning guard: a caller mutating the returned dict
+        (including nested lists) must not corrupt the cached entry for
+        subsequent callers. The public wrapper deep-copies the cached
+        value on every call, so each caller gets its own object graph.
+        """
+        with patch("app.matcher.tmdb_client.requests.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_response.json.return_value = {
+                "name": "Breaking Bad",
+                "number_of_seasons": 5,
+                "genres": [{"id": 18, "name": "Drama"}],
+            }
+            mock_get.return_value = mock_response
+            with patch("app.services.config_service.get_config_sync") as cfg:
+                cfg.return_value.tmdb_api_key = "test"
+                first = fetch_show_details(81189)
+                # Caller scribbles on both a top-level field AND a nested list.
+                first["name"] = "MUTATED"
+                first["genres"].append({"id": 999, "name": "POISON"})
+
+                second = fetch_show_details(81189)
+
+        # Network was only hit once — second call came from the cache.
+        assert mock_get.call_count == 1
+        # Mutation on the first object did NOT leak into the second.
+        assert second["name"] == "Breaking Bad"
+        assert second["genres"] == [{"id": 18, "name": "Drama"}]
+        # The two return values are distinct objects (deepcopy contract).
+        assert first is not second
+        assert first["genres"] is not second["genres"]
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from app.matcher.tmdb_client import fetch_season_details, fetch_show_id
+from app.matcher.tmdb_client import fetch_season_details, fetch_show_details, fetch_show_id
 from tests.fixtures.tmdb_responses import (
     TMDB_SEARCH_ARRESTED_DEVELOPMENT,
     TMDB_SEARCH_BREAKING_BAD,
@@ -14,6 +14,57 @@ from tests.fixtures.tmdb_responses import (
     TMDB_SEARCH_STAR_TREK,
     TMDB_SEASON_DETAILS_S01_3EP,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_tmdb_caches():
+    """Reset the in-process TMDB lru_cache between tests.
+
+    Tests patch ``requests.get`` with different mocks but the cached fetch
+    functions persist across the test module — without this fixture, a later
+    test calling ``fetch_show_id("Arrested Development")`` would receive a
+    None cached by an earlier test's mock instead of hitting the new mock.
+    """
+    fetch_show_id.cache_clear()
+    fetch_show_details.cache_clear()
+    fetch_season_details.cache_clear()
+    yield
+
+
+@pytest.mark.unit
+class TestLruCache:
+    """The build script calls these fetches once per show during selection AND
+    again per season during download. ``@lru_cache`` collapses the duplicates
+    inside a single process; these tests guard against future refactors that
+    accidentally remove the decorator or change argument types."""
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_repeat_call_with_same_arg_hits_cache(self, mock_get):
+        mock_response = Mock()
+        mock_response.json.return_value = {"results": [{"id": "4589", "name": "X"}]}
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test"
+            a = fetch_show_id("X")
+            b = fetch_show_id("X")
+
+        assert a == b
+        # First call hit the network exactly once; second call returned from
+        # the cache without re-invoking requests.get.
+        assert fetch_show_id.cache_info().hits == 1
+
+    def test_cache_clear_resets_state(self):
+        """``cache_clear()`` is the contract test fixtures rely on; if it ever
+        stops working, every test that mutates config between calls breaks
+        silently with the wrong cached value."""
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = ""  # forces early-return path
+            fetch_show_id("Anything")
+            assert fetch_show_id.cache_info().currsize >= 1
+            fetch_show_id.cache_clear()
+            assert fetch_show_id.cache_info().currsize == 0
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -330,14 +330,32 @@ class TestFetchShowIdExactMatch:
 
     @patch("app.matcher.tmdb_client.requests.get")
     def test_api_error_returns_none(self, mock_get):
-        """Test that API error returns None."""
-        mock_get.return_value = Mock(status_code=500)
+        """Test that API error returns None.
+
+        Mock now actually raises HTTPError on raise_for_status() — the
+        previous version of this test relied on the function having an
+        ``if response.status_code == 200:`` guard that silently fell
+        through to return None, which let a 429/500 get permanently
+        cached as None by @lru_cache. With raise_for_status() in place,
+        a transient HTTPError propagates through retries, exhausts, and
+        the public wrapper's try/except returns None — without poisoning
+        the cache.
+        """
+        err_response = Mock(status_code=500)
+        err_response.raise_for_status = Mock(
+            side_effect=requests.exceptions.HTTPError("500 Server Error")
+        )
+        mock_get.return_value = err_response
 
         with patch("app.services.config_service.get_config_sync") as mock_conf:
             mock_conf.return_value.tmdb_api_key = "test_key"
             result = fetch_show_id("Test Show")
 
         assert result is None
+        # Critical: the post-retry HTTPError must NOT be cached as None.
+        # If it were, the next call for "Test Show" would return None
+        # from the cache without ever hitting the network again.
+        assert _fetch_show_id_cached.cache_info().currsize == 0
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -107,6 +107,19 @@ class TestLruCache:
             clear_caches()
             assert _fetch_show_id_cached.cache_info().currsize == 0
 
+    def test_cached_inner_raises_when_called_without_key(self):
+        """Misuse guard: calling ``_fetch_show_id_cached`` directly (bypassing
+        the public wrapper) with no API key must raise loudly, not cache
+        ``None``. This is what the inner/outer split is for — silently
+        caching None here is the exact failure mode we're guarding against.
+        """
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = ""
+            with pytest.raises(RuntimeError, match="without a TMDB API key"):
+                _fetch_show_id_cached("Show")
+        # Confirm the exception didn't leak into the cache.
+        assert _fetch_show_id_cached.cache_info().currsize == 0
+
 
 @pytest.mark.unit
 class TestFetchShowIdVariations:

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -5,7 +5,12 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from app.matcher.tmdb_client import fetch_season_details, fetch_show_details, fetch_show_id
+from app.matcher.tmdb_client import (
+    _fetch_show_id_cached,
+    clear_caches,
+    fetch_season_details,
+    fetch_show_id,
+)
 from tests.fixtures.tmdb_responses import (
     TMDB_SEARCH_ARRESTED_DEVELOPMENT,
     TMDB_SEARCH_BREAKING_BAD,
@@ -25,9 +30,7 @@ def _clear_tmdb_caches():
     test calling ``fetch_show_id("Arrested Development")`` would receive a
     None cached by an earlier test's mock instead of hitting the new mock.
     """
-    fetch_show_id.cache_clear()
-    fetch_show_details.cache_clear()
-    fetch_season_details.cache_clear()
+    clear_caches()
     yield
 
 
@@ -41,6 +44,7 @@ class TestLruCache:
     @patch("app.matcher.tmdb_client.requests.get")
     def test_repeat_call_with_same_arg_hits_cache(self, mock_get):
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {"results": [{"id": "4589", "name": "X"}]}
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
@@ -52,19 +56,56 @@ class TestLruCache:
 
         assert a == b
         # First call hit the network exactly once; second call returned from
-        # the cache without re-invoking requests.get.
-        assert fetch_show_id.cache_info().hits == 1
+        # the cache (the *inner* cached function — the public wrapper itself
+        # is intentionally NOT @lru_cache'd so the no-key early-return
+        # cannot poison the cache).
+        assert _fetch_show_id_cached.cache_info().hits == 1
 
-    def test_cache_clear_resets_state(self):
-        """``cache_clear()`` is the contract test fixtures rely on; if it ever
-        stops working, every test that mutates config between calls breaks
-        silently with the wrong cached value."""
+    def test_no_api_key_does_not_poison_cache(self):
+        """First-boot regression guard.
+
+        Without the inner/outer split, ``fetch_show_id("X")`` called before
+        the user runs ConfigWizard would cache ``None`` keyed on ``"X"``.
+        After the key is set, subsequent calls for the same show would keep
+        returning the cached None until process restart — silently
+        disabling TMDB lookups for those shows. With the split, the no-key
+        path returns without consulting the cache, so a later call with a
+        valid key hits the network normally.
+        """
+        # No key → public wrapper short-circuits; cache must stay empty.
         with patch("app.services.config_service.get_config_sync") as cfg:
-            cfg.return_value.tmdb_api_key = ""  # forces early-return path
-            fetch_show_id("Anything")
-            assert fetch_show_id.cache_info().currsize >= 1
-            fetch_show_id.cache_clear()
-            assert fetch_show_id.cache_info().currsize == 0
+            cfg.return_value.tmdb_api_key = ""
+            assert fetch_show_id("Show With No Key") is None
+        assert _fetch_show_id_cached.cache_info().currsize == 0
+
+        # Key configured → cached path runs and stores the result.
+        with patch("app.matcher.tmdb_client.requests.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200  # branches in the impl gate on this
+            mock_response.json.return_value = {"results": [{"id": "42", "name": "X"}]}
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+            with patch("app.services.config_service.get_config_sync") as cfg:
+                cfg.return_value.tmdb_api_key = "test"
+                assert fetch_show_id("Show With No Key") == "42"
+        assert _fetch_show_id_cached.cache_info().currsize == 1
+
+    def test_clear_caches_resets_all_three(self):
+        """``clear_caches()`` is the contract test fixtures rely on; if it
+        stops working every test that mutates config between calls breaks
+        silently with the wrong cached value."""
+        with patch("app.matcher.tmdb_client.requests.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"results": [{"id": "42", "name": "X"}]}
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+            with patch("app.services.config_service.get_config_sync") as cfg:
+                cfg.return_value.tmdb_api_key = "test"
+                fetch_show_id("X")
+            assert _fetch_show_id_cached.cache_info().currsize >= 1
+            clear_caches()
+            assert _fetch_show_id_cached.cache_info().currsize == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Three workstreams audited against the [OpenSubtitles best-practices doc](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices), plus a long-overdue progress UX for the subtitle-cache build script.

## TL;DR

| Commit | What | Why |
|--------|------|-----|
| [fix(matcher)](https://github.com/Jsakkos/engram/commit/0c314eb) | OS API compliance: User-Agent format, unified retry, daily quota tracking | UA was `"Engram"` / `"Oz 1.0.0"` — non-compliant. Three retry call sites diverged. Daily quota was logged once at login then never refreshed. |
| [perf(tmdb)](https://github.com/Jsakkos/engram/commit/af536d6) | `@lru_cache` on three TMDB fetches | 300-show × 5-season build wasted ~1800 TMDB requests on data that doesn't change within a process. |
| [feat(scripts)](https://github.com/Jsakkos/engram/commit/3eb9223) | rich.progress + RunTally + per-show summary + final tally | A 12h build today shows "[idx/total] Show" and nothing else. No ETA, no quota counter, no per-show roll-up. |

## OpenSubtitles audit findings

Direct read of [.venv/.../opensubtitlescom/opensubtitles.py](https://github.com/opensubtitles/opensubtitlescom-python) revealed the library wraps `requests.HTTPError` into a bare `OpenSubtitlesException(str(http_err))` and **discards the response object** — so `Retry-After` can't be read from exceptions today. The new helper honors the header defensively (auto-benefits if upstream fixes this) and falls back to capped exponential.

The library's `client.user_downloads_remaining` is a free side-effect attribute updated by `login()`/`user_info()`/`download()`. Cheaper than periodic `user_info()` polling — snapshot after each season block.

| Finding | Severity | Resolution |
|---------|----------|------------|
| User-Agent not in "AppName vX.Y.Z" form | SHOULD-FIX | `f"Engram v{__version__}"` at both call sites |
| Login/search/download retries diverged | SHOULD-FIX | Unified through `os_api_retry.os_api_call` |
| Daily quota stale after login | SHOULD-FIX | Snapshot via `client.user_downloads_remaining`, log on 10+ drop |
| `Retry-After` ignored | LIBRARY-LIMITED | Honored defensively; falls back to exponential (no change today) |
| `parent_tmdb_id`/`season_number` usage | ALREADY-CORRECT | n/a |

## Verification

- 594/594 unit tests pass (47 new across `test_os_api_retry.py`, `test_testing_service.py`, `test_tmdb_client.py`, `test_build_subtitle_cache.py`).
- `ruff check . && ruff format --check .` clean.
- The drop-of-10 quota test caught a real implementation bug pre-commit (was comparing against previous snapshot instead of last *logged* value — would have swallowed slow drips).
- A B023 lint catch caught a real loop-variable-capture bug in the Progress callback lambda.

## What this PR does NOT do

- Persistent on-disk TMDB cache across runs (deferred — GitHub Actions cache already preserves SRTs; TMDB metadata cross-run waste is small).
- Show-level skip beyond the existing per-season pre-check (subsumed by lru_cache — duplicate TMDB calls are now free).
- Multi-language support (currently hardcoded `"en"`, out of scope).
- CI workflow changes — see follow-up PR for rolling-release `subtitle-cache-latest` + ops docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)