### PR TITLE
matcher: from-disk subtitle cache packager + harvest robustness

### DIFF
--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -485,6 +485,16 @@ class EpisodeMatcher:
         self._precomputed_manifest = manifest
         return manifest
 
+    def load_precomputed_season(self, season_number):
+        """Public entry point over the precomputed-cache loader.
+
+        Exposed so the cache packager's publish-gate verification can exercise
+        the real load path without reaching into a private method. Returns
+        (ref_matrix, episode_codes, idf_array) when the shipped cache covers
+        this show+season, otherwise None.
+        """
+        return self._load_precomputed_season(season_number)
+
     def _load_precomputed_season(self, season_number):
         """Load precomputed hashed TF-IDF vectors for this show/season.
 

--- a/backend/app/matcher/provider_scheduler.py
+++ b/backend/app/matcher/provider_scheduler.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import queue
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -78,6 +79,98 @@ class EpisodeJob:
     result: dict[str, Any] | None = None
 
 
+class _CircuitBreaker:
+    """Per-provider circuit breaker.
+
+    A provider that's *down* (connect timeouts, 5xx) otherwise costs one
+    failed attempt — and its full timeout — for EVERY episode in the batch,
+    because residual jobs are all queued at the same head provider upfront.
+    This breaker trips after ``failure_threshold`` consecutive transport
+    failures, after which the worker fast-skips its remaining jobs to the
+    next provider without calling the dead one. After ``cooldown`` seconds it
+    half-opens and lets a single probe job through: success closes it, failure
+    re-opens it with a doubled cooldown (capped at ``max_cooldown``).
+
+    Only transport failures (exceptions) count. A clean miss or an unusable
+    download means the provider *responded* — it's reachable — so those reset
+    the counter. ``now`` is injectable purely so the state machine is testable
+    without wall-clock sleeps; production passes ``time.monotonic()``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 3,
+        base_cooldown: float = 30.0,
+        max_cooldown: float = 300.0,
+    ):
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.base_cooldown = base_cooldown
+        self.max_cooldown = max_cooldown
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._open = False
+        self._opened_at = 0.0
+        self._cooldown = base_cooldown
+        self._probe_in_flight = False
+
+    def allow(self, now: float | None = None) -> bool:
+        """True if a job may be sent to this provider right now."""
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            if not self._open:
+                return True
+            if now - self._opened_at < self._cooldown:
+                return False
+            # Cooldown elapsed → half-open. Let exactly ONE probe through; its
+            # outcome (record_success / record_failure) decides what happens
+            # next. Concurrent callers see probe_in_flight and stay blocked.
+            if self._probe_in_flight:
+                return False
+            self._probe_in_flight = True
+            logger.info(f"{self.name} circuit half-open: probing recovery")
+            return True
+
+    def record_success(self) -> None:
+        """The provider responded (hit, miss, or unusable download). Reset."""
+        with self._lock:
+            if self._open:
+                logger.info(f"{self.name} circuit closed (recovered)")
+            self._consecutive_failures = 0
+            self._open = False
+            self._probe_in_flight = False
+            self._cooldown = self.base_cooldown
+
+    def record_failure(self, now: float | None = None) -> None:
+        """A transport-level failure (exception) talking to the provider."""
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            was_probe = self._probe_in_flight
+            self._probe_in_flight = False
+            if self._open:
+                # A probe failed → stay open and back off further. Stragglers
+                # (jobs dispatched just before the trip) failing while already
+                # open don't move the window.
+                if was_probe:
+                    self._cooldown = min(self._cooldown * 2, self.max_cooldown)
+                    self._opened_at = now
+                    logger.warning(
+                        f"{self.name} circuit re-opened after failed probe; "
+                        f"cooldown now {self._cooldown:.0f}s"
+                    )
+                return
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= self.failure_threshold:
+                self._open = True
+                self._opened_at = now
+                self._cooldown = self.base_cooldown
+                logger.warning(
+                    f"{self.name} circuit opened after {self._consecutive_failures} "
+                    f"consecutive failures; skipping it for {self._cooldown:.0f}s"
+                )
+
+
 class ProviderWorker(threading.Thread):
     """Thread bound to one provider client. Pulls from its private
     ``queue.Queue``; the scheduler dispatches jobs whose
@@ -101,44 +194,65 @@ class ProviderWorker(threading.Thread):
                 self.queue.task_done()
 
     def _process_job(self, job: EpisodeJob) -> None:
+        # Skip without touching the network if this provider's breaker is open.
+        # This is what makes a dead provider cheap: the residual jobs were all
+        # queued at the head provider upfront, so once it trips the worker
+        # fast-advances its backlog instead of paying a timeout per job.
+        if not self.scheduler.provider_allows(self.provider_name):
+            logger.debug(f"{self.provider_name} circuit open; skipping {job.episode_code}")
+            self.scheduler.advance_or_fail(job)
+            return
+
         try:
-            entry = self.client.get_best_subtitle(job.show_name, job.season, job.episode)
-            if entry is None:
-                logger.debug(
-                    f"{self.provider_name} miss for {job.show_name} S{job.season:02d}"
-                    f"E{job.episode:02d}"
-                )
-                self.scheduler.advance_or_fail(job)
-                return
-
-            result = self.client.download_subtitle(entry, job.srt_target)
-            if result is None:
-                self.scheduler.advance_or_fail(job)
-                return
-
-            if not is_valid_srt_file(Path(result)):
-                logger.warning(
-                    f"{self.provider_name} returned an invalid SRT for "
-                    f"{job.episode_code}; deleting and trying next provider"
-                )
-                Path(result).unlink(missing_ok=True)
-                self.scheduler.advance_or_fail(job)
-                return
-
-            job.result = {
-                "code": job.episode_code,
-                "status": "downloaded",
-                "path": str(result),
-                "source": self.provider_name,
-            }
-            logger.info(f"{self.provider_name} downloaded {job.episode_code}")
-            self.scheduler.mark_complete(job)
+            outcome = self._attempt(job)
         except Exception as e:
+            # Transport-level failure — count it toward the breaker so a
+            # consistently-down provider trips and stops costing every episode.
             logger.warning(
                 f"{self.provider_name} raised on {job.episode_code}: {e}",
                 exc_info=True,
             )
+            self.scheduler.record_provider_failure(self.provider_name)
             self.scheduler.advance_or_fail(job)
+            return
+
+        # No exception → the provider responded (hit, miss, or unusable
+        # download). It's reachable, so reset the breaker either way.
+        self.scheduler.record_provider_success(self.provider_name)
+        if outcome is None:
+            self.scheduler.advance_or_fail(job)
+        else:
+            job.result = outcome
+            self.scheduler.mark_complete(job)
+
+    def _attempt(self, job: EpisodeJob) -> dict[str, Any] | None:
+        """One provider attempt. Returns the result dict on a usable download,
+        or ``None`` for a miss / unusable download (both "reachable"). Raises
+        on transport errors so the caller can record a breaker failure."""
+        entry = self.client.get_best_subtitle(job.show_name, job.season, job.episode)
+        if entry is None:
+            logger.debug(f"{self.provider_name} miss for {job.episode_code}")
+            return None
+
+        result = self.client.download_subtitle(entry, job.srt_target)
+        if result is None:
+            return None
+
+        if not is_valid_srt_file(Path(result)):
+            logger.warning(
+                f"{self.provider_name} returned an invalid SRT for "
+                f"{job.episode_code}; deleting and trying next provider"
+            )
+            Path(result).unlink(missing_ok=True)
+            return None
+
+        logger.info(f"{self.provider_name} downloaded {job.episode_code}")
+        return {
+            "code": job.episode_code,
+            "status": "downloaded",
+            "path": str(result),
+            "source": self.provider_name,
+        }
 
     def stop(self) -> None:
         self.queue.put(None)
@@ -155,6 +269,7 @@ class Scheduler:
 
     def __init__(self):
         self.workers: dict[str, ProviderWorker] = {}
+        self._breakers: dict[str, _CircuitBreaker] = {}
         self._pending_count = 0
         self._lock = threading.Lock()
         self._done = threading.Event()
@@ -164,6 +279,23 @@ class Scheduler:
         if name in self.workers:
             return
         self.workers[name] = ProviderWorker(name, client, self)
+        self._breakers[name] = _CircuitBreaker(name)
+
+    def provider_allows(self, name: str) -> bool:
+        """Worker hook: may a job be sent to ``name`` right now? False when its
+        circuit breaker is open (and still cooling down)."""
+        breaker = self._breakers.get(name)
+        return breaker is None or breaker.allow()
+
+    def record_provider_failure(self, name: str) -> None:
+        breaker = self._breakers.get(name)
+        if breaker is not None:
+            breaker.record_failure()
+
+    def record_provider_success(self, name: str) -> None:
+        breaker = self._breakers.get(name)
+        if breaker is not None:
+            breaker.record_success()
 
     def run(
         self, jobs: list[EpisodeJob], timeout: float | None = None

--- a/backend/app/matcher/subtitle_utils.py
+++ b/backend/app/matcher/subtitle_utils.py
@@ -10,7 +10,7 @@ def is_valid_srt_file(file_path: Path) -> bool:
 
     Checks:
     1. File exists and is at least 50 bytes.
-    2. First 500 bytes don't contain HTML markers.
+    2. Header doesn't contain HTML markers.
     3. Contains the SRT timestamp arrow ``-->`` somewhere in the header.
 
     Lives in ``subtitle_utils`` so every provider client and the
@@ -23,8 +23,17 @@ def is_valid_srt_file(file_path: Path) -> bool:
         if not file_path.exists() or file_path.stat().st_size < 50:
             return False
 
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
-            header = f.read(500).lower()
+        # Decode by BOM. TVsubtitles (and others) sometimes serve
+        # UTF-16-encoded SRTs; read as UTF-8 those keep a NUL between every
+        # character, so the ASCII ``-->`` check below never matches and a
+        # perfectly valid subtitle gets rejected. Read a generous chunk of
+        # raw bytes (UTF-16 is 2 bytes/char, so 1000 bytes ≈ 500 chars —
+        # still well past the first timestamp).
+        raw = file_path.read_bytes()[:1000]
+        if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+            header = raw.decode("utf-16", errors="ignore").lower()
+        else:
+            header = raw.decode("utf-8", errors="ignore").lower()
 
         if any(marker in header for marker in ["<!doctype", "<html", "<head", "<body", "<div"]):
             logger.warning(f"Rejecting {file_path.name}: appears to be HTML, not SRT")

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -18,7 +18,7 @@ from loguru import logger
 from app import __version__
 from app.matcher.addic7ed_client import Addic7edClient
 from app.matcher.asr_provider import get_asr_provider
-from app.matcher.os_api_retry import _RETRYABLE_EXCEPTIONS, os_api_call
+from app.matcher.os_api_retry import os_api_call
 from app.matcher.provider_scheduler import EpisodeJob, run_jobs
 from app.matcher.srt_utils import extract_audio_chunk, get_video_duration
 from app.matcher.subtitle_provider import LocalSubtitleProvider
@@ -177,9 +177,11 @@ def _get_os_client(config) -> object | None:
         # and, as a side effect, updates ``client.user_downloads_remaining``.
         try:
             os_api_call(client.user_info)
-        except _RETRYABLE_EXCEPTIONS as e:
+        except Exception as e:
             # Non-fatal: if the probe itself fails we proceed with whatever
-            # the library seeded (the cap) rather than blocking the run.
+            # the library seeded (the cap) rather than blocking the run. Catch
+            # broadly (not just retryable transport errors) so an unexpected
+            # library error degrades gracefully instead of aborting login.
             logger.debug(f"OS user-info probe failed (non-fatal): {e}", exc_info=True)
         remaining = getattr(client, "user_downloads_remaining", None)
 

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -18,7 +18,7 @@ from loguru import logger
 from app import __version__
 from app.matcher.addic7ed_client import Addic7edClient
 from app.matcher.asr_provider import get_asr_provider
-from app.matcher.os_api_retry import os_api_call
+from app.matcher.os_api_retry import _RETRYABLE_EXCEPTIONS, os_api_call
 from app.matcher.provider_scheduler import EpisodeJob, run_jobs
 from app.matcher.srt_utils import extract_audio_chunk, get_video_duration
 from app.matcher.subtitle_provider import LocalSubtitleProvider
@@ -154,7 +154,7 @@ def _get_os_client(config) -> object | None:
         # would propagate that AttributeError to the caller unhandled.
         try:
             client = _OSApi(_USER_AGENT, config.opensubtitles_api_key)
-            login_response = os_api_call(
+            os_api_call(
                 client.login,
                 config.opensubtitles_username,
                 config.opensubtitles_password,
@@ -168,16 +168,44 @@ def _get_os_client(config) -> object | None:
             _OS.failed = True
             return None
 
+        # The login response only carries ``allowed_downloads`` — the daily
+        # CAP (e.g. 1000 for VIP), NOT how many remain. Trusting it makes the
+        # build believe quota is full when it may already be exhausted, then
+        # 406 ("quota exceeded") on every per-season download while logging a
+        # reassuring "1000 remaining". One ``/infos/user`` call up front (it
+        # does NOT consume download quota) yields the true ``remaining_downloads``
+        # and, as a side effect, updates ``client.user_downloads_remaining``.
         try:
-            remaining = login_response["user"]["allowed_downloads"]
+            os_api_call(client.user_info)
+        except _RETRYABLE_EXCEPTIONS as e:
+            # Non-fatal: if the probe itself fails we proceed with whatever
+            # the library seeded (the cap) rather than blocking the run.
+            logger.debug(f"OS user-info probe failed (non-fatal): {e}", exc_info=True)
+        remaining = getattr(client, "user_downloads_remaining", None)
+
+        if remaining is not None and remaining <= 0:
+            # Quota is spent for today. Skip OpenSubtitles for the rest of the
+            # run instead of paying a search + 406 + retry on every season —
+            # the daily bucket won't refill for hours. Falls straight through
+            # to the scrapers (Addic7ed / TVsubtitles).
+            logger.warning(
+                f"OpenSubtitles API: daily download quota exhausted "
+                f"({remaining} remaining) — skipping OpenSubtitles for this run; "
+                "falling back to scrapers (Addic7ed/TVsubtitles)"
+            )
+            _OS.failed = True
+            _snapshot_os_quota(client)
+            return None
+
+        if remaining is not None:
             logger.info(f"OpenSubtitles API login OK — {remaining} downloads remaining today")
-        except (KeyError, TypeError):
+        else:
             logger.info("OpenSubtitles API login OK")
         _OS.client = client
         _OS.login_time = time.monotonic()
-        # Seed the quota snapshot from the login response — gives the build
-        # script's final summary a starting baseline even if no downloads
-        # happen this run (e.g., the whole cache is already populated).
+        # Seed the quota snapshot from the (now accurate) client attribute —
+        # gives the build script's final summary a starting baseline even if
+        # no downloads happen this run (e.g., the whole cache is already populated).
         _snapshot_os_quota(client)
         return client
 

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -188,6 +188,9 @@ def _read_show_list(path: str) -> list[dict]:
                 for r in rows
                 if (n := (r.get("name") or "").strip())
             ]
+        raise SystemExit(
+            f"--show-list CSV has no 'tmdb_id' or 'name' column (got: {sorted(fields)})"
+        )
 
     names = [
         ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -8,6 +8,7 @@ for hosting on GitHub Releases.
 Usage (from backend/):
     uv run python scripts/build_subtitle_cache.py --limit 300
     uv run python scripts/build_subtitle_cache.py --shows "The Expanse,Arrested Development"
+    uv run python scripts/build_subtitle_cache.py --show-list scripts/curated_shows.csv
 
 TMDB / OpenSubtitles credentials are read from the AppConfig DB row; in CI they
 are bootstrapped from the env vars TMDB_API_KEY, OPENSUBTITLES_API_KEY,
@@ -15,8 +16,10 @@ OPENSUBTITLES_USERNAME, OPENSUBTITLES_PASSWORD.
 """
 
 import argparse
