### PR TITLE
Add Dependabot auto-merge for patch/minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-approves and enables auto-merge on Dependabot PRs for `semver-patch` and `semver-minor` updates
- Major version bumps are intentionally excluded and still require manual review
- Auto-merge only completes after all required CI checks pass — the existing test suite (unit, integration, smoke, E2E, lint) acts as the safety net

## Prerequisites (manual step required)

You need to enable **Allow auto-merge** in your repo settings before this takes effect:

> GitHub repo → Settings → General → Pull Requests → ✅ Allow auto-merge

## Test plan

- [ ] Enable "Allow auto-merge" in repo settings
- [ ] Merge this PR
- [ ] Wait for the next Dependabot PR — it should be automatically approved and set to auto-merge once CI is green
- [ ] Confirm a major-version Dependabot PR (if any) is NOT auto-approved

https://claude.ai/code/session_01DmzHfSSfdKnVcZ7tRL2c2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmzHfSSfdKnVcZ7tRL2c2P)_