### PR TITLE
fix(matcher): correct tvsubtitles episode resolution and candidate parsing

### DIFF
--- a/backend/app/matcher/tvsubtitles_client.py
+++ b/backend/app/matcher/tvsubtitles_client.py
@@ -330,6 +330,11 @@ def _find_episode_page(html: str, season: int, episode: int, base_url: str) -> s
     # ``episode-7308-gr.html`` that appear in the flags cell.
     href_re = re.compile(r"^/?episode-\d+\.html$")
     for row in soup.find_all("tr"):
+        # ``recursive=False`` for the cell scan: only the row's OWN cells,
+        # so the wrapper <tr> (whose descendants span every episode) can't
+        # match. The link search below is deliberately recursive — the
+        # ``<a href="episode-*.html">`` lives inside a child <td>, not as a
+        # direct <tr> child, so ``recursive=False`` there would find nothing.
         cells_text = [td.get_text(strip=True) for td in row.find_all("td", recursive=False)]
         if target not in cells_text:
             continue
@@ -389,9 +394,7 @@ def _parse_downloads_near(anchor) -> int:
     labelled cell *within this anchor* (each anchor wraps exactly one entry)
     and pull the integer out, tolerating spaced thousands like ``32 167``.
     """
-    cell = anchor.find("p", attrs={"title": "downloaded"}) or anchor.find(
-        "p", attrs={"alt": "downloaded"}
-    )
+    cell = anchor.find("p", attrs={"title": "downloaded"})
     if cell is None:
         return 0
     digits = re.sub(r"\D", "", cell.get_text())
@@ -403,8 +406,10 @@ def _parse_release_near(anchor) -> str:
 
     The site exposes the rip source and release group in two labelled cells
     (``<p title="rip">DVDRip</p>`` / ``<p title="release">ORPHEUS</p>``);
-    we join the non-empty parts (``"DVDRip.ORPHEUS"``). When both are blank
-    we fall back to the entry's ``<h5>`` display name. Everything is read
+    we join the non-empty parts (``"DVDRip.ORPHEUS"``). When both are blank —
+    e.g. an uploader put the tag only in the title — we fall back to the
+    ``<h5>`` parenthetical (``"... 1x07 (WEB-DL)"`` → ``"WEB-DL"``), or the
+    whole ``<h5>`` label if there is no parenthetical. Everything is read
     from *within this anchor* — the entries are siblings in a shared
     container with no per-entry ``<tr>``, so walking up to a parent would
     grab a neighbouring (often different-language) entry's tag.
@@ -419,7 +424,11 @@ def _parse_release_near(anchor) -> str:
     if parts:
         return ".".join(parts)
     h5 = anchor.find("h5")
-    return h5.get_text(strip=True) if h5 else ""
+    if h5 is None:
+        return ""
+    label = h5.get_text(strip=True)
+    paren = re.search(r"\(([^)]+)\)\s*$", label)
+    return paren.group(1) if paren else label
 
 
 def _extract_download_page_url(html: str, base_url: str) -> str | None:

--- a/backend/app/matcher/tvsubtitles_client.py
+++ b/backend/app/matcher/tvsubtitles_client.py
@@ -310,21 +310,27 @@ def _find_episode_page(html: str, season: int, episode: int, base_url: str) -> s
     ``{season}x{episode}`` row.
 
     The season page renders episodes as a table where one cell of each row
-    contains the literal text ``{S}x{EE}`` (zero-padded episode). We scan
-    every row, look for that cell anywhere in the row (NOT just the first
-    cell — the row layout puts a per-row counter before the episode
-    designator), and return the ``/episode-{n}.html`` anchor from the same
-    row.
+    contains the literal text ``{S}x{EE}`` (zero-padded episode), and the
+    ``/episode-{n}.html`` link sits in another cell of the SAME row.
+
+    Crucially, that episode table is nested inside outer layout tables, so
+    ``find_all("td")`` is restricted to each row's DIRECT children
+    (``recursive=False``). Without that restriction the outermost wrapper
+    ``<tr>`` transitively contains every episode's cells, matches any
+    target, and returns the first episode link in the document — i.e. every
+    requested episode resolves to the highest-numbered episode's page.
     """
     soup = BeautifulSoup(html, "html.parser")
     target = f"{season}x{episode:02d}"
     # Season-page episode hrefs are RELATIVE (``episode-8080.html``), not
     # absolute. urljoin with a base_url ending in ``/`` reattaches the
     # host correctly. The regex tolerates either form so the parser
