### PR TITLE
fix(review): re-match all re-runs matching and shows live progress

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1759,6 +1759,12 @@ async def rematch_job(
     job: DiscJob = Depends(get_job_or_404),
 ):
     """Re-match all titles for a job."""
+    if job.state != JobState.REVIEW_NEEDED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot re-match in state: {job.state.value}",
+        )
+
     from app.services.job_manager import job_manager
 
     await job_manager.rerun_matching(job.id, request.source_preference)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -538,6 +538,21 @@ class JobManager:
                 (job_id, job.detected_title, job.detected_season) if needs_subtitle_retry else None
             )
 
+            # Leave REVIEW_NEEDED for MATCHING so the dashboard's live (WebSocket)
+            # view follows the re-matching that now runs in the background. Without
+            # this the static review page stays mounted showing only cleared matches.
+            if job is not None and job.state == JobState.REVIEW_NEEDED:
+                job.state = JobState.MATCHING
+                job.updated_at = datetime.now(UTC)
+                await session.commit()
+                await ws_manager.broadcast_job_update(
+                    job_id,
+                    JobState.MATCHING.value,
+                    content_type=job.content_type.value,
+                    detected_title=job.detected_title,
+                    detected_season=job.detected_season,
+                )
+
         if retry_args is not None:
             await self._matching.restart_subtitle_download(*retry_args)
 