+import csv
 import datetime
 import hashlib
+import io
 import json
 import os
 import shutil
@@ -146,9 +149,58 @@ def _bootstrap_config_from_env() -> None:
     logger.info(f"Bootstrapped config from env: {sorted(updates)}")
 
 
+def _read_show_list(path: str) -> list[dict]:
+    """Parse a curated show-list file into ``[{name, id}]`` candidates.
+
+    Two formats are supported:
+    - A CSV with a ``tmdb_id`` column (e.g. the curated_shows.csv produced by the
+      curation tooling). IDs are used directly, so name-collision titles like the
+      US vs UK "The Office" resolve unambiguously. A ``name`` column is kept for
+      logging; any row whose tmdb_id is missing/non-numeric falls back to a name
+      lookup via ``fetch_show_id``.
+    - A plain name list: a ``.txt`` with one show per line, or a CSV whose only
+      useful column is ``name``. Each name is resolved via ``fetch_show_id`` (the
+      same path as ``--shows``).
+
+    Blank lines and ``#`` comment lines are ignored.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise SystemExit(f"--show-list file not found: {path}")
+    text = p.read_text(encoding="utf-8-sig")
+
+    if p.suffix.lower() == ".csv":
+        rows = list(csv.DictReader(io.StringIO(text)))
+        fields = set(rows[0].keys()) if rows else set()
+        if "tmdb_id" in fields:
+            candidates = []
+            for r in rows:
+                tid = (r.get("tmdb_id") or "").strip()
+                name = (r.get("name") or "").strip()
+                if tid.isdigit():
+                    candidates.append({"name": name or tid, "id": int(tid)})
+                elif name:
+                    candidates.append({"name": name, "id": fetch_show_id(name)})
+            return candidates
+        if "name" in fields:
+            return [
+                {"name": n, "id": fetch_show_id(n)}
+                for r in rows
+                if (n := (r.get("name") or "").strip())
+            ]
+
+    names = [
+        ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")
+    ]
+    return [{"name": n, "id": fetch_show_id(n)} for n in names]
+
+
 def _select_shows(args) -> list[dict]:
     """Return [{name, tmdb_id, seasons}] for the shows to cache."""
-    if args.shows:
+    if args.show_list:
+        candidates = _read_show_list(args.show_list)
+        logger.info(f"Loaded {len(candidates)} shows from {args.show_list}")
+    elif args.shows:
         names = [s.strip() for s in args.shows.split(",") if s.strip()]
         candidates = [{"name": n, "id": fetch_show_id(n)} for n in names]
     else:
@@ -288,6 +340,16 @@ def main() -> int:
     parser.add_argument("--pages", type=int, default=15, help="TMDB discover pages to scan")
     parser.add_argument(
         "--shows", type=str, default="", help="Comma-separated show names (overrides popular)"
+    )
+    parser.add_argument(
+        "--show-list",
+        type=str,
+        default="",
+        help=(
+            "Path to a curated show-list file (overrides --shows and popularity). "
+            "A CSV with a tmdb_id column (e.g. scripts/curated_shows.csv) is matched "
+            "by ID for unambiguous lookup; a plain name-per-line .txt also works."
+        ),
     )
     parser.add_argument(
         "--min-episodes-ratio", type=float, default=0.6, help="Min episode coverage per season"

--- a/backend/scripts/curated_shows.csv
+++ b/backend/scripts/curated_shows.csv
@@ -1,0 +1,600 @@
+rank,tmdb_id,name,year,origin_country,networks,discdb_discs
+1,1399,Game of Thrones,2011,US,HBO,33
+2,66732,Stranger Things,2016,US,Netflix,4
+3,71446,Money Heist,2017,ES,Netflix; Antena 3,0
+4,1402,The Walking Dead,2010,US,AMC,54
+5,1396,Breaking Bad,2008,US,AMC,0
+7,63174,Lucifer,2016,US,FOX; Netflix,0
+8,69050,Riverdale,2017,US,The CW,0
+9,71712,The Good Doctor,2017,US,ABC,0
+10,85271,WandaVision,2021,US,Disney+,2
+11,76479,The Boys,2019,US,Prime Video,6
+12,1418,The Big Bang Theory,2007,US,CBS,16
+13,84958,Loki,2021,US,Disney+,4
+14,60735,The Flash,2014,US,The CW,0
+15,60574,Peaky Blinders,2013,GB,BBC One; BBC Two,0
+16,1416,Grey's Anatomy,2005,US,ABC,0
+17,82856,The Mandalorian,2019,US,Disney+,6
+18,60625,Rick and Morty,2013,US,Adult Swim,7
+19,456,The Simpsons,1989,US,FOX,0
+20,85552,Euphoria,2019,US,HBO,0
+21,119051,Wednesday,2022,US,Netflix,2
+23,18165,The Vampire Diaries,2009,US,The CW,0
+25,1668,Friends,1994,US,NBC,25
+26,88396,The Falcon and the Winter Soldier,2021,US,Disney+,0
+27,31910,Naruto Shippūden,2007,JP,TV Tokyo,0
+28,48866,The 100,2014,US,The CW,0
+29,1622,Supernatural,2005,US,The WB; The CW,58
+30,87108,Chernobyl,2019,US,HBO,0
+32,44217,Vikings,2013,CA,Prime Video; History,27
+33,1408,House,2004,US,FOX,0
+34,70523,Dark,2017,DE,Netflix,0
+35,1429,Attack on Titan,2013,JP,MBS; NHK G; Tokyo MX,0
+36,85937,Demon Slayer: Kimetsu no Yaiba,2019,JP,Fuji TV; Gunma TV; Tokyo MX; BS11; Tokai Television Broadcasting; Kansai TV; Tochigi TV; Fukui TV; Hokkaido Cultural Broadcasting; Iwate Menkoi Television; TOS; Sendai Television; SAGA TV; Ishikawa TV; TNC; OHK; Kochi Sun Sun Broadcasting; Television Shin Hiroshima System; TV Shizuoka; UMK TV Miyazaki; NST; NBS; Sakuranbo TV; TSK; Ehime Broadcasting; KTS; Fukushima TV; NIB; KKT; AKT; Toyama Television; TV Kumamoto; Okinawa Television Broadcasting,0
+37,100088,The Last of Us,2023,US,HBO,7
+40,60059,Better Call Saul,2015,US,AMC,0
+41,19885,Sherlock,2010,GB,BBC One,4
+42,1412,Arrow,2012,US,The CW,0
+43,42009,Black Mirror,2011,GB,Channel 4; Netflix,0
+44,63247,Westworld,2016,US,HBO,9
+45,1413,American Horror Story,2011,US,FX,0
+46,46260,Naruto,2002,JP,TV Tokyo,0
+47,94997,House of the Dragon,2022,US,HBO,12
+48,2288,Prison Break,2005,US,FOX,0
+49,94605,Arcane,2021,US,Netflix,4
+50,95557,INVINCIBLE,2021,US,Prime Video,0
+51,37680,Suits,2011,US,USA Network,34
+52,1100,How I Met Your Mother,2005,US,CBS,0
+53,1405,Dexter,2006,US,Showtime,24
+55,62560,Mr. Robot,2015,US,USA Network,0
+56,37854,One Piece,1999,JP,Fuji TV; Tokai Television Broadcasting,0
+57,65930,My Hero Academia,2016,JP,Nippon TV; MBS; TBS; CBC; YTV; Tulip Television; SBC; FBS; BSN; tys; NBC; Chukyo TV; RNB; HTV; FCT; HBC; STV; RKK; KNB; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; YBS; KTK; KUTV; NKT; RAB; TVI; MMT; ABS; JRT; TOS; RBC; YBC; UTY; RCC; MRT; ATV; MBC; TSB; TeNY; RNC; NIB; KKT; Daiichi-TV; FBC; RKC; KYT; KRY,0
+58,62715,Dragon Ball Super,2015,JP,Fuji TV,0
+59,12637,Rebelde,2004,MX,Univision; Las Estrellas,0
+60,2316,The Office,2005,US,NBC,72
+62,62286,Fear the Walking Dead,2015,US,AMC,0
+64,62104,The Seven Deadly Sins,2014,JP,tv asahi; MBS; TV Tokyo; TBS; CBC; TV Aichi; TVQ; TV Osaka; Tulip Television; TVh; SBC; TSC; BSN; tys; NBC; HBC; RKK; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; KUTV; RBC; UTY; RCC; MRT; ATV; MBC,0
+65,4607,Lost,2004,US,ABC,0
+66,2190,South Park,1997,US,Comedy Central,93
+67,1434,Family Guy,1999,US,FOX,0
+68,70785,Anne with an E,2017,CA,CBC Television,0
+69,13916,Death Note,2006,JP,Nippon TV,0
+70,12971,Dragon Ball Z,1989,JP,Fuji TV,37
+71,246,Avatar: The Last Airbender,2005,US,Nickelodeon,19
+72,2004,Malcolm in the Middle,2000,US,FOX,0
+73,34524,Teen Wolf,2011,US,MTV,0
+74,91363,What If...?,2021,US,Disney+,0
+75,65334,Miraculous: Tales of Ladybug & Cat Noir,2015,FR,TF1,0
+77,4604,Smallville,2001,US,The WB; The CW,42
+78,95479,JUJUTSU KAISEN,2020,JP,MBS; TBS; CBC; Tulip Television; SBC; BSN; tys; NBC; HBC; RKK; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; KUTV; RBC; UTY; RCC; MRT; ATV; MBC,0
+79,62688,Supergirl,2015,US,CBS; The CW,0
+81,5920,The Mentalist,2008,US,CBS,0
+83,2734,Law & Order: Special Victims Unit,1999,US,NBC,0
+84,90462,Chucky,2021,US,USA Network; Syfy,2
+85,4613,Band of Brothers,2001,US,HBO,6
+86,60797,Scorpion,2014,US,CBS,0
+87,46648,True Detective,2014,US,HBO,0
+88,63926,One-Punch Man,2015,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+89,4057,Criminal Minds,2005,US,CBS; Paramount+,0
+91,48891,Brooklyn Nine-Nine,2013,US,NBC; FOX,17
+92,78191,You,2018,US,Lifetime; Netflix,0
+93,46331,Under the Dome,2013,US,CBS,0
+94,1403,Marvel's Agents of S.H.I.E.L.D.,2013,US,ABC,0
+96,615,Futurama,1999,US,FOX; Comedy Central; Hulu,0
+97,88329,Hawkeye,2021,US,Disney+,0
+99,43348,Pablo Escobar: The Drug Lord,2012,CO,Caracol TV,0
+100,60708,Gotham,2014,US,FOX,18
+101,2691,Two and a Half Men,2003,US,CBS,0
+102,46896,The Originals,2013,US,The CW,0
+103,46952,The Blacklist,2013,US,NBC,0
+104,4087,The X-Files,1993,US,FOX,60
+105,74577,The End of the F***ing World,2017,GB,Channel 4,0
+106,16286,"Yo soy Betty, la fea",1999,CO,RCN,0
+107,39351,Grimm,2011,US,NBC,0
+108,1911,Bones,2005,US,FOX,0
+109,92749,Moon Knight,2022,US,Disney+,2
+110,40075,Gravity Falls,2012,US,Disney Channel; Disney XD,0
+111,1398,The Sopranos,1999,US,HBO,0
+112,44953,El Señor de los Cielos,2013,US,Telemundo,0
+113,71886,Siren,2018,US,Freeform,0
+114,80213,The Purge,2018,US,USA Network,0
+115,12609,Dragon Ball,1986,JP,Fuji TV,0
+116,110492,Peacemaker,2022,US,HBO Max; HBO Max,0
+117,57243,Doctor Who,2005,GB,BBC One,59
+118,1421,Modern Family,2009,US,ABC,0
+119,34307,Shameless,2011,US,Showtime,0
+120,19614,It,1990,US,ABC,0
+123,124364,FROM,2022,US,Epix; MGM+,0
+124,1409,Sons of Anarchy,2008,US,FX,23
+125,60622,Fargo,2014,US,FX,0
+126,79744,The Rookie,2018,US,ABC,0
+127,69478,The Handmaid's Tale,2017,US,Hulu,0
+128,387,SpongeBob SquarePants,1999,US,Nickelodeon,8
+129,1425,House of Cards,2013,US,Netflix,0
+130,52814,Halo,2022,US,Paramount+,0
+131,80020,Super Dragon Ball Heroes,2018,JP,Fuji TV,0
+132,104877,Love Is in the Air,2020,TR,FOX,0
+133,73586,Yellowstone,2018,US,Paramount Network,26
+134,15260,Adventure Time,2010,US,Cartoon Network,0
+136,67915,Guardian: The Lonely and Great God,2016,KR,tvN,0
+137,79460,Legacies,2018,US,The CW,0
+138,71728,Young Sheldon,2017,US,CBS,0
+139,115036,The Book of Boba Fett,2021,US,Disney+,0
+141,46296,Spartacus,2010,US,STARZ,0
+142,60866,iZombie,2015,US,The CW,0
+143,67335,Sin senos sí hay paraíso,2016,CO/US,Telemundo,0
+144,40008,Hannibal,2013,US,NBC,0
+145,56570,Outlander,2014,US,STARZ,0
+147,61222,BoJack Horseman,2014,US,Netflix,4
+148,75450,Titans,2018,US,DC Universe; HBO Max,0
+151,106379,Fallout,2024,US,Prime Video,3
+152,63639,The Expanse,2015,US,Syfy; Prime Video,15
+153,1424,Orange Is the New Black,2013,US,Netflix,0
+154,31917,Pretty Little Liars,2010,US,ABC Family; Freeform,0
+155,1705,Fringe,2008,US,FOX,0
+156,75219,9-1-1,2018,US,ABC; FOX,0
+159,110316,Alice in Borderland,2020,JP,Netflix,0
+160,95057,Superman & Lois,2021,US,The CW,0
+162,1438,The Wire,2002,US,HBO,0
+163,112888,True Beauty,2020,KR,tvN,0
+164,95396,Severance,2022,US,Apple TV,3
+168,58841,Chicago P.D.,2014,US,NBC,0
+170,1407,Homeland,2011,US,Showtime,0
+171,1920,Twin Peaks,1990,US,ABC; Showtime,21
+172,1639,Heroes,2006,US,NBC,0
+173,62710,Blindspot,2015,US,NBC,0
+174,61374,Tokyo Ghoul,2014,JP,Tokyo MX,0
+175,16997,The Pacific,2010,US,HBO,0
+176,62455,Locked Up,2015,ES,FOX España; Antena 3,0
+177,1981,Charmed,1998,US,The WB,0
+178,4614,NCIS,2003,US,CBS,0
+180,70881,Boruto: Naruto Next Generations,2017,JP,TV Tokyo,0
+181,39272,Once Upon a Time,2011,US,ABC,0
+182,1892,The Fresh Prince of Bel-Air,1990,US,NBC,0
+183,62643,DC's Legends of Tomorrow,2016,US,The CW,0
+184,31911,Fullmetal Alchemist: Brotherhood,2009,JP,MBS; TBS; CBC; Tulip Television; SBC; BSN; tys; NBC; HBC; RKK; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; KUTV; RBC; UTY; RCC; MRT; ATV; MBC,0
+186,44006,Chicago Fire,2012,US,NBC,0
+187,1437,Firefly,2002,US,FOX,0
+188,1433,American Dad!,2005,US,FOX; TBS,0
+190,4194,Star Wars: The Clone Wars,2008,US,Cartoon Network; Netflix; Disney+,0
+191,65494,The Crown,2016,GB/US,Netflix,48
+192,97546,Ted Lasso,2020,US,Apple TV,15
+193,1400,Seinfeld,1989,US,NBC,24
+194,33880,The Legend of Korra,2012,US,Nickelodeon,8
+196,1395,Gossip Girl,2007,US,The CW,0
+197,27240,Seven Deadly Sins,2008,US,History,0
+199,120089,SPY x FAMILY,2022,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+200,31132,Regular Show,2010,US,Cartoon Network,0
+201,92830,Obi-Wan Kenobi,2022,US,Disney+,2
+203,60572,Pokémon,1997,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+205,105,Sex and the City,1998,US,HBO,0
+207,114410,Chainsaw Man,2022,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+208,30984,Bleach,2004,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC; BS TV Tokyo,0
+209,11250,Pasión de Gavilanes,2003,US,Telemundo,0
+210,73223,Black Clover,2017,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+211,46298,Hunter x Hunter,2011,JP,Nippon TV,0
+212,45782,Sword Art Online,2012,JP,Gunma TV; Tokyo MX; tvk; BS11; Tochigi TV,0
+213,1419,Castle,2009,US,ABC,0
+214,35610,InuYasha,2000,JP,ANIMAX; Nippon TV; YTV,0
+215,890,Neon Genesis Evangelion,1995,JP,TV Tokyo,0
+216,693,Desperate Housewives,2004,US,ABC,0
+217,18347,Community,2009,US,NBC; Yahoo! Screen,12
+218,12697,Dragon Ball GT,1996,JP,Fuji TV; Tokai Television Broadcasting; Kansai TV; Fukui TV; Hokkaido Cultural Broadcasting; Iwate Menkoi Television; Sendai Television; SAGA TV; Ishikawa TV; TNC; OHK; Television Shin Hiroshima System; TV Shizuoka; UMK TV Miyazaki; NST; NBS; TSK; Ehime Broadcasting; KTS; Fukushima TV; NIB; AKT; Toyama Television; TV Kumamoto; Okinawa Television Broadcasting,0
+219,10545,True Blood,2008,US,HBO,0
+222,1411,Person of Interest,2011,US,CBS,0
+224,45950,High School DxD,2012,JP,AT-X,0
+225,47,El Chavo del Ocho,1973,MX,Las Estrellas,0
+226,45871,Locked Up: The Oasis,2020,ES,FOX España,0
+227,83867,Andor,2022,US,Disney+,3
+228,67198,Star Trek: Discovery,2017,US,CBS All Access; Paramount+,0
+230,95,Buffy the Vampire Slayer,1997,US,The WB; UPN,0
+231,47640,The Strain,2014,US,FX,0
+232,61550,Marvel's Agent Carter,2015,US,ABC,0
+234,63333,The Last Kingdom,2015,GB,Netflix; BBC Two,0
+235,66573,The Good Place,2016,US,NBC,9
+236,31586,La Reina del Sur,2011,US,Telemundo,0
+237,2038,Drake & Josh,2004,US,Nickelodeon,0
+238,30991,Cowboy Bebop,1998,JP,TV Tokyo; WOWOW Prime,0
+239,60573,Silicon Valley,2014,US,HBO,0
+242,76121,DARLING in the FRANXX,2018,JP,Tokyo MX,0
+243,85949,Star Trek: Picard,2020,US,CBS All Access; Paramount+,0
+244,68507,His Dark Materials,2019,GB,BBC One,2
+246,114868,Record of Ragnarok,2021,JP,Netflix,0
+247,1606,Ghost Whisperer,2005,US,CBS,0
+248,32798,Hawaii Five-0,2010,US,CBS,0
+249,63401,We Bare Bears,2015,US,Cartoon Network,0
+252,1415,Elementary,2012,US,CBS,0
+253,16420,Boys Over Flowers,2009,KR,KBS2,0
+254,2098,Batman: The Animated Series,1992,US,FOX; Fox Kids,0
+255,67070,Fleabag,2016,GB,BBC Three; BBC One,0
+256,4629,Stargate SG-1,1997,CA/US,Showtime; Syfy,0
+257,12926,Teresa,2010,MX,Univision; Las Estrellas,0
+258,62046,Scream Queens,2015,US,FOX,0
+259,8592,Parks and Recreation,2009,US,NBC,20
+260,74428,Rosario Tijeras (Mexico),2016,MX,Netflix; Azteca Trece; Azteca 7,0
+262,92685,The Owl House,2020,US,Disney Channel,0
+263,4686,Ben 10,2005,US,Cartoon Network,0
+264,79696,Manifest,2018,US,NBC; Netflix,0
+265,105248,Cyberpunk: Edgerunners,2022,JP,Netflix,0
+268,46639,American Gods,2017,US,STARZ,0
+269,1973,24,2001,US,FOX,0
+270,61056,How to Get Away with Murder,2014,US,ABC,0
+272,1972,Battlestar Galactica,2004,CA/GB/US,Syfy,41
+274,46786,Bates Motel,2013,US,A&E,0
+275,655,Star Trek: The Next Generation,1987,US,Syndication,41
+276,61617,Over the Garden Wall,2014,US,Cartoon Network,1
+277,62264,Ash vs Evil Dead,2015,US,STARZ,0
+278,126308,Shōgun,2024,US,FX; Hulu,0
+279,64464,11.22.63,2016,US,Hulu,0
+280,37606,The Amazing World of Gumball,2011,IE/DE/US/GB,Cartoon Network,0
+281,31251,Victorious,2010,US,Nickelodeon,0
+282,127532,Solo Leveling,2024,JP,Gunma TV; Tokyo MX; BS11; Tochigi TV,0
+283,39340,2 Broke Girls,2011,US,CBS,0
+285,1620,CSI: Miami,2002,US,CBS,0
+288,64432,The Magicians,2015,US,Syfy,0
+290,42035,The Boat,2011,ES,Antena 3,0
+291,31356,Big Time Rush,2009,US,Nickelodeon,0
+292,66292,Big Little Lies,2017,US,HBO,0
+293,86430,Your Honor,2020,US,Showtime,0
+294,58474,Cosmos,2014,US,FOX; National Geographic,0
+295,86031,Dr. STONE,2019,JP,Tokyo MX; KBS Kyoto,0
+296,84661,The Outsider,2020,US,HBO,0
+297,8358,Lie to Me,2009,US,FOX,0
+298,115004,Mare of Easttown,2021,US,HBO,0
+299,1420,New Girl,2011,US,FOX,0
+300,71411,El Chapo,2017,US,Univision,0
+301,4589,Arrested Development,2003,US,FOX; Netflix,0
+304,2085,Courage the Cowardly Dog,1999,US,Cartoon Network,8
+305,71789,SEAL Team,2017,US,CBS; Paramount+,0
+306,67136,This Is Us,2016,US,NBC,0
+307,76331,Succession,2018,US,HBO,12
+308,60743,Constantine,2014,US,NBC,0
+309,79699,La hija del Mariachi,2006,CO,RCN; Telemundo,0
+310,2490,The IT Crowd,2006,GB,Channel 4,5
+311,79788,Watchmen,2019,US,HBO,0
+313,45790,JoJo's Bizarre Adventure,2012,JP,Netflix; Tokyo MX; BS11,0
+314,128839,La Brea,2021,US,NBC,0
+316,52,That '70s Show,1998,US,FOX,0
+317,89247,Batwoman,2019,US,The CW,5
+318,131927,Dexter: New Blood,2021,US,Showtime,4
+319,69629,The Gifted,2017,US,FOX,0
+320,72305,Kakegurui,2017,JP,MBS; Tokyo MX,0
+321,71790,S.W.A.T.,2017,US,CBS,0
+322,89456,Primal,2019,US,Adult Swim,0
+323,80240,The Queen of Flow,2018,CO,Caracol TV,0
+324,4327,Mr. Bean,1990,GB,ITV1,0
+328,100049,TONIKAWA: Over the Moon for You,2020,JP,Tokyo MX,0
+331,83095,The Rising of the Shield Hero,2019,JP,AT-X,0
+332,76773,Station 19,2018,US,ABC,0
+333,21510,White Collar,2009,US,USA Network,0
+336,5371,iCarly,2007,US,Nickelodeon,0
+338,67195,Legion,2017,US,FX,0
+339,72637,Once,2017,AR,Disney XD,0
+341,57706,Ranma ½,1989,JP,Fuji TV,0
+343,54671,Penny Dreadful,2014,US,Showtime,0
+344,1104,Mad Men,2007,US,AMC,0
+345,60863,Haikyu!!,2014,JP,MBS; TBS; CBC; BSN; tys,0
+348,61923,Star vs. the Forces of Evil,2015,US,Disney XD; Disney Channel,0
+349,72750,Killing Eve,2018,US,BBC America,0
+350,1891,Rome,2005,US,HBO,0
+351,253,Star Trek,1966,US,NBC,0
+352,92396,"Lady, la vendedora de rosas",2015,CO,RCN,0
+353,79525,The Last Dance,2020,US,ESPN,3
+354,62017,The Man in the High Castle,2015,US,Prime Video,0
+355,96462,It's Okay to Not Be Okay,2020,KR,tvN,0
+356,94664,Mushoku Tensei: Jobless Reincarnation,2021,JP,Tokyo MX; BS11; KBS Kyoto,0
+357,65708,Taboo,2017,GB,BBC One,0
+359,47665,Black Sails,2014,US,STARZ,12
+360,79501,Doom Patrol,2019,US,DC Universe; HBO Max; Max,0
+361,200875,IT: Welcome to Derry,2025,US,HBO,3
+363,42671,Elfen Lied,2004,JP,AT-X,2
+364,92782,Ms. Marvel,2022,US,Disney+,0
+365,65844,KONOSUBA - God's blessing on this wonderful world!,2016,JP,Tokyo MX,0
+367,56296,Orphan Black,2013,US/CA,Space; BBC America,0
+368,10283,Archer,2009,US,FX; FXX,0
+370,2384,Knight Rider,1982,US,NBC,16
+371,42444,Saint Seiya,1986,JP,tv asahi,0
+372,111803,The White Lotus,2021,US,HBO,3
+373,79680,Snowpiercer,2020,US,TNT; AMC,0
+374,90461,Monsters at Work,2021,US,Disney XD; Disney Channel; Disney+,0
+375,61459,Parasyte -the maxim-,2014,JP,Nippon TV,0
+376,4616,Xena: Warrior Princess,1995,US,Syndication,0
+378,900,Skins,2007,GB,E4,0
+380,71738,The Orville,2017,US,FOX; Hulu,0
+382,1431,CSI: Crime Scene Investigation,2000,US,CBS,0
+383,41727,Banshee,2013,US,Cinemax,0
+384,80623,BAKI,2018,JP,Netflix,0
+387,58450,What Life Took From Me,2013,MX,Las Estrellas,0
+388,5451,Without Breasts There Is No Paradise,2008,CO,Telemundo; RTI Televisión,0
+389,4574,X-Men,1992,US,FOX; YTV; Syndication; Fox Kids,0
+391,4336,Drawn Together,2004,US,Comedy Central,0
+392,89905,Normal People,2020,GB,BBC Three,0
+393,61175,Steven Universe,2013,US,Cartoon Network,0
+394,2710,It's Always Sunny in Philadelphia,2005,US,FX; FXX,0
+396,194764,The Penguin,2024,US,HBO,0
+397,105009,Tokyo Revengers,2021,JP,MBS,0
+398,34967,Falling Skies,2011,US,TNT,0
+400,604,Teen Titans,2003,US,The WB; Cartoon Network,0
+401,74016,The Resident,2018,US,FOX,0
+402,83100,Dororo,2019,JP,TV Tokyo,0
+404,1215,Californication,2007,US,Showtime,0
+405,45815,Brazil Avenue,2012,BR,TV Globo,0
+406,82739,Rascal Does Not Dream of Bunny Girl Senpai,2018,JP,Gunma TV; Tokyo MX; BS11; ABC TV; Tochigi TV,0
+407,66276,The Night Of,2016,US,HBO,0
+409,67075,Mob Psycho 100,2016,JP,Tokyo MX,0
+410,61859,The Night Manager,2016,GB,BBC One,0
+411,64230,Preacher,2016,US,AMC,0
+412,90937,BEASTARS,2019,JP,Fuji TV; Netflix,0
+413,54650,Power,2014,US,STARZ,0
+414,2352,The Nanny,1993,US,CBS,0
+416,83097,The Promised Neverland,2019,JP,Fuji TV,0
+418,1621,Boardwalk Empire,2010,US,HBO,23
+419,31268,El Capo,2009,CO,RCN,0
+420,62650,Chicago Med,2015,US,NBC,0
+422,65249,ERASED,2016,JP,Fuji TV; Iwate Menkoi Television; Sakuranbo TV,0
+423,4586,Gilmore Girls,2000,US,The WB; The CW,0
+424,1695,Monk,2002,US,USA Network,32
+425,1044,Planet Earth,2006,GB,BBC One,0
+426,17610,NCIS: Los Angeles,2009,US,CBS,0
+427,39852,The Sinner,2017,US,USA Network,0
+429,62110,Assassination Classroom,2015,JP,Fuji TV; Iwate Menkoi Television,0
+430,605,"Sabrina, the Teenage Witch",1996,US,ABC; The WB,24
+432,89393,9-1-1: Lone Star,2020,US,FOX,0
+433,33217,Young Justice,2010,US,Cartoon Network; DC Universe; HBO Max,0
+434,4658,ALF,1986,US,NBC,0
+436,63407,Mi corazón es tuyo,2014,MX,Las Estrellas,0
+437,63210,Shadowhunters,2016,US,Freeform,0
+439,94305,The Walking Dead: World Beyond,2020,US,AMC,0
+440,114461,Ahsoka,2023,US,Disney+,0
+441,61223,Akame ga Kill!,2014,JP,Tokyo MX,0
+442,54344,The Leftovers,2014,US,HBO,0
+444,1404,Chuck,2007,US,NBC,0
+445,1426,Luther,2010,GB,BBC One,0
+446,33907,Downton Abbey,2010,GB,ITV1,0
+447,4239,Married... with Children,1987,US,FOX,0
+448,42705,Fighting Spirit,2000,JP,Nippon TV,0
+451,70828,Surviving Escobar - Alias JJ,2017,CO,Caracol TV,0
+452,5178,Stairway to Heaven,2003,KR,SBS,0
+454,62914,Merlí,2015,ES,TV3; TV3,0
+455,6040,Ben 10: Alien Force,2008,US,Cartoon Network,0
+456,3498,Wizards of Waverly Place,2007,US,Disney Channel,0
+457,7842,The Tom and Jerry Show,1975,US,ABC,0
+458,62823,Scream: The TV Series,2015,US,MTV; VH1,0
+460,2290,Stargate Atlantis,2004,CA/US,Syfy,0
+461,60948,12 Monkeys,2015,US,Syfy,0
+462,2309,Danny Phantom,2004,US,Nickelodeon,0
+463,80986,DC's Stargirl,2020,US,The CW; DC Universe,0
+466,74440,Harley Quinn,2019,US,DC Universe; HBO Max; Max,0
+467,61852,Henry Danger,2014,US,Nickelodeon,0
+470,61663,Your Lie in April,2014,JP,Fuji TV,0
+471,73107,Barry,2018,US,HBO,0
+473,888,Spider-Man,1994,US,FOX; Fox Kids,0
+474,13027,Amor Real,2003,MX,Las Estrellas,0
+475,7225,Merlin,2008,GB,BBC One,0
+476,4313,Full House,1987,US,ABC,0
+477,80307,Bodyguard,2018,GB,BBC One,0
+479,67026,Designated Survivor,2016,US,ABC; Netflix,0
+480,63109,Moses and the Ten Commandments,2015,BR,Record,0
+481,81146,Rosario Tijeras,2010,CO,RCN,0
+482,79649,Project Blue Book,2019,US,History,0
+483,110070,Horimiya,2021,JP,Gunma TV; Tokyo MX; BS11; Tochigi TV,0
+484,2317,My Name Is Earl,2005,US,NBC,0
+485,18123,Scooby-Doo! Mystery Incorporated,2010,US,Cartoon Network,0
+486,222766,The Day of the Jackal,2024,GB,Sky Atlantic; Sky Showcase,0
+487,50825,Sleepy Hollow,2013,US,FOX,0
+488,1274,Six Feet Under,2001,US,HBO,0
+489,252,Everybody Hates Chris,2005,US,UPN; The CW,0
+490,66203,Soy Luna,2016,AR,Disney Channel; Disney+,0
+492,4630,The Fairly OddParents,2001,CA/US,Nickelodeon; Nicktoons,0
+493,73481,Ecomoda,2001,CO,RCN,0
+494,1855,Star Trek: Voyager,1995,US,UPN,0
+496,64196,Overlord,2015,JP,AT-X,0
+497,18011,Vecinos,2005,MX,Distrito Comedia; Blim; Las Estrellas,0
+498,1988,ThunderCats,1985,US,Syndication,0
+499,4500,The Wonder Years,1988,US,ABC,0
+500,80350,New Amsterdam,2018,US,NBC,0
+501,32726,Bob's Burgers,2011,US,FOX,0
+502,3763,Dinosaurs,1991,US,ABC; Syndication,0
+503,31072,La familia P. Luche,2002,MX,Las Estrellas,0
+505,117376,Vincenzo,2021,KR,tvN,0
+506,1778,Zoey 101,2005,US,Nickelodeon,0
+507,42589,Another,2012,JP,KNB,0
+508,70453,Sharp Objects,2018,US,HBO,0
+509,1516,The A-Team,1983,US,NBC,0
+511,46533,The Americans,2013,US,FX,0
+512,79240,Swamp Thing,2019,US,DC Universe,0
+513,64513,American Crime Story,2016,US,FX,0
+514,92967,Mucize Doktor,2019,TR,FOX,0
+516,102966,100 días para enamorarnos,2020,US,Telemundo,0
+517,90660,KENGAN ASHURA,2019,JP,Netflix,0
+518,34391,Marvel's Ultimate Spider-Man,2012,US,Disney XD,0
+519,37863,Fullmetal Alchemist,2003,JP,TBS,0
+521,46261,Fairy Tail,2009,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+522,64122,The Shannara Chronicles,2016,US,MTV; Spike,0
+523,6357,The Twilight Zone,1959,US,CBS,24
+524,62852,Billions,2016,US,Showtime,0
+525,902,Yu-Gi-Oh! Duel Monsters,2000,JP,TV Tokyo; TV Osaka; TVh; TSC,0
+526,99071,Redo of Healer,2021,JP,AT-X,0
+528,86848,Evil,2019,US,CBS; Paramount+,0
+529,3570,Sailor Moon,1992,JP,tv asahi,0
+530,60802,The Last Ship,2014,US,TNT,0
+532,31295,Misfits,2009,GB,E4,0
+533,897,The Grim Adventures of Billy and Mandy,2001,US,Cartoon Network,0
+534,1877,Phineas and Ferb,2007,US,Disney XD; Disney Channel,0
+535,66084,Acapulco Shore,2014,MX,MTV Latin America,0
+536,157239,Alien: Earth,2025,US,FX; Hulu,0
+537,62741,Kamisama Kiss,2012,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+538,1600,Ned's Declassified School Survival Guide,2004,US,Nickelodeon,0
+540,32692,Blue Bloods,2010,US,CBS,0
+541,2426,Angel,1999,US,The WB,0
+542,607,The Powerpuff Girls,1998,US,Cartoon Network,0
+545,60554,Star Wars Rebels,2014,US,Disney XD,0
+547,83631,What We Do in the Shadows,2019,US,FX,0
+548,98986,Uzaki-chan Wants to Hang Out!,2020,JP,AT-X,0
+549,1781,Little House on the Prairie,1974,US,NBC,0
+550,186,Weeds,2005,US,Showtime,0
+551,433,Terminator: The Sarah Connor Chronicles,2008,US,FOX,0
+552,1996,The Flintstones,1960,US,ABC,0
+553,1427,Broadchurch,2013,GB,ITV1,0
+555,75191,The Terror,2018,US,AMC; Shudder; AMC+,0
+556,14141,V,1983,US,NBC,0
+557,1447,Psych,2006,US,USA Network,0
+558,537,Hey Arnold!,1996,US,Nickelodeon,0
+560,2391,Tales from the Crypt,1989,US,HBO,0
+561,56998,High School of the Dead,2010,JP,AT-X,0
+562,63767,She Was Pretty,2015,KR,MBC,0
+564,49010,The Fall,2013,IE,RTÉ One,0
+565,67133,MacGyver,2016,US,CBS,0
+566,66330,W: Two Worlds Apart,2016,KR,MBC,0
+567,42573,Slam Dunk,1993,JP,tv asahi,0
+569,71365,Battlestar Galactica,2003,CA,Syfy,0
+570,96580,Resident Alien,2021,US,USA Network; Syfy,0
+571,96316,Rent-a-Girlfriend,2020,JP,MBS; TBS; CBC; Tulip Television; SBC; BSN; tys; NBC; HBC; RKK; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; KUTV; RBC; UTY; RCC; MRT; ATV; MBC,0
+572,61888,The Last Man on Earth,2015,US,FOX,0
+575,74387,Final Space,2018,US/CA,Adult Swim; TBS,0
+577,68349,Weightlifting Fairy Kim Bok-joo,2016,KR,MBC,0
+578,43899,The Bible,2013,US,History,0
+579,580,Star Trek: Deep Space Nine,1993,US,Syndication,0
+580,117488,Yellowjackets,2021,US,Showtime; Paramount+ with Showtime,0
+581,75214,Violet Evergarden,2018,JP,Tokyo MX,0
+582,2996,The Office,2001,GB,BBC Two,0
+584,71663,Black Lightning,2018,US,The CW,0
+585,83639,Girl from Nowhere,2018,TH,Netflix; GMM 25,0
+586,61345,Z Nation,2014,US,Syfy,0
+587,1406,Deadwood,2004,US,HBO,0
+588,42509,Steins;Gate,2011,JP,Teletama; Sun TV,0
+589,314,Star Trek: Enterprise,2001,US,UPN,0
+590,1417,Glee,2009,US,FOX,0
+591,62687,Limitless,2015,US,CBS,0
+592,88803,Vinland Saga,2019,JP,YouTube; NHK G; Tokyo MX; BS11; GBS,0
+593,43020,Continuum,2012,CA,Showcase,0
+594,2673,The O.C.,2003,US,FOX,0
+598,197067,Extraordinary Attorney Woo,2022,KR,ENA,0
+599,118357,1883,2021,US,Paramount+,3
+601,68595,Planet Earth II,2016,GB,BBC One,0
+602,12313,Shadow Hunter,2005,CA,Space,0
+603,65820,Van Helsing,2016,US,Syfy,0
+605,4588,ER,1994,US,NBC,0
+607,14814,Keeping Up with the Kardashians,2007,US,E!,0
+608,94796,Crash Landing on You,2019,KR,tvN,0
+609,2875,MacGyver,1985,US,ABC,0
+610,80564,Banana Fish,2018,JP,Fuji TV; Iwate Menkoi Television; Sakuranbo TV,0
+611,4546,Curb Your Enthusiasm,2000,US,HBO,24
+613,31654,Digimon: Digital Monsters,1999,JP,Fuji TV,0
+616,86374,War of the Worlds,2019,FR,Canal+,0
+617,18350,Atrévete a Soñar,2009,MX,Las Estrellas,0
+618,80748,FBI,2018,US,CBS,0
+619,3854,The Spectacular Spider-Man,2008,US,Disney XD; The CW,0
+620,72002,Dynasty,2017,US,The CW,0
+621,93846,The King: Eternal Monarch,2020,KR,SBS,0
+622,61418,Jane the Virgin,2014,US,The CW,0
+623,67773,Dirk Gently's Holistic Detective Agency,2016,US,BBC America,0
+624,53425,Wayward Pines,2015,US,FOX,0
+627,123249,My Dress-Up Darling,2022,JP,Gunma TV; Tokyo MX; BS11; Tochigi TV,0
+629,82684,That Time I Got Reincarnated as a Slime,2018,JP,Nippon TV; YTV; Tokyo MX; BS11; FBS; Chukyo TV; RNB; HTV; FCT; STV; KNB; YBS; KTK; NKT; RAB; TVI; MMT; ABS; JRT; TOS; YBC; TSB; TeNY; RNC; NIB; KKT; Daiichi-TV; FBC; RKC; KYT; KRY,0
+631,46994,Slugterra,2012,CA,Disney XD; Family Chrgd,0
+632,110642,RESIDENT EVIL: Infinite Darkness,2021,JP,Netflix,0
+633,2723,Samurai Jack,2001,US,Cartoon Network; Adult Swim,5
+634,4229,Dexter's Laboratory,1996,US,Cartoon Network,0
+636,2382,Freaks and Geeks,1999,US,NBC; Fox Family,0
+638,31109,Ben 10: Ultimate Alien,2010,US,Cartoon Network,0
+640,31724,Code Geass: Lelouch of the Rebellion,2006,JP,MBS,0
+641,48865,Reign,2013,US,The CW,0
+642,3452,Frasier,1993,US,NBC,0
+643,32754,Terra Nova,2011,US,FOX,0
+644,69291,Miss Kobayashi's Dragon Maid,2017,JP,Tokyo MX,0
+645,240,Jackie Chan Adventures,2000,US,The WB,0
+647,224372,A Knight of the Seven Kingdoms,2026,US,HBO,0
+648,84200,Justice League Unlimited,2004,US,Cartoon Network,0
+649,34415,The Killing,2011,US,AMC; Netflix,0
+650,97617,The Misfit of Demon King Academy,2020,JP,AT-X; Gunma TV; Tokyo MX; BS11; Tochigi TV,0
+651,45,Top Gear,2002,GB,BBC One; BBC Two,0
+652,110290,Mums Make Porn,2019,GB,Channel 4,0
+653,98387,Rubi,2020,US,Univision,0
+654,85077,The Chosen,2019,US,Prime Video; VidAngel; Angel; TheChosen.tv,0
+655,1414,The Shield,2002,US,FX,18
+656,211684,The Walking Dead: Daryl Dixon,2023,US,AMC,0
+657,77236,A Discovery of Witches,2018,GB,Sky One; Sky Max,0
+658,3475,The L Word,2004,US,Showtime,0
+659,62425,Dark Matter,2015,CA,Syfy; Space,0
+660,2129,The Adventures of Jimmy Neutron: Boy Genius,2002,US,Nickelodeon,0
+661,67683,Travelers,2016,CA,Showcase; Netflix,0
+662,67557,The Grand Tour,2016,GB,Prime Video,0
+664,83851,The Undoing,2020,US,HBO,0
+665,61593,Mr. Pickles,2014,US,Adult Swim,0
+666,1436,Justified,2010,US,FX,19
+667,65495,Atlanta,2016,US,FX,0
+668,39358,Revenge,2011,US,ABC,0
+669,2328,Power Rangers,1993,US,ABC; Nickelodeon; ABC Family; Toon Disney; Netflix; Fox Kids,0
+670,240411,Dan Da Dan,2024,JP,MBS; TBS; CBC; Tulip Television; SBC; BSN; tys; NBC; HBC; RKK; i-Television; SBS; IBC; BSS; MRO; OBS; TUF; RSK; TUY; tbc; RKB; KUTV; RBC; UTY; RCC; MRT; ATV; MBC,0
+671,95601,Merlí. Sapere Aude,2019,ES,TV3; Movistar Plus+,0
+672,3322,Oz,1997,US,HBO,0
+673,9687,The Odyssey,1997,ZA/TR/DE/IT/US/GB,CTV; NBC,0
+674,83121,Kaguya-sama: Love Is War,2019,JP,Gunma TV; Tokyo MX; BS11; Tochigi TV,0
+676,1423,Ray Donovan,2013,US,Showtime,0
+677,160,Teenage Mutant Ninja Turtles,1987,US,CBS; USA Network; Syndication,0
+678,209867,Frieren: Beyond Journey's End,2023,JP,Nippon TV; YTV; FBS; Chukyo TV; RNB; HTV; FCT; STV; KNB; YBS; KTK; NKT; RAB; TVI; MMT; ABS; JRT; YBC; UMK TV Miyazaki; TSB; TeNY; RNC; NIB; KKT; Daiichi-TV; FBC; RKC; KYT; KRY,0
+679,25707,Captain Tsubasa,1983,JP,TV Tokyo,0
+680,2942,The Tudors,2007,US,Showtime,0
+681,873,Columbo,1971,US,ABC; NBC,0
+682,76231,Mayans M.C.,2018,US,FX,0
+683,74682,I Am Not a Robot,2017,KR,MBC,0
+684,47450,Into the Badlands,2015,US,AMC,0
+685,86850,Dracula,2020,GB,BBC One,0
+687,68315,The Mist,2017,US,Spike,0
+688,62273,Food Wars! Shokugeki no Soma,2015,JP,TBS; Tokyo MX; BS11,0
+689,926,"Scooby-Doo, Where Are You!",1969,US,ABC; CBS,0
+691,1660,I Dream of Jeannie,1965,US,NBC,0
+692,60957,My Love from the Star,2013,KR,SBS,0
+693,2025,"Beverly Hills, 90210",1990,US,FOX,0
+694,78722,Una familia de diez,2007,MX,Las Estrellas,0
+696,57532,PAW Patrol,2013,US,Nickelodeon,0
+697,105556,"DON'T TOY WITH ME, MISS NAGATORO",2021,JP,Tokyo MX; BS11,0
+698,61709,Dragon Ball Z Kai,2009,JP,Fuji TV,0
+699,65143,Descendants of the Sun,2016,KR,KBS2,0
+700,62649,Superstore,2015,US,NBC,0
+701,28136,Rurouni Kenshin,1996,JP,Fuji TV,0
+702,2207,Fawlty Towers,1975,GB,BBC Two,0
+703,62704,Ballers,2015,US,HBO,2
+704,65988,Wynonna Earp,2016,CA/US,Syfy; Space; CTV Sci-Fi Channel,0
+705,72517,Classroom of the Elite,2017,JP,AT-X,0
+709,60694,Last Week Tonight with John Oliver,2014,US,HBO,0
+710,606,"Ed, Edd n Eddy",1999,US/CA,Cartoon Network,0
+711,21494,V,2009,CA/US,ABC,0
+712,34899,The Magnificent Century,2011,TR,Show TV,0
+714,36250,xxxHOLiC,2006,JP,TBS,0
+717,4608,30 Rock,2006,US,NBC,20
+718,67116,Lethal Weapon,2016,US,FOX,0
+719,35790,Cardcaptor Sakura,1998,JP,SBS; NHK BS2; NHK BS Premium; Tooniverse,0
+720,88040,given,2019,JP,Fuji TV,0
+722,66786,Timeless,2016,US,NBC,0
+723,100,I Am Not an Animal,2004,GB,BBC Two,0
+724,51817,Teenage Mutant Ninja Turtles,2012,US,Nickelodeon; Nicktoons,0
+726,5148,Stargate Universe,2009,US,Syfy,0
+727,93149,Plunderer,2020,JP,Tokyo MX; KBS Kyoto,0
+728,35935,Berserk,1997,JP,Nippon TV,0
+729,2660,Codename: Kids Next Door,2002,US,Cartoon Network,0
+730,95269,Toilet-Bound Hanako-kun,2020,JP,TBS,0
+733,135157,Alchemy of Souls,2022,KR,tvN,0
+734,38693,Ninjago: Masters of Spinjitzu,2012,US,YTV; Cartoon Network; Teletoon,0
+735,4018,Quantum Leap,1989,US,NBC,0
+736,33623,The Avengers: Earth's Mightiest Heroes,2010,US,Disney XD,0
+737,30981,Monster,2004,JP,Nippon TV,0
+738,12782,Marimar,1994,MX,Las Estrellas,0
+739,1063,Samurai Champloo,2004,JP,Fuji TV,0
+740,82,Animaniacs,1993,US,The WB; Fox Kids,0
+741,62428,Saint Seiya: Soul of Gold,2015,JP,Bandai Channel,0
+744,82816,Lovecraft Country,2020,US,HBO,0
+745,94280,Steven Universe Future,2019,US,Cartoon Network,0
+748,68716,Marvel's Inhumans,2017,US,ABC,0
+749,61733,Empire,2015,US,FOX,0
+751,71694,Snowfall,2017,US,FX,0
+752,13023,El Chapulín Colorado,1973,MX,Las Estrellas,0
+753,44305,DreamWorks Dragons,2012,US,Cartoon Network,0
+754,157744,1923,2022,US,Paramount+,3
+755,68734,El Chema,2016,US,Telemundo,0
+756,2458,CSI: NY,2004,US,CBS,0
+757,66398,"Diomedes, el Cacique de La Junta",2015,CO,RCN,0
+758,207468,Kaiju No. 8,2024,JP,TV Tokyo; TV Aichi; TVQ; TV Osaka; TVh; TSC,0
+759,30983,Detective Conan,1996,JP,YTV,0
+760,15819,Warehouse 13,2009,US,Syfy,0

--- a/backend/scripts/curated_shows.txt
+++ b/backend/scripts/curated_shows.txt
@@ -1,0 +1,599 @@
+Game of Thrones
+Stranger Things
+Money Heist
+The Walking Dead
+Breaking Bad
+Lucifer
+Riverdale
+The Good Doctor
+WandaVision
+The Boys
+The Big Bang Theory
+Loki
+The Flash
+Peaky Blinders
+Grey's Anatomy
+The Mandalorian
+Rick and Morty
+The Simpsons
+Euphoria
+Wednesday
+The Vampire Diaries
+Friends
+The Falcon and the Winter Soldier
+Naruto Shippūden
+The 100
+Supernatural
+Chernobyl
+Vikings
+House
+Dark
+Attack on Titan
+Demon Slayer: Kimetsu no Yaiba
+The Last of Us
+Better Call Saul
+Sherlock
+Arrow
+Black Mirror
+Westworld
+American Horror Story
+Naruto
+House of the Dragon
+Prison Break
+Arcane
+INVINCIBLE
+Suits
+How I Met Your Mother
+Dexter
+Mr. Robot
+One Piece
+My Hero Academia
+Dragon Ball Super
+Rebelde
+The Office
+Fear the Walking Dead
+The Seven Deadly Sins
+Lost
+South Park
+Family Guy
+Anne with an E
+Death Note
+Dragon Ball Z
+Avatar: The Last Airbender
+Malcolm in the Middle
+Teen Wolf
+What If...?
+Miraculous: Tales of Ladybug & Cat Noir
+Smallville
+JUJUTSU KAISEN
+Supergirl
+The Mentalist
+Law & Order: Special Victims Unit
+Chucky
+Band of Brothers
+Scorpion
+True Detective
+One-Punch Man
+Criminal Minds
+Brooklyn Nine-Nine
+You
+Under the Dome
+Marvel's Agents of S.H.I.E.L.D.
+Futurama
+Hawkeye
+Pablo Escobar: The Drug Lord
+Gotham
+Two and a Half Men
+The Originals
+The Blacklist
+The X-Files
+The End of the F***ing World
+Yo soy Betty, la fea
+Grimm
+Bones
+Moon Knight
+Gravity Falls
+The Sopranos
+El Señor de los Cielos
+Siren
+The Purge
+Dragon Ball
+Peacemaker
+Doctor Who
+Modern Family
+Shameless
+It
+FROM
+Sons of Anarchy
+Fargo
+The Rookie
+The Handmaid's Tale
+SpongeBob SquarePants
+House of Cards
+Halo
+Super Dragon Ball Heroes
+Love Is in the Air
+Yellowstone
+Adventure Time
+Guardian: The Lonely and Great God
+Legacies
+Young Sheldon
+The Book of Boba Fett
+Spartacus
+iZombie
+Sin senos sí hay paraíso
+Hannibal
+Outlander
+BoJack Horseman
+Titans
+Fallout
+The Expanse
+Orange Is the New Black
+Pretty Little Liars
+Fringe
+9-1-1
+Alice in Borderland
+Superman & Lois
+The Wire
+True Beauty
+Severance
+Chicago P.D.
+Homeland
+Twin Peaks
+Heroes
+Blindspot
+Tokyo Ghoul
+The Pacific
+Locked Up
+Charmed
+NCIS
+Boruto: Naruto Next Generations
+Once Upon a Time
+The Fresh Prince of Bel-Air
+DC's Legends of Tomorrow
+Fullmetal Alchemist: Brotherhood
+Chicago Fire
+Firefly
+American Dad!
+Star Wars: The Clone Wars
+The Crown
+Ted Lasso
+Seinfeld
+The Legend of Korra
+Gossip Girl
+Seven Deadly Sins
+SPY x FAMILY
+Regular Show
+Obi-Wan Kenobi
+Pokémon
+Sex and the City
+Chainsaw Man
+Bleach
+Pasión de Gavilanes
+Black Clover
+Hunter x Hunter
+Sword Art Online
+Castle
+InuYasha
+Neon Genesis Evangelion
+Desperate Housewives
+Community
+Dragon Ball GT
+True Blood
+Person of Interest
+High School DxD
+El Chavo del Ocho
+Locked Up: The Oasis
+Andor
+Star Trek: Discovery
+Buffy the Vampire Slayer
+The Strain
+Marvel's Agent Carter
+The Last Kingdom
+The Good Place
+La Reina del Sur
+Drake & Josh
+Cowboy Bebop
+Silicon Valley
+DARLING in the FRANXX
+Star Trek: Picard
+His Dark Materials
+Record of Ragnarok
+Ghost Whisperer
+Hawaii Five-0
+We Bare Bears
+Elementary
+Boys Over Flowers
+Batman: The Animated Series
+Fleabag
+Stargate SG-1
+Teresa
+Scream Queens
+Parks and Recreation
+Rosario Tijeras (Mexico)
+The Owl House
+Ben 10
+Manifest
+Cyberpunk: Edgerunners
+American Gods
+24
+How to Get Away with Murder
+Battlestar Galactica
+Bates Motel
+Star Trek: The Next Generation
+Over the Garden Wall
+Ash vs Evil Dead
+Shōgun
+11.22.63
+The Amazing World of Gumball
+Victorious
+Solo Leveling
+2 Broke Girls
+CSI: Miami
+The Magicians
+The Boat
+Big Time Rush
+Big Little Lies
+Your Honor
+Cosmos
+Dr. STONE
+The Outsider
+Lie to Me
+Mare of Easttown
+New Girl
+El Chapo
+Arrested Development
+Courage the Cowardly Dog
+SEAL Team
+This Is Us
+Succession
+Constantine
+La hija del Mariachi
+The IT Crowd
+Watchmen
+JoJo's Bizarre Adventure
+La Brea
+That '70s Show
+Batwoman
+Dexter: New Blood
+The Gifted
+Kakegurui
+S.W.A.T.
+Primal
+The Queen of Flow
+Mr. Bean
+TONIKAWA: Over the Moon for You
+The Rising of the Shield Hero
+Station 19
+White Collar
+iCarly
+Legion
+Once
+Ranma ½
+Penny Dreadful
+Mad Men
+Haikyu!!
+Star vs. the Forces of Evil
+Killing Eve
+Rome
+Star Trek
+Lady, la vendedora de rosas
+The Last Dance
+The Man in the High Castle
+It's Okay to Not Be Okay
+Mushoku Tensei: Jobless Reincarnation
+Taboo
+Black Sails
+Doom Patrol
+IT: Welcome to Derry
+Elfen Lied
+Ms. Marvel
+KONOSUBA - God's blessing on this wonderful world!
+Orphan Black
+Archer
+Knight Rider
+Saint Seiya
+The White Lotus
+Snowpiercer
+Monsters at Work
+Parasyte -the maxim-
+Xena: Warrior Princess
+Skins
+The Orville
+CSI: Crime Scene Investigation
+Banshee
+BAKI
+What Life Took From Me
+Without Breasts There Is No Paradise
+X-Men
+Drawn Together
+Normal People
+Steven Universe
+It's Always Sunny in Philadelphia
+The Penguin
+Tokyo Revengers
+Falling Skies
+Teen Titans
+The Resident
+Dororo
+Californication
+Brazil Avenue
+Rascal Does Not Dream of Bunny Girl Senpai
+The Night Of
+Mob Psycho 100
+The Night Manager
+Preacher
+BEASTARS
+Power
+The Nanny
+The Promised Neverland
+Boardwalk Empire
+El Capo
+Chicago Med
+ERASED
+Gilmore Girls
+Monk
+Planet Earth
+NCIS: Los Angeles
+The Sinner
+Assassination Classroom
+Sabrina, the Teenage Witch
+9-1-1: Lone Star
+Young Justice
+ALF
+Mi corazón es tuyo
+Shadowhunters
+The Walking Dead: World Beyond
+Ahsoka
+Akame ga Kill!
+The Leftovers
+Chuck
+Luther
+Downton Abbey
+Married... with Children
+Fighting Spirit
+Surviving Escobar - Alias JJ
+Stairway to Heaven
+Merlí
+Ben 10: Alien Force
+Wizards of Waverly Place
+The Tom and Jerry Show
+Scream: The TV Series
+Stargate Atlantis
+12 Monkeys
+Danny Phantom
+DC's Stargirl
+Harley Quinn
+Henry Danger
+Your Lie in April
+Barry
+Spider-Man
+Amor Real
+Merlin
+Full House
+Bodyguard
+Designated Survivor
+Moses and the Ten Commandments
+Rosario Tijeras
+Project Blue Book
+Horimiya
+My Name Is Earl
+Scooby-Doo! Mystery Incorporated
+The Day of the Jackal
+Sleepy Hollow
+Six Feet Under
+Everybody Hates Chris
+Soy Luna
+The Fairly OddParents
+Ecomoda
+Star Trek: Voyager
+Overlord
+Vecinos
+ThunderCats
+The Wonder Years
+New Amsterdam
+Bob's Burgers
+Dinosaurs
+La familia P. Luche
+Vincenzo
+Zoey 101
+Another
+Sharp Objects
+The A-Team
+The Americans
+Swamp Thing
+American Crime Story
+Mucize Doktor
+100 días para enamorarnos
+KENGAN ASHURA
+Marvel's Ultimate Spider-Man
+Fullmetal Alchemist
+Fairy Tail
+The Shannara Chronicles
+The Twilight Zone
+Billions
+Yu-Gi-Oh! Duel Monsters
+Redo of Healer
+Evil
+Sailor Moon
+The Last Ship
+Misfits
+The Grim Adventures of Billy and Mandy
+Phineas and Ferb
+Acapulco Shore
+Alien: Earth
+Kamisama Kiss
+Ned's Declassified School Survival Guide
+Blue Bloods
+Angel
+The Powerpuff Girls
+Star Wars Rebels
+What We Do in the Shadows
+Uzaki-chan Wants to Hang Out!
+Little House on the Prairie
+Weeds
+Terminator: The Sarah Connor Chronicles
+The Flintstones
+Broadchurch
+The Terror
+V
+Psych
+Hey Arnold!
+Tales from the Crypt
+High School of the Dead
+She Was Pretty
+The Fall
+MacGyver
+W: Two Worlds Apart
+Slam Dunk
+Battlestar Galactica
+Resident Alien
+Rent-a-Girlfriend
+The Last Man on Earth
+Final Space
+Weightlifting Fairy Kim Bok-joo
+The Bible
+Star Trek: Deep Space Nine
+Yellowjackets
+Violet Evergarden
+The Office
+Black Lightning
+Girl from Nowhere
+Z Nation
+Deadwood
+Steins;Gate
+Star Trek: Enterprise
+Glee
+Limitless
+Vinland Saga
+Continuum
+The O.C.
+Extraordinary Attorney Woo
+1883
+Planet Earth II
+Shadow Hunter
+Van Helsing
+ER
+Keeping Up with the Kardashians
+Crash Landing on You
+MacGyver
+Banana Fish
+Curb Your Enthusiasm
+Digimon: Digital Monsters
+War of the Worlds
+Atrévete a Soñar
+FBI
+The Spectacular Spider-Man
+Dynasty
+The King: Eternal Monarch
+Jane the Virgin
+Dirk Gently's Holistic Detective Agency
+Wayward Pines
+My Dress-Up Darling
+That Time I Got Reincarnated as a Slime
+Slugterra
+RESIDENT EVIL: Infinite Darkness
+Samurai Jack
+Dexter's Laboratory
+Freaks and Geeks
+Ben 10: Ultimate Alien
+Code Geass: Lelouch of the Rebellion
+Reign
+Frasier
+Terra Nova
+Miss Kobayashi's Dragon Maid
+Jackie Chan Adventures
+A Knight of the Seven Kingdoms
+Justice League Unlimited
+The Killing
+The Misfit of Demon King Academy
+Top Gear
+Mums Make Porn
+Rubi
+The Chosen
+The Shield
+The Walking Dead: Daryl Dixon
+A Discovery of Witches
+The L Word
+Dark Matter
+The Adventures of Jimmy Neutron: Boy Genius
+Travelers
+The Grand Tour
+The Undoing
+Mr. Pickles
+Justified
+Atlanta
+Revenge
+Power Rangers
+Dan Da Dan
+Merlí. Sapere Aude
+Oz
+The Odyssey
+Kaguya-sama: Love Is War
+Ray Donovan
+Teenage Mutant Ninja Turtles
+Frieren: Beyond Journey's End
+Captain Tsubasa
+The Tudors
+Columbo
+Mayans M.C.
+I Am Not a Robot
+Into the Badlands
+Dracula
+The Mist
+Food Wars! Shokugeki no Soma
+Scooby-Doo, Where Are You!
+I Dream of Jeannie
+My Love from the Star
+Beverly Hills, 90210
+Una familia de diez
+PAW Patrol
+DON'T TOY WITH ME, MISS NAGATORO
+Dragon Ball Z Kai
+Descendants of the Sun
+Superstore
+Rurouni Kenshin
+Fawlty Towers
+Ballers
+Wynonna Earp
+Classroom of the Elite
+Last Week Tonight with John Oliver
+Ed, Edd n Eddy
+V
+The Magnificent Century
+xxxHOLiC
+30 Rock
+Lethal Weapon
+Cardcaptor Sakura
+given
+Timeless
+I Am Not an Animal
+Teenage Mutant Ninja Turtles
+Stargate Universe
+Plunderer
+Berserk
+Codename: Kids Next Door
+Toilet-Bound Hanako-kun
+Alchemy of Souls
+Ninjago: Masters of Spinjitzu
+Quantum Leap
+The Avengers: Earth's Mightiest Heroes
+Monster
+Marimar
+Samurai Champloo
+Animaniacs
+Saint Seiya: Soul of Gold
+Lovecraft Country
+Steven Universe Future
+Marvel's Inhumans
+Empire
+Snowfall
+El Chapulín Colorado
+DreamWorks Dragons
+1923
+El Chema
+CSI: NY
+Diomedes, el Cacique de La Junta
+Kaiju No. 8
+Detective Conan
+Warehouse 13

--- a/backend/scripts/curated_shows.txt
+++ b/backend/scripts/curated_shows.txt
@@ -446,7 +446,6 @@ The Fall
 MacGyver
 W: Two Worlds Apart
 Slam Dunk
-Battlestar Galactica
 Resident Alien
 Rent-a-Girlfriend
 The Last Man on Earth
@@ -456,7 +455,6 @@ The Bible
 Star Trek: Deep Space Nine
 Yellowjackets
 Violet Evergarden
-The Office
 Black Lightning
 Girl from Nowhere
 Z Nation
@@ -476,7 +474,6 @@ Van Helsing
 ER
 Keeping Up with the Kardashians
 Crash Landing on You
-MacGyver
 Banana Fish
 Curb Your Enthusiasm
 Digimon: Digital Monsters
@@ -559,7 +556,6 @@ Wynonna Earp
 Classroom of the Elite
 Last Week Tonight with John Oliver
 Ed, Edd n Eddy
-V
 The Magnificent Century
 xxxHOLiC
 30 Rock
@@ -568,7 +564,6 @@ Cardcaptor Sakura
 given
 Timeless
 I Am Not an Animal
-Teenage Mutant Ninja Turtles
 Stargate Universe
 Plunderer
 Berserk

--- a/backend/scripts/pack_subtitle_cache.py
+++ b/backend/scripts/pack_subtitle_cache.py
@@ -176,11 +176,14 @@ def _verify(precomputed_dir: Path, output_path: Path, manifest: dict) -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         with tarfile.open(output_path, "r:gz") as tar:
-            tar.extractall(tmp_path, filter="data")
+            # filter= was backported to CPython only in 3.11.4 (PEP 706); guard
+            # for 3.11.0-3.11.3 where passing it raises TypeError.
+            extract_kw = {"filter": "data"} if sys.version_info >= (3, 11, 4) else {}
+            tar.extractall(tmp_path, **extract_kw)
         for key in sample_keys:
             matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=key)
             season = manifest["shows"][key]["seasons"][0]
-            loaded = matcher._load_precomputed_season(season)
+            loaded = matcher.load_precomputed_season(season)
             if loaded is None or loaded[0].shape[0] == 0:
                 raise SystemExit(f"verify: consumer round-trip failed for {key} S{season:02d}")
             logger.info(f"  round-trip OK: {key} S{season:02d} ({loaded[0].shape[0]} eps)")

--- a/backend/scripts/pack_subtitle_cache.py
+++ b/backend/scripts/pack_subtitle_cache.py
@@ -1,0 +1,371 @@
+"""Pack the Engram subtitle-vector cache from already-harvested SRTs on disk.
+
+Unlike ``scripts/build_subtitle_cache.py``, this NEVER downloads subtitles. It
+walks the local subtitle cache (``<cache>/data/<show>/<show> - SxxExx.srt``),
+reduces every episode to the shared v2 hashed-TF-IDF vector format, verifies the
+artifact, and optionally publishes it to the rolling GitHub release. Use it to
+ship whatever is already on disk -- including shows added manually that
+popularity-mode selection in ``build_subtitle_cache.py`` would never pick.
+
+Show directories are stored under *sanitized* names (``sanitize_filename`` maps
+``:`` -> `` -``, ``/`` -> ``-``, ...), but the runtime matcher looks the cache up
+by the *canonical* TMDB show name (``manifest["shows"][show_name]``). By default
+each show dir is resolved to its canonical name via TMDB (cache-first; this is
+metadata only, never a subtitle download) and accepted only if it sanitizes back
+to the dir name -- guaranteeing the runtime lookup + on-disk subdir handshake.
+``--offline`` skips TMDB entirely and keys the manifest by the dir name; shows
+whose real title contains ``:`` or ``/`` then won't be matched at runtime.
+
+Usage (from backend/):
+    uv run python scripts/pack_subtitle_cache.py            # build + verify
+    uv run python scripts/pack_subtitle_cache.py --offline  # no TMDB
+    uv run python scripts/pack_subtitle_cache.py --publish  # + upload release
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+# Idempotent path insert so ``app.*`` and the sibling build script import whether
+# run as ``python scripts/pack_subtitle_cache.py`` or imported in a test.
+_backend_dir = str(Path(__file__).parent.parent)
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+
+import numpy as np
+
+# Reuse the canonical DB-bootstrap helpers so the standalone script sets up the
+# same schema/credentials path the running app uses (see build_subtitle_cache).
+from build_subtitle_cache import _bootstrap_config_from_env, _ensure_db_schema
+from loguru import logger
+from scipy import sparse
+
+from app.matcher.episode_identification import EpisodeMatcher, SubtitleCache
+from app.matcher.subtitle_utils import sanitize_filename
+from app.matcher.tmdb_client import fetch_show_details, fetch_show_id
+from app.matcher.vectorizer_config import (
+    CACHE_FORMAT_VERSION,
+    HASHING_N_FEATURES,
+    build_hashing_vectorizer,
+    compute_idf,
+    vectorizer_config_hash,
+)
+
+# "S01E01" (single) -- the only shape the harvester writes. A multi-episode file
+# ("S01E01E02") is ambiguous to vectorize as one row, so it's logged and skipped.
+_SINGLE_EP_RE = re.compile(r"[Ss](\d{1,2})[Ee](\d{1,4})\.srt$")
+_MULTI_EP_RE = re.compile(r"[Ss]\d{1,2}[Ee]\d{1,4}[Ee]\d{1,4}")
+
+_TRAILING_YEAR_RE = re.compile(r"\s*\(\d{4}\)\s*$")
+
+
+def _norm_title(s: str) -> str:
+    """Collapse a title to comparable form: drop a trailing ``(YYYY)`` and all
+    non-alphanumerics, lowercase. Lets a disk dir match its canonical TMDB title
+    across cosmetic differences (``:`` stored as space, a Windows-stripped
+    trailing dot, an added disambiguation year) while still requiring the actual
+    title content to be identical -- so it won't accept a different show.
+    """
+    return re.sub(r"[^a-z0-9]", "", _TRAILING_YEAR_RE.sub("", s.lower()))
+
+
+def _discover_shows(data_dir: Path) -> dict[str, dict[int, list[tuple[int, str, Path]]]]:
+    """Walk ``data_dir`` into ``{dir_name: {season: [(ep, code, path)]}}``.
+
+    ``dir_name`` is the sanitized show directory name as stored on disk;
+    ``code`` is the normalized ``S%02dE%02d`` episode code.
+    """
+    shows: dict[str, dict[int, list[tuple[int, str, Path]]]] = {}
+    for show_dir in sorted(p for p in data_dir.iterdir() if p.is_dir()):
+        by_season: dict[int, list[tuple[int, str, Path]]] = {}
+        for srt in sorted(show_dir.glob("*.srt")):
+            if _MULTI_EP_RE.search(srt.name):
+                logger.warning(f"  {show_dir.name}: skipping multi-episode file {srt.name}")
+                continue
+            m = _SINGLE_EP_RE.search(srt.name)
+            if not m:
+                logger.warning(f"  {show_dir.name}: unparseable filename {srt.name}; skipping")
+                continue
+            season, episode = int(m.group(1)), int(m.group(2))
+            code = f"S{season:02d}E{episode:02d}"
+            by_season.setdefault(season, []).append((episode, code, srt))
+        if by_season:
+            shows[show_dir.name] = by_season
+    return shows
+
+
+def _resolve_canonical(dir_name: str, offline: bool) -> tuple[str, int | None, bool]:
+    """Map a sanitized show dir name to ``(manifest_key, tmdb_id, resolved)``.
+
+    Search TMDB for the dir name and accept its canonical title when it matches
+    the dir -- either exactly via ``sanitize_filename`` or, failing that, via
+    ``_norm_title`` (which tolerates cosmetic differences). The returned key is
+    always the canonical title, and the cache subdir/manifest key are both
+    derived from it (``sanitize_filename(key)``), so runtime lookup works
+    regardless of the on-disk dir name. On any miss -- offline, no TMDB hit, or a
+    non-matching title -- fall back to the dir name with no tmdb_id, so
+    non-punctuated titles still work.
+    """
+    if offline:
+        return dir_name, None, False
+    try:
+        cid = fetch_show_id(dir_name)
+        if not cid:
+            logger.warning(f"  {dir_name}: no TMDB match; keying by dir name")
+            return dir_name, None, False
+        details = fetch_show_details(cid)
+        canonical = (details or {}).get("name")
+        if canonical and sanitize_filename(canonical) == dir_name:
+            return canonical, cid, True
+        if canonical and _norm_title(canonical) == _norm_title(dir_name):
+            logger.info(f"  {dir_name}: matched canonical {canonical!r} (normalized)")
+            return canonical, cid, True
+        logger.warning(
+            f"  {dir_name}: TMDB returned {canonical!r} (id {cid}) which does not "
+            f"match the dir name; keying by dir name"
+        )
+        return dir_name, None, False
+    except Exception as e:  # noqa: BLE001 - per-show resolution must never abort the build
+        logger.warning(f"  {dir_name}: TMDB resolution failed ({e}); keying by dir name")
+        return dir_name, None, False
+
+
+def _verify(precomputed_dir: Path, output_path: Path, manifest: dict) -> None:
+    """Validate the staged artifact, then prove a fresh consumer accepts it.
+
+    Raises ``SystemExit`` on any failure so a broken cache is never published.
+    """
+    if manifest["cache_format_version"] != CACHE_FORMAT_VERSION:
+        raise SystemExit(
+            f"verify: format {manifest['cache_format_version']} != {CACHE_FORMAT_VERSION}"
+        )
+    if manifest["vectorizer_config_hash"] != vectorizer_config_hash():
+        raise SystemExit("verify: vectorizer_config_hash mismatch")
+    if manifest["n_features"] != HASHING_N_FEATURES:
+        raise SystemExit(f"verify: n_features {manifest['n_features']} != {HASHING_N_FEATURES}")
+
+    idf = np.load(precomputed_dir / "idf.npy")
+    if idf.shape[0] != HASHING_N_FEATURES:
+        raise SystemExit(f"verify: idf length {idf.shape[0]} != {HASHING_N_FEATURES}")
+
+    for key, entry in manifest["shows"].items():
+        show_dir = precomputed_dir / sanitize_filename(key)
+        for season in entry["seasons"]:
+            npz = show_dir / f"S{season:02d}.npz"
+            index = show_dir / f"S{season:02d}.index.json"
+            if not npz.exists() or not index.exists():
+                raise SystemExit(f"verify: missing files for {key} S{season:02d}")
+            n_rows = sparse.load_npz(npz).shape[0]
+            n_codes = len(json.loads(index.read_text(encoding="utf-8")))
+            if n_rows != n_codes:
+                raise SystemExit(f"verify: row/index mismatch for {key} S{season:02d}")
+
+    # End-to-end consumer round-trip: extract the tarball and load it through the
+    # exact runtime path. Prefer a colon-titled show -- that's the case a dir-name
+    # key would silently break.
+    sample_keys = [k for k in manifest["shows"] if ":" in k or "/" in k][:1]
+    sample_keys += [k for k in manifest["shows"] if k not in sample_keys][:2]
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        with tarfile.open(output_path, "r:gz") as tar:
+            tar.extractall(tmp_path, filter="data")
+        for key in sample_keys:
+            matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=key)
+            season = manifest["shows"][key]["seasons"][0]
+            loaded = matcher._load_precomputed_season(season)
+            if loaded is None or loaded[0].shape[0] == 0:
+                raise SystemExit(f"verify: consumer round-trip failed for {key} S{season:02d}")
+            logger.info(f"  round-trip OK: {key} S{season:02d} ({loaded[0].shape[0]} eps)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pack the Engram subtitle cache from disk")
+    parser.add_argument(
+        "--data-dir", default="", help="SRT cache dir (default: <subtitles_cache_path>/data)"
+    )
+    parser.add_argument(
+        "--output", default="engram-subtitle-cache.tar.gz", help="Output tarball path"
+    )
+    parser.add_argument(
+        "--content-version", default="", help="Cache content version (default: today)"
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip TMDB; key the manifest by dir name (colon/slash titles won't match at runtime)",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Upload to the rolling release with gh (default: print the command only)",
+    )
+    parser.add_argument("--cache-tag", default="subtitle-cache-latest", help="Release tag")
+    args = parser.parse_args()
+
+    _ensure_db_schema()
+    _bootstrap_config_from_env()
+
+    from app.services.config_service import get_config_sync
+
+    config = get_config_sync()
+    if not args.offline and not config.tmdb_api_key:
+        logger.error("TMDB API key not configured; pass --offline to key by dir name instead")
+        return 1
+
+    cache_dir = Path(config.subtitles_cache_path).expanduser()
+    data_dir = Path(args.data_dir).expanduser() if args.data_dir else cache_dir / "data"
+    if not data_dir.is_dir():
+        logger.error(f"Data dir not found: {data_dir}")
+        return 1
+
+    precomputed_dir = cache_dir / "precomputed"
+    if precomputed_dir.exists():
+        shutil.rmtree(precomputed_dir)
+    precomputed_dir.mkdir(parents=True, exist_ok=True)
+
+    content_version = args.content_version or datetime.date.today().isoformat()
+    mode = "offline (dir-name keys)" if args.offline else "TMDB-resolved canonical names"
+    logger.info(f"Packing cache from {data_dir} [{mode}]")
+
+    discovered = _discover_shows(data_dir)
+    if not discovered:
+        logger.error("No harvested SRTs found; nothing to pack")
+        return 1
+    logger.info(f"Discovered {len(discovered)} show dirs on disk")
+
+    subtitle_cache = SubtitleCache()
+    hv = build_hashing_vectorizer()
+    blocks: list[tuple[str, int, list[str], object]] = []
+    manifest_shows: dict[str, dict] = {}
+    fallbacks: list[str] = []
+
+    for dir_name, by_season in discovered.items():
+        key, tmdb_id, resolved = _resolve_canonical(dir_name, args.offline)
+        if not args.offline and not resolved:
+            fallbacks.append(dir_name)
+
+        show_seasons: list[int] = []
+        episode_counts: dict[str, int] = {}
+        for season in sorted(by_season):
+            episodes = sorted(by_season[season], key=lambda x: x[0])
+            texts, codes = [], []
+            for _ep, code, path in episodes:
+                text = subtitle_cache.get_full_text(str(path))
+                if text:
+                    texts.append(text)
+                    codes.append(code)
+            if not texts:
+                continue
+            counts = hv.transform(texts)  # raw hashed term counts
+            blocks.append((key, season, codes, counts))
+            show_seasons.append(season)
+            episode_counts[str(season)] = len(codes)
+
+        if show_seasons:
+            manifest_shows[key] = {
+                "tmdb_id": tmdb_id,
+                "seasons": show_seasons,
+                "episode_counts": episode_counts,
+            }
+
+    if not blocks:
+        logger.error("No usable subtitle text extracted; nothing to pack")
+        return 1
+
+    # --- Fit one global IDF across the whole corpus ---------------------------
+    all_counts = sparse.vstack([b[3] for b in blocks], format="csr")
+    idf = compute_idf(all_counts)
+    np.save(precomputed_dir / "idf.npy", idf)
+    logger.info(f"Global IDF fit over {all_counts.shape[0]} episodes")
+
+    # --- Write per-(show, season) uint16 hashed-count matrices (cache v2) -----
+    u16_max = np.iinfo(np.uint16).max
+    for show_name, season, codes, counts in blocks:
+        show_dir = precomputed_dir / sanitize_filename(show_name)
+        show_dir.mkdir(parents=True, exist_ok=True)
+        counts_u16 = sparse.csr_matrix(
+            (
+                np.minimum(counts.data, u16_max).astype(np.uint16),
+                counts.indices,
+                counts.indptr,
+            ),
+            shape=counts.shape,
+        )
+        sparse.save_npz(show_dir / f"S{season:02d}.npz", counts_u16)
+        with open(show_dir / f"S{season:02d}.index.json", "w", encoding="utf-8") as fh:
+            json.dump(codes, fh)
+
+    # --- In-tarball manifest (read by the matcher) ----------------------------
+    manifest = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "vectorizer_config_hash": vectorizer_config_hash(),
+        "content_version": content_version,
+        "built_at": datetime.datetime.now(datetime.UTC).isoformat(),
+        "n_features": HASHING_N_FEATURES,
+        "shows": manifest_shows,
+    }
+    with open(precomputed_dir / "manifest.json", "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+    # --- Package + checksum ---------------------------------------------------
+    output_path = Path(args.output).resolve()
+    with tarfile.open(output_path, "w:gz") as tar:
+        tar.add(precomputed_dir, arcname="precomputed")
+
+    sha = hashlib.sha256()
+    with open(output_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            sha.update(chunk)
+
+    release_manifest = dict(manifest, tarball_sha256=sha.hexdigest())
+    release_manifest_path = output_path.with_name("manifest.json")
+    with open(release_manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(release_manifest, fh, indent=2)
+
+    # --- Verify before anyone can publish a broken cache ----------------------
+    logger.info("Verifying artifact...")
+    _verify(precomputed_dir, output_path, manifest)
+
+    total_episodes = sum(len(c) for _, _, c, _ in blocks)
+    size_mb = output_path.stat().st_size / (1024 * 1024)
+    logger.info(
+        f"Packed {len(manifest_shows)} shows, {total_episodes} episodes, "
+        f"{size_mb:.1f} MB -> {output_path}"
+    )
+    logger.info(f"Release manifest -> {release_manifest_path}")
+    if fallbacks:
+        logger.warning(
+            f"{len(fallbacks)} show(s) keyed by dir name (TMDB unresolved); these won't "
+            f"match at runtime if their real title has ':' or '/': {', '.join(sorted(fallbacks))}"
+        )
+
+    # --- Publish (rolling release, in-place asset replace) --------------------
+    upload_cmd = [
+        "gh",
+        "release",
+        "upload",
+        args.cache_tag,
+        str(output_path),
+        str(release_manifest_path),
+        "--clobber",
+    ]
+    if args.publish:
+        logger.info(f"Publishing to release {args.cache_tag} ...")
+        subprocess.run(upload_cmd, check=True)
+        logger.info("Published. Verify with: gh release view " + args.cache_tag)
+    else:
+        logger.info("Dry run (no --publish). To publish, run:\n  " + " ".join(upload_cmd))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/pack_subtitle_cache.py
+++ b/backend/scripts/pack_subtitle_cache.py
@@ -176,10 +176,11 @@ def _verify(precomputed_dir: Path, output_path: Path, manifest: dict) -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         with tarfile.open(output_path, "r:gz") as tar:
-            # filter= was backported to CPython only in 3.11.4 (PEP 706); guard
-            # for 3.11.0-3.11.3 where passing it raises TypeError.
-            extract_kw = {"filter": "data"} if sys.version_info >= (3, 11, 4) else {}
-            tar.extractall(tmp_path, **extract_kw)
+            # filter="data" (Python 3.11.4+) rejects members that escape the
+            # destination -- path traversal, absolute paths, unsafe links.
+            # Matches the runtime extractor in precomputed_cache_service.py; the
+            # project already standardizes on 3.11.4+ for tarball extraction.
+            tar.extractall(tmp_path, filter="data")
         for key in sample_keys:
             matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=key)
             season = manifest["shows"][key]["seasons"][0]

--- a/backend/tests/unit/test_provider_scheduler.py
+++ b/backend/tests/unit/test_provider_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from app.matcher.provider_scheduler import EpisodeJob, run_jobs
+from app.matcher.provider_scheduler import EpisodeJob, _CircuitBreaker, run_jobs
 
 
 def _make_job(
@@ -235,3 +235,79 @@ class TestEmptyInput:
     def test_no_jobs_returns_empty(self):
         results = run_jobs([], workers={"addic7ed": _missing_client()})
         assert results == {}
+
+
+@pytest.mark.unit
+class TestCircuitBreaker:
+    """Deterministic tests of the breaker state machine. ``now`` is injected
+    so cooldown transitions don't depend on wall-clock sleeps."""
+
+    def test_closed_allows_by_default(self):
+        cb = _CircuitBreaker("addic7ed", failure_threshold=3)
+        assert cb.allow(now=0.0) is True
+
+    def test_trips_after_threshold_consecutive_failures(self):
+        cb = _CircuitBreaker("addic7ed", failure_threshold=3, base_cooldown=30.0)
+        cb.record_failure(now=0.0)
+        cb.record_failure(now=0.0)
+        assert cb.allow(now=0.0) is True  # 2 failures: still closed
+        cb.record_failure(now=0.0)
+        assert cb.allow(now=0.0) is False  # 3rd consecutive failure trips it
+
+    def test_success_resets_failure_count(self):
+        cb = _CircuitBreaker("addic7ed", failure_threshold=3)
+        cb.record_failure(now=0.0)
+        cb.record_failure(now=0.0)
+        cb.record_success()  # reachable again → counter resets
+        cb.record_failure(now=0.0)
+        cb.record_failure(now=0.0)
+        assert cb.allow(now=0.0) is True  # only 2 failures since reset → still closed
+
+    def test_open_blocks_until_cooldown_then_half_open_probe(self):
+        cb = _CircuitBreaker("addic7ed", failure_threshold=1, base_cooldown=30.0)
+        cb.record_failure(now=0.0)  # threshold 1 → trips immediately
+        assert cb.allow(now=10.0) is False  # within cooldown window
+        assert cb.allow(now=31.0) is True  # cooldown elapsed → one probe allowed
+        assert cb.allow(now=31.0) is False  # probe already in flight → others blocked
+
+    def test_probe_success_closes_circuit(self):
+        cb = _CircuitBreaker("addic7ed", failure_threshold=1, base_cooldown=30.0)
+        cb.record_failure(now=0.0)
+        assert cb.allow(now=31.0) is True  # probe
+        cb.record_success()  # probe succeeded → circuit closes
+        assert cb.allow(now=31.0) is True
+
+    def test_probe_failure_reopens_with_doubled_cooldown(self):
+        cb = _CircuitBreaker(
+            "addic7ed", failure_threshold=1, base_cooldown=30.0, max_cooldown=300.0
+        )
+        cb.record_failure(now=0.0)  # open, cooldown 30
+        assert cb.allow(now=31.0) is True  # probe
+        cb.record_failure(now=31.0)  # probe failed → cooldown doubles to 60
+        assert cb.allow(now=61.0) is False  # 31 + 60 = 91 not yet reached
+        assert cb.allow(now=92.0) is True  # 91 elapsed → probe again
+
+
+@pytest.mark.unit
+class TestCircuitBreakerIntegration:
+    def test_tripped_provider_skipped_for_remaining_jobs(self, tmp_path):
+        """Once a provider fails enough consecutive times, the scheduler stops
+        calling it for the rest of the batch and routes straight to the next
+        provider — so a dead provider costs at most `threshold` attempts, not
+        one per episode (the whole point: no 8s timeout per job)."""
+        addic7ed = _failing_client(RuntimeError("connect timeout"))
+        podnapisi = _writing_client()
+        jobs = [
+            _make_job(
+                episode=i,
+                providers=["addic7ed", "podnapisi"],
+                srt_target=tmp_path / f"{i}.srt",
+            )
+            for i in range(1, 7)  # 6 jobs; default threshold is 3
+        ]
+        results = run_jobs(jobs, workers={"addic7ed": addic7ed, "podnapisi": podnapisi}, timeout=5)
+        # Every job still resolved via the healthy fallback.
+        assert all(results[f"S01E{i:02d}"]["source"] == "podnapisi" for i in range(1, 7))
+        # But the dead provider was hit only `threshold` (3) times — jobs 4-6
+        # skipped it entirely instead of each paying a failed call.
+        assert addic7ed.get_best_subtitle.call_count == 3

--- a/backend/tests/unit/test_subtitle_utils.py
+++ b/backend/tests/unit/test_subtitle_utils.py
@@ -1,0 +1,41 @@
+"""Unit tests for subtitle_utils.is_valid_srt_file."""
+
+import pytest
+
+from app.matcher.subtitle_utils import is_valid_srt_file
+
+_SRT_TEXT = "1\r\n00:00:07,130 --> 00:00:09,000\nHello there\n\n2\r\n00:00:10,000 --> 00:00:12,000\nGeneral Kenobi\n"
+
+
+@pytest.mark.unit
+class TestIsValidSrtFile:
+    def test_accepts_plain_utf8_srt(self, tmp_path):
+        p = tmp_path / "utf8.srt"
+        p.write_text(_SRT_TEXT, encoding="utf-8")
+        assert is_valid_srt_file(p) is True
+
+    def test_accepts_utf16_srt_with_bom(self, tmp_path):
+        """TVsubtitles (and others) sometimes serve UTF-16-encoded SRTs.
+        Read as UTF-8 they keep a NUL between every character, so the ASCII
+        ``-->`` check never matches and a valid subtitle is wrongly rejected.
+        The validator must decode by BOM."""
+        p = tmp_path / "utf16.srt"
+        p.write_text(_SRT_TEXT, encoding="utf-16")  # writes a BOM
+        assert is_valid_srt_file(p) is True
+
+    def test_rejects_html(self, tmp_path):
+        p = tmp_path / "html.srt"
+        p.write_text("<!DOCTYPE html><html><body>Not found</body></html>" * 5, encoding="utf-8")
+        assert is_valid_srt_file(p) is False
+
+    def test_rejects_too_short(self, tmp_path):
+        p = tmp_path / "tiny.srt"
+        p.write_text("1\n", encoding="utf-8")
+        assert is_valid_srt_file(p) is False
+
+    def test_rejects_text_without_timestamps(self, tmp_path):
+        p = tmp_path / "notes.srt"
+        p.write_text(
+            "just some plain notes with no subtitle timing at all here" * 2, encoding="utf-8"
+        )
+        assert is_valid_srt_file(p) is False

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -451,3 +451,55 @@ class TestQuotaSnapshot:
             client.user_downloads_remaining = 988
             testing_service._snapshot_os_quota(client)
             assert log.info.call_count == 3, "post-refill drops still log"
+
+
+@pytest.mark.unit
+class TestGetOsClientQuota:
+    """``_get_os_client`` must learn the TRUE remaining download count at
+    login. The login response only carries ``allowed_downloads`` (the daily
+    CAP), so trusting it makes the build believe quota is full when it is
+    actually exhausted — then every per-season download 406s and the run
+    silently degrades to slow scrapers while logging "1000 remaining"."""
+
+    def setup_method(self):
+        testing_service._OS = testing_service._OSState()
+
+    def _config(self):
+        config = Mock()
+        config.opensubtitles_api_key = "key"
+        config.opensubtitles_username = "user"
+        config.opensubtitles_password = "pass"
+        return config
+
+    @patch("opensubtitlescom.OpenSubtitles")
+    def test_exhausted_quota_skips_opensubtitles(self, mock_os_api):
+        """remaining == 0 after the user-info probe → return None, mark the
+        process failed so later seasons short-circuit, and never hand back a
+        client that would 406 on every download."""
+        client = Mock()
+        client.login.return_value = {"user": {"allowed_downloads": 1000}}
+        # /infos/user reports the real state: cap reached, zero left.
+        client.user_downloads_remaining = 0
+        mock_os_api.return_value = client
+
+        result = testing_service._get_os_client(self._config())
+
+        assert result is None
+        assert testing_service._OS.failed is True
+        client.user_info.assert_called_once()
+        snap = testing_service.get_last_quota()
+        assert snap is not None and snap["remaining"] == 0
+
+    @patch("opensubtitlescom.OpenSubtitles")
+    def test_available_quota_returns_client(self, mock_os_api):
+        """remaining > 0 → cache and return the client as before."""
+        client = Mock()
+        client.login.return_value = {"user": {"allowed_downloads": 1000}}
+        client.user_downloads_remaining = 950
+        mock_os_api.return_value = client
+
+        result = testing_service._get_os_client(self._config())
+
+        assert result is client
+        assert testing_service._OS.failed is False
+        client.user_info.assert_called_once()


### PR DESCRIPTION
## Summary

Bundles the recent matcher/subtitle-cache work that was committed locally but
not yet on `main`, plus a new from-disk cache packager.

- **New `scripts/pack_subtitle_cache.py`** — builds the v2 precomputed
  subtitle-vector cache from SRTs already on disk (never downloads subtitles),
  verifies it via the real `EpisodeMatcher` consumer path, and optionally
  publishes it to the rolling `subtitle-cache-latest` release. Resolves each
  sanitized show dir to its canonical TMDB title (cache-first; metadata only),
  accepting it on an exact or normalized match so manually-added and
  punctuated-title shows (e.g. `Avatar: The Last Airbender`,
  `Dexter: New Blood`) are keyed correctly. `--offline` skips TMDB.
- `feat(matcher)`: `--show-list` input for the cache builder
- `feat(matcher)`: per-provider circuit breaker in the subtitle scheduler
- `fix(matcher)`: accept UTF-16-encoded SRTs in `is_valid_srt_file`
- `fix(matcher)`: report true OpenSubtitles quota and skip when exhausted

The packager reuses the shared vectorization + v2 layout, so its output is
format-identical to `build_subtitle_cache.py`. It was used to refresh the live
`subtitle-cache-latest` release to v2 (138 shows / 11,031 episodes).

## Test plan

- [x] `ruff check` / `ruff format` clean (pre-commit hooks pass)
- [x] Packager dry run: 138 shows, 11,031 episodes, format v2 (uint16), 0 unresolved titles
- [x] In-script verify: per-show npz/index row counts match; consumer round-trip loads a colon-titled show
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)