-    # doesn't silently miss episodes if the markup ever flips.
+    # doesn't silently miss episodes if the markup ever flips, and the
+    # trailing ``\.html$`` rejects language-suffixed links such as
+    # ``episode-7308-gr.html`` that appear in the flags cell.
     href_re = re.compile(r"^/?episode-\d+\.html$")
     for row in soup.find_all("tr"):
-        cells_text = [td.get_text(strip=True) for td in row.find_all("td")]
+        cells_text = [td.get_text(strip=True) for td in row.find_all("td", recursive=False)]
         if target not in cells_text:
             continue
         link = row.find("a", href=href_re)
@@ -374,29 +380,46 @@ _LANGUAGE_NAMES = {"en": "english", "es": "spanish", "fr": "french", "de": "germ
 
 
 def _parse_downloads_near(anchor) -> int:
-    """Best-effort download-count extraction.
+    """Extract one subtitle entry's download count.
 
-    The page renders counts as ``"123 downloads"`` in the row or as
-    a coloured ``<span>{good}/{total}</span>`` widget. The integer right
-    before ``downloads`` (case-insensitive) is the most reliable signal.
+    The count is a bare integer inside the entry's own
+    ``<p title="downloaded"><img .../> 32167</p>`` cell — there is no
+    literal "downloads" text on the page, and the small ``{x}/{y}`` widget
+    at the top of each entry is a rating, not a download count. We read the
+    labelled cell *within this anchor* (each anchor wraps exactly one entry)
+    and pull the integer out, tolerating spaced thousands like ``32 167``.
     """
-    container = anchor.find_parent("tr") or anchor.parent
-    if container is None:
+    cell = anchor.find("p", attrs={"title": "downloaded"}) or anchor.find(
+        "p", attrs={"alt": "downloaded"}
+    )
+    if cell is None:
         return 0
-    text = container.get_text(" ", strip=True)
-    m = re.search(r"(\d+)\s*downloads?", text, flags=re.IGNORECASE)
-    if m:
-        return int(m.group(1))
-    return 0
+    digits = re.sub(r"\D", "", cell.get_text())
+    return int(digits) if digits else 0
 
 
 def _parse_release_near(anchor) -> str:
-    """Best-effort release-tag extraction."""
-    container = anchor.find_parent("tr") or anchor.parent
-    if container is None:
-        return ""
-    rel = container.find(string=re.compile(r"\b(?:WEB|HDTV|BluRay|x264|x265)\b", re.IGNORECASE))
-    return str(rel).strip() if rel else ""
+    """Extract one subtitle entry's release tag.
+
+    The site exposes the rip source and release group in two labelled cells
+    (``<p title="rip">DVDRip</p>`` / ``<p title="release">ORPHEUS</p>``);
+    we join the non-empty parts (``"DVDRip.ORPHEUS"``). When both are blank
+    we fall back to the entry's ``<h5>`` display name. Everything is read
+    from *within this anchor* — the entries are siblings in a shared
+    container with no per-entry ``<tr>``, so walking up to a parent would
+    grab a neighbouring (often different-language) entry's tag.
+    """
+    parts = []
+    for label in ("rip", "release"):
+        cell = anchor.find("p", attrs={"title": label})
+        if cell:
+            text = cell.get_text(strip=True)
+            if text:
+                parts.append(text)
+    if parts:
+        return ".".join(parts)
+    h5 = anchor.find("h5")
+    return h5.get_text(strip=True) if h5 else ""
 
 
 def _extract_download_page_url(html: str, base_url: str) -> str | None:

--- a/backend/tests/integration/test_subtitle_workflow.py
+++ b/backend/tests/integration/test_subtitle_workflow.py
@@ -267,6 +267,7 @@ class TestCacheBehavior:
         assert "Downloaded subtitle content" in (show_dir / "Test Show - S01E02.srt").read_text()
         assert "Downloaded subtitle content" in (show_dir / "Test Show - S01E03.srt").read_text()
 
+    @patch("app.matcher.testing_service.TVSubtitlesClient")
     @patch("app.matcher.testing_service.Addic7edClient")
     @patch("app.matcher.tmdb_client.requests.get")
     @patch("app.services.config_service.get_config_sync")
@@ -275,9 +276,15 @@ class TestCacheBehavior:
         mock_config_sync,
         mock_requests,
         mock_addic7ed,
+        mock_tvsubtitles,
         tmp_path,
     ):
-        """Test workflow with mixed cache hits, downloads, and not found."""
+        """Test workflow with mixed cache hits, downloads, and not found.
+
+        Both fallback providers must be mocked: episode 3 is "not found"
+        only if *no* provider resolves it, so TVSubtitlesClient is stubbed
+        to return nothing. Without this stub the scheduler would fall
+        through to the live tvsubtitles.net for the not-found episode."""
         # Pre-populate cache with episode 1 (valid SRT content with --> markers, >= 50 bytes)
         show_dir = tmp_path / "data" / "Test Show"
         show_dir.mkdir(parents=True)
@@ -330,6 +337,13 @@ class TestCacheBehavior:
             return save_path
 
         addic7ed_client.download_subtitle.side_effect = download_side_effect
+
+        # TVsubtitles is the second provider in the fallback chain; stub it
+        # to find nothing so episode 3 stays genuinely "not found" instead
+        # of reaching the live site.
+        tvsubtitles_client = Mock()
+        mock_tvsubtitles.return_value = tvsubtitles_client
+        tvsubtitles_client.get_best_subtitle.return_value = None
 
         # Execute
         result = download_subtitles("Test Show", 1)

--- a/backend/tests/unit/test_tvsubtitles_client.py
+++ b/backend/tests/unit/test_tvsubtitles_client.py
@@ -236,11 +236,22 @@ class TestFindEpisodePage:
         assert mid != "https://x/episode-7310.html"
 
     def test_ignores_language_suffixed_episode_links(self):
-        """The flags cell can carry ``episode-{n}-{lang}.html`` links; the
-        href regex must require ``.html`` right after the digits so those
-        don't shadow the canonical episode link."""
-        url = _find_episode_page(_SEASON_HTML, 1, 1, base_url="https://x")
-        assert url == "https://x/episode-7289.html"
+        """The flags cell can carry ``episode-{n}-{lang}.html`` links. Here
+        the language-suffixed link is placed BEFORE the canonical one in the
+        row's link order, so a regex not anchored with ``\\.html$`` right
+        after the digits would return it. The parser must skip it and pick
+        the canonical ``episode-{n}.html``."""
+        html = """
+        <html><body><table><tr>
+          <td>1x01</td>
+          <td>
+            <a href="episode-555-gr.html">greek</a>
+            <a href="episode-555.html"><b>Pilot</b></a>
+          </td>
+        </tr></table></body></html>
+        """
+        url = _find_episode_page(html, 1, 1, base_url="https://x")
+        assert url == "https://x/episode-555.html"
 
 
 @pytest.mark.unit
@@ -286,6 +297,26 @@ class TestParseSubtitleCandidates:
         assert english.subtitle_page_url.endswith("/subtitle-8548.html")
         assert english.downloads == 32167
         assert "HDTV" not in english.release
+
+    def test_release_falls_back_to_h5_parenthetical_when_cells_empty(self):
+        """When the structured rip/release cells are blank (an uploader put
+        the tag only in the title), the release is taken from the <h5>
+        parenthetical — ``"... 3x04 (WEB-DL)"`` → ``"WEB-DL"`` — not the
+        whole label."""
+        html = """
+        <html><body><div class="left_articles">
+        <a href="/subtitle-9001.html"><div title="Download English subtitles" class="subtitlen">
+          <h5>Some Show 3x04 (WEB-DL)</h5>
+          <p title="rip"></p>
+          <p title="release"></p>
+          <p title="downloaded">777</p>
+        </div></a>
+        </div></body></html>
+        """
+        results = _parse_subtitle_candidates(html, base_url="https://x", language="en")
+        assert len(results) == 1
+        assert results[0].release == "WEB-DL"
+        assert results[0].downloads == 777
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_tvsubtitles_client.py
+++ b/backend/tests/unit/test_tvsubtitles_client.py
@@ -33,34 +33,137 @@ _SEARCH_HTML = """
 </body></html>
 """
 
-# Season page: each row has a per-row counter cell, an episode designator
-# in ``{S}x{EE}`` form, and an /episode-{n}.html link.
+# Season page: VERBATIM-captured shape from tvshow-110-1.html (How I Met
+# Your Mother S1, 2026-05-20). Two structural facts the old hand-written
+# fixture missed and which broke _find_episode_page in production:
+#   1. The episode table is wrapped in OUTER tables (``table4`` → ``table5``),
+#      so a recursive ``find_all('td')`` on the outer <tr> collects EVERY
+#      episode's cells at once.
+#   2. Episodes are listed in DESCENDING order (1x22 first), and the first
+#      column IS the ``{S}x{EE}`` designator (no separate counter cell).
+# Together these made the old parser match the wrapper row for any target
+# and return the first episode link (1x22) regardless of the request.
+# The ``episode-7289-gr.html`` link in the flags cell guards the href regex
+# against language-suffixed episode links.
 _SEASON_HTML = """
 <html><body>
-<table>
-  <tr><td>15</td><td>1x01</td><td><a href="/episode-8080.html">Pilot</a></td></tr>
-  <tr><td>15</td><td>1x02</td><td><a href="/episode-8081.html">Cat's in the Bag</a></td></tr>
-  <tr><td>15</td><td>1x03</td><td><a href="/episode-8082.html">And the Bag's in the River</a></td></tr>
+<table id="table4" align="center" width=100%><tr><td>
+<table id="table5">
+<tr align="middle"><th><b>#</b></th><th><b>Episode</b></th><th><b>Amount</b></th><th><b>Subtitles</b></th></tr>
+<tr align="middle" bgcolor="#ffffff">
+<td>1x22</td>
+<td align=left style="padding: 0 4px;"><a href="episode-7310.html"><b>Come On</b></a></td>
+<td>10</td>
+<td><nobr><a href="subtitle-8548.html"><img src="images/flags/en.gif" alt="en" border=0></a></nobr></td>
+</tr>
+<tr align="middle" bgcolor="#ffffff">
+<td>1x02</td>
+<td align=left style="padding: 0 4px;"><a href="episode-7290.html"><b>Purple Giraffe</b></a></td>
+<td>10</td>
+<td><nobr><a href="subtitle-8528.html"><img src="images/flags/en.gif" alt="en" border=0></a></nobr></td>
+</tr>
+<tr align="middle" bgcolor="#ffffff">
+<td>1x01</td>
+<td align=left style="padding: 0 4px;"><a href="episode-7289.html"><b>Pilot</b></a></td>
+<td>11</td>
+<td><nobr><a href="subtitle-8527.html"><img src="images/flags/en.gif" alt="en" border=0></a>&nbsp;<a href="episode-7289-gr.html"><img src="images/flags/gr.gif" alt="gr" border=0></a></nobr></td>
+</tr>
 </table>
+</td></tr></table>
 </body></html>
 """
 
-# Episode page: each subtitle entry is an anchor with an inner div whose
-# title attribute identifies the language. English-only here.
+# Episode page: VERBATIM-captured shape from episode-8600.html (Breaking
+# Bad, 2026-05-20). Each subtitle is ``<a href="/subtitle-N.html"><div
+# class="subtitlen">…</div></a>`` and all anchors are SIBLINGS inside one
+# ``left_articles`` container — there are NO per-entry <tr> rows. The real
+# download count is a bare integer in ``<p title="downloaded">`` (there is
+# no literal "downloads" text anywhere), and rip/release tags live in
+# labelled <p> cells / the <h5>. Two English entries (different releases &
+# counts) plus one Spanish entry exercise language filtering, per-entry
+# download parsing, and download-descending selection.
 _EPISODE_HTML = """
 <html><body>
-<table>
-  <tr><td>
-    <a href="/subtitle-2001.html">
-      <div title="Download English subtitles" class="subtitlen">WEB-DL.x264 — 1250 downloads</div>
-    </a>
-  </td></tr>
-  <tr><td>
-    <a href="/subtitle-2002.html">
-      <div title="Download Spanish subtitles" class="subtitlen">HDTV — 400 downloads</div>
-    </a>
-  </td></tr>
-</table>
+<div id="content"><div class="left"><div class="left_articles">
+<h2>Breaking Bad 1x07</h2>
+<b>Subtitles for this episode:</b>
+<div style="clear:both; padding-top:10px;"><span style="color:#666666"><b>English  subtitles</b></span></div>
+<a href="/subtitle-11668.html"><div title="Download English subtitles"  class="subtitlen" >
+<div style="float:right; margin:0 2px;"><span style="color:black; font-weight:bold"><span style="color:red">9</span>/<span style="color:green">34</span></span></div>
+    <h5 style="width:600px;"><img src="images/flags/en.gif" width="18" height="12" alt="" border=0 hspace=4 align=absmiddle>Breaking Bad 1x07 (DSR.LOL)</h5>
+    <p style="width:110px; margin-left:50px" alt="rip" title="rip"><img src="images/rip.gif" width="16" height="16" alt="rip" title="rip" border=0 hspace=4 align="absmiddle">
+	DSR</p>
+	<p style="width:110px;" alt="release" title="release"><img src="images/release.gif" width="16" height="16" alt="release" title="release" border=0 hspace=4 align="absmiddle">
+	LOL</p>
+    <p style="width:70px;line-height: 10px;margin-right:40px;\\ alt="uploaded" title="uploaded"><img src="images/time.png" width="16" height="16" alt="uploaded" title="uploaded" border=0 vspace=4 hspace=4 align="left">
+	<small style="margin:0; padding:0; display:inline; line-height: 10px;">02.11.09 10:49:44</small></p>
+	<p style="width:120px; line-height: 10px;" alt="author" title="author"><nobr><img src="images/user.png" width="16" height="16" alt="author" title="author" border=0 hspace=2 align="absmiddle">
+	<small style="margin:0; padding:0; display:inline; line-height: 10px;">&nbsp;</small></nobr></p>
+	<p style="width:100px;" alt="downloaded" title="downloaded"><img src="images/downloads.png" width="16" height="16" alt="downloaded" title="downloaded" border=0 hspace=4 align="absmiddle">
+	29041</p>
+</div></a>
+<a href="/subtitle-51323.html"><div title="Download English subtitles"  class="subtitlen" >
+<div style="float:right; margin:0 2px;"><span style="color:black; font-weight:bold"><span style="color:red">0</span>/<span style="color:green">6</span></span></div>
+    <h5 style="width:600px;"><img src="images/flags/en.gif" width="18" height="12" alt="" border=0 hspace=4 align=absmiddle>Breaking Bad 1x07 (DVDRip.ORPHEUS)</h5>
+    <p style="width:110px; margin-left:50px" alt="rip" title="rip"><img src="images/rip.gif" width="16" height="16" alt="rip" title="rip" border=0 hspace=4 align="absmiddle">
+	DVDRip</p>
+	<p style="width:110px;" alt="release" title="release"><img src="images/release.gif" width="16" height="16" alt="release" title="release" border=0 hspace=4 align="absmiddle">
+	ORPHEUS</p>
+    <p style="width:70px;line-height: 10px;margin-right:40px;\\ alt="uploaded" title="uploaded"><img src="images/time.png" width="16" height="16" alt="uploaded" title="uploaded" border=0 vspace=4 hspace=4 align="left">
+	<small style="margin:0; padding:0; display:inline; line-height: 10px;">02.11.09 10:51:16</small></p>
+	<p style="width:120px; line-height: 10px;" alt="author" title="author"><nobr><img src="images/user.png" width="16" height="16" alt="author" title="author" border=0 hspace=2 align="absmiddle">
+	<small style="margin:0; padding:0; display:inline; line-height: 10px;">&nbsp;</small></nobr></p>
+	<p style="width:100px;" alt="downloaded" title="downloaded"><img src="images/downloads.png" width="16" height="16" alt="downloaded" title="downloaded" border=0 hspace=4 align="absmiddle">
+	30749</p>
+</div></a>
+<div style="clear:both; padding-top:10px;"><span style="color:#666666"><b>Spanish  subtitles</b></span></div>
+<a href="/subtitle-72826.html"><div title="Download Spanish subtitles"  class="subtitlen" >
+<div style="float:right; margin:0 2px;"><span style="color:black; font-weight:bold"><span style="color:red">1</span>/<span style="color:green">3</span></span></div>
+    <h5 style="width:600px;"><img src="images/flags/es.gif" width="18" height="12" alt="" border=0 hspace=4 align=absmiddle>Breaking Bad 1x07 </h5>
+    <p style="width:110px; margin-left:50px" alt="rip" title="rip"><img src="images/rip.gif" width="16" height="16" alt="rip" title="rip" border=0 hspace=4 align="absmiddle">
+	</p>
+	<p style="width:110px;" alt="release" title="release"><img src="images/release.gif" width="16" height="16" alt="release" title="release" border=0 hspace=4 align="absmiddle">
+	</p>
+	<p style="width:100px;" alt="downloaded" title="downloaded"><img src="images/downloads.png" width="16" height="16" alt="downloaded" title="downloaded" border=0 hspace=4 align="absmiddle">
+	8104</p>
+</div></a>
+</div></div></div>
+</body></html>
+"""
+
+# Cross-language episode shape from episode-7310.html (How I Met Your
+# Mother, 2026-05-20). The English entry has NO release tag (empty rip/
+# release cells, no parenthetical in its <h5>), and it sits immediately
+# before a Russian entry whose <h5> and rip cell say "HDTV". This is the
+# exact arrangement that made the old shared-container release parser
+# attribute the Russian "(HDTV)" tag to the English subtitle.
+_EPISODE_HTML_CROSS_LANG = """
+<html><body>
+<div id="content"><div class="left"><div class="left_articles">
+<h2>How I Met Your Mother 1x22</h2>
+<div style="clear:both; padding-top:10px;"><span style="color:#666666"><b>English  subtitles</b></span></div>
+<a href="/subtitle-8548.html"><div title="Download English subtitles"  class="subtitlen" >
+<div style="float:right; margin:0 2px;"><span style="color:black; font-weight:bold"><span style="color:red">12</span>/<span style="color:green">5</span></span></div>
+    <h5 style="width:600px;"><img src="images/flags/en.gif" width="18" height="12" alt="" border=0 hspace=4 align=absmiddle>How I Met Your Mother 1x22 </h5>
+    <p style="width:110px; margin-left:50px" alt="rip" title="rip"><img src="images/rip.gif" width="16" height="16" alt="rip" title="rip" border=0 hspace=4 align="absmiddle">
+	</p>
+	<p style="width:110px;" alt="release" title="release"><img src="images/release.gif" width="16" height="16" alt="release" title="release" border=0 hspace=4 align="absmiddle">
+	</p>
+	<p style="width:100px;" alt="downloaded" title="downloaded"><img src="images/downloads.png" width="16" height="16" alt="downloaded" title="downloaded" border=0 hspace=4 align="absmiddle">
+	32167</p>
+</div></a>
+<div style="clear:both; padding-top:10px;"><span style="color:#666666"><b>Russian  subtitles</b></span></div>
+<a href="/subtitle-23772.html"><div title="Download Russian subtitles"  class="subtitlen" >
+<div style="float:right; margin:0 2px;"><span style="color:black; font-weight:bold"><span style="color:red">0</span>/<span style="color:green">0</span></span></div>
+    <h5 style="width:600px;"><img src="images/flags/ru.gif" width="18" height="12" alt="" border=0 hspace=4 align=absmiddle>How I Met Your Mother 1x22 (HDTV)</h5>
+    <p style="width:110px; margin-left:50px" alt="rip" title="rip"><img src="images/rip.gif" width="16" height="16" alt="rip" title="rip" border=0 hspace=4 align="absmiddle">
+	HDTV</p>
+	<p style="width:110px;" alt="release" title="release"><img src="images/release.gif" width="16" height="16" alt="release" title="release" border=0 hspace=4 align="absmiddle">
+	</p>
+	<p style="width:100px;" alt="downloaded" title="downloaded"><img src="images/downloads.png" width="16" height="16" alt="downloaded" title="downloaded" border=0 hspace=4 align="absmiddle">
+	1793</p>
+</div></a>
+</div></div></div>
 </body></html>
 """
 
@@ -111,20 +214,33 @@ class TestParseFirstShowId:
 class TestFindEpisodePage:
     def test_returns_url_for_matched_episode(self):
         url = _find_episode_page(
-            _SEASON_HTML, season=1, episode=2, base_url="https://tvsubtitles.net"
+            _SEASON_HTML, season=1, episode=1, base_url="https://tvsubtitles.net"
         )
-        assert url == "https://tvsubtitles.net/episode-8081.html"
+        assert url == "https://tvsubtitles.net/episode-7289.html"
 
     def test_returns_none_for_missing_episode(self):
         assert _find_episode_page(_SEASON_HTML, 1, 99, base_url="x") is None
 
-    def test_does_not_match_per_row_counter(self):
-        """The first cell of each row is a per-row counter (often 15 or
-        similar) — it must NOT be mistaken for the episode number."""
-        url = _find_episode_page(
-            _SEASON_HTML, season=1, episode=15, base_url="https://tvsubtitles.net"
-        )
-        assert url is None
+    def test_nested_wrapper_tables_do_not_collapse_to_first_episode(self):
+        """The season table is wrapped in outer tables, so the outermost
+        <tr> transitively contains every episode's cells. A recursive cell
+        scan matched that wrapper row for ANY target and returned the first
+        episode link (1x22) — so every requested episode resolved to the
+        same wrong page. Each target must resolve to its OWN episode link."""
+        first = _find_episode_page(_SEASON_HTML, 1, 1, base_url="https://x")
+        mid = _find_episode_page(_SEASON_HTML, 1, 2, base_url="https://x")
+        assert first == "https://x/episode-7289.html"
+        assert mid == "https://x/episode-7290.html"
+        # If the wrapper-row bug regressed, both would collapse to 1x22.
+        assert first != "https://x/episode-7310.html"
+        assert mid != "https://x/episode-7310.html"
+
+    def test_ignores_language_suffixed_episode_links(self):
+        """The flags cell can carry ``episode-{n}-{lang}.html`` links; the
+        href regex must require ``.html`` right after the digits so those
+        don't shadow the canonical episode link."""
+        url = _find_episode_page(_SEASON_HTML, 1, 1, base_url="https://x")
+        assert url == "https://x/episode-7289.html"
 
 
 @pytest.mark.unit
@@ -133,9 +249,43 @@ class TestParseSubtitleCandidates:
         results = _parse_subtitle_candidates(
             _EPISODE_HTML, base_url="https://tvsubtitles.net", language="en"
         )
+        # Two English entries are kept; the Spanish entry is filtered out.
+        assert {r.subtitle_page_url for r in results} == {
+            "https://tvsubtitles.net/subtitle-11668.html",
+            "https://tvsubtitles.net/subtitle-51323.html",
+        }
+
+    def test_parses_each_entrys_own_download_count(self):
+        """The count is a bare integer in the entry's ``<p title="downloaded">``
+        cell. The old ``(\\d+)\\s*downloads?`` regex found no "downloads"
+        text on the page and returned 0 for every entry, making the
+        download-descending selection arbitrary."""
+        results = _parse_subtitle_candidates(_EPISODE_HTML, base_url="https://x", language="en")
+        by_file = {r.subtitle_page_url.rsplit("/", 1)[-1]: r for r in results}
+        assert by_file["subtitle-11668.html"].downloads == 29041
+        assert by_file["subtitle-51323.html"].downloads == 30749
+
+    def test_release_uses_structured_rip_and_release_cells(self):
+        results = _parse_subtitle_candidates(_EPISODE_HTML, base_url="https://x", language="en")
+        by_file = {r.subtitle_page_url.rsplit("/", 1)[-1]: r for r in results}
+        assert by_file["subtitle-11668.html"].release == "DSR.LOL"
+        assert by_file["subtitle-51323.html"].release == "DVDRip.ORPHEUS"
+
+    def test_release_is_read_from_the_same_entry_not_a_neighbour(self):
+        """Regression: the English entry has empty rip/release cells and no
+        parenthetical, while the adjacent Russian entry is tagged "HDTV".
+        The old parser walked up to the shared ``left_articles`` container
+        (no per-entry <tr> exists) and grabbed the Russian tag for the
+        English subtitle. Each entry's data must come from within its own
+        anchor."""
+        results = _parse_subtitle_candidates(
+            _EPISODE_HTML_CROSS_LANG, base_url="https://x", language="en"
+        )
         assert len(results) == 1
-        assert results[0].subtitle_page_url.endswith("/subtitle-2001.html")
-        assert results[0].downloads == 1250
+        english = results[0]
+        assert english.subtitle_page_url.endswith("/subtitle-8548.html")
+        assert english.downloads == 32167
+        assert "HDTV" not in english.release
 
 
 @pytest.mark.unit
@@ -171,8 +321,9 @@ class TestExtractZipPathFromJs:
 @pytest.mark.unit
 class TestGetBestSubtitle:
     def test_walks_search_to_episode_to_subtitle(self):
-        """End-to-end walk: search (POST) → season → episode → first
-        English subtitle entry."""
+        """End-to-end walk: search (POST) → season → episode → English
+        subtitle entries. Of the two English entries the higher
+        download count (30749, subtitle-51323) must win the selection."""
         client = TVSubtitlesClient()
         with (
             patch.object(client, "_post") as mock_post,
@@ -183,10 +334,10 @@ class TestGetBestSubtitle:
                 Mock(text=_SEASON_HTML, raise_for_status=Mock()),
                 Mock(text=_EPISODE_HTML, raise_for_status=Mock()),
             ]
-            result = client.get_best_subtitle("Breaking Bad", season=1, episode=2)
+            result = client.get_best_subtitle("Breaking Bad", season=1, episode=1)
         assert result is not None
-        assert result.downloads == 1250
-        assert result.subtitle_page_url.endswith("/subtitle-2001.html")
+        assert result.downloads == 30749
+        assert result.subtitle_page_url.endswith("/subtitle-51323.html")
 
     def test_returns_none_when_show_not_found(self):
         client = TVSubtitlesClient()
@@ -210,8 +361,8 @@ class TestGetBestSubtitle:
                 Mock(text=_SEASON_HTML, raise_for_status=Mock()),
                 Mock(text=_EPISODE_HTML, raise_for_status=Mock()),
             ]
