### PR TITLE
feat(matcher): surface subtitle provider contribution

### DIFF
--- a/backend/app/matcher/provider_scheduler.py
+++ b/backend/app/matcher/provider_scheduler.py
@@ -131,6 +131,7 @@ class ProviderWorker(threading.Thread):
                 "path": str(result),
                 "source": self.provider_name,
             }
+            logger.info(f"{self.provider_name} downloaded {job.episode_code}")
             self.scheduler.mark_complete(job)
         except Exception as e:
             logger.warning(

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -83,10 +83,11 @@ class RunTally:
     seasons_done: int = 0
     seasons_skipped_below_threshold: int = 0
     seasons_failed: int = 0
-    # Per-provider hit counts (cache, opensubtitles_api, addic7ed, tvsubtitles).
-    # Surfaces which source actually served each episode so a quiet fallback
-    # provider's contribution is visible in the final summary.
-    by_source: Counter = field(default_factory=Counter)
+    # Per-provider download counts (opensubtitles_api, addic7ed, tvsubtitles).
+    # Surfaces which provider served each NEW download so a quiet fallback's
+    # contribution is visible in the final summary. Cache hits are excluded --
+    # they're reported separately and carry no originating-provider info.
+    by_source: Counter[str] = field(default_factory=Counter)
     start_time: float = field(default_factory=time.monotonic)
 
     def elapsed_str(self) -> str:
@@ -245,7 +246,7 @@ def _harvest_show(
             elif status == "not_found":
                 tally.not_found += 1
             source = ep.get("source")
-            if source and status in _VALID_STATUSES:
+            if source and status == "downloaded":
                 tally.by_source[source] += 1
 
         episodes = [

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -23,6 +23,7 @@ import shutil
 import sys
 import tarfile
 import time
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -82,6 +83,10 @@ class RunTally:
     seasons_done: int = 0
     seasons_skipped_below_threshold: int = 0
     seasons_failed: int = 0
+    # Per-provider hit counts (cache, opensubtitles_api, addic7ed, tvsubtitles).
+    # Surfaces which source actually served each episode so a quiet fallback
+    # provider's contribution is visible in the final summary.
+    by_source: Counter = field(default_factory=Counter)
     start_time: float = field(default_factory=time.monotonic)
 
     def elapsed_str(self) -> str:
@@ -239,6 +244,9 @@ def _harvest_show(
                 tally.downloaded += 1
             elif status == "not_found":
                 tally.not_found += 1
+            source = ep.get("source")
+            if source and status in _VALID_STATUSES:
+                tally.by_source[source] += 1
 
         episodes = [
             ep for ep in result["episodes"] if ep["status"] in _VALID_STATUSES and ep.get("path")
@@ -528,6 +536,7 @@ def main() -> int:
     # Progress context but stays usable after the ``with`` exits.
     quota = get_last_quota()
     quota_str = f"{quota['remaining']}" if quota and quota.get("remaining") is not None else "n/a"
+    by_source = ", ".join(f"{s}={n}" for s, n in sorted(tally.by_source.items())) or "none"
     console.log(
         "[bold]Final summary[/]: "
         f"{len(manifest_shows)} shows, {total_episodes} episodes packaged "
@@ -537,6 +546,7 @@ def main() -> int:
         f"  new downloads:    {tally.downloaded}\n"
         f"  not found:        {tally.not_found}\n"
         f"  cache hit rate:   {tally.cache_hit_rate:.0%}\n"
+        f"  by source:        {by_source}\n"
         f"  seasons OK:       {tally.seasons_done}\n"
         f"  seasons skipped:  {tally.seasons_skipped_below_threshold} (below coverage threshold)\n"
         f"  seasons failed:   {tally.seasons_failed}\n"

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -117,6 +117,9 @@ class TestHarvestShowAccumulatesTally:
         assert tally.downloaded == 2
         assert tally.not_found == 1
         assert tally.seasons_done == 1
+        # Per-source breakdown counts only episodes that produced a file;
+        # the not_found episode (source=None) is correctly excluded.
+        assert tally.by_source == {"cache": 1, "opensubtitles_api": 1, "addic7ed": 1}
 
     def test_on_season_done_called_on_success_skip_and_fail(self, bsc):
         """The progress-bar advance hook must fire for every season —

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -117,9 +117,10 @@ class TestHarvestShowAccumulatesTally:
         assert tally.downloaded == 2
         assert tally.not_found == 1
         assert tally.seasons_done == 1
-        # Per-source breakdown counts only episodes that produced a file;
-        # the not_found episode (source=None) is correctly excluded.
-        assert tally.by_source == {"cache": 1, "opensubtitles_api": 1, "addic7ed": 1}
+        # Per-source breakdown counts only NEW downloads by provider; the
+        # cached episode (source=cache) and the not_found episode (source=None)
+        # are both excluded.
+        assert tally.by_source == {"opensubtitles_api": 1, "addic7ed": 1}
 
     def test_on_season_done_called_on_success_skip_and_fail(self, bsc):
         """The progress-bar advance hook must fire for every season —


### PR DESCRIPTION
## Summary
- Investigated why TVsubtitles.net (added in #155) appeared unused in `scripts/build_subtitle_cache.py`. Root cause: **not a routing bug** — TVsubtitles is correctly wired and unit-tested, but it was *invisible* because the scheduler logs nothing on a successful download and the TVsubtitles client is silent on its happy path, while Addic7ed logs a line per episode.
- Add an INFO log on every successful provider download in `provider_scheduler.py` so each provider's contribution (including the quiet TVsubtitles fallback) is visible in real time.
- Add a per-source breakdown (`by source: addic7ed=…, opensubtitles_api=…, tvsubtitles=…`) to the build-cache final summary via a new `RunTally.by_source` counter.
- No download/behavior change — reporting only.

## Verification
- `uv run pytest tests/unit/test_provider_scheduler.py tests/unit/test_build_subtitle_cache.py` → 17 passed
- `ruff check` / `ruff format --check` clean
- Live probe confirmed TVsubtitles resolves "How I Met Your Mother" (show id 110) and returns a valid S01E01 subtitle — i.e. it was silently working all along.

## Test plan
- [x] Unit tests pass
- [x] Lint/format clean
- [ ] Run `uv run python scripts/build_subtitle_cache.py --shows "How I Met Your Mother" --retry-low-coverage` and confirm `tvsubtitles downloaded SxxExx` lines + `by source:` summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)