--- a/backend/tests/integration/test_rematch.py
+++ b/backend/tests/integration/test_rematch.py
@@ -4,7 +4,9 @@ Tests POST /api/jobs/{id}/titles/{tid}/rematch,
 POST /api/jobs/{id}/rematch, and POST /api/jobs/{id}/titles/{tid}/reassign.
 """
 
+import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -138,6 +140,102 @@ async def test_rematch_nonexistent_title_returns_404(client, job_with_matched_ti
         json={"source_preference": "discdb"},
     )
     assert resp.status_code == 404
+
+
+@pytest.fixture
+async def engram_review_job(tmp_path):
+    """Create a REVIEW_NEEDED TV job whose title was matched via engram (audio).
+
+    No DiscDB details, subtitles already completed — the realistic state when a
+    disc lands in review because one episode could not be auto-matched.
+    """
+    ripped_file = tmp_path / "B1_t00.mkv"
+    ripped_file.write_bytes(b"fake mkv")
+
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="ARRESTED_DEVELOPMENT_S1D2",
+            content_type=ContentType.TV,
+            state=JobState.REVIEW_NEEDED,
+            detected_title="Arrested Development",
+            detected_season=1,
+            subtitle_status="completed",
+            staging_path=str(tmp_path),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+
+        title = DiscTitle(
+            job_id=job.id,
+            title_index=0,
+            duration_seconds=1300,
+            file_size_bytes=1024 * 1024 * 1024,
+            chapter_count=8,
+            state=TitleState.MATCHED,
+            matched_episode="S01E01",
+            match_confidence=0.9,
+            match_source="engram",
+            is_selected=True,
+            output_filename=str(ripped_file),
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+
+        return job, title
+
+
+@pytest.mark.asyncio
+async def test_bulk_rematch_transitions_job_to_matching(client, engram_review_job, monkeypatch):
+    """Re-match all must move the job out of REVIEW_NEEDED into MATCHING.
+
+    Otherwise the review page stays mounted and never reflects the re-matching
+    that runs in the background — the reported bug.
+    """
+    job, title = engram_review_job
+
+    from app.services.job_manager import job_manager
+
+    monkeypatch.setattr(job_manager._matching, "match_single_file", AsyncMock())
+
+    resp = await client.post(
+        f"/api/jobs/{job.id}/rematch",
+        json={"source_preference": "engram"},
+    )
+    assert resp.status_code == 200
+
+    async with async_session() as session:
+        reloaded_job = await session.get(DiscJob, job.id)
+        reloaded_title = await session.get(DiscTitle, title.id)
+        assert reloaded_job.state == JobState.MATCHING
+        assert reloaded_title.matched_episode is None
+
+
+@pytest.mark.asyncio
+async def test_bulk_rematch_dispatches_matching(client, engram_review_job, monkeypatch):
+    """Re-match all must actually dispatch matching for each ripped title."""
+    job, title = engram_review_job
+
+    from app.services.job_manager import job_manager
+
+    mock_match = AsyncMock()
+    monkeypatch.setattr(job_manager._matching, "match_single_file", mock_match)
+
+    resp = await client.post(
+        f"/api/jobs/{job.id}/rematch",
+        json={"source_preference": "engram"},
+    )
+    assert resp.status_code == 200
+
+    # Background tasks are fire-and-forget; let the event loop run them.
+    await asyncio.sleep(0.1)
+
+    assert mock_match.await_count == 1
+    dispatched_job_id, dispatched_title_id, _path = mock_match.await_args.args
+    assert dispatched_job_id == job.id
+    assert dispatched_title_id == title.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_rematch.py
+++ b/backend/tests/integration/test_rematch.py
@@ -109,6 +109,29 @@ async def test_bulk_rematch_returns_200(client, job_with_matched_title):
 
 
 @pytest.mark.asyncio
+async def test_bulk_rematch_rejects_non_review_state(client, engram_review_job):
+    """Re-match all on a job that is not in review must be rejected, not silently
+    backgrounded — otherwise the UI navigates away while matching runs invisibly."""
+    job, _ = engram_review_job
+
+    async with async_session() as session:
+        reloaded = await session.get(DiscJob, job.id)
+        reloaded.state = JobState.FAILED
+        session.add(reloaded)
+        await session.commit()
+
+    resp = await client.post(
+        f"/api/jobs/{job.id}/rematch",
+        json={"source_preference": "engram"},
+    )
+    assert resp.status_code == 409
+
+    async with async_session() as session:
+        unchanged = await session.get(DiscJob, job.id)
+        assert unchanged.state == JobState.FAILED
+
+
+@pytest.mark.asyncio
 async def test_reassign_episode_returns_200(client, job_with_matched_title):
     """POST /api/jobs/{id}/titles/{tid}/reassign should return 200 and update DB."""
     job, title = job_with_matched_title
@@ -229,8 +252,11 @@ async def test_bulk_rematch_dispatches_matching(client, engram_review_job, monke
     )
     assert resp.status_code == 200
 
-    # Background tasks are fire-and-forget; let the event loop run them.
-    await asyncio.sleep(0.1)
+    # Background tasks are fire-and-forget; yield until dispatched (with a hard
+    # timeout) rather than a fixed sleep, which is racy under CI load.
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while mock_match.await_count == 0 and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0)
 
     assert mock_match.await_count == 1
     dispatched_job_id, dispatched_title_id, _path = mock_match.await_args.args

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -329,7 +329,8 @@ function ReviewQueue() {
                 const text = await response.text();
                 throw new Error(`Failed to re-match all: ${text}`);
             }
-            await fetchJobDetails();
+            // The job moves to MATCHING; the dashboard's live view shows progress.
+            navigate('/');
         } catch (err) {
             console.error('Failed to re-match all:', err);
             setError(err instanceof Error ? err.message : 'Failed to re-match all');


### PR DESCRIPTION
## Summary

Fixes the **"Re-match all"** button in the review screen. It removed every existing match but the disc then appeared to do nothing — matching never visibly re-ran.

### Root cause
Two re-match paths share the dispatch helper `JobManager._rerun_matching`:
- `re_identify` (post-rip) sets the job to `JobState.MATCHING` and broadcasts a `job_update` first — **works**.
- `rerun_matching` ("Re-match all") called the same helper but **left the job in `REVIEW_NEEDED`** and broadcast nothing.

Because the job stayed in `REVIEW_NEEDED`, the standalone `/review/:jobId` page stayed mounted. That page has **no WebSocket subscription** and `handleRematchAll` refetched immediately, capturing the just-cleared matches and never receiving the background results. Matching actually ran — it just had nowhere to surface.

### Fix
- **Backend** (`job_manager.py`): `rerun_matching` now transitions `REVIEW_NEEDED -> MATCHING` and broadcasts `job_update` before dispatching, mirroring `re_identify`.
- **Frontend** (`ReviewQueue.tsx`): `handleRematchAll` now `navigate('/')` on success (like *Start rip*), sending the user to the WebSocket-aware dashboard where matching progress and restored matches appear live.

## Test plan
- [x] New failing-first tests in `tests/integration/test_rematch.py`: `test_bulk_rematch_transitions_job_to_matching` (job ends in `MATCHING`, matches cleared) and `test_bulk_rematch_dispatches_matching` (matching dispatched per ripped title).
- [x] Full backend suite green: **790 passed** (incl. existing `test_subtitle_restart.py` covering `rerun_matching`).
- [x] `ruff check` / `ruff format` clean; pre-commit (incl. Frontend ESLint) passed.
- [x] Manual E2E with a real Arrested Development S1D2 review job: clicked **Re-match all** -> navigated to dashboard -> job showed **MATCHING** with live per-track progress -> the previously-unmatched title re-matched to **S01E14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)