+            client.get_best_subtitle("Breaking Bad", 1, 1)
             client.get_best_subtitle("Breaking Bad", 1, 2)
-            client.get_best_subtitle("Breaking Bad", 1, 3)
         # 1 POST + 2×(season GET + episode GET) = 1 + 4 = 5 total.
         assert mock_post.call_count == 1
         assert mock_get.call_count == 4


### PR DESCRIPTION
## Summary
A live probe of `get_best_subtitle('How I Met Your Mother',1,1)` returned `downloads=0`, `release='How I Met Your Mother 1x22 (HDTV)'` for a query of S01**E01**. Investigation surfaced **three** parsing bugs in `tvsubtitles_client.py`, all masked by hand-written unit fixtures that didn't match the deployed site:

1. **Wrong episode entirely** — `_find_episode_page` used a recursive `find_all("td")`. The real season table is nested inside outer layout tables, so the outermost `<tr>` transitively contained *every* episode's cells, matched any target, and returned the first episode link. **Every** requested episode resolved to the highest-numbered episode's page (the real source of the `1x22` symptom). Fixed with `recursive=False`.
2. **Always `downloads=0`** — `_parse_downloads_near` matched `(\d+)\s*downloads?`, but the page has no "downloads" text; the count is a bare integer in `<p title="downloaded">`. With every candidate at 0, the download-descending "best" selection was arbitrary. Now reads the labelled cell within the entry's anchor.
3. **Cross-row release contamination** — `_parse_release_near` walked up to a shared container (entries are sibling `<a>` in one `left_articles` div; there is no per-entry `<tr>`) and grabbed a neighbouring language's tag. Now reads the entry's own `rip`/`release` cells (fallback `<h5>`).

### Live result, before → after
```
before: release='How I Met Your Mother 1x22 (HDTV)', downloads=0,      subtitle-8548.html
after:  release='How I Met Your Mother 1x01',        downloads=144174, subtitle-8527.html
```

## Tests
- Replaced the synthetic season/episode fixtures with **verbatim-captured** HTML (nested season table, Breaking Bad multi-English episode, HIMYM cross-language episode).
- Added regression tests for all three bugs (each verified red→green).
- Mocked `TVSubtitlesClient` in the subtitle-workflow not-found test so the fallback no longer reaches the live site.

## Test plan
- [x] `uv run pytest tests/unit/test_tvsubtitles_client.py` — 21 passed
- [x] `uv run pytest tests/unit` — 678 passed
- [x] subtitle consumers + integration workflow — 64 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Live repro returns correct episode, nonzero downloads, correct release

🤖 Generated with [Claude Code](https://claude.com/claude-code)