### PR TITLE
Redesign TV disc review as an inspector layout with disc-level conflict detection

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -21,6 +21,7 @@ from sqlmodel import select
 from app.config import settings
 from app.core.security import is_allowed_image_url
 from app.database import get_session
+from app.matcher.tmdb_client import fetch_season_episodes
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle
 
@@ -474,6 +475,105 @@ async def get_job_titles(
         select(DiscTitle).where(DiscTitle.job_id == job.id).order_by(DiscTitle.title_index)
     )
     return list(result.scalars().all())
+
+
+_EPISODE_CODE_RE = re.compile(r"S(\d+)E(\d+)", re.IGNORECASE)
+
+
+class RosterEpisode(BaseModel):
+    """One episode slot in the season roster with cross-disc coverage."""
+
+    episode_code: str
+    episode_number: int
+    name: str
+    status: str  # "assigned" | "duplicate" | "missing" | "off"
+    assigned_title_ids: list[int]
+
+
+class SeasonRosterResponse(BaseModel):
+    """Season episode list (code + name) plus per-episode coverage.
+
+    ``status`` reflects the persisted state: ``assigned`` (one title),
+    ``duplicate`` (two+ titles share the episode), ``missing`` (no title but
+    inside the disc's covered range — a gap to fill) and ``off`` (outside the
+    range, i.e. on another disc). The frontend recomputes status live as the
+    user edits unsaved selections.
+    """
+
+    available: bool
+    season_number: int | None = None
+    show_id: int | None = None
+    episodes: list[RosterEpisode] = []
+    reason: str | None = None
+
+
+@router.get("/jobs/{job_id}/season-roster", response_model=SeasonRosterResponse)
+async def get_season_roster(
+    job: DiscJob = Depends(get_job_or_404),
+    session: AsyncSession = Depends(get_session),
+) -> SeasonRosterResponse:
+    """Season episode list with per-episode coverage for the review UI."""
+    if job.content_type != ContentType.TV:
+        return SeasonRosterResponse(available=False, reason="Not a TV disc")
+    if not job.tmdb_id or job.detected_season is None:
+        return SeasonRosterResponse(
+            available=False,
+            season_number=job.detected_season,
+            show_id=job.tmdb_id,
+            reason="Show or season not identified yet",
+        )
+
+    season = job.detected_season
+    episodes_raw = fetch_season_episodes(str(job.tmdb_id), season)
+    if not episodes_raw:
+        return SeasonRosterResponse(
+            available=False,
+            season_number=season,
+            show_id=job.tmdb_id,
+            reason="Could not load season episodes from TMDB",
+        )
+
+    # Map this season's matched episodes → the title ids claiming them.
+    result = await session.execute(
+        select(DiscTitle).where(DiscTitle.job_id == job.id).order_by(DiscTitle.title_index)
+    )
+    assigned: dict[int, list[int]] = {}
+    for title in result.scalars().all():
+        if not title.matched_episode:
+            continue
+        match = _EPISODE_CODE_RE.search(title.matched_episode)
+        if not match or int(match.group(1)) != season:
+            continue
+        assigned.setdefault(int(match.group(2)), []).append(title.id)
+
+    present = sorted(assigned)
+    lo, hi = (present[0], present[-1]) if present else (0, -1)
+
+    episodes = [
+        RosterEpisode(
+            episode_code=f"S{season:02d}E{ep['episode_number']:02d}",
+            episode_number=ep["episode_number"],
+            name=ep.get("name") or "",
+            status=(
+                "duplicate"
+                if len(assigned.get(ep["episode_number"], [])) > 1
+                else "assigned"
+                if len(assigned.get(ep["episode_number"], [])) == 1
+                else "missing"
+                if lo <= ep["episode_number"] <= hi
+                else "off"
+            ),
+            assigned_title_ids=assigned.get(ep["episode_number"], []),
+        )
+        for ep in episodes_raw
+    ]
+
+    return SeasonRosterResponse(
+        available=True,
+        season_number=season,
+        show_id=job.tmdb_id,
+        episodes=episodes,
+    )
 
 
 @router.get("/jobs/{job_id}/detail", response_model=JobDetailResponse)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1893,14 +1893,19 @@ async def rematch_conflict(
     """
     from app.services.job_manager import job_manager
 
-    title_ids = await job_manager.rematch_conflict(job.id, request.episode_code)
-    if not title_ids:
+    result = await job_manager.rematch_conflict(job.id, request.episode_code)
+    if not result["dispatched"] and not result["skipped"]:
         raise HTTPException(
             status_code=404,
             detail=f"No titles are currently matched to {request.episode_code}",
         )
 
-    return {"status": "rematching", "episode_code": request.episode_code, "title_ids": title_ids}
+    return {
+        "status": "rematching",
+        "episode_code": request.episode_code,
+        "title_ids": result["dispatched"],
+        "skipped": result["skipped"],
+    }
 
 
 @router.post("/jobs/{job_id}/titles/{title_id}/reassign")

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1874,6 +1874,35 @@ async def rematch_job(
     return {"status": "rematching", "job_id": job.id}
 
 
+class RematchConflictRequest(BaseModel):
+    """Request model for re-matching all titles claiming one episode."""
+
+    episode_code: str
+
+
+@router.post("/jobs/{job_id}/rematch-conflict")
+async def rematch_conflict(
+    request: RematchConflictRequest,
+    job: DiscJob = Depends(get_job_or_404),
+):
+    """Deep re-match every title currently claiming ``episode_code``.
+
+    Re-runs the audio matcher with stricter parameters (denser sampling + a
+    higher vote requirement) for each contested title so a same-episode
+    collision can resolve either way.
+    """
+    from app.services.job_manager import job_manager
+
+    title_ids = await job_manager.rematch_conflict(job.id, request.episode_code)
+    if not title_ids:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No titles are currently matched to {request.episode_code}",
+        )
+
+    return {"status": "rematching", "episode_code": request.episode_code, "title_ids": title_ids}
+
+
 @router.post("/jobs/{job_id}/titles/{title_id}/reassign")
 async def reassign_episode(
     title_id: int,

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -524,7 +524,10 @@ async def get_season_roster(
         )
 
     season = job.detected_season
-    episodes_raw = fetch_season_episodes(str(job.tmdb_id), season)
+    from app.services.config_service import get_config
+
+    config = await get_config()
+    episodes_raw = fetch_season_episodes(str(job.tmdb_id), season, config.tmdb_api_key)
     if not episodes_raw:
         return SeasonRosterResponse(
             available=False,

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,5 +1,6 @@
 """REST API routes for Engram."""
 
+import asyncio
 import json
 import logging
 import platform
@@ -486,7 +487,7 @@ class RosterEpisode(BaseModel):
     episode_code: str
     episode_number: int
     name: str
-    status: str  # "assigned" | "duplicate" | "missing" | "off"
+    status: Literal["assigned", "duplicate", "missing", "off"]
     assigned_title_ids: list[int]
 
 
@@ -527,7 +528,11 @@ async def get_season_roster(
     from app.services.config_service import get_config
 
     config = await get_config()
-    episodes_raw = fetch_season_episodes(str(job.tmdb_id), season, config.tmdb_api_key)
+    # fetch_season_episodes does a synchronous requests.get; run it off the
+    # event loop so a slow TMDB call doesn't stall other requests / WS pushes.
+    episodes_raw = await asyncio.to_thread(
+        fetch_season_episodes, str(job.tmdb_id), season, config.tmdb_api_key
+    )
     if not episodes_raw:
         return SeasonRosterResponse(
             available=False,

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -175,8 +175,14 @@ class EpisodeCurator:
         series_name: str | None,
         season: int | None,
         progress_callback: Callable[..., None] | None = None,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
     ) -> MatchResult:
-        """Match a single file to an episode using audio fingerprinting."""
+        """Match a single file to an episode using audio fingerprinting.
+
+        ``num_points``/``min_vote_count`` override the matcher's scan density and
+        minimum vote gate (used by the deep re-match path); None keeps defaults.
+        """
         logger.info(
             f"match_single_file called: {file_path.name}, series={series_name}, season={season}"
         )
@@ -205,6 +211,8 @@ class EpisodeCurator:
                 self._cache_dir,
                 season,
                 progress_callback,
+                num_points,
+                min_vote_count,
             )
             logger.debug(f"[Curator] identify_episode returned for {file_path.name}: {match}")
 

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -709,9 +709,23 @@ class EpisodeMatcher:
             logger.error(f"Error during full file fallback: {e}", exc_info=True)
             return None
 
-    def identify_episode(self, video_file, temp_dir, season_number, progress_callback=None):
+    def identify_episode(
+        self,
+        video_file,
+        temp_dir,
+        season_number,
+        progress_callback=None,
+        num_points=None,
+        min_vote_count=None,
+    ):
         """
         Identify episode using ranked voting with weighted confidence scoring.
+
+        ``num_points`` overrides the number of evenly-spaced audio scan points
+        (default 10); a denser scan yields more robust votes and a clearer
+        score gap — used by the "deep re-match" path to disambiguate conflicts.
+        ``min_vote_count`` overrides the minimum matched-chunk count required to
+        accept a match (default ``self.min_vote_count``).
 
         Process:
         1. Extract audio chunks using sparse sampling strategy
@@ -824,7 +838,8 @@ class EpisodeMatcher:
 
             # TF-IDF matching is fast (~1ms/query) and accurate. More sample
             # points reduce false positives from commentary/alternate audio tracks.
-            num_points = 10
+            # Caller may request a denser scan (deep re-match) for disambiguation.
+            num_points = num_points if num_points and num_points > 1 else 10
 
             # Calculate actual interval to evenly distribute points across available duration
             interval = available_duration / (num_points - 1)
@@ -1058,21 +1073,25 @@ class EpisodeMatcher:
                     f"total_weight={result['total_weight']:.4f}"
                 )
 
+            effective_min_votes = (
+                min_vote_count if min_vote_count is not None else self.min_vote_count
+            )
+
             if best_match and best_match["score"] > self.match_threshold:
                 vote_count = best_match["match_details"]["vote_count"]
 
                 logger.info(
                     f"Best match evaluation: "
                     f"score {best_match['score']:.3f} vs threshold {self.match_threshold}, "
-                    f"votes {vote_count} vs minimum {self.min_vote_count}"
+                    f"votes {vote_count} vs minimum {effective_min_votes}"
                 )
 
-                if vote_count < self.min_vote_count:
+                if vote_count < effective_min_votes:
                     logger.warning(
                         f"⚠ Match rejected: insufficient evidence. "
                         f"Episode: {best_match['match_details']['episode']}, "
                         f"score: {best_match['score']:.3f}, "
-                        f"votes: {vote_count}/{self.min_vote_count}, "
+                        f"votes: {vote_count}/{effective_min_votes}, "
                         f"coverage: {best_match['match_details']['file_cov']:.1%}, "
                         f"matched_at: {best_match['matched_at']}s"
                     )

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -715,7 +715,6 @@ def fetch_season_episode_runtimes(show_id: str, season_number: int) -> list[int]
     return runtimes
 
 
-@retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_season_episodes(show_id: str, season_number: int, api_key: str) -> list[dict]:
     """Fetch the episode list (number + name + runtime) for a show season.
 
@@ -725,6 +724,10 @@ def fetch_season_episodes(show_id: str, season_number: int, api_key: str) -> lis
     bare codes. The caller supplies the TMDB key (avoids importing the config
     service from the matcher layer). Returns an empty list when the key is
     missing or the request fails — callers treat that as "roster unavailable".
+
+    No ``@retry_network_operation``: ``_tmdb_get_json`` swallows
+    ``RequestException`` and returns None, so nothing would propagate for the
+    retry wrapper to catch — the decorator would be a no-op here.
     """
     if not api_key:
         logger.warning("TMDB API key not configured")

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -716,25 +716,22 @@ def fetch_season_episode_runtimes(show_id: str, season_number: int) -> list[int]
 
 
 @retry_network_operation(max_retries=3, base_delay=1.0)
-def fetch_season_episodes(show_id: str, season_number: int) -> list[dict]:
+def fetch_season_episodes(show_id: str, season_number: int, api_key: str) -> list[dict]:
     """Fetch the episode list (number + name + runtime) for a show season.
 
     Reuses the same /tv/{id}/season/{n} endpoint as
     ``fetch_season_episode_runtimes`` but keeps the episode name so the review
     UI can label candidates and the season roster with real titles instead of
-    bare codes. Returns an empty list when the key is missing or the request
-    fails — callers treat that as "roster unavailable".
+    bare codes. The caller supplies the TMDB key (avoids importing the config
+    service from the matcher layer). Returns an empty list when the key is
+    missing or the request fails — callers treat that as "roster unavailable".
     """
-    from app.services.config_service import get_config_sync
-
-    config = get_config_sync()
-    tmdb_api_key = config.tmdb_api_key
-    if not tmdb_api_key:
+    if not api_key:
         logger.warning("TMDB API key not configured")
         return []
 
     url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_number}"
-    season_data = _tmdb_get_json(url, tmdb_api_key)
+    season_data = _tmdb_get_json(url, api_key)
     if season_data is None:
         return []
     return [

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -716,6 +716,39 @@ def fetch_season_episode_runtimes(show_id: str, season_number: int) -> list[int]
 
 
 @retry_network_operation(max_retries=3, base_delay=1.0)
+def fetch_season_episodes(show_id: str, season_number: int) -> list[dict]:
+    """Fetch the episode list (number + name + runtime) for a show season.
+
+    Reuses the same /tv/{id}/season/{n} endpoint as
+    ``fetch_season_episode_runtimes`` but keeps the episode name so the review
+    UI can label candidates and the season roster with real titles instead of
+    bare codes. Returns an empty list when the key is missing or the request
+    fails — callers treat that as "roster unavailable".
+    """
+    from app.services.config_service import get_config_sync
+
+    config = get_config_sync()
+    tmdb_api_key = config.tmdb_api_key
+    if not tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return []
+
+    url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_number}"
+    season_data = _tmdb_get_json(url, tmdb_api_key)
+    if season_data is None:
+        return []
+    return [
+        {
+            "episode_number": ep.get("episode_number"),
+            "name": ep.get("name") or "",
+            "runtime": ep.get("runtime") or 0,
+        }
+        for ep in season_data.get("episodes", [])
+        if ep.get("episode_number") is not None
+    ]
+
+
+@retry_network_operation(max_retries=3, base_delay=1.0)
 def get_number_of_seasons(show_id: str) -> int:
     """
     Retrieves the number of seasons for a given TV show from the TMDB API.

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -114,7 +114,18 @@ class FinalizationCoordinator:
         has_completed = any(t.state == TitleState.COMPLETED for t in titles)
         all_failed = all(t.state == TitleState.FAILED for t in titles)
 
-        if has_matched:
+        # Review takes priority: while ANY title still needs manual review, do
+        # not organize anything — hold the whole disc in staging until it is
+        # fully resolved. (finalize_disc_job also guards against conflicts it
+        # creates mid-run; this avoids even starting finalization when the
+        # matcher already flagged a title for review.)
+        if has_review:
+            await self._state_machine.transition_to_review(
+                job,
+                session,
+                reason=f"{sum(1 for t in titles if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
+            )
+        elif has_matched:
             try:
                 await self.finalize_disc_job(job_id)
             except Exception as e:
@@ -122,12 +133,6 @@ class FinalizationCoordinator:
                 await self._state_machine.transition_to_failed(
                     job, session, error_message=f"Finalization failed: {e}"
                 )
-        elif has_review:
-            await self._state_machine.transition_to_review(
-                job,
-                session,
-                reason=f"{sum(1 for t in titles if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
-            )
         elif all_failed and not has_completed:
             await self._state_machine.transition_to_failed(
                 job, session, error_message="All titles failed to process"
@@ -281,6 +286,24 @@ class FinalizationCoordinator:
 
                 if not reassigned_any:
                     break
+
+            # Defer organization: if conflict resolution left any title needing
+            # review, organize NOTHING — hold the entire disc in staging until
+            # the user resolves the remaining title(s). Organizing only the
+            # winners here would move files out from under an unresolved disc.
+            if any(t.state == TitleState.REVIEW for t in titles):
+                await session.commit()
+                review_count = sum(1 for t in titles if t.state == TitleState.REVIEW)
+                logger.info(
+                    f"Job {job_id}: {review_count} title(s) need review — "
+                    f"deferring organization until the disc is fully resolved"
+                )
+                await self._state_machine.transition_to_review(
+                    job,
+                    session,
+                    reason=f"{review_count} title(s) need manual episode assignment",
+                )
+                return
 
             # Organize all MATCHED winners
             for t in titles:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -553,8 +553,11 @@ class JobManager:
         """Re-match a single title. Delegates to matching coordinator."""
         await self._matching.rematch_single_title(job_id, title_id, source_preference)
 
-    async def rematch_conflict(self, job_id: int, episode_code: str) -> list[int]:
-        """Deep re-match every title claiming ``episode_code`` (strict params)."""
+    async def rematch_conflict(self, job_id: int, episode_code: str) -> dict:
+        """Deep re-match every title claiming ``episode_code`` (strict params).
+
+        Returns ``{"dispatched": [...], "skipped": [{"title_id", "reason"}]}``.
+        """
         return await self._matching.rematch_conflict(
             job_id,
             episode_code,

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -31,7 +31,11 @@ from app.services.event_broadcaster import EventBroadcaster
 from app.services.finalization_coordinator import FinalizationCoordinator
 from app.services.identification_coordinator import IdentificationCoordinator
 from app.services.job_state_machine import JobStateMachine
-from app.services.matching_coordinator import MatchingCoordinator
+from app.services.matching_coordinator import (
+    STRICT_MIN_VOTES,
+    STRICT_SCAN_POINTS,
+    MatchingCoordinator,
+)
 from app.services.ripping_helpers import (
     SpeedCalculator,
     resolve_title_from_filename,
@@ -548,6 +552,15 @@ class JobManager:
     ) -> None:
         """Re-match a single title. Delegates to matching coordinator."""
         await self._matching.rematch_single_title(job_id, title_id, source_preference)
+
+    async def rematch_conflict(self, job_id: int, episode_code: str) -> list[int]:
+        """Deep re-match every title claiming ``episode_code`` (strict params)."""
+        return await self._matching.rematch_conflict(
+            job_id,
+            episode_code,
+            num_points=STRICT_SCAN_POINTS,
+            min_vote_count=STRICT_MIN_VOTES,
+        )
 
     async def process_matched_titles(self, job_id: int) -> dict:
         """Process all matched titles for a job."""

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -6,7 +6,6 @@ Extracted from JobManager to isolate matching concerns.
 import asyncio
 import json
 import logging
-import re
 import time
 from pathlib import Path
 
@@ -29,8 +28,6 @@ logger = logging.getLogger(__name__)
 # and require more matched chunks before accepting (vs the default 2).
 STRICT_SCAN_POINTS = 25
 STRICT_MIN_VOTES = 4
-
-_EPISODE_CODE_RE = re.compile(r"S(\d+)E(\d+)", re.IGNORECASE)
 
 
 class MatchingCoordinator:

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -6,6 +6,7 @@ Extracted from JobManager to isolate matching concerns.
 import asyncio
 import json
 import logging
+import re
 import time
 from pathlib import Path
 
@@ -22,6 +23,14 @@ from app.services.job_state_machine import JobStateMachine
 from app.services.ripping_helpers import find_staging_file
 
 logger = logging.getLogger(__name__)
+
+# Stricter matcher parameters for the "deep re-match" conflict path: sample more
+# audio chunks (vs the default 10) for more robust votes + a clearer score gap,
+# and require more matched chunks before accepting (vs the default 2).
+STRICT_SCAN_POINTS = 25
+STRICT_MIN_VOTES = 4
+
+_EPISODE_CODE_RE = re.compile(r"S(\d+)E(\d+)", re.IGNORECASE)
 
 
 class MatchingCoordinator:
@@ -171,8 +180,46 @@ class MatchingCoordinator:
 
         return True
 
+    async def rematch_conflict(
+        self,
+        job_id: int,
+        episode_code: str,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+    ) -> list[int]:
+        """Re-run audio matching for every title currently claiming ``episode_code``.
+
+        Used to break a same-episode collision: each contested title is re-matched
+        (engram) with stricter parameters so the tie can resolve either way.
+        Returns the ids of the titles that were re-matched.
+        """
+        async with async_session() as session:
+            result = await session.execute(
+                select(DiscTitle).where(DiscTitle.job_id == job_id).order_by(DiscTitle.title_index)
+            )
+            title_ids = [
+                t.id
+                for t in result.scalars().all()
+                if t.matched_episode and t.matched_episode.upper() == episode_code.upper()
+            ]
+
+        for tid in title_ids:
+            await self.rematch_single_title(
+                job_id,
+                tid,
+                source_preference="engram",
+                num_points=num_points,
+                min_vote_count=min_vote_count,
+            )
+        return title_ids
+
     async def rematch_single_title(
-        self, job_id: int, title_id: int, source_preference: str | None = None
+        self,
+        job_id: int,
+        title_id: int,
+        source_preference: str | None = None,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
     ) -> None:
         """Re-match a single title with the specified source preference.
 
@@ -180,6 +227,9 @@ class MatchingCoordinator:
             "discdb" — restore from stored discdb_match_details
             "engram" — clear match and re-run audio fingerprinting
             None — try discdb first if available, else engram
+
+        ``num_points``/``min_vote_count`` override the matcher scan density and
+        vote gate for the engram path (deep re-match); None keeps defaults.
         """
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
@@ -243,13 +293,26 @@ class MatchingCoordinator:
             await ws_manager.broadcast_title_update(job_id, title.id, TitleState.MATCHING.value)
 
         # Fire-and-forget: matching runs in background, progress via WebSocket
-        match_task = asyncio.create_task(self.match_single_file(job_id, title_id, file_path))
+        match_task = asyncio.create_task(
+            self.match_single_file(job_id, title_id, file_path, num_points, min_vote_count)
+        )
         match_task.add_done_callback(
             lambda t, jid=job_id, tid=title_id: self.on_match_task_done(t, jid, tid)
         )
 
-    async def match_single_file(self, job_id: int, title_id: int, file_path: Path) -> None:
-        """Run matching for a single ripped file."""
+    async def match_single_file(
+        self,
+        job_id: int,
+        title_id: int,
+        file_path: Path,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+    ) -> None:
+        """Run matching for a single ripped file.
+
+        ``num_points``/``min_vote_count`` override the matcher's scan density and
+        vote gate (deep re-match); None keeps defaults.
+        """
         logger.info(
             f"[MATCH] Title {title_id} (Job {job_id}): match task started for {file_path.name}"
         )
@@ -413,7 +476,9 @@ class MatchingCoordinator:
 
         # 7. Run matching
         try:
-            await self._match_single_file_inner(job_id, title_id, file_path)
+            await self._match_single_file_inner(
+                job_id, title_id, file_path, num_points, min_vote_count
+            )
         except Exception as e:
             logger.exception(
                 f"[MATCH] Title {title_id} (Job {job_id}): error in _match_single_file_inner: {e}"
@@ -424,7 +489,14 @@ class MatchingCoordinator:
                 self._match_semaphore.release()
                 logger.info(f"[MATCH] Title {title_id} (Job {job_id}): released match semaphore")
 
-    async def _match_single_file_inner(self, job_id: int, title_id: int, file_path: Path) -> None:
+    async def _match_single_file_inner(
+        self,
+        job_id: int,
+        title_id: int,
+        file_path: Path,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+    ) -> None:
         """Inner matching logic, called under the match semaphore."""
         match_start = time.monotonic()
 
@@ -488,6 +560,8 @@ class MatchingCoordinator:
                     series_name=job.detected_title,
                     season=job.detected_season,
                     progress_callback=on_progress,
+                    num_points=num_points,
+                    min_vote_count=min_vote_count,
                 )
 
                 elapsed = time.monotonic() - match_start

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -183,12 +183,14 @@ class MatchingCoordinator:
         episode_code: str,
         num_points: int | None = None,
         min_vote_count: int | None = None,
-    ) -> list[int]:
+    ) -> dict:
         """Re-run audio matching for every title currently claiming ``episode_code``.
 
         Used to break a same-episode collision: each contested title is re-matched
         (engram) with stricter parameters so the tie can resolve either way.
-        Returns the ids of the titles that were re-matched.
+        Returns ``{"dispatched": [ids], "skipped": [{"title_id", "reason"}]}`` so
+        callers can tell the user which titles could not be re-matched (e.g. their
+        ripped file is no longer in staging).
         """
         async with async_session() as session:
             result = await session.execute(
@@ -201,6 +203,7 @@ class MatchingCoordinator:
             ]
 
         dispatched: list[int] = []
+        skipped: list[dict] = []
         for tid in title_ids:
             try:
                 await self.rematch_single_title(
@@ -214,9 +217,10 @@ class MatchingCoordinator:
             except ValueError as e:
                 # e.g. staging file missing for a title that was matched earlier
                 # but whose ripped file is no longer present — skip it rather
-                # than failing the whole conflict re-match.
+                # than failing the whole conflict re-match, and report it.
                 logger.warning(f"Conflict re-match: skipping title {tid} (job {job_id}): {e}")
-        return dispatched
+                skipped.append({"title_id": tid, "reason": str(e)})
+        return {"dispatched": dispatched, "skipped": skipped}
 
     async def rematch_single_title(
         self,

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -200,15 +200,23 @@ class MatchingCoordinator:
                 if t.matched_episode and t.matched_episode.upper() == episode_code.upper()
             ]
 
+        dispatched: list[int] = []
         for tid in title_ids:
-            await self.rematch_single_title(
-                job_id,
-                tid,
-                source_preference="engram",
-                num_points=num_points,
-                min_vote_count=min_vote_count,
-            )
-        return title_ids
+            try:
+                await self.rematch_single_title(
+                    job_id,
+                    tid,
+                    source_preference="engram",
+                    num_points=num_points,
+                    min_vote_count=min_vote_count,
+                )
+                dispatched.append(tid)
+            except ValueError as e:
+                # e.g. staging file missing for a title that was matched earlier
+                # but whose ripped file is no longer present — skip it rather
+                # than failing the whole conflict re-match.
+                logger.warning(f"Conflict re-match: skipping title {tid} (job {job_id}): {e}")
+        return dispatched
 
     async def rematch_single_title(
         self,

--- a/backend/app/services/ripping_helpers.py
+++ b/backend/app/services/ripping_helpers.py
@@ -116,6 +116,8 @@ def find_staging_file(job: DiscJob, title: DiscTitle) -> Path | None:
     1. The recorded ``output_filename`` path directly.
     2. ``staging_path / output_filename.name`` (file moved/renamed staging dir).
     3. A ``*_t{index:02d}.mkv`` glob within ``staging_path``.
+    4. ``organized_to`` — the library path, for re-matching an already-organized
+       title (e.g. from a completed job).
     """
     if title.output_filename:
         p = Path(title.output_filename)
@@ -130,6 +132,12 @@ def find_staging_file(job: DiscJob, title: DiscTitle) -> Path | None:
         matches = list(Path(job.staging_path).glob(f"*_t{title.title_index:02d}.mkv"))
         if matches:
             return matches[0]
+
+    organized_to = getattr(title, "organized_to", None)
+    if organized_to:
+        p = Path(organized_to)
+        if p.exists():
+            return p
 
     return None
 

--- a/backend/tests/unit/test_defer_organization.py
+++ b/backend/tests/unit/test_defer_organization.py
@@ -1,0 +1,121 @@
+"""Organization must be deferred until the ENTIRE disc is resolved.
+
+Regression guard for eager per-title organization: when any title still needs
+review (including a conflict loser created during finalization), the disc must
+not be organized at all — files stay in staging until the whole disc is clean.
+"""
+
+import json
+
+import pytest
+
+from app.models import DiscJob, DiscTitle
+from app.models.disc_job import ContentType, JobState, TitleState
+from tests.unit.conftest import _unit_session_factory
+
+
+async def _seed_job() -> DiscJob:
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="F:",
+            volume_label="SHOW_S1D2",
+            content_type=ContentType.TV,
+            state=JobState.MATCHING,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path="/tmp/staging/job_x",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job
+
+
+async def _seed_title(job_id, index, ep, conf, votes, runner_ups=None, output=None) -> DiscTitle:
+    async with _unit_session_factory() as session:
+        t = DiscTitle(
+            job_id=job_id,
+            title_index=index,
+            duration_seconds=1380,
+            file_size_bytes=1_000_000_000,
+            matched_episode=ep,
+            match_confidence=conf,
+            state=TitleState.MATCHED,
+            output_filename=output,
+            match_details=json.dumps(
+                {
+                    "score": conf,
+                    "vote_count": votes,
+                    "file_cov": conf,
+                    "runner_ups": runner_ups or [],
+                }
+            ),
+        )
+        session.add(t)
+        await session.commit()
+        await session.refresh(t)
+        return t
+
+
+@pytest.fixture(autouse=True)
+def _patch_session(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.finalization_coordinator.async_session", _unit_session_factory
+    )
+
+
+@pytest.mark.unit
+class TestDeferOrganization:
+    async def test_does_not_organize_while_a_title_needs_review(self, monkeypatch, tmp_path):
+        """A conflict whose loser has no runner-up → REVIEW → organize nothing."""
+        wfile = tmp_path / "winner.mkv"
+        wfile.write_bytes(b"x")  # winner has a real file, so organize WOULD run without the fix
+        job = await _seed_job()
+        winner = await _seed_title(job.id, 7, "S01E14", 0.9, votes=9, output=str(wfile))
+        loser = await _seed_title(job.id, 8, "S01E14", 0.5, votes=4)  # no runner_ups → REVIEW
+
+        from app.services.job_manager import job_manager
+
+        calls: list = []
+        monkeypatch.setattr(
+            "app.core.organizer.tv_organizer.organize",
+            lambda *a, **k: calls.append(a) or {"success": True, "final_path": "/lib/x.mkv"},
+        )
+
+        await job_manager._finalization.finalize_disc_job(job.id)
+
+        # Nothing organized while a title still needs review.
+        assert calls == []
+        async with _unit_session_factory() as s:
+            j = await s.get(DiscJob, job.id)
+            w = await s.get(DiscTitle, winner.id)
+            ll = await s.get(DiscTitle, loser.id)
+            assert j.state == JobState.REVIEW_NEEDED
+            assert w.state == TitleState.MATCHED  # winner held, NOT organized
+            assert w.organized_to is None
+            assert ll.state == TitleState.REVIEW
+
+    async def test_organizes_everything_when_disc_is_clean(self, monkeypatch, tmp_path):
+        """No conflicts / no review → organize all in one pass → COMPLETED."""
+        f0 = tmp_path / "t00.mkv"
+        f1 = tmp_path / "t01.mkv"
+        f0.write_bytes(b"x")
+        f1.write_bytes(b"y")
+        job = await _seed_job()
+        await _seed_title(job.id, 0, "S01E01", 0.9, votes=9, output=str(f0))
+        await _seed_title(job.id, 1, "S01E02", 0.9, votes=9, output=str(f1))
+
+        from app.services.job_manager import job_manager
+
+        calls: list = []
+        monkeypatch.setattr(
+            "app.core.organizer.tv_organizer.organize",
+            lambda *a, **k: calls.append(a) or {"success": True, "final_path": "/lib/x.mkv"},
+        )
+
+        await job_manager._finalization.finalize_disc_job(job.id)
+
+        assert len(calls) == 2  # both organized
+        async with _unit_session_factory() as s:
+            j = await s.get(DiscJob, job.id)
+            assert j.state == JobState.COMPLETED

--- a/backend/tests/unit/test_matcher_params.py
+++ b/backend/tests/unit/test_matcher_params.py
@@ -1,0 +1,41 @@
+"""The deep re-match path passes denser-sampling / higher-vote overrides down
+to the matcher. This locks the curator -> identify_episode plumbing so a future
+refactor can't silently drop the kwargs."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from app.core.curator import EpisodeCurator
+
+
+@pytest.mark.unit
+async def test_match_single_file_forwards_overrides_to_matcher():
+    curator = EpisodeCurator()
+    curator._matcher = Mock()
+    curator._matcher.identify_episode.return_value = {
+        "season": 1,
+        "episode": 5,
+        "confidence": 0.9,
+        "match_details": {"vote_count": 6},
+        "runner_ups": [],
+    }
+    curator._initialized = True
+    curator._current_show = "Some Show"
+    curator._cache_dir = Path("/tmp/cache")
+
+    await curator.match_single_file(
+        Path("/tmp/title.mkv"),
+        series_name="Some Show",
+        season=1,
+        num_points=25,
+        min_vote_count=4,
+    )
+
+    curator._matcher.identify_episode.assert_called_once()
+    args = curator._matcher.identify_episode.call_args.args
+    # (video_file, temp_dir, season, progress_callback, num_points, min_vote_count)
+    assert args[2] == 1
+    assert args[4] == 25
+    assert args[5] == 4

--- a/backend/tests/unit/test_rematch_conflict.py
+++ b/backend/tests/unit/test_rematch_conflict.py
@@ -105,6 +105,28 @@ class TestRematchConflict:
             assert npts == STRICT_SCAN_POINTS
             assert mv == STRICT_MIN_VOTES
 
+    async def test_skips_titles_whose_staging_file_is_missing(self, client, monkeypatch):
+        """A missing staging file for one claimant must not fail the whole batch."""
+        job = await _seed_job()
+        t1 = await _seed_title(job.id, 0, "S01E05")  # file present
+        t2 = await _seed_title(job.id, 1, "S01E05")  # file missing → ValueError
+
+        from app.services.job_manager import job_manager
+
+        async def fake_rematch_single(job_id, title_id, source_preference=None, **kw):
+            if title_id == t2.id:
+                raise ValueError("Staging file not found")
+
+        monkeypatch.setattr(job_manager._matching, "rematch_single_title", fake_rematch_single)
+
+        resp = await client.post(
+            f"/api/jobs/{job.id}/rematch-conflict", json={"episode_code": "S01E05"}
+        )
+
+        assert resp.status_code == 200
+        # Only the title whose file existed was re-matched.
+        assert resp.json()["title_ids"] == [t1.id]
+
     async def test_404_when_no_title_claims_the_episode(self, client, monkeypatch):
         job = await _seed_job()
         await _seed_title(job.id, 0, "S01E01")

--- a/backend/tests/unit/test_rematch_conflict.py
+++ b/backend/tests/unit/test_rematch_conflict.py
@@ -1,0 +1,122 @@
+"""Unit tests for the conflict re-match endpoint.
+
+POST /api/jobs/{job_id}/rematch-conflict re-runs the audio matcher for *every*
+title currently claiming a given episode code, using stricter parameters
+(denser sampling + higher minimum vote count) so a contested episode can break
+either way. The matcher itself (ASR) is stubbed here — these tests cover the
+title-selection and parameter-passing logic.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_session
+from app.main import app
+from app.models import DiscJob, DiscTitle
+from app.models.disc_job import ContentType, JobState, TitleState
+from app.services.matching_coordinator import STRICT_MIN_VOTES, STRICT_SCAN_POINTS
+from tests.unit.conftest import _unit_session_factory
+
+
+async def _seed_job() -> DiscJob:
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=ContentType.TV,
+            state=JobState.REVIEW_NEEDED,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path="/tmp/staging/job_1",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job
+
+
+async def _seed_title(job_id: int, index: int, matched_episode: str) -> DiscTitle:
+    async with _unit_session_factory() as session:
+        title = DiscTitle(
+            job_id=job_id,
+            title_index=index,
+            duration_seconds=1380,
+            file_size_bytes=1_100_000_000,
+            matched_episode=matched_episode,
+            match_confidence=0.6,
+            state=TitleState.MATCHED,
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+        return title
+
+
+@pytest.fixture(autouse=True)
+def _patch_coordinator_session(monkeypatch):
+    """matching_coordinator binds async_session at import; point it at the test DB."""
+    monkeypatch.setattr("app.services.matching_coordinator.async_session", _unit_session_factory)
+
+
+@pytest.fixture
+async def client():
+    async def override_get_session():
+        async with _unit_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.unit
+class TestRematchConflict:
+    async def test_rematches_every_title_claiming_the_episode(self, client, monkeypatch):
+        job = await _seed_job()
+        t1 = await _seed_title(job.id, 0, "S01E05")
+        t2 = await _seed_title(job.id, 1, "S01E05")
+        await _seed_title(job.id, 2, "S01E02")  # not in the conflict
+
+        from app.services.job_manager import job_manager
+
+        calls: list[tuple] = []
+
+        async def fake_rematch_single(
+            job_id, title_id, source_preference=None, num_points=None, min_vote_count=None
+        ):
+            calls.append((title_id, source_preference, num_points, min_vote_count))
+
+        monkeypatch.setattr(job_manager._matching, "rematch_single_title", fake_rematch_single)
+
+        resp = await client.post(
+            f"/api/jobs/{job.id}/rematch-conflict", json={"episode_code": "S01E05"}
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data["title_ids"]) == {t1.id, t2.id}
+
+        # Only the two contested titles were re-matched, with strict engram params.
+        assert {c[0] for c in calls} == {t1.id, t2.id}
+        for _tid, src, npts, mv in calls:
+            assert src == "engram"
+            assert npts == STRICT_SCAN_POINTS
+            assert mv == STRICT_MIN_VOTES
+
+    async def test_404_when_no_title_claims_the_episode(self, client, monkeypatch):
+        job = await _seed_job()
+        await _seed_title(job.id, 0, "S01E01")
+
+        from app.services.job_manager import job_manager
+
+        async def fake_rematch_single(*a, **k):
+            raise AssertionError("should not be called when there is no conflict")
+
+        monkeypatch.setattr(job_manager._matching, "rematch_single_title", fake_rematch_single)
+
+        resp = await client.post(
+            f"/api/jobs/{job.id}/rematch-conflict", json={"episode_code": "S09E09"}
+        )
+        assert resp.status_code == 404

--- a/backend/tests/unit/test_rematch_conflict.py
+++ b/backend/tests/unit/test_rematch_conflict.py
@@ -124,8 +124,12 @@ class TestRematchConflict:
         )
 
         assert resp.status_code == 200
-        # Only the title whose file existed was re-matched.
-        assert resp.json()["title_ids"] == [t1.id]
+        body = resp.json()
+        # Only the title whose file existed was re-matched...
+        assert body["title_ids"] == [t1.id]
+        # ...and the skipped one is reported with a reason.
+        assert [s["title_id"] for s in body["skipped"]] == [t2.id]
+        assert "not found" in body["skipped"][0]["reason"].lower()
 
     async def test_404_when_no_title_claims_the_episode(self, client, monkeypatch):
         job = await _seed_job()

--- a/backend/tests/unit/test_ripping_helpers.py
+++ b/backend/tests/unit/test_ripping_helpers.py
@@ -1,0 +1,38 @@
+"""Unit tests for staging-file location."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.ripping_helpers import find_staging_file
+
+
+@pytest.mark.unit
+def test_find_staging_file_prefers_output_filename(tmp_path):
+    f = tmp_path / "Show_t07.mkv"
+    f.write_bytes(b"x")
+    job = SimpleNamespace(staging_path=str(tmp_path))
+    title = SimpleNamespace(output_filename=str(f), title_index=7, organized_to=None)
+    assert find_staging_file(job, title) == f
+
+
+@pytest.mark.unit
+def test_find_staging_file_falls_back_to_organized_to(tmp_path):
+    """When the staging file is gone, re-match can read the organized library file."""
+    organized = tmp_path / "library" / "Show - S01E14.mkv"
+    organized.parent.mkdir()
+    organized.write_bytes(b"x")
+    job = SimpleNamespace(staging_path=str(tmp_path / "empty_staging"))
+    title = SimpleNamespace(
+        output_filename=str(tmp_path / "gone.mkv"),  # no longer exists
+        title_index=7,
+        organized_to=str(organized),
+    )
+    assert find_staging_file(job, title) == organized
+
+
+@pytest.mark.unit
+def test_find_staging_file_returns_none_when_nothing_found(tmp_path):
+    job = SimpleNamespace(staging_path=str(tmp_path / "empty"))
+    title = SimpleNamespace(output_filename=None, title_index=3, organized_to=None)
+    assert find_staging_file(job, title) is None

--- a/backend/tests/unit/test_season_roster.py
+++ b/backend/tests/unit/test_season_roster.py
@@ -1,0 +1,158 @@
+"""Unit tests for the season-roster endpoint.
+
+GET /api/jobs/{job_id}/season-roster returns the detected season's episode
+list (code + name from TMDB) plus per-episode coverage computed across the
+job's titles: assigned / duplicate / missing (gap within the covered range) /
+off (outside the disc's range). Powers the review-redesign roster strip.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_session
+from app.main import app
+from app.models import AppConfig, DiscJob, DiscTitle
+from app.models.disc_job import ContentType, JobState, TitleState
+from tests.unit.conftest import _unit_session_factory
+
+# Episodes 1-6 of a season, as fetch_season_episodes would return them.
+_FAKE_EPISODES = [
+    {"episode_number": 1, "name": "Polaris", "runtime": 58},
+    {"episode_number": 2, "name": "Game Changer", "runtime": 57},
+    {"episode_number": 3, "name": "All In", "runtime": 59},
+    {"episode_number": 4, "name": "Happy Valley", "runtime": 56},
+    {"episode_number": 5, "name": "Seven Minutes of Terror", "runtime": 58},
+    {"episode_number": 6, "name": "New Eden", "runtime": 60},
+]
+
+
+async def _seed_config() -> None:
+    async with _unit_session_factory() as session:
+        session.add(
+            AppConfig(
+                makemkv_path="/usr/bin/makemkvcon",
+                makemkv_key="T-test-key-1234567890",
+                staging_path="/tmp/staging",
+                library_movies_path="/media/movies",
+                library_tv_path="/media/tv",
+                tmdb_api_key="eyJhbGciOiJIUzI1NiJ9.test_jwt_token",
+                ffmpeg_path="/usr/bin/ffmpeg",
+            )
+        )
+        await session.commit()
+
+
+async def _seed_tv_job(**kwargs) -> DiscJob:
+    defaults = dict(
+        drive_id="E:",
+        volume_label="FOR_ALL_MANKIND_S3",
+        content_type=ContentType.TV,
+        state=JobState.REVIEW_NEEDED,
+        detected_title="For All Mankind",
+        detected_season=3,
+        tmdb_id=12345,
+        staging_path="/tmp/staging/job_1",
+    )
+    defaults.update(kwargs)
+    async with _unit_session_factory() as session:
+        job = DiscJob(**defaults)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job
+
+
+async def _seed_title(job_id: int, index: int, matched_episode: str | None) -> DiscTitle:
+    async with _unit_session_factory() as session:
+        title = DiscTitle(
+            job_id=job_id,
+            title_index=index,
+            duration_seconds=3400,
+            file_size_bytes=4_000_000_000,
+            matched_episode=matched_episode,
+            state=TitleState.MATCHED if matched_episode else TitleState.REVIEW,
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+        return title
+
+
+@pytest.fixture
+async def client():
+    async def override_get_session():
+        async with _unit_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.unit
+class TestSeasonRoster:
+    async def test_roster_returns_episode_names_and_coverage(self, client):
+        """Roster lists season episodes with names and per-episode status.
+
+        Scenario: titles cover E01, E02, E05, with E05 doubled and E03/E04
+        empty inside the covered range (1..5). E06 is outside the range.
+        """
+        await _seed_config()
+        job = await _seed_tv_job()
+        await _seed_title(job.id, 0, "S03E01")
+        await _seed_title(job.id, 1, "S03E02")
+        t_c = await _seed_title(job.id, 2, "S03E05")
+        t_d = await _seed_title(job.id, 3, "S03E05")  # duplicate of E05
+        await _seed_title(job.id, 4, None)  # unmatched
+
+        with patch("app.api.routes.fetch_season_episodes", return_value=_FAKE_EPISODES):
+            response = await client.get(f"/api/jobs/{job.id}/season-roster")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["available"] is True
+        assert data["season_number"] == 3
+        episodes = {ep["episode_code"]: ep for ep in data["episodes"]}
+
+        # Names come through.
+        assert episodes["S03E01"]["name"] == "Polaris"
+        assert episodes["S03E04"]["name"] == "Happy Valley"
+
+        # Coverage status.
+        assert episodes["S03E01"]["status"] == "assigned"
+        assert episodes["S03E02"]["status"] == "assigned"
+        assert episodes["S03E03"]["status"] == "missing"  # gap inside range
+        assert episodes["S03E04"]["status"] == "missing"  # gap inside range
+        assert episodes["S03E05"]["status"] == "duplicate"  # two titles
+        assert episodes["S03E06"]["status"] == "off"  # outside covered range
+
+        # Duplicate slot reports both title ids; assigned slot reports one.
+        assert set(episodes["S03E05"]["assigned_title_ids"]) == {t_c.id, t_d.id}
+        assert episodes["S03E01"]["assigned_title_ids"] == [(await _title_id(job.id, 0))]
+
+    async def test_roster_unavailable_without_tmdb_id(self, client):
+        """No tmdb_id → roster cannot be built; respond gracefully, not 500."""
+        await _seed_config()
+        job = await _seed_tv_job(tmdb_id=None)
+
+        response = await client.get(f"/api/jobs/{job.id}/season-roster")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["available"] is False
+        assert data["episodes"] == []
+        assert data["reason"]
+
+
+async def _title_id(job_id: int, index: int) -> int:
+    from sqlalchemy import select
+
+    async with _unit_session_factory() as session:
+        result = await session.execute(
+            select(DiscTitle).where(DiscTitle.job_id == job_id, DiscTitle.title_index == index)
+        )
+        return result.scalar_one().id

--- a/docs/design_handoff_synapse/explorations/review-redesign-compare.html
+++ b/docs/design_handoff_synapse/explorations/review-redesign-compare.html
@@ -1,0 +1,284 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Review redesign · C · Compare</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+ --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+ --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+ --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;--magenta:#ff3d7f;--magentaHi:#ff7aa5;
+ --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;--red:#ff5555;--purple:#a78bfa;
+ --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+ --mono:"JetBrains Mono",ui-monospace,monospace;--display:"Chakra Petch",sans-serif;
+}
+html,body{height:100%}
+body{background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;line-height:1.5;
+ -webkit-font-smoothing:antialiased;min-height:100vh;
+ background-image:radial-gradient(1200px 620px at 0% 0%, rgba(94,234,212,.07), transparent 60%),
+   radial-gradient(1000px 620px at 100% 100%, rgba(255,61,127,.06), transparent 60%)}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:1;
+ background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px)}
+.wrap{max-width:1600px;margin:0 auto;padding:0 24px 80px;position:relative;z-index:2}
+.switch{position:sticky;top:0;z-index:30;display:flex;align-items:center;gap:10px;padding:10px 24px;margin:0 -24px;
+ background:rgba(5,7,12,.86);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+.switch .lbl{font-size:10px;letter-spacing:.22em;color:var(--inkFaint);text-transform:uppercase}
+.switch a{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkDim);text-decoration:none;
+ border:1px solid var(--lineMid);padding:5px 10px;transition:.15s}
+.switch a:hover{color:var(--cyan);border-color:var(--lineHi)}
+.switch a.on{color:var(--bg0);background:var(--cyan);border-color:var(--cyan);font-weight:600}
+.switch .grow{flex:1}.switch .tag{font-size:10px;letter-spacing:.16em;color:var(--magenta);text-transform:uppercase}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;padding:26px 0 18px}
+.head .back{font-size:11px;letter-spacing:.18em;color:var(--inkDim);text-transform:uppercase;margin-bottom:10px}
+.head h1{font-family:var(--display);font-weight:600;font-size:26px;letter-spacing:.02em;color:var(--cyanHi);text-shadow:0 0 18px rgba(94,234,212,.28)}
+.head .sub{font-size:12px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase;margin-top:6px}
+.head .sub b{color:var(--ink);font-weight:600}
+.actions{display:flex;gap:8px}
+.btn{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;padding:9px 14px;
+ background:transparent;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;transition:.15s}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.yellow{color:var(--yellow);border-color:rgba(253,224,71,.5)}
+.btn.solid{background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600}
+.btn.sm{padding:6px 10px;font-size:9px}
+.panel{position:relative;background:linear-gradient(180deg,var(--bg2),var(--bg1));border:1px solid var(--line)}
+.panel::before,.panel::after{content:"";position:absolute;width:9px;height:9px;border:1px solid var(--cyan);pointer-events:none;opacity:.7}
+.panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.panel.yellow::before,.panel.yellow::after{border-color:var(--yellow)}
+.badge{display:inline-flex;align-items:center;gap:5px;font-size:9px;letter-spacing:.14em;text-transform:uppercase;
+ padding:3px 7px;border:1px solid var(--lineMid);color:var(--inkDim)}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.45);background:rgba(134,239,172,.07)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.45);background:rgba(253,224,71,.07)}
+.badge.red{color:var(--red);border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.09)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.45);background:rgba(94,234,212,.07)}
+.badge.ghost{color:var(--inkFaint)}
+.dot{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 6px currentColor}
+.sec{display:flex;align-items:center;gap:9px;margin:20px 0 12px}
+.sec .lab{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkDim)}
+.sec .ct{font-size:11px;color:var(--inkFaint)}
+.roster{display:flex;gap:6px;flex-wrap:wrap;padding:14px 16px}
+.cell{position:relative;min-width:78px;flex:1;border:1px solid var(--lineMid);padding:8px 8px 9px;background:var(--bg0)}
+.cell .ep{font-size:11px;font-weight:600;letter-spacing:.06em}
+.cell .nm{font-size:9.5px;color:var(--inkDim);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cell .who{font-size:9px;color:var(--inkFaint);margin-top:5px;letter-spacing:.1em;text-transform:uppercase}
+.cell.ok{border-color:rgba(94,234,212,.4)}.cell.ok .ep{color:var(--cyan)}
+.cell.gap{border-style:dashed;border-color:var(--yellow);background:rgba(253,224,71,.05)}.cell.gap .ep{color:var(--yellow)}
+.cell.coll{border-color:var(--red);background:rgba(255,85,85,.07)}.cell.coll .ep{color:var(--red)}
+.cell.off{opacity:.42;border-color:var(--inkGhost)}.cell.off .ep{color:var(--inkFaint)}
+.cell.sug{box-shadow:0 0 0 1px var(--yellow),0 0 16px rgba(253,224,71,.25)}
+.cell .pin{position:absolute;top:-7px;right:-1px;font-size:8px;letter-spacing:.1em;padding:1px 5px;background:var(--yellow);color:var(--bg0);font-weight:600}
+
+/* pager */
+.pager{display:flex;align-items:center;justify-content:space-between;gap:14px;padding:12px 16px;margin-bottom:14px}
+.pager .who{display:flex;align-items:center;gap:12px}
+.pager .nav{font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkDim);cursor:pointer;
+ border:1px solid var(--lineMid);padding:7px 12px;transition:.15s}
+.pager .nav:hover{color:var(--cyan);border-color:var(--lineHi)}
+.pager .pos{font-size:11px;color:var(--inkFaint);letter-spacing:.1em}
+.pager .fn{font-family:var(--display);font-size:16px;color:var(--ink)}
+.pager .fm{font-size:10px;color:var(--inkFaint);letter-spacing:.08em;margin-top:2px}
+
+/* compare grid */
+.compare{display:grid;grid-template-columns:0.85fr 1fr 1fr 1fr;gap:12px;align-items:stretch}
+.col{position:relative;display:flex;flex-direction:column;background:var(--bg0);border:1px solid var(--lineMid);padding:16px}
+.col.subject{background:linear-gradient(180deg,var(--bg2),var(--bg1));border-color:var(--lineMid)}
+.col.coll{border-color:rgba(255,85,85,.5)}
+.col.sug{border-color:var(--yellow);box-shadow:0 0 18px rgba(253,224,71,.16)}
+.col.best{border-color:rgba(94,234,212,.55)}
+.col .ribbon{position:absolute;top:-1px;right:-1px;font-size:8px;letter-spacing:.12em;text-transform:uppercase;
+ padding:3px 8px;font-weight:600}
+.col.sug .ribbon{background:var(--yellow);color:var(--bg0)}
+.col.coll .ribbon{background:var(--red);color:#fff}
+.col.best .ribbon{background:var(--cyan);color:var(--bg0)}
+.col h4{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint);margin-bottom:12px}
+.epcode{font-family:var(--display);font-size:24px;font-weight:600;color:var(--ink);letter-spacing:.02em}
+.epname{font-size:12px;color:var(--inkDim);margin-top:4px;min-height:32px}
+.bigscore{font-family:var(--display);font-size:40px;font-weight:700;line-height:1;margin:14px 0 2px}
+.bigscore.hi{color:var(--green)}.bigscore.mid{color:var(--yellow)}.bigscore.lo{color:var(--red)}
+.bigscore .pct{font-size:18px;color:var(--inkFaint)}
+.bar{height:6px;background:var(--bg3);position:relative;overflow:hidden;margin:6px 0 16px}
+.bar i{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,var(--cyanDim),var(--cyan))}
+.bar.lo i{background:linear-gradient(90deg,#b45309,var(--yellow))}
+.metrics{display:flex;flex-direction:column;gap:0;border-top:1px solid var(--line)}
+.metric{display:flex;justify-content:space-between;align-items:center;padding:9px 0;border-bottom:1px solid var(--line);font-size:11px}
+.metric .k{color:var(--inkFaint);letter-spacing:.06em}
+.metric .v{color:var(--ink);font-weight:500}
+.metric .v.good{color:var(--green)}.metric .v.warn{color:var(--yellow)}.metric .v.bad{color:var(--red)}
+.coltags{display:flex;gap:6px;flex-wrap:wrap;margin:14px 0}
+.col .cta{margin-top:auto;width:100%;font-size:10px;letter-spacing:.16em;text-transform:uppercase;padding:11px;cursor:pointer;
+ border:1px solid var(--lineMid);background:transparent;color:var(--inkDim);transition:.15s}
+.col .cta:hover{color:var(--cyan);border-color:var(--cyan)}
+.col.sug .cta{background:var(--yellow);color:var(--bg0);border-color:var(--yellow);font-weight:600}
+/* subject column */
+.subject .epcode{color:var(--yellow)}
+.waveform{display:flex;align-items:flex-end;gap:2px;height:46px;margin:14px 0}
+.waveform i{flex:1;background:var(--inkGhost)}
+.waveform i.m{background:var(--cyan);box-shadow:0 0 6px rgba(94,234,212,.4)}
+.subject .reasonbox{margin-top:8px;border-top:1px solid var(--line);padding-top:12px}
+.subject .reasonbox .r{display:flex;gap:8px;align-items:center;font-size:11px;color:var(--inkDim);padding:5px 0}
+.manualbar{display:flex;align-items:center;gap:10px;margin-top:14px;padding:14px 16px}
+.manualbar .l{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkFaint)}
+.field{font-family:var(--mono);font-size:12px;background:var(--bg0);border:1px solid var(--lineMid);color:var(--ink);padding:8px 10px;outline:none}
+.field:focus{border-color:var(--cyan);box-shadow:0 0 8px rgba(94,234,212,.2)}
+.note{font-size:11px;color:var(--inkFaint);line-height:1.7;margin-top:26px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="switch">
+    <span class="lbl">Review redesign · mockups</span>
+    <a href="review-redesign-inspector.html">A · Inspector</a>
+    <a href="review-redesign-inline.html">B · Inline rows</a>
+    <a class="on" href="review-redesign-compare.html">C · Compare</a>
+    <a href="review-redesign-roster.html">D · Roster board</a>
+    <a href="review-redesign-index.html">Index</a>
+    <span class="grow"></span>
+    <span class="tag">Static mockup — not wired</span>
+  </nav>
+
+  <header class="head">
+    <div>
+      <div class="back">‹ Back to dashboard</div>
+      <h1>Resolve title</h1>
+      <div class="sub">› <b>For All Mankind</b> / Season 3 · 6 titles · Blu-ray</div>
+    </div>
+    <div class="actions">
+      <button class="btn">Skip</button>
+      <button class="btn yellow">Save &amp; next ›</button>
+    </div>
+  </header>
+
+  <div class="sec"><span class="dot" style="color:var(--cyan)"></span><span class="lab">Season roster</span><span class="ct">— E04 is the only gap; E05 is doubled</span></div>
+  <div class="panel">
+    <div class="roster">
+      <div class="cell ok"><div class="ep">E01</div><div class="nm">Polaris</div><div class="who">Title 1</div></div>
+      <div class="cell ok"><div class="ep">E02</div><div class="nm">Game Changer</div><div class="who">Title 2</div></div>
+      <div class="cell ok"><div class="ep">E03</div><div class="nm">All In</div><div class="who">Title 5</div></div>
+      <div class="cell gap sug"><span class="pin">SUGGEST</span><div class="ep">E04</div><div class="nm">Happy Valley</div><div class="who">— gap —</div></div>
+      <div class="cell coll"><div class="ep">E05</div><div class="nm">Seven Min. of Terror</div><div class="who">Title 4 ⚠ Title 6</div></div>
+      <div class="cell ok"><div class="ep">E06</div><div class="nm">New Eden</div><div class="who">Title 3</div></div>
+      <div class="cell off"><div class="ep">E07</div><div class="nm">Bring it Down</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E08</div><div class="nm">Sands of Ares</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E09</div><div class="nm">Coming Home</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E10</div><div class="nm">Stranger…</div><div class="who">other disc</div></div>
+    </div>
+  </div>
+
+  <div class="panel pager" style="margin-top:18px">
+    <div class="who">
+      <span class="nav">‹ Prev</span>
+      <div><div class="fn">title_t04.mkv</div><div class="fm">56:20 · 3.9 GB · 1080p · 18 chapters · matched by engram</div></div>
+    </div>
+    <div style="display:flex;align-items:center;gap:14px">
+      <span class="badge yellow"><span class="dot"></span>needs review</span>
+      <span class="pos">1 of 1 unresolved · title 4 of 6</span>
+      <span class="nav">Next ›</span>
+    </div>
+  </div>
+
+  <div class="compare">
+
+    <!-- subject -->
+    <div class="col subject">
+      <h4>This title</h4>
+      <div class="epcode">UNPLACED</div>
+      <div class="epname">No assignment yet · matcher was unsure</div>
+      <div class="waveform">
+        <i style="height:30%"></i><i class="m" style="height:70%"></i><i style="height:20%"></i><i class="m" style="height:55%"></i>
+        <i style="height:18%"></i><i style="height:24%"></i><i class="m" style="height:80%"></i><i style="height:15%"></i>
+        <i class="m" style="height:60%"></i><i style="height:22%"></i><i style="height:28%"></i><i style="height:12%"></i>
+      </div>
+      <div class="metrics">
+        <div class="metric"><span class="k">Sampled chunks</span><span class="v">10</span></div>
+        <div class="metric"><span class="k">Chunks matched</span><span class="v warn">4 / 10</span></div>
+        <div class="metric"><span class="k">Runtime</span><span class="v">56m 20s</span></div>
+        <div class="metric"><span class="k">Subtitles</span><span class="v good">complete</span></div>
+      </div>
+      <div class="reasonbox">
+        <div class="r"><span class="dot" style="color:var(--yellow)"></span>Low confidence (top 54%)</div>
+        <div class="r"><span class="dot" style="color:var(--yellow)"></span>Few votes (4 of 10)</div>
+        <div class="r"><span class="dot" style="color:var(--red)"></span>Top guess conflicts with Title 6</div>
+      </div>
+    </div>
+
+    <!-- candidate 1: top score but conflict -->
+    <div class="col coll">
+      <span class="ribbon">Conflict</span>
+      <h4>Candidate · top score</h4>
+      <div class="epcode">S03E05</div>
+      <div class="epname">Seven Minutes of Terror</div>
+      <div class="bigscore lo">54<span class="pct">%</span></div>
+      <div class="bar"><i style="width:54%"></i></div>
+      <div class="metrics">
+        <div class="metric"><span class="k">Votes</span><span class="v">4 / 10</span></div>
+        <div class="metric"><span class="k">Coverage</span><span class="v warn">61%</span></div>
+        <div class="metric"><span class="k">Score gap to next</span><span class="v bad">+5% · uncertain</span></div>
+        <div class="metric"><span class="k">Runtime fit</span><span class="v">±0m</span></div>
+      </div>
+      <div class="coltags"><span class="badge red"><span class="dot"></span>taken by Title 6 (88%)</span></div>
+      <button class="cta">Assign anyway</button>
+    </div>
+
+    <!-- candidate 2: suggested, fills gap -->
+    <div class="col sug">
+      <span class="ribbon">Suggested</span>
+      <h4>Candidate · fills disc gap</h4>
+      <div class="epcode">S03E04</div>
+      <div class="epname">Happy Valley</div>
+      <div class="bigscore mid">49<span class="pct">%</span></div>
+      <div class="bar lo"><i style="width:49%"></i></div>
+      <div class="metrics">
+        <div class="metric"><span class="k">Votes</span><span class="v">4 / 10</span></div>
+        <div class="metric"><span class="k">Coverage</span><span class="v warn">58%</span></div>
+        <div class="metric"><span class="k">Score gap to next</span><span class="v">+18% over E03</span></div>
+        <div class="metric"><span class="k">Runtime fit</span><span class="v good">±0m · matches</span></div>
+      </div>
+      <div class="coltags"><span class="badge yellow"><span class="dot"></span>only gap on disc</span><span class="badge cyan">free slot</span></div>
+      <button class="cta">Assign · fill gap</button>
+    </div>
+
+    <!-- candidate 3 -->
+    <div class="col">
+      <h4>Candidate</h4>
+      <div class="epcode">S03E03</div>
+      <div class="epname">All In</div>
+      <div class="bigscore lo">31<span class="pct">%</span></div>
+      <div class="bar lo"><i style="width:31%"></i></div>
+      <div class="metrics">
+        <div class="metric"><span class="k">Votes</span><span class="v">2 / 10</span></div>
+        <div class="metric"><span class="k">Coverage</span><span class="v bad">40%</span></div>
+        <div class="metric"><span class="k">Score gap to next</span><span class="v">+9%</span></div>
+        <div class="metric"><span class="k">Runtime fit</span><span class="v warn">+3m</span></div>
+      </div>
+      <div class="coltags"><span class="badge ghost">taken by Title 5 (93%)</span></div>
+      <button class="cta">Assign</button>
+    </div>
+
+  </div>
+
+  <div class="panel manualbar" style="margin-top:12px">
+    <span class="l">Manual override</span>
+    <select class="field"><option>S03</option></select>
+    <select class="field"><option>Pick episode…</option><option>E04 — Happy Valley</option><option>E07 — Bring it Down</option><option>E08 — The Sands of Ares</option></select>
+    <span style="flex:1"></span>
+    <button class="btn sm">Mark as extra</button>
+    <button class="btn sm">Discard title</button>
+    <button class="btn solid">Assign &amp; next ›</button>
+  </div>
+
+  <p class="note">
+    <b>Option C — Full compare view.</b> One title at a time, with the candidates laid out as columns so every metric
+    lines up for a head-to-head read (votes, coverage, score gap, runtime fit). The leftmost column profiles the title
+    itself and why it needs review; a pager walks you through only the unresolved titles. Most room and the clearest
+    head-to-head, at the cost of more clicks to see the whole disc. · Static mockup, For All Mankind S3 scenario.
+  </p>
+
+</div>
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/review-redesign-index.html
+++ b/docs/design_handoff_synapse/explorations/review-redesign-index.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Review redesign · mockups index</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+ --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+ --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+ --cyan:#5eead4;--cyanHi:#9ff8e8;--magenta:#ff3d7f;--yellow:#fde047;--green:#86efac;--red:#ff5555;
+ --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+ --mono:"JetBrains Mono",ui-monospace,monospace;--display:"Chakra Petch",sans-serif;
+}
+body{background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;line-height:1.6;
+ -webkit-font-smoothing:antialiased;min-height:100vh;
+ background-image:radial-gradient(1200px 620px at 0% 0%, rgba(94,234,212,.07), transparent 60%),
+   radial-gradient(1000px 620px at 100% 100%, rgba(255,61,127,.06), transparent 60%)}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:1;
+ background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px)}
+.wrap{max-width:1040px;margin:0 auto;padding:48px 24px 80px;position:relative;z-index:2}
+.kicker{font-size:11px;letter-spacing:.24em;text-transform:uppercase;color:var(--magenta)}
+h1{font-family:var(--display);font-weight:700;font-size:34px;letter-spacing:.01em;color:var(--cyanHi);
+ text-shadow:0 0 22px rgba(94,234,212,.28);margin:10px 0 6px}
+.lede{color:var(--inkDim);font-size:13.5px;max-width:760px}
+.panel{position:relative;background:linear-gradient(180deg,var(--bg2),var(--bg1));border:1px solid var(--line);padding:20px 22px;margin-top:28px}
+.panel::before,.panel::after{content:"";position:absolute;width:9px;height:9px;border:1px solid var(--cyan);pointer-events:none;opacity:.7}
+.panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.panel h2{font-family:var(--display);font-size:13px;letter-spacing:.16em;text-transform:uppercase;color:var(--cyan);margin-bottom:14px}
+.scenario{display:grid;grid-template-columns:auto 1fr;gap:8px 16px;font-size:12.5px}
+.scenario .k{color:var(--yellow);white-space:nowrap}
+.scenario .v{color:var(--inkDim)}
+.scenario .v b{color:var(--ink)}
+.shared{list-style:none;display:flex;flex-direction:column;gap:9px;font-size:12.5px;color:var(--inkDim)}
+.shared li{display:flex;gap:10px}
+.shared li::before{content:"▹";color:var(--cyan)}
+.shared b{color:var(--ink)}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:14px}
+.card{position:relative;display:block;text-decoration:none;color:inherit;border:1px solid var(--lineMid);
+ background:var(--bg0);padding:18px 18px 16px;transition:.16s}
+.card:hover{border-color:var(--lineHi);box-shadow:0 0 22px rgba(94,234,212,.12);transform:translateY(-2px)}
+.card .letter{font-family:var(--display);font-size:13px;font-weight:700;color:var(--bg0);background:var(--cyan);
+ display:inline-block;padding:2px 9px;letter-spacing:.1em}
+.card h3{font-family:var(--display);font-size:17px;color:var(--ink);margin:12px 0 6px}
+.card p{font-size:12px;color:var(--inkDim);line-height:1.6}
+.card .pc{display:flex;flex-direction:column;gap:4px;margin-top:11px;font-size:11px}
+.card .pro{color:var(--green)}.card .con{color:var(--inkFaint)}
+.card .pro::before{content:"+ ";color:var(--green)}
+.card .con::before{content:"– ";color:var(--inkFaint)}
+.card .go{position:absolute;top:18px;right:18px;color:var(--inkFaint);font-size:16px;transition:.16s}
+.card:hover .go{color:var(--cyan);transform:translateX(3px)}
+.tag{display:inline-block;font-size:9px;letter-spacing:.16em;text-transform:uppercase;color:var(--magenta);
+ border:1px solid rgba(255,61,127,.4);padding:4px 9px;margin-top:24px}
+.foot{font-size:11.5px;color:var(--inkFaint);margin-top:24px;line-height:1.8}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="kicker">Engram · Synapse v2</div>
+  <h1>TV review redesign — direction mockups</h1>
+  <p class="lede">Four static directions for the disc-review screen, all built on the same data and the same hard case:
+  making it easy to manually correct a TV disc when the matches are <i>interdependent</i>. Pick one (or a hybrid) and
+  we'll build it. Nothing here is wired — they're visual references.</p>
+
+  <div class="panel">
+    <h2>The seed scenario (identical in all four)</h2>
+    <div class="scenario">
+      <div class="k">Disc</div><div class="v"><b>For All Mankind</b> · Season 3 · 6 ripped titles</div>
+      <div class="k">Confident</div><div class="v">Titles 1,2,5,3 → E01, E02, E03, E06 (90–96%)</div>
+      <div class="k">Conflict</div><div class="v">Title 6 <b>and</b> Title 4 both land on <b>E05</b> — Title 6 is stronger (88% vs 54%)</div>
+      <div class="k">Unmatched</div><div class="v">Title 4 is low-confidence; its top guess (E05) is taken</div>
+      <div class="k">The gap</div><div class="v"><b>E04 — Happy Valley</b> is the only empty slot, and it fits Title 4's runtime</div>
+      <div class="k">The fix</div><div class="v">Move Title 4 off E05 and into E04 — a <b>whole-disc</b> reconciliation, not a single edit</div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Shared data &amp; feature layer</h2>
+    <ul class="shared">
+      <li><b>Ranked candidates with evidence</b> — each shows episode code + name, score %, votes (x/10), coverage %, and the top match's score gap ("decisive" vs "uncertain"). Already computed by the matcher.</li>
+      <li><b>Episode names</b> — pulled from a new season-roster endpoint (codes → titles), so you never decide on a bare "S03E05".</li>
+      <li><b>Season roster + conflict/coverage</b> — the season's episodes marked assigned / duplicated / missing across the disc, with the obvious gap suggested for an unmatched title.</li>
+      <li><b>Provenance</b> — engram / discdb / manual source and any DiscDB review flag.</li>
+    </ul>
+  </div>
+
+  <div class="grid">
+    <a class="card" href="review-redesign-inspector.html">
+      <span class="go">→</span>
+      <span class="letter">A</span>
+      <h3>Inspector panel</h3>
+      <p>Compact title list; selecting one opens a focused side panel with ranked candidates, evidence, and the suggestion.</p>
+      <div class="pc"><span class="pro">keeps the list in view while you fix</span><span class="con">one title at a time in the panel</span></div>
+    </a>
+    <a class="card" href="review-redesign-inline.html">
+      <span class="go">→</span>
+      <span class="letter">B</span>
+      <h3>Inline rows</h3>
+      <p>One column; review titles expand in place to show candidates and a disc-aware note. Conflict and its counterpart side by side.</p>
+      <div class="pc"><span class="pro">densest, fast top-to-bottom pass</span><span class="con">can get tall with several open</span></div>
+    </a>
+    <a class="card" href="review-redesign-compare.html">
+      <span class="go">→</span>
+      <span class="letter">C</span>
+      <h3>Full compare</h3>
+      <p>One title at a time; candidates as aligned columns for a head-to-head read of every metric, with a pager through unresolved titles.</p>
+      <div class="pc"><span class="pro">clearest head-to-head decision</span><span class="con">more clicks to see the disc</span></div>
+    </a>
+    <a class="card" href="review-redesign-roster.html">
+      <span class="go">→</span>
+      <span class="letter">D</span>
+      <h3>Roster board</h3>
+      <p>The disc is the season: episodes are slots, titles drop in. Doubled E05 and empty E04 are obvious; fix by moving Title 4.</p>
+      <div class="pc"><span class="pro">built for whole-disc reconciliation</span><span class="con">furthest from today's row UI</span></div>
+    </a>
+  </div>
+
+  <span class="tag">Static mockups — not wired</span>
+  <p class="foot">
+    Files in <code>docs/design_handoff_synapse/explorations/review-redesign-*.html</code>.
+    Open each in a browser, or use the switcher bar at the top of any mockup to flip between them.
+    After you pick a direction, the backend adds a small season-roster endpoint and the frontend rebuilds
+    <code>ReviewQueue</code> around the chosen layout.
+  </p>
+</div>
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/review-redesign-inline.html
+++ b/docs/design_handoff_synapse/explorations/review-redesign-inline.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Review redesign · B · Inline rows</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+ --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+ --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+ --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;
+ --magenta:#ff3d7f;--magentaHi:#ff7aa5;
+ --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;--red:#ff5555;--purple:#a78bfa;
+ --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+ --mono:"JetBrains Mono",ui-monospace,monospace;--display:"Chakra Petch",sans-serif;
+}
+html,body{height:100%}
+body{background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;line-height:1.5;
+ -webkit-font-smoothing:antialiased;min-height:100vh;
+ background-image:radial-gradient(1200px 620px at 0% 0%, rgba(94,234,212,.07), transparent 60%),
+   radial-gradient(1000px 620px at 100% 100%, rgba(255,61,127,.06), transparent 60%)}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:1;
+ background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px)}
+.wrap{max-width:1600px;margin:0 auto;padding:0 24px 80px;position:relative;z-index:2}
+.switch{position:sticky;top:0;z-index:30;display:flex;align-items:center;gap:10px;padding:10px 24px;margin:0 -24px;
+ background:rgba(5,7,12,.86);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+.switch .lbl{font-size:10px;letter-spacing:.22em;color:var(--inkFaint);text-transform:uppercase}
+.switch a{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkDim);text-decoration:none;
+ border:1px solid var(--lineMid);padding:5px 10px;transition:.15s}
+.switch a:hover{color:var(--cyan);border-color:var(--lineHi)}
+.switch a.on{color:var(--bg0);background:var(--cyan);border-color:var(--cyan);font-weight:600}
+.switch .grow{flex:1}.switch .tag{font-size:10px;letter-spacing:.16em;color:var(--magenta);text-transform:uppercase}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;padding:26px 0 18px}
+.head .back{font-size:11px;letter-spacing:.18em;color:var(--inkDim);text-transform:uppercase;margin-bottom:10px}
+.head h1{font-family:var(--display);font-weight:600;font-size:26px;letter-spacing:.02em;color:var(--cyanHi);text-shadow:0 0 18px rgba(94,234,212,.28)}
+.head .sub{font-size:12px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase;margin-top:6px}
+.head .sub b{color:var(--ink);font-weight:600}
+.head .reason{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
+.actions{display:flex;gap:8px}
+.btn{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;padding:9px 14px;
+ background:transparent;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;transition:.15s}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.mag{color:var(--magenta);border-color:rgba(255,61,127,.5)}
+.btn.yellow{color:var(--yellow);border-color:rgba(253,224,71,.5)}
+.btn.solid{background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600}
+.btn.sm{padding:6px 10px;font-size:9px}
+.panel{position:relative;background:linear-gradient(180deg,var(--bg2),var(--bg1));border:1px solid var(--line)}
+.panel::before,.panel::after{content:"";position:absolute;width:9px;height:9px;border:1px solid var(--cyan);pointer-events:none;opacity:.7}
+.panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.panel.yellow::before,.panel.yellow::after{border-color:var(--yellow)}
+.panel.red::before,.panel.red::after{border-color:var(--red)}
+.badge{display:inline-flex;align-items:center;gap:5px;font-size:9px;letter-spacing:.14em;text-transform:uppercase;
+ padding:3px 7px;border:1px solid var(--lineMid);color:var(--inkDim)}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.45);background:rgba(134,239,172,.07)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.45);background:rgba(253,224,71,.07)}
+.badge.red{color:var(--red);border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.09)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.45);background:rgba(94,234,212,.07)}
+.badge.amber{color:var(--amber);border-color:rgba(252,211,77,.4)}
+.badge.ghost{color:var(--inkFaint)}
+.dot{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 6px currentColor}
+.sec{display:flex;align-items:center;gap:9px;margin:22px 0 12px}
+.sec .lab{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkDim)}
+.sec .ct{font-size:11px;color:var(--inkFaint)}
+.roster{display:flex;gap:6px;flex-wrap:wrap;padding:14px 16px}
+.cell{position:relative;min-width:78px;flex:1;border:1px solid var(--lineMid);padding:8px 8px 9px;background:var(--bg0)}
+.cell .ep{font-size:11px;font-weight:600;letter-spacing:.06em}
+.cell .nm{font-size:9.5px;color:var(--inkDim);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cell .who{font-size:9px;color:var(--inkFaint);margin-top:5px;letter-spacing:.1em;text-transform:uppercase}
+.cell.ok{border-color:rgba(94,234,212,.4)}.cell.ok .ep{color:var(--cyan)}
+.cell.gap{border-style:dashed;border-color:var(--yellow);background:rgba(253,224,71,.05)}.cell.gap .ep{color:var(--yellow)}
+.cell.coll{border-color:var(--red);background:rgba(255,85,85,.07)}.cell.coll .ep{color:var(--red)}
+.cell.off{opacity:.42;border-color:var(--inkGhost)}.cell.off .ep{color:var(--inkFaint)}
+.cell.sug{box-shadow:0 0 0 1px var(--yellow),0 0 16px rgba(253,224,71,.25)}
+.cell .pin{position:absolute;top:-7px;right:-1px;font-size:8px;letter-spacing:.1em;padding:1px 5px;background:var(--yellow);color:var(--bg0);font-weight:600}
+
+/* inline rows */
+.rows{display:flex;flex-direction:column;gap:8px}
+.row{padding:0}
+.rmain{display:flex;align-items:center;gap:14px;padding:13px 16px}
+.chev{font-size:12px;color:var(--inkFaint);width:14px;transition:.15s}
+.row.open .chev{color:var(--cyan);transform:rotate(90deg)}
+.idx{font-size:10px;color:var(--inkFaint);min-width:24px}
+.rname{flex:1;min-width:0}
+.rname .n{font-size:13px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.rname .m{font-size:10px;color:var(--inkFaint);margin-top:3px;letter-spacing:.08em}
+.rtags{display:flex;gap:6px;flex-wrap:wrap;max-width:280px;justify-content:flex-end}
+.rep{font-size:12px;color:var(--cyan);min-width:170px;text-align:right;white-space:nowrap}
+.rep .epn{color:var(--inkDim);font-size:10.5px}
+.rep.bad{color:var(--red)}
+.conf{font-size:14px;font-weight:600;min-width:46px;text-align:right;font-family:var(--display)}
+.conf.hi{color:var(--green)}.conf.mid{color:var(--yellow)}.conf.lo{color:var(--red)}
+.rquick{display:flex;gap:6px}
+
+/* expanded drawer */
+.draw{display:none;border-top:1px solid var(--line);padding:16px;background:rgba(5,7,12,.5)}
+.row.open .draw{display:block}
+.disc{font-size:10.5px;color:var(--inkDim);letter-spacing:.06em;margin-bottom:12px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.disc b{color:var(--ink)}
+.cands{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.cand{position:relative;border:1px solid var(--lineMid);padding:12px 13px;background:var(--bg0);transition:.15s}
+.cand:hover{border-color:var(--lineHi)}
+.cand.coll{border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.05)}
+.cand.sug{border-color:var(--yellow);background:rgba(253,224,71,.05);box-shadow:0 0 14px rgba(253,224,71,.14)}
+.cand .top{display:flex;justify-content:space-between;align-items:flex-start;gap:8px}
+.cand .cep{font-size:13px;font-weight:600;color:var(--ink)}
+.cand .cn{display:block;color:var(--inkDim);font-weight:400;font-size:11px;margin-top:2px}
+.cand .sc{font-family:var(--display);font-size:20px;font-weight:600;line-height:1}
+.sc.hi{color:var(--green)}.sc.mid{color:var(--yellow)}.sc.lo{color:var(--red)}
+.bar{height:5px;background:var(--bg3);margin-top:11px;position:relative;overflow:hidden}
+.bar i{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,var(--cyanDim),var(--cyan))}
+.bar.lo i{background:linear-gradient(90deg,#b45309,var(--yellow))}
+.evid{display:flex;gap:12px;margin-top:9px;font-size:10px;color:var(--inkFaint);letter-spacing:.05em}
+.evid b{color:var(--inkDim);font-weight:500}
+.cand .ctags{display:flex;gap:5px;margin-top:9px;flex-wrap:wrap}
+.cand .assign{margin-top:11px;width:100%;font-size:9px;letter-spacing:.16em;text-transform:uppercase;padding:7px;cursor:pointer;
+ border:1px solid var(--lineMid);background:transparent;color:var(--inkDim);transition:.15s}
+.cand .assign:hover{color:var(--cyan);border-color:var(--cyan)}
+.cand.sug .assign{color:var(--bg0);background:var(--yellow);border-color:var(--yellow);font-weight:600}
+.drawfoot{display:flex;align-items:center;gap:8px;margin-top:14px;padding-top:14px;border-top:1px dashed var(--lineMid)}
+.drawfoot .l{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkFaint)}
+.field{font-family:var(--mono);font-size:12px;background:var(--bg0);border:1px solid var(--lineMid);color:var(--ink);padding:7px 9px;outline:none}
+.field:focus{border-color:var(--cyan);box-shadow:0 0 8px rgba(94,234,212,.2)}
+.note{font-size:11px;color:var(--inkFaint);line-height:1.7;margin-top:26px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="switch">
+    <span class="lbl">Review redesign · mockups</span>
+    <a href="review-redesign-inspector.html">A · Inspector</a>
+    <a class="on" href="review-redesign-inline.html">B · Inline rows</a>
+    <a href="review-redesign-compare.html">C · Compare</a>
+    <a href="review-redesign-roster.html">D · Roster board</a>
+    <a href="review-redesign-index.html">Index</a>
+    <span class="grow"></span>
+    <span class="tag">Static mockup — not wired</span>
+  </nav>
+
+  <header class="head">
+    <div>
+      <div class="back">‹ Back to dashboard</div>
+      <h1>Review titles</h1>
+      <div class="sub">› <b>For All Mankind</b> / Season 3 · 6 titles · Blu-ray</div>
+      <div class="reason">
+        <span class="badge yellow"><span class="dot"></span>1 title needs assignment</span>
+        <span class="badge red"><span class="dot"></span>1 episode conflict</span>
+        <span class="badge ghost">1 gap on disc · S03E04</span>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="btn">Re-match all</button>
+      <button class="btn yellow">Save 1</button>
+      <button class="btn solid">Process disc</button>
+    </div>
+  </header>
+
+  <div class="sec"><span class="dot" style="color:var(--cyan)"></span><span class="lab">Season roster</span><span class="ct">— coverage across this disc</span></div>
+  <div class="panel">
+    <div class="roster">
+      <div class="cell ok"><div class="ep">E01</div><div class="nm">Polaris</div><div class="who">Title 1</div></div>
+      <div class="cell ok"><div class="ep">E02</div><div class="nm">Game Changer</div><div class="who">Title 2</div></div>
+      <div class="cell ok"><div class="ep">E03</div><div class="nm">All In</div><div class="who">Title 5</div></div>
+      <div class="cell gap sug"><span class="pin">SUGGEST</span><div class="ep">E04</div><div class="nm">Happy Valley</div><div class="who">— gap —</div></div>
+      <div class="cell coll"><div class="ep">E05</div><div class="nm">Seven Min. of Terror</div><div class="who">Title 4 ⚠ Title 6</div></div>
+      <div class="cell ok"><div class="ep">E06</div><div class="nm">New Eden</div><div class="who">Title 3</div></div>
+      <div class="cell off"><div class="ep">E07</div><div class="nm">Bring it Down</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E08</div><div class="nm">Sands of Ares</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E09</div><div class="nm">Coming Home</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E10</div><div class="nm">Stranger…</div><div class="who">other disc</div></div>
+    </div>
+  </div>
+
+  <div class="sec"><span class="dot" style="color:var(--yellow)"></span><span class="lab">Titles</span><span class="ct">[6] — review rows expand inline</span></div>
+  <div class="rows">
+
+    <!-- expanded: needs review -->
+    <div class="panel yellow row open">
+      <div class="rmain">
+        <span class="chev">▸</span>
+        <span class="idx">#4</span>
+        <div class="rname"><div class="n">title_t04.mkv</div><div class="m">56:20 · 3.9 GB · 1080p · engram</div></div>
+        <div class="rtags"><span class="badge red"><span class="dot"></span>conflict</span><span class="badge yellow">low conf</span><span class="badge ghost">few votes</span></div>
+        <div class="rep bad" style="min-width:170px">unassigned</div>
+        <div class="conf lo">54%</div>
+      </div>
+      <div class="draw">
+        <div class="disc">
+          <span class="badge yellow"><span class="dot"></span>disc-aware</span>
+          <span>Top score <b>S03E05</b> is already taken by <b>Title 6</b>.</span>
+          <span>Only gap on disc: <b>S03E04 — Happy Valley</b> (runtime ✓).</span>
+        </div>
+        <div class="cands">
+          <div class="cand coll">
+            <div class="top"><div><div class="cep">S03E05<span class="cn">Seven Minutes of Terror</span></div></div><div class="sc lo">54%</div></div>
+            <div class="bar"><i style="width:54%"></i></div>
+            <div class="evid"><span><b>4</b>/10 votes</span><span><b>61%</b> cov</span><span>gap <b>+5%</b></span></div>
+            <div class="ctags"><span class="badge ghost">top score</span><span class="badge red">conflict · Title 6</span></div>
+            <button class="assign">Assign anyway</button>
+          </div>
+          <div class="cand sug">
+            <div class="top"><div><div class="cep">S03E04<span class="cn">Happy Valley</span></div></div><div class="sc mid">49%</div></div>
+            <div class="bar lo"><i style="width:49%"></i></div>
+            <div class="evid"><span><b>4</b>/10 votes</span><span><b>58%</b> cov</span><span>runtime ✓</span></div>
+            <div class="ctags"><span class="badge yellow"><span class="dot"></span>fills gap</span><span class="badge cyan">56m ✓</span></div>
+            <button class="assign">Assign · fill gap</button>
+          </div>
+          <div class="cand">
+            <div class="top"><div><div class="cep">S03E03<span class="cn">All In</span></div></div><div class="sc lo">31%</div></div>
+            <div class="bar lo"><i style="width:31%"></i></div>
+            <div class="evid"><span><b>2</b>/10 votes</span><span><b>40%</b> cov</span></div>
+            <div class="ctags"><span class="badge ghost">taken · Title 5</span></div>
+            <button class="assign">Assign</button>
+          </div>
+        </div>
+        <div class="drawfoot">
+          <span class="l">Manual</span>
+          <select class="field"><option>S03</option></select>
+          <select class="field"><option>Pick episode…</option><option>E04 — Happy Valley</option><option>E07 — Bring it Down</option></select>
+          <span style="flex:1"></span>
+          <button class="btn sm">Mark extra</button>
+          <button class="btn sm">Discard</button>
+          <button class="btn sm">Skip</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- collision counterpart, expanded -->
+    <div class="panel red row open">
+      <div class="rmain">
+        <span class="chev">▸</span>
+        <span class="idx">#6</span>
+        <div class="rname"><div class="n">title_t06.mkv</div><div class="m">58:05 · 4.2 GB · 1080p · engram</div></div>
+        <div class="rtags"><span class="badge red"><span class="dot"></span>shares episode</span></div>
+        <div class="rep bad">S03E05 <span class="epn">⚠ also Title 4</span></div>
+        <div class="conf mid">88%</div>
+      </div>
+      <div class="draw">
+        <div class="disc">
+          <span class="badge red"><span class="dot"></span>conflict</span>
+          <span>This title and <b>Title 4</b> both claim <b>S03E05</b>. This one is the stronger match (88% vs 54%) — keep it here and move Title 4 to the gap.</span>
+        </div>
+        <div class="cands">
+          <div class="cand sug">
+            <div class="top"><div><div class="cep">S03E05<span class="cn">Seven Minutes of Terror</span></div></div><div class="sc hi">88%</div></div>
+            <div class="bar"><i style="width:88%"></i></div>
+            <div class="evid"><span><b>7</b>/10 votes</span><span><b>88%</b> cov</span><span>gap <b>+12%</b></span></div>
+            <div class="ctags"><span class="badge green"><span class="dot"></span>best · keep</span></div>
+            <button class="assign">Keep S03E05</button>
+          </div>
+          <div class="cand">
+            <div class="top"><div><div class="cep">S03E06<span class="cn">New Eden</span></div></div><div class="sc lo">22%</div></div>
+            <div class="bar lo"><i style="width:22%"></i></div>
+            <div class="evid"><span><b>2</b>/10 votes</span><span><b>30%</b> cov</span></div>
+            <div class="ctags"><span class="badge ghost">taken · Title 3</span></div>
+            <button class="assign">Assign</button>
+          </div>
+          <div class="cand" style="opacity:.5;display:flex;align-items:center;justify-content:center;color:var(--inkFaint);font-size:11px">no other strong candidates</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- collapsed confident rows -->
+    <div class="panel row">
+      <div class="rmain"><span class="chev">▸</span><span class="idx">#1</span>
+        <div class="rname"><div class="n">title_t01.mkv</div><div class="m">58:12 · 4.3 GB · 1080p · engram</div></div>
+        <div class="rtags"><span class="badge green"><span class="dot"></span>decisive</span></div>
+        <div class="rep">S03E01 <span class="epn">Polaris</span></div><div class="conf hi">96%</div>
+      </div>
+    </div>
+    <div class="panel row">
+      <div class="rmain"><span class="chev">▸</span><span class="idx">#2</span>
+        <div class="rname"><div class="n">title_t02.mkv</div><div class="m">57:48 · 4.1 GB · 1080p · engram</div></div>
+        <div class="rtags"><span class="badge green"><span class="dot"></span>decisive</span></div>
+        <div class="rep">S03E02 <span class="epn">Game Changer</span></div><div class="conf hi">90%</div>
+      </div>
+    </div>
+    <div class="panel row">
+      <div class="rmain"><span class="chev">▸</span><span class="idx">#5</span>
+        <div class="rname"><div class="n">title_t05.mkv</div><div class="m">59:30 · 4.5 GB · 1080p · discdb</div></div>
+        <div class="rtags"><span class="badge cyan">discdb</span><span class="badge green"><span class="dot"></span>decisive</span></div>
+        <div class="rep">S03E03 <span class="epn">All In</span></div><div class="conf hi">93%</div>
+      </div>
+    </div>
+    <div class="panel row">
+      <div class="rmain"><span class="chev">▸</span><span class="idx">#3</span>
+        <div class="rname"><div class="n">title_t03.mkv</div><div class="m">60:10 · 4.6 GB · 1080p · engram</div></div>
+        <div class="rtags"><span class="badge green"><span class="dot"></span>decisive</span></div>
+        <div class="rep">S03E06 <span class="epn">New Eden</span></div><div class="conf hi">91%</div>
+      </div>
+    </div>
+
+  </div>
+
+  <p class="note">
+    <b>Option B — Richer inline rows.</b> One scannable column. Confident matches stay one line each; titles that need
+    attention expand in place to reveal the ranked candidates, full evidence, and a disc-aware note — no separate panel,
+    so you see the conflict and its counterpart together. Densest option; great for working a whole disc top-to-bottom.
+    · Static mockup, seeded with the For All Mankind S3 conflict scenario.
+  </p>
+
+</div>
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/review-redesign-inspector.html
+++ b/docs/design_handoff_synapse/explorations/review-redesign-inspector.html
@@ -1,0 +1,365 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Review redesign · A · Inspector panel</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+ --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+ --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+ --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;
+ --magenta:#ff3d7f;--magentaHi:#ff7aa5;
+ --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;--red:#ff5555;--purple:#a78bfa;
+ --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+ --mono:"JetBrains Mono",ui-monospace,monospace;
+ --display:"Chakra Petch",sans-serif;
+}
+html,body{height:100%}
+body{
+ background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;line-height:1.5;
+ -webkit-font-smoothing:antialiased;min-height:100vh;
+ background-image:
+   radial-gradient(1200px 620px at 0% 0%, rgba(94,234,212,.07), transparent 60%),
+   radial-gradient(1000px 620px at 100% 100%, rgba(255,61,127,.06), transparent 60%);
+}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:1;
+ background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px)}
+.wrap{max-width:1600px;margin:0 auto;padding:0 24px 80px;position:relative;z-index:2}
+
+/* mockup switcher chrome */
+.switch{position:sticky;top:0;z-index:30;display:flex;align-items:center;gap:10px;
+ padding:10px 24px;margin:0 -24px 0;background:rgba(5,7,12,.86);backdrop-filter:blur(8px);
+ border-bottom:1px solid var(--line)}
+.switch .lbl{font-size:10px;letter-spacing:.22em;color:var(--inkFaint);text-transform:uppercase}
+.switch a{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkDim);
+ text-decoration:none;border:1px solid var(--lineMid);padding:5px 10px;transition:.15s}
+.switch a:hover{color:var(--cyan);border-color:var(--lineHi)}
+.switch a.on{color:var(--bg0);background:var(--cyan);border-color:var(--cyan);font-weight:600}
+.switch .grow{flex:1}
+.switch .tag{font-size:10px;letter-spacing:.16em;color:var(--magenta);text-transform:uppercase}
+
+/* page header */
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;padding:26px 0 18px}
+.head .back{font-size:11px;letter-spacing:.18em;color:var(--inkDim);text-transform:uppercase;margin-bottom:10px}
+.head h1{font-family:var(--display);font-weight:600;font-size:26px;letter-spacing:.02em;color:var(--cyanHi);
+ text-shadow:0 0 18px rgba(94,234,212,.28)}
+.head .sub{font-size:12px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase;margin-top:6px}
+.head .sub b{color:var(--ink);font-weight:600}
+.head .reason{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
+.actions{display:flex;gap:8px}
+
+/* buttons */
+.btn{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+ padding:9px 14px;background:transparent;border:1px solid var(--lineMid);color:var(--inkDim);
+ cursor:pointer;transition:.15s}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.cyan{color:var(--cyan);border-color:rgba(94,234,212,.5)}
+.btn.cyan:hover{background:rgba(94,234,212,.1);box-shadow:0 0 14px rgba(94,234,212,.18)}
+.btn.mag{color:var(--magenta);border-color:rgba(255,61,127,.5)}
+.btn.mag:hover{background:rgba(255,61,127,.1)}
+.btn.yellow{color:var(--yellow);border-color:rgba(253,224,71,.5)}
+.btn.solid{background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600}
+.btn.sm{padding:6px 10px;font-size:9px}
+
+/* panels — sharp 90° with corner ticks */
+.panel{position:relative;background:linear-gradient(180deg,var(--bg2),var(--bg1));
+ border:1px solid var(--line)}
+.panel::before,.panel::after{content:"";position:absolute;width:9px;height:9px;
+ border:1px solid var(--cyan);pointer-events:none;opacity:.7}
+.panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.panel.mag::before,.panel.mag::after{border-color:var(--magenta)}
+.panel.yellow::before,.panel.yellow::after{border-color:var(--yellow)}
+
+/* badges */
+.badge{display:inline-flex;align-items:center;gap:5px;font-size:9px;letter-spacing:.14em;
+ text-transform:uppercase;padding:3px 7px;border:1px solid var(--lineMid);color:var(--inkDim)}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.45);background:rgba(134,239,172,.07)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.45);background:rgba(253,224,71,.07)}
+.badge.red{color:var(--red);border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.09)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.45);background:rgba(94,234,212,.07)}
+.badge.mag{color:var(--magenta);border-color:rgba(255,61,127,.45);background:rgba(255,61,127,.08)}
+.badge.amber{color:var(--amber);border-color:rgba(252,211,77,.4)}
+.badge.ghost{color:var(--inkFaint)}
+.dot{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 6px currentColor}
+
+/* section heading */
+.sec{display:flex;align-items:center;gap:9px;margin:22px 0 12px}
+.sec .lab{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkDim)}
+.sec .ct{font-size:11px;color:var(--inkFaint)}
+
+/* roster strip */
+.roster{display:flex;gap:6px;flex-wrap:wrap;padding:14px 16px}
+.cell{position:relative;min-width:78px;flex:1;border:1px solid var(--lineMid);padding:8px 8px 9px;
+ background:var(--bg0);transition:.15s}
+.cell .ep{font-size:11px;font-weight:600;letter-spacing:.06em}
+.cell .nm{font-size:9.5px;color:var(--inkDim);margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.cell .who{font-size:9px;color:var(--inkFaint);margin-top:5px;letter-spacing:.1em;text-transform:uppercase}
+.cell.ok{border-color:rgba(94,234,212,.4)}.cell.ok .ep{color:var(--cyan)}
+.cell.gap{border-style:dashed;border-color:var(--yellow);background:rgba(253,224,71,.05)}
+.cell.gap .ep{color:var(--yellow)}
+.cell.coll{border-color:var(--red);background:rgba(255,85,85,.07)}.cell.coll .ep{color:var(--red)}
+.cell.off{opacity:.42;border-color:var(--inkGhost)}.cell.off .ep{color:var(--inkFaint)}
+.cell.sug{box-shadow:0 0 0 1px var(--yellow),0 0 16px rgba(253,224,71,.25)}
+.cell .pin{position:absolute;top:-7px;right:-1px;font-size:8px;letter-spacing:.1em;padding:1px 5px;
+ background:var(--yellow);color:var(--bg0);font-weight:600}
+
+/* title list (left) */
+.layout{display:grid;grid-template-columns:1fr 1.05fr;gap:18px;align-items:start}
+.tlist{display:flex;flex-direction:column;gap:8px}
+.trow{display:flex;align-items:center;gap:12px;padding:12px 14px;cursor:pointer;transition:.15s}
+.trow:hover{border-color:var(--lineMid)}
+.trow.active{box-shadow:0 0 0 1px var(--cyan),0 0 18px rgba(94,234,212,.16)}
+.trow.review::before,.trow.review::after{border-color:var(--yellow)}
+.idx{font-size:10px;color:var(--inkFaint);min-width:22px}
+.tmid{flex:1;min-width:0}
+.tname{font-size:12.5px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.tmeta{font-size:10px;color:var(--inkFaint);margin-top:3px;letter-spacing:.08em}
+.tep{font-size:11px;color:var(--cyan);text-align:right;white-space:nowrap}
+.tep .epn{color:var(--inkDim);font-size:10px}
+.conf{font-size:12px;font-weight:600;min-width:40px;text-align:right}
+.conf.hi{color:var(--green)}.conf.mid{color:var(--yellow)}.conf.lo{color:var(--red)}
+
+/* inspector (right) */
+.insp{position:sticky;top:64px;padding:0}
+.insp .ihead{display:flex;align-items:center;justify-content:space-between;gap:12px;
+ padding:14px 16px;border-bottom:1px solid var(--line)}
+.insp .ihead .t{font-family:var(--display);font-size:15px;color:var(--ink)}
+.insp .ihead .m{font-size:10px;color:var(--inkFaint);letter-spacing:.1em;margin-top:3px}
+.ibody{padding:16px}
+.callout{display:flex;gap:12px;align-items:center;padding:12px 14px;margin-bottom:14px;
+ border:1px solid var(--yellow);background:rgba(253,224,71,.07)}
+.callout .big{font-family:var(--display);font-size:13px;color:var(--yellow)}
+.callout .s{font-size:10.5px;color:var(--inkDim);margin-top:2px}
+.callout .grow{flex:1}
+
+.candlab{font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkFaint);margin:6px 0 10px}
+.cand{position:relative;display:grid;grid-template-columns:1fr auto;gap:10px;align-items:center;
+ padding:11px 13px;border:1px solid var(--lineMid);margin-bottom:8px;background:var(--bg0);transition:.15s}
+.cand:hover{border-color:var(--lineHi)}
+.cand.best{border-color:rgba(94,234,212,.5)}
+.cand.coll{border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.05)}
+.cand.sug{border-color:var(--yellow);background:rgba(253,224,71,.05);box-shadow:0 0 14px rgba(253,224,71,.14)}
+.cand .ci{min-width:0}
+.cand .cep{font-size:13px;font-weight:600;color:var(--ink)}
+.cand .cep .cn{color:var(--inkDim);font-weight:400;font-size:11.5px}
+.cand .ctags{display:flex;gap:6px;margin-top:7px;flex-wrap:wrap}
+.bar{height:5px;background:var(--bg3);margin-top:9px;position:relative;overflow:hidden}
+.bar i{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,var(--cyanDim),var(--cyan))}
+.bar.lo i{background:linear-gradient(90deg,#b45309,var(--yellow))}
+.evid{display:flex;gap:14px;margin-top:9px;font-size:10px;color:var(--inkFaint);letter-spacing:.06em}
+.evid b{color:var(--inkDim);font-weight:500}
+.cright{display:flex;flex-direction:column;align-items:flex-end;gap:8px}
+.score{font-family:var(--display);font-size:20px;font-weight:600;line-height:1}
+.score.hi{color:var(--green)}.score.mid{color:var(--yellow)}.score.lo{color:var(--red)}
+.assign{font-size:9px;letter-spacing:.16em;text-transform:uppercase;padding:6px 11px;cursor:pointer;
+ border:1px solid var(--lineMid);background:transparent;color:var(--inkDim);transition:.15s}
+.assign:hover{color:var(--cyan);border-color:var(--cyan)}
+.assign.go{color:var(--bg0);background:var(--yellow);border-color:var(--yellow);font-weight:600}
+
+.foot{display:flex;gap:8px;justify-content:flex-end;padding:14px 16px;border-top:1px solid var(--line)}
+.manual{display:flex;align-items:center;gap:8px;margin-top:14px;padding-top:14px;border-top:1px dashed var(--lineMid)}
+.manual .l{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkFaint)}
+.field{font-family:var(--mono);font-size:12px;background:var(--bg0);border:1px solid var(--lineMid);
+ color:var(--ink);padding:7px 9px;outline:none}
+.field:focus{border-color:var(--cyan);box-shadow:0 0 8px rgba(94,234,212,.2)}
+.note{font-size:11px;color:var(--inkFaint);line-height:1.7;margin-top:26px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="switch">
+    <span class="lbl">Review redesign · mockups</span>
+    <a class="on" href="review-redesign-inspector.html">A · Inspector</a>
+    <a href="review-redesign-inline.html">B · Inline rows</a>
+    <a href="review-redesign-compare.html">C · Compare</a>
+    <a href="review-redesign-roster.html">D · Roster board</a>
+    <a href="review-redesign-index.html">Index</a>
+    <span class="grow"></span>
+    <span class="tag">Static mockup — not wired</span>
+  </nav>
+
+  <header class="head">
+    <div>
+      <div class="back">‹ Back to dashboard</div>
+      <h1>Review titles</h1>
+      <div class="sub">› <b>For All Mankind</b> / Season 3 · 6 titles · Blu-ray</div>
+      <div class="reason">
+        <span class="badge yellow"><span class="dot"></span>1 title needs assignment</span>
+        <span class="badge red"><span class="dot"></span>1 episode conflict</span>
+        <span class="badge ghost">1 gap on disc · S03E04</span>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="btn">Re-match all</button>
+      <button class="btn yellow">Save 1</button>
+      <button class="btn solid">Process disc</button>
+    </div>
+  </header>
+
+  <!-- season roster -->
+  <div class="sec"><span class="dot" style="color:var(--cyan)"></span><span class="lab">Season roster</span><span class="ct">— coverage across this disc</span></div>
+  <div class="panel">
+    <div class="roster">
+      <div class="cell ok"><div class="ep">E01</div><div class="nm">Polaris</div><div class="who">Title 1</div></div>
+      <div class="cell ok"><div class="ep">E02</div><div class="nm">Game Changer</div><div class="who">Title 2</div></div>
+      <div class="cell ok"><div class="ep">E03</div><div class="nm">All In</div><div class="who">Title 5</div></div>
+      <div class="cell gap sug"><span class="pin">SUGGEST</span><div class="ep">E04</div><div class="nm">Happy Valley</div><div class="who">— gap —</div></div>
+      <div class="cell coll"><div class="ep">E05</div><div class="nm">Seven Min. of Terror</div><div class="who">Title 4 ⚠ Title 6?</div></div>
+      <div class="cell ok"><div class="ep">E06</div><div class="nm">New Eden</div><div class="who">Title 6</div></div>
+      <div class="cell off"><div class="ep">E07</div><div class="nm">Bring it Down</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E08</div><div class="nm">Sands of Ares</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E09</div><div class="nm">Coming Home</div><div class="who">other disc</div></div>
+      <div class="cell off"><div class="ep">E10</div><div class="nm">Stranger…</div><div class="who">other disc</div></div>
+    </div>
+  </div>
+
+  <div class="layout" style="margin-top:20px">
+    <!-- LEFT: title list -->
+    <div>
+      <div class="sec"><span class="dot" style="color:var(--yellow)"></span><span class="lab">Titles</span><span class="ct">[6] — select one to inspect</span></div>
+      <div class="tlist">
+
+        <div class="panel trow review active">
+          <div class="idx">#4</div>
+          <div class="tmid">
+            <div class="tname">title_t04.mkv</div>
+            <div class="tmeta">56:20 · 3.9 GB · 1080p · engram</div>
+          </div>
+          <div class="tep"><span class="badge yellow">needs review</span></div>
+          <div class="conf lo">54%</div>
+        </div>
+
+        <div class="panel trow">
+          <div class="idx">#1</div>
+          <div class="tmid"><div class="tname">title_t01.mkv</div><div class="tmeta">58:12 · 4.3 GB · 1080p · engram</div></div>
+          <div class="tep">S03E01 <span class="epn">Polaris</span></div>
+          <div class="conf hi">96%</div>
+        </div>
+
+        <div class="panel trow">
+          <div class="idx">#2</div>
+          <div class="tmid"><div class="tname">title_t02.mkv</div><div class="tmeta">57:48 · 4.1 GB · 1080p · engram</div></div>
+          <div class="tep">S03E02 <span class="epn">Game Changer</span></div>
+          <div class="conf hi">90%</div>
+        </div>
+
+        <div class="panel trow">
+          <div class="idx">#5</div>
+          <div class="tmid"><div class="tname">title_t05.mkv</div><div class="tmeta">59:30 · 4.5 GB · 1080p · discdb</div></div>
+          <div class="tep">S03E03 <span class="epn">All In</span></div>
+          <div class="conf hi">93%</div>
+        </div>
+
+        <div class="panel trow">
+          <div class="idx">#6</div>
+          <div class="tmid"><div class="tname">title_t06.mkv</div><div class="tmeta">58:05 · 4.2 GB · 1080p · engram</div></div>
+          <div class="tep" style="color:var(--red)">S03E05 <span class="epn">⚠ also Title 4</span></div>
+          <div class="conf mid">88%</div>
+        </div>
+
+        <div class="panel trow">
+          <div class="idx">#3</div>
+          <div class="tmid"><div class="tname">title_t03.mkv</div><div class="tmeta">60:10 · 4.6 GB · 1080p · engram</div></div>
+          <div class="tep">S03E06 <span class="epn">New Eden</span></div>
+          <div class="conf hi">91%</div>
+        </div>
+
+      </div>
+    </div>
+
+    <!-- RIGHT: inspector -->
+    <div>
+      <div class="sec"><span class="dot" style="color:var(--yellow)"></span><span class="lab">Inspector</span><span class="ct">— Title #4</span></div>
+      <div class="panel yellow insp">
+        <div class="ihead">
+          <div>
+            <div class="t">title_t04.mkv</div>
+            <div class="m">56:20 · 3.9 GB · 1080p · 18 chapters · matched by engram</div>
+          </div>
+          <span class="badge yellow"><span class="dot"></span>needs review</span>
+        </div>
+        <div class="ibody">
+
+          <div class="callout">
+            <div>
+              <div class="big">↳ Suggested: S03E04 — Happy Valley</div>
+              <div class="s">Only unfilled gap on this disc. Top score (E05) is already taken by Title 6.</div>
+            </div>
+            <div class="grow"></div>
+            <button class="assign go">Accept</button>
+          </div>
+
+          <div class="candlab">Ranked candidates — why review</div>
+
+          <div class="cand coll">
+            <div class="ci">
+              <div class="cep">S03E05 <span class="cn">— Seven Minutes of Terror</span></div>
+              <div class="ctags">
+                <span class="badge ghost">top score</span>
+                <span class="badge red"><span class="dot"></span>conflict · Title 6</span>
+              </div>
+              <div class="bar"><i style="width:54%"></i></div>
+              <div class="evid"><span><b>4</b>/10 votes</span><span><b>61%</b> coverage</span><span>gap <b>+5%</b></span></div>
+            </div>
+            <div class="cright"><div class="score lo">54%</div><button class="assign">Assign anyway</button></div>
+          </div>
+
+          <div class="cand sug">
+            <div class="ci">
+              <div class="cep">S03E04 <span class="cn">— Happy Valley</span></div>
+              <div class="ctags">
+                <span class="badge yellow"><span class="dot"></span>fills disc gap</span>
+                <span class="badge cyan">runtime ✓ 56m</span>
+              </div>
+              <div class="bar lo"><i style="width:49%"></i></div>
+              <div class="evid"><span><b>4</b>/10 votes</span><span><b>58%</b> coverage</span><span>runtime match</span></div>
+            </div>
+            <div class="cright"><div class="score mid">49%</div><button class="assign go">Assign</button></div>
+          </div>
+
+          <div class="cand">
+            <div class="ci">
+              <div class="cep">S03E03 <span class="cn">— All In</span></div>
+              <div class="ctags"><span class="badge ghost">already taken · Title 5</span></div>
+              <div class="bar lo"><i style="width:31%"></i></div>
+              <div class="evid"><span><b>2</b>/10 votes</span><span><b>40%</b> coverage</span></div>
+            </div>
+            <div class="cright"><div class="score lo">31%</div><button class="assign">Assign</button></div>
+          </div>
+
+          <div class="manual">
+            <span class="l">Manual</span>
+            <select class="field"><option>S03</option></select>
+            <select class="field"><option>Pick episode…</option><option>E04 — Happy Valley</option><option>E07 — Bring it Down</option></select>
+            <span style="flex:1"></span>
+            <button class="btn sm">Mark extra</button>
+            <button class="btn sm">Discard</button>
+          </div>
+
+        </div>
+        <div class="foot">
+          <button class="btn sm">Skip for now</button>
+          <button class="btn sm yellow">Save this title</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p class="note">
+    <b>Option A — Inspector panel.</b> The title list stays compact and scannable; selecting any title opens a focused
+    inspector on the right showing ranked candidates with full evidence (votes, coverage, score gap), the disc-aware
+    suggestion, and a manual override. The season roster across the top gives constant disc-level context — conflicts in
+    red, the gap in dashed yellow. Best when you fix one or two titles at a time without losing the list. · Static mockup,
+    seeded with the For All Mankind S3 conflict scenario.
+  </p>
+
+</div>
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/review-redesign-roster.html
+++ b/docs/design_handoff_synapse/explorations/review-redesign-roster.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Review redesign · D · Roster board</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+ --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+ --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+ --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;--magenta:#ff3d7f;--magentaHi:#ff7aa5;
+ --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;--red:#ff5555;--purple:#a78bfa;
+ --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+ --mono:"JetBrains Mono",ui-monospace,monospace;--display:"Chakra Petch",sans-serif;
+}
+html,body{height:100%}
+body{background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;line-height:1.5;
+ -webkit-font-smoothing:antialiased;min-height:100vh;
+ background-image:radial-gradient(1200px 620px at 0% 0%, rgba(94,234,212,.07), transparent 60%),
+   radial-gradient(1000px 620px at 100% 100%, rgba(255,61,127,.06), transparent 60%)}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:1;
+ background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px)}
+.wrap{max-width:1600px;margin:0 auto;padding:0 24px 80px;position:relative;z-index:2}
+.switch{position:sticky;top:0;z-index:30;display:flex;align-items:center;gap:10px;padding:10px 24px;margin:0 -24px;
+ background:rgba(5,7,12,.86);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+.switch .lbl{font-size:10px;letter-spacing:.22em;color:var(--inkFaint);text-transform:uppercase}
+.switch a{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkDim);text-decoration:none;
+ border:1px solid var(--lineMid);padding:5px 10px;transition:.15s}
+.switch a:hover{color:var(--cyan);border-color:var(--lineHi)}
+.switch a.on{color:var(--bg0);background:var(--cyan);border-color:var(--cyan);font-weight:600}
+.switch .grow{flex:1}.switch .tag{font-size:10px;letter-spacing:.16em;color:var(--magenta);text-transform:uppercase}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;padding:26px 0 18px}
+.head .back{font-size:11px;letter-spacing:.18em;color:var(--inkDim);text-transform:uppercase;margin-bottom:10px}
+.head h1{font-family:var(--display);font-weight:600;font-size:26px;letter-spacing:.02em;color:var(--cyanHi);text-shadow:0 0 18px rgba(94,234,212,.28)}
+.head .sub{font-size:12px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase;margin-top:6px}
+.head .sub b{color:var(--ink);font-weight:600}
+.head .reason{margin-top:10px;display:flex;gap:8px;flex-wrap:wrap}
+.actions{display:flex;gap:8px}
+.btn{font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;padding:9px 14px;
+ background:transparent;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;transition:.15s}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.yellow{color:var(--yellow);border-color:rgba(253,224,71,.5)}
+.btn.solid{background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600}
+.btn.sm{padding:6px 10px;font-size:9px}
+.panel{position:relative;background:linear-gradient(180deg,var(--bg2),var(--bg1));border:1px solid var(--line)}
+.panel::before,.panel::after{content:"";position:absolute;width:9px;height:9px;border:1px solid var(--cyan);pointer-events:none;opacity:.7}
+.panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.panel.mag::before,.panel.mag::after{border-color:var(--magenta)}
+.badge{display:inline-flex;align-items:center;gap:5px;font-size:9px;letter-spacing:.14em;text-transform:uppercase;
+ padding:3px 7px;border:1px solid var(--lineMid);color:var(--inkDim)}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.45);background:rgba(134,239,172,.07)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.45);background:rgba(253,224,71,.07)}
+.badge.red{color:var(--red);border-color:rgba(255,85,85,.5);background:rgba(255,85,85,.09)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.45);background:rgba(94,234,212,.07)}
+.badge.ghost{color:var(--inkFaint)}
+.dot{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 6px currentColor}
+.sec{display:flex;align-items:center;gap:9px;margin:20px 0 12px}
+.sec .lab{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkDim)}
+.sec .ct{font-size:11px;color:var(--inkFaint)}
+
+/* board grid */
+.board{display:grid;grid-template-columns:repeat(5,1fr);gap:12px}
+.slot{position:relative;border:1px solid var(--lineMid);background:var(--bg0);padding:12px;min-height:148px;display:flex;flex-direction:column}
+.slot .sh{display:flex;align-items:baseline;justify-content:space-between;gap:8px;margin-bottom:10px}
+.slot .ep{font-family:var(--display);font-size:15px;font-weight:600;color:var(--inkDim)}
+.slot .en{font-size:10px;color:var(--inkFaint);text-align:right;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:110px}
+.slot.ok{border-color:rgba(94,234,212,.4)}.slot.ok .ep{color:var(--cyan)}
+.slot.off{opacity:.4;border-color:var(--inkGhost)}
+.slot.gap{border-style:dashed;border-color:var(--yellow);background:rgba(253,224,71,.04);box-shadow:0 0 18px rgba(253,224,71,.15)}
+.slot.gap .ep{color:var(--yellow)}
+.slot.coll{border-color:var(--red);background:rgba(255,85,85,.06)}.slot.coll .ep{color:var(--red)}
+.slot .pin{position:absolute;top:-8px;left:10px;font-size:8px;letter-spacing:.12em;padding:2px 6px;font-weight:600}
+.slot.gap .pin{background:var(--yellow);color:var(--bg0)}
+.slot.coll .pin{background:var(--red);color:#fff}
+
+.chip{border:1px solid var(--lineMid);background:var(--bg2);padding:8px 9px;margin-top:auto}
+.chip+.chip{margin-top:7px}
+.chip .cn{font-size:11px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.chip .cm{display:flex;align-items:center;gap:7px;margin-top:5px;font-size:9px;color:var(--inkFaint);letter-spacing:.08em}
+.chip .conf{font-weight:600}
+.chip .conf.hi{color:var(--green)}.chip .conf.mid{color:var(--yellow)}.chip .conf.lo{color:var(--red)}
+.chip.keep{border-color:rgba(134,239,172,.4)}
+.chip.move{border-color:rgba(255,85,85,.5);border-style:dashed}
+.chip.ghost{border-style:dashed;border-color:var(--lineMid);background:transparent;color:var(--inkFaint);text-align:center;font-size:10px;padding:14px 9px}
+.slotcta{margin-top:8px;display:flex;gap:6px}
+.mini{font-size:8.5px;letter-spacing:.12em;text-transform:uppercase;padding:5px 7px;cursor:pointer;border:1px solid var(--lineMid);background:transparent;color:var(--inkDim);transition:.15s;flex:1;text-align:center}
+.mini:hover{color:var(--cyan);border-color:var(--cyan)}
+.mini.go{background:var(--yellow);color:var(--bg0);border-color:var(--yellow);font-weight:600}
+
+/* tray */
+.tray{display:flex;align-items:center;gap:14px;padding:14px 16px;flex-wrap:wrap}
+.tray .tl{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--yellow)}
+.tcard{display:flex;align-items:center;gap:10px;border:1px solid var(--yellow);background:rgba(253,224,71,.06);padding:9px 12px;cursor:grab}
+.tcard .g{color:var(--inkFaint);font-size:13px}
+.tcard .cn{font-size:12px;color:var(--ink)}
+.tcard .cm{font-size:9px;color:var(--inkFaint);letter-spacing:.08em;margin-top:2px}
+.tcard .hint{font-size:9px;color:var(--yellow);letter-spacing:.1em;margin-left:6px}
+.legend{display:flex;gap:16px;flex-wrap:wrap;font-size:10px;color:var(--inkFaint);letter-spacing:.06em;padding:0 2px;margin-top:14px}
+.legend span{display:inline-flex;align-items:center;gap:6px}
+.sw{width:14px;height:10px;border:1px solid}
+.sw.ok{border-color:rgba(94,234,212,.5)}.sw.gap{border-style:dashed;border-color:var(--yellow)}
+.sw.coll{border-color:var(--red);background:rgba(255,85,85,.1)}.sw.off{border-color:var(--inkGhost)}
+.note{font-size:11px;color:var(--inkFaint);line-height:1.7;margin-top:26px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="switch">
+    <span class="lbl">Review redesign · mockups</span>
+    <a href="review-redesign-inspector.html">A · Inspector</a>
+    <a href="review-redesign-inline.html">B · Inline rows</a>
+    <a href="review-redesign-compare.html">C · Compare</a>
+    <a class="on" href="review-redesign-roster.html">D · Roster board</a>
+    <a href="review-redesign-index.html">Index</a>
+    <span class="grow"></span>
+    <span class="tag">Static mockup — not wired</span>
+  </nav>
+
+  <header class="head">
+    <div>
+      <div class="back">‹ Back to dashboard</div>
+      <h1>Place the disc</h1>
+      <div class="sub">› <b>For All Mankind</b> / Season 3 · 6 titles · Blu-ray</div>
+      <div class="reason">
+        <span class="badge yellow"><span class="dot"></span>1 title to place</span>
+        <span class="badge red"><span class="dot"></span>E05 doubled</span>
+        <span class="badge yellow">E04 empty</span>
+        <span class="badge green">4 placed</span>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="btn">Re-match all</button>
+      <button class="btn solid" disabled style="opacity:.5;cursor:not-allowed">Process disc · resolve first</button>
+    </div>
+  </header>
+
+  <div class="sec"><span class="dot" style="color:var(--cyan)"></span><span class="lab">Season 3 board</span><span class="ct">— each title dropped into its episode slot · resolve red &amp; dashed</span></div>
+
+  <div class="board">
+
+    <div class="slot ok">
+      <div class="sh"><span class="ep">E01</span><span class="en">Polaris</span></div>
+      <div class="chip"><div class="cn">title_t01.mkv</div><div class="cm"><span>58:12</span>·<span class="conf hi">96%</span>·<span>engram</span></div></div>
+    </div>
+
+    <div class="slot ok">
+      <div class="sh"><span class="ep">E02</span><span class="en">Game Changer</span></div>
+      <div class="chip"><div class="cn">title_t02.mkv</div><div class="cm"><span>57:48</span>·<span class="conf hi">90%</span>·<span>engram</span></div></div>
+    </div>
+
+    <div class="slot ok">
+      <div class="sh"><span class="ep">E03</span><span class="en">All In</span></div>
+      <div class="chip"><div class="cn">title_t05.mkv</div><div class="cm"><span>59:30</span>·<span class="conf hi">93%</span>·<span>discdb</span></div></div>
+    </div>
+
+    <!-- GAP -->
+    <div class="slot gap">
+      <span class="pin">GAP · SUGGESTED</span>
+      <div class="sh"><span class="ep">E04</span><span class="en">Happy Valley</span></div>
+      <div class="chip ghost">drop a title here<br><span style="color:var(--yellow)">↳ Title 4 fits (runtime ✓)</span></div>
+      <div class="slotcta"><button class="mini go">Place Title 4 here</button></div>
+    </div>
+
+    <!-- COLLISION -->
+    <div class="slot coll">
+      <span class="pin">CONFLICT · 2 TITLES</span>
+      <div class="sh"><span class="ep">E05</span><span class="en">Seven Min. of Terror</span></div>
+      <div class="chip keep"><div class="cn">title_t06.mkv</div><div class="cm"><span>58:05</span>·<span class="conf hi">88%</span>·<span>keep</span></div></div>
+      <div class="chip move"><div class="cn">title_t04.mkv</div><div class="cm"><span>56:20</span>·<span class="conf lo">54%</span>·<span style="color:var(--red)">move?</span></div></div>
+      <div class="slotcta"><button class="mini go">→ Move Title 4 to E04</button></div>
+    </div>
+
+    <div class="slot ok">
+      <div class="sh"><span class="ep">E06</span><span class="en">New Eden</span></div>
+      <div class="chip"><div class="cn">title_t03.mkv</div><div class="cm"><span>60:10</span>·<span class="conf hi">91%</span>·<span>engram</span></div></div>
+    </div>
+
+    <div class="slot off">
+      <div class="sh"><span class="ep">E07</span><span class="en">Bring it Down</span></div>
+      <div class="chip ghost">other disc</div>
+    </div>
+    <div class="slot off">
+      <div class="sh"><span class="ep">E08</span><span class="en">Sands of Ares</span></div>
+      <div class="chip ghost">other disc</div>
+    </div>
+    <div class="slot off">
+      <div class="sh"><span class="ep">E09</span><span class="en">Coming Home</span></div>
+      <div class="chip ghost">other disc</div>
+    </div>
+    <div class="slot off">
+      <div class="sh"><span class="ep">E10</span><span class="en">Stranger…</span></div>
+      <div class="chip ghost">other disc</div>
+    </div>
+
+  </div>
+
+  <div class="legend">
+    <span><i class="sw ok"></i> placed</span>
+    <span><i class="sw gap"></i> gap on disc</span>
+    <span><i class="sw coll"></i> conflict</span>
+    <span><i class="sw off"></i> not on this disc</span>
+  </div>
+
+  <div class="sec"><span class="dot" style="color:var(--yellow)"></span><span class="lab">Needs placement</span><span class="ct">— drag onto a slot, or use the suggestion</span></div>
+  <div class="panel mag tray">
+    <span class="tl">Unresolved →</span>
+    <div class="tcard">
+      <span class="g">⠿</span>
+      <div>
+        <div class="cn">title_t04.mkv</div>
+        <div class="cm">56:20 · 3.9 GB · top guess E05 (54%) · 3 candidates</div>
+      </div>
+      <span class="hint">↳ suggested slot: E04 — Happy Valley</span>
+    </div>
+    <span style="flex:1"></span>
+    <button class="btn sm">View candidates</button>
+    <button class="btn sm">Mark extra</button>
+    <button class="btn sm">Discard</button>
+  </div>
+
+  <p class="note">
+    <b>Option D — Roster board.</b> The disc <i>is</i> the season. Every episode is a slot; titles drop into the slot they
+    belong to, so coverage, the doubled E05, and the empty E04 are visible at a glance — and the fix is spatial: move
+    Title 4 out of the conflict and into the gap. Titles still needing placement wait in the tray with their suggested
+    slot. Most direct for your "revisit the whole disc" case; least like the current row UI. · Static mockup, For All
+    Mankind S3 scenario.
+  </p>
+
+</div>
+</body>
+</html>

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -294,6 +294,30 @@ function ReviewQueue() {
         }
     };
 
+    // Deep re-match every title claiming a contested episode (denser sampling +
+    // stricter votes) so a collision can resolve either way.
+    const handleRematchConflict = async (episodeCode: string) => {
+        setIsRematching(true);
+        setError(null);
+        try {
+            const response = await fetch(`/api/jobs/${jobId}/rematch-conflict`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ episode_code: episodeCode }),
+            });
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Deep re-match failed: ${text}`);
+            }
+            await fetchJobDetails();
+        } catch (err) {
+            console.error('Failed to deep re-match conflict:', err);
+            setError(err instanceof Error ? err.message : 'Failed to deep re-match');
+        } finally {
+            setIsRematching(false);
+        }
+    };
+
     // POST every pending episode selection to the review endpoint.
     // Throws on the first failure so callers can abort their follow-up step.
     const submitPendingSelections = async () => {
@@ -760,6 +784,7 @@ function ReviewQueue() {
                                 onAssign={(code) => handleEpisodeChange(selectedTitle.id, code)}
                                 onAction={(a) => handleTitleAction(selectedTitle.id, a)}
                                 onRematch={handleRematch}
+                                onDeepRematch={handleRematchConflict}
                             />
                         ) : (
                             <SvPanel pad={24}>

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -169,6 +169,7 @@ function ReviewQueue() {
     const [selectedEditions, setSelectedEditions] = useState<Record<number, string>>({});
     const [titleActions, setTitleActions] = useState<Record<number, TitleAction>>({});
     const [selectedTitleId, setSelectedTitleId] = useState<number | null>(null);
+    const [rematchNotice, setRematchNotice] = useState<string | null>(null);
 
     const { roster, error: rosterError, episodeName } = useSeasonRoster(jobId);
 
@@ -301,6 +302,7 @@ function ReviewQueue() {
     const handleRematchConflict = async (episodeCode: string) => {
         setIsRematching(true);
         setError(null);
+        setRematchNotice(null);
         try {
             const response = await fetch(`/api/jobs/${jobId}/rematch-conflict`, {
                 method: 'POST',
@@ -310,6 +312,19 @@ function ReviewQueue() {
             if (!response.ok) {
                 const text = await response.text();
                 throw new Error(`Deep re-match failed: ${text}`);
+            }
+            const data = await response.json();
+            const skipped: Array<{ title_id: number }> = data.skipped || [];
+            if (skipped.length > 0) {
+                const labels = skipped
+                    .map((s) => {
+                        const t = titles.find((x) => x.id === s.title_id);
+                        return `#${t ? t.title_index : s.title_id}`;
+                    })
+                    .join(', ');
+                setRematchNotice(
+                    `Re-matched ${data.title_ids?.length ?? 0} title(s); skipped ${labels} (already organized or file not in staging).`,
+                );
             }
             await fetchJobDetails();
         } catch (err) {
@@ -686,6 +701,7 @@ function ReviewQueue() {
                         › SEASON ROSTER UNAVAILABLE — RELOAD TO RETRY.
                     </SvNotice>
                 )}
+                {rematchNotice && <SvNotice tone="warn">› {rematchNotice}</SvNotice>}
 
                 {/* Season roster */}
                 {roster?.available && rosterEpisodes.length > 0 && (

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -1,15 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'motion/react';
-import { Save, Trash2, Package, SkipForward, ChevronDown, ChevronRight } from 'lucide-react';
+import { Save, Package } from 'lucide-react';
 import { IcoDisc, IcoPlay, IcoRetry } from '../app/components/icons';
 import type { CSSProperties, FocusEvent, ReactNode } from 'react';
 import { Job, DiscTitle } from '../types';
-import { formatDuration, formatSize, parseMatchDetails, generateEpisodeOptions, getReviewReasons } from './ReviewQueue/utils';
-import { MATCHING_CONFIG, EPISODE_CONFIG, FEATURES } from '../config/constants';
+import { formatDuration, formatSize, titleDisplayName } from './ReviewQueue/utils';
+import { MATCHING_CONFIG } from '../config/constants';
 import { SvActionButton, SvAtmosphere, SvBadge, SvLabel, SvNotice, SvPageHeader, SvPanel, sv } from '../app/components/synapse';
+import { useSeasonRoster } from '../hooks/useSeasonRoster';
+import { assignmentsByCode, buildCandidates, collidingCodes, computeCoverage, suggestGapCode } from './ReviewQueue/coverage';
+import { SeasonRosterStrip } from './ReviewQueue/SeasonRosterStrip';
+import { TitleList } from './ReviewQueue/TitleList';
+import { Inspector } from './ReviewQueue/Inspector';
 
-/** Uppercase mono caption styling, reused for metadata rows and table cells. */
+/** Uppercase mono caption styling, reused for metadata rows. */
 const monoLabelStyle: CSSProperties = {
     fontFamily: sv.mono,
     fontSize: 11,
@@ -23,7 +28,7 @@ const truncateStyle: CSSProperties = {
     whiteSpace: 'nowrap',
 };
 
-/** Shared base for bare (borderless-chrome) inputs in the title rows. */
+/** Shared base for bare (borderless-chrome) inputs. */
 const fieldBaseStyle: CSSProperties = {
     background: sv.bg0,
     border: `1px solid ${sv.lineMid}`,
@@ -31,9 +36,6 @@ const fieldBaseStyle: CSSProperties = {
     fontFamily: sv.mono,
     outline: 'none',
 };
-
-/** Padding shared by every cell in the competing-matches table. */
-const tableCellStyle: CSSProperties = { padding: '6px 16px 6px 0' };
 
 /** Highlight an input's border on focus. */
 function applyFieldFocus(e: FocusEvent<HTMLElement>): void {
@@ -45,16 +47,8 @@ function applyFieldBlur(e: FocusEvent<HTMLElement>): void {
     e.currentTarget.style.borderColor = sv.lineMid;
 }
 
-/** Display name for a title — filename basename, or a generic fallback. */
-function titleDisplayName(title: DiscTitle): string {
-    return title.output_filename
-        ? title.output_filename.split(/[/\\]/).pop() ?? `Title ${title.title_index}`
-        : `Title ${title.title_index}`;
-}
-
 /**
- * Synapse text input — used for the Edition tag field on movie titles and
- * the manual episode-code input in the TV title row.
+ * Synapse text input — used for the Edition tag field on movie titles.
  */
 function SvTextInput({
     value,
@@ -101,51 +95,8 @@ function SvTextInput({
 }
 
 /**
- * Section heading — colored dot + uppercase mono label + bracket count.
- * Used for the Auto-matched / Needs review / Processed groupings on the TV
- * review page.
- */
-function SectionHeading({
-    color,
-    count,
-    children,
-}: {
-    color: string;
-    count: number;
-    children: ReactNode;
-}) {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-            <span
-                style={{
-                    width: 8,
-                    height: 8,
-                    background: color,
-                    boxShadow: `0 0 8px ${color}cc`,
-                }}
-            />
-            <h2
-                style={{
-                    margin: 0,
-                    fontFamily: sv.mono,
-                    fontSize: 13,
-                    fontWeight: 700,
-                    letterSpacing: '0.20em',
-                    textTransform: 'uppercase',
-                    color,
-                }}
-            >
-                {children}
-                <span style={{ marginLeft: 8, color: `${color}aa` }}>[{count}]</span>
-            </h2>
-        </div>
-    );
-}
-
-/**
  * Small uniform header-action button for the ReviewQueue. Inline-styled with
- * sv tokens so it matches the `SvPageHeader` chrome and the dashboard's
- * ActionButtons family.
+ * sv tokens so it matches the `SvPageHeader` chrome.
  */
 function HeaderButton({
     color,
@@ -217,7 +168,9 @@ function ReviewQueue() {
     const [selectedEpisodes, setSelectedEpisodes] = useState<Record<number, string>>({});
     const [selectedEditions, setSelectedEditions] = useState<Record<number, string>>({});
     const [titleActions, setTitleActions] = useState<Record<number, TitleAction>>({});
-    const [expandedTitles, setExpandedTitles] = useState<Set<number>>(new Set());
+    const [selectedTitleId, setSelectedTitleId] = useState<number | null>(null);
+
+    const { roster, episodeName } = useSeasonRoster(jobId);
 
     useEffect(() => {
         fetchJobDetails();
@@ -259,6 +212,17 @@ function ReviewQueue() {
         }
     };
 
+    // Default the inspector to the first title that needs attention.
+    useEffect(() => {
+        if (selectedTitleId !== null) return;
+        const active = titles.filter((t) => t.state !== 'completed' && t.state !== 'failed');
+        if (active.length === 0) return;
+        const firstReview = active.find(
+            (t) => !t.matched_episode || t.match_confidence < MATCHING_CONFIG.AUTO_MATCH_THRESHOLD,
+        );
+        setSelectedTitleId((firstReview ?? active[0]).id);
+    }, [titles, selectedTitleId]);
+
     const handleEpisodeChange = (titleId: number, episodeCode: string) => {
         setSelectedEpisodes(prev => ({ ...prev, [titleId]: episodeCode }));
         setTitleActions(prev => ({ ...prev, [titleId]: 'episode' }));
@@ -282,14 +246,6 @@ function ReviewQueue() {
                 return next;
             });
         }
-    };
-
-    const toggleExpand = (titleId: number) => {
-        setExpandedTitles(prev => {
-            const next = new Set(prev);
-            next.has(titleId) ? next.delete(titleId) : next.add(titleId);
-            return next;
-        });
     };
 
     // --- API Handlers ---
@@ -439,14 +395,44 @@ function ReviewQueue() {
         }
     };
 
-    // --- Categorize titles ---
-    const matchedTitles = titles.filter(t =>
-        t.matched_episode && t.match_confidence >= MATCHING_CONFIG.AUTO_MATCH_THRESHOLD && t.state !== 'completed' && t.state !== 'failed'
+    // --- Derived disc-level coverage (live, from current selections) ---
+    const rosterEpisodes = useMemo(() => roster?.episodes ?? [], [roster]);
+    const titleIndexById = useMemo(
+        () => Object.fromEntries(titles.map((t) => [t.id, t.title_index])) as Record<number, number>,
+        [titles],
     );
-    const needsReviewTitles = titles.filter(t =>
-        (!t.matched_episode || t.match_confidence < MATCHING_CONFIG.AUTO_MATCH_THRESHOLD) && t.state !== 'completed' && t.state !== 'failed'
+    const coverage = useMemo(
+        () => computeCoverage(selectedEpisodes, rosterEpisodes),
+        [selectedEpisodes, rosterEpisodes],
     );
-    const completedTitles = titles.filter(t => t.state === 'completed' || t.state === 'failed');
+    const holders = useMemo(() => assignmentsByCode(selectedEpisodes), [selectedEpisodes]);
+    const collisions = useMemo(() => collidingCodes(selectedEpisodes), [selectedEpisodes]);
+    const hasConflicts = collisions.size > 0;
+
+    const activeTitles = titles.filter((t) => t.state !== 'completed' && t.state !== 'failed');
+    const completedTitles = titles.filter((t) => t.state === 'completed' || t.state === 'failed');
+    const selectedTitle =
+        activeTitles.find((t) => t.id === selectedTitleId) ?? activeTitles[0] ?? null;
+
+    const candidates = selectedTitle ? buildCandidates(selectedTitle, episodeName) : [];
+
+    // Suggest the disc's remaining gap for the selected title when it is
+    // unassigned or its current pick collides with another title.
+    let inspectorSuggestion: { code: string; name: string } | null = null;
+    let suggestedForSelected: string | null = null;
+    if (selectedTitle) {
+        const currentSel = selectedEpisodes[selectedTitle.id];
+        const needsHelp = !currentSel || collisions.has(currentSel);
+        if (needsHelp) {
+            const others = { ...selectedEpisodes };
+            delete others[selectedTitle.id];
+            const gap = suggestGapCode(others, rosterEpisodes);
+            if (gap) {
+                inspectorSuggestion = { code: gap, name: episodeName(gap) };
+                suggestedForSelected = gap;
+            }
+        }
+    }
 
     const assignedCount = Object.keys(selectedEpisodes).length;
 
@@ -603,7 +589,7 @@ function ReviewQueue() {
         );
     }
 
-    // ==================== TV REVIEW ====================
+    // ==================== TV REVIEW (inspector layout) ====================
     const subtitleText = `› ${job.detected_title || job.volume_label}${job.detected_season ? ` / SEASON ${job.detected_season}` : ''}`;
     return (
         <SvAtmosphere>
@@ -626,7 +612,7 @@ function ReviewQueue() {
                             <HeaderButton
                                 color={sv.yellow}
                                 onClick={handleSaveAll}
-                                disabled={isSaving || isProcessing}
+                                disabled={isSaving || isProcessing || hasConflicts}
                                 icon={<Save size={12} />}
                             >
                                 {isSaving ? 'Saving…' : `Save ${assignedCount}`}
@@ -636,7 +622,7 @@ function ReviewQueue() {
                             <HeaderButton
                                 color={sv.green}
                                 onClick={handleProcessMatched}
-                                disabled={isSaving || isProcessing}
+                                disabled={isSaving || isProcessing || hasConflicts}
                                 icon={<Package size={12} />}
                             >
                                 {isProcessing ? 'Processing…' : `Process ${assignedCount}`}
@@ -658,459 +644,128 @@ function ReviewQueue() {
             <div className="max-w-[1280px] mx-auto px-6 py-8 relative z-0 pb-24">
                 {error && <SvNotice tone="error">› ERROR: {error}</SvNotice>}
                 {job.error_message && <SvNotice tone="warn">› {job.error_message}</SvNotice>}
+                {hasConflicts && (
+                    <SvNotice tone="warn">
+                        › {collisions.size} EPISODE CONFLICT{collisions.size > 1 ? 'S' : ''} — TWO TITLES SHARE AN EPISODE. RESOLVE BEFORE SAVING.
+                    </SvNotice>
+                )}
                 {job.subtitle_status === 'failed' && !job.error_message?.includes('Subtitle') && (
                     <SvNotice tone="warn">
                         › SUBTITLE DOWNLOAD FAILED. MANUAL FETCH MAY BE REQUIRED.
                     </SvNotice>
                 )}
 
-                {/* Matched Section */}
-                {matchedTitles.length > 0 && (
-                    <div style={{ marginBottom: 32 }}>
-                        <SectionHeading color={sv.green} count={matchedTitles.length}>Auto-matched</SectionHeading>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                            {matchedTitles.map(title => (
-                                <TVTitleRow
-                                    key={title.id}
-                                    title={title}
-                                    job={job}
-                                    selectedEpisode={selectedEpisodes[title.id] || ''}
-                                    titleAction={titleActions[title.id]}
-                                    isExpanded={expandedTitles.has(title.id)}
-                                    onEpisodeChange={handleEpisodeChange}
-                                    onTitleAction={handleTitleAction}
-                                    onToggleExpand={toggleExpand}
-                                    onRematch={handleRematch}
-                                    variant="matched"
-                                />
-                            ))}
+                {/* Season roster */}
+                {roster?.available && rosterEpisodes.length > 0 && (
+                    <div style={{ marginBottom: 24 }}>
+                        <div style={{ marginBottom: 12 }}>
+                            <SvLabel>Season roster — coverage across this disc</SvLabel>
                         </div>
+                        <SvPanel pad={14}>
+                            <SeasonRosterStrip
+                                episodes={rosterEpisodes}
+                                coverage={coverage}
+                                suggestedCode={suggestedForSelected}
+                                titleIndexById={titleIndexById}
+                            />
+                        </SvPanel>
                     </div>
                 )}
 
-                {/* Needs Review Section */}
-                {needsReviewTitles.length > 0 && (
-                    <div style={{ marginBottom: 32 }}>
-                        <SectionHeading color={sv.yellow} count={needsReviewTitles.length}>Needs review</SectionHeading>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                            {needsReviewTitles.map(title => (
-                                <TVTitleRow
-                                    key={title.id}
-                                    title={title}
-                                    job={job}
-                                    selectedEpisode={selectedEpisodes[title.id] || ''}
-                                    titleAction={titleActions[title.id]}
-                                    isExpanded={expandedTitles.has(title.id)}
-                                    onEpisodeChange={handleEpisodeChange}
-                                    onTitleAction={handleTitleAction}
-                                    onToggleExpand={toggleExpand}
-                                    onRematch={handleRematch}
-                                    variant="review"
-                                />
-                            ))}
+                {/* List + inspector */}
+                <div
+                    style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1.05fr)',
+                        gap: 18,
+                        alignItems: 'start',
+                    }}
+                >
+                    {/* Left: title list */}
+                    <div>
+                        <div style={{ marginBottom: 12 }}>
+                            <SvLabel>Titles [{activeTitles.length}] — select one to inspect</SvLabel>
                         </div>
-                    </div>
-                )}
-
-                {/* Completed Section */}
-                {completedTitles.length > 0 && (
-                    <div style={{ marginBottom: 32 }}>
-                        <SectionHeading color={sv.inkFaint} count={completedTitles.length}>Processed</SectionHeading>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, opacity: 0.55 }}>
-                            {completedTitles.map(title => (
-                                <div
-                                    key={title.id}
-                                    style={{
-                                        ...monoLabelStyle,
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: 24,
-                                        padding: '14px 16px',
-                                        background: sv.bg1,
-                                        border: `1px solid ${sv.line}`,
-                                    }}
-                                >
-                                    <SvBadge size="sm" tone={sv.inkFaint} dot={false}>#{title.title_index}</SvBadge>
-                                    <span style={{ ...truncateStyle, flex: 1 }}>
-                                        {titleDisplayName(title)}
-                                    </span>
-                                    <span>{formatDuration(title.duration_seconds)}</span>
-                                    <span>{title.matched_episode || '—'}</span>
-                                    <SvBadge
-                                        size="sm"
-                                        state={title.state === 'completed' ? 'complete' : 'error'}
-                                        dot={false}
-                                    >
-                                        {title.state.toUpperCase()}
-                                    </SvBadge>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                )}
-            </div>
-        </SvAtmosphere>
-    );
-}
-
-// ==================== TV Title Row Component ====================
-
-interface TVTitleRowProps {
-    title: DiscTitle;
-    job: Job;
-    selectedEpisode: string;
-    titleAction?: TitleAction;
-    isExpanded: boolean;
-    onEpisodeChange: (titleId: number, episodeCode: string) => void;
-    onTitleAction: (titleId: number, action: TitleAction) => void;
-    onToggleExpand: (titleId: number) => void;
-    onRematch: (titleId: number, sourcePreference?: string) => void;
-    variant: 'matched' | 'review';
-}
-
-function TVTitleRow({
-    title,
-    job,
-    selectedEpisode,
-    titleAction,
-    isExpanded,
-    onEpisodeChange,
-    onTitleAction,
-    onToggleExpand,
-    onRematch,
-    variant,
-}: TVTitleRowProps) {
-    const [season, setSeason] = useState(job?.detected_season || 1);
-    const details = parseMatchDetails(title);
-    const isConflict = details.error === 'file_exists';
-    const reasons = getReviewReasons(title);
-    const alternatives = details.runner_ups || [];
-
-    const borderColor = isConflict
-        ? `${sv.yellow}66`
-        : variant === 'matched'
-        ? `${sv.green}33`
-        : `${sv.cyan}33`;
-
-    const confColor =
-        title.match_confidence >= MATCHING_CONFIG.AUTO_MATCH_THRESHOLD ? sv.green :
-        title.match_confidence >= MATCHING_CONFIG.MIN_CONFIDENCE ? sv.yellow : sv.red;
-
-    const sourceTone =
-        title.match_source === 'discdb' ? '#60a5fa' :
-        title.match_source === 'user' ? sv.green : sv.purple;
-    const sourceLabel =
-        title.match_source === 'discdb' ? 'DISCDB' :
-        title.match_source === 'user' ? 'MANUAL' : 'ENGRAM';
-
-    return (
-        <motion.div initial={{ opacity: 0, y: 5 }} animate={{ opacity: 1, y: 0 }}>
-            <SvPanel pad={16} accent={borderColor}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                    {/* Expand button */}
-                    <button
-                        type="button"
-                        onClick={() => onToggleExpand(title.id)}
-                        aria-expanded={isExpanded}
-                        aria-label={isExpanded ? `Collapse details for title ${title.title_index}` : `Expand details for title ${title.title_index}`}
-                        style={{
-                            background: 'transparent',
-                            border: 0,
-                            color: sv.inkFaint,
-                            cursor: 'pointer',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            transition: 'color 120ms',
-                        }}
-                        onMouseEnter={(e) => { e.currentTarget.style.color = sv.cyan; }}
-                        onMouseLeave={(e) => { e.currentTarget.style.color = sv.inkFaint; }}
-                    >
-                        {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    </button>
-
-                    {/* Title index */}
-                    <SvBadge size="sm" tone={sv.inkDim} dot={false}>
-                        #{title.title_index}
-                    </SvBadge>
-
-                    {/* Title name + conflict indicator */}
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                            <span
-                                style={{
-                                    ...truncateStyle,
-                                    fontFamily: sv.mono,
-                                    fontSize: 13,
-                                    color: sv.cyanHi,
-                                }}
-                            >
-                                {titleDisplayName(title)}
-                            </span>
-                            {isConflict && (
-                                <SvBadge size="sm" state="warn" dot={false}>
-                                    File exists
-                                </SvBadge>
-                            )}
-                        </div>
-                        <div
-                            style={{
-                                ...monoLabelStyle,
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 16,
-                                marginTop: 4,
-                            }}
-                        >
-                            <span>{formatDuration(title.duration_seconds)}</span>
-                            <span>{formatSize(title.file_size_bytes)}</span>
-                        </div>
-                    </div>
-
-                    {/* Confidence + source */}
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-                        {title.match_confidence > 0 ? (
-                            <SvBadge size="sm" tone={confColor} dot={false}>
-                                {Math.round(title.match_confidence * 100)}%
-                            </SvBadge>
-                        ) : (
-                            <SvBadge size="sm" tone={sv.inkFaint} dot={false}>—</SvBadge>
-                        )}
-                        {FEATURES.DISCDB && title.match_source && (
-                            <SvBadge size="sm" tone={sourceTone}>{sourceLabel}</SvBadge>
-                        )}
-                    </div>
-
-                    {/* Review reasons */}
-                    {reasons.length > 0 && (
-                        <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
-                            {reasons.slice(0, 2).map((r, i) => (
-                                <SvBadge key={i} size="sm" tone="#fb923c">{r}</SvBadge>
-                            ))}
-                        </div>
-                    )}
-
-                    {/* Episode selector with season input */}
-                    <div style={{ width: 208, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4 }}>
-                        <span
-                            style={{
-                                fontFamily: sv.mono,
-                                fontSize: 11,
-                                color: sv.inkDim,
-                                letterSpacing: '0.10em',
-                            }}
-                            title="Season"
-                        >
-                            S
-                        </span>
-                        <input
-                            type="number"
-                            min={1}
-                            max={20}
-                            value={season}
-                            onChange={(e) => setSeason(Math.max(1, Math.min(20, parseInt(e.target.value) || 1)))}
-                            title="Season number"
-                            aria-label="Season number"
-                            style={{
-                                ...fieldBaseStyle,
-                                width: 40,
-                                padding: '4px 6px',
-                                fontSize: 11,
-                                textAlign: 'center',
-                            }}
-                            onFocus={applyFieldFocus}
-                            onBlur={applyFieldBlur}
+                        <TitleList
+                            titles={activeTitles}
+                            selectedTitleId={selectedTitle?.id ?? null}
+                            selections={selectedEpisodes}
+                            collisions={collisions}
+                            episodeName={episodeName}
+                            onSelect={setSelectedTitleId}
                         />
-                        <select
-                            value={selectedEpisode}
-                            onChange={(e) => onEpisodeChange(title.id, e.target.value)}
-                            aria-label={`Episode assignment for title ${title.title_index}`}
-                            style={{
-                                ...fieldBaseStyle,
-                                flex: 1,
-                                padding: '6px 8px',
-                                fontSize: 11,
-                                cursor: 'pointer',
-                            }}
-                            onFocus={applyFieldFocus}
-                            onBlur={applyFieldBlur}
-                        >
-                            <option value="">Select episode…</option>
-                            {title.matched_episode && (
-                                <option value={title.matched_episode}>
-                                    {title.matched_episode} — Best ({Math.round(title.match_confidence * 100)}%)
-                                </option>
-                            )}
-                            {alternatives.map((alt, idx) => (
-                                <option key={`alt-${idx}`} value={alt.episode}>
-                                    {alt.episode} — Alt ({Math.round(alt.confidence * 100)}%)
-                                </option>
-                            ))}
-                            {(title.matched_episode || alternatives.length > 0) && (
-                                <option disabled>{'─'.repeat(20)}</option>
-                            )}
-                            {generateEpisodeOptions(season, EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON).map(ep => (
-                                <option key={ep} value={ep}>{ep}</option>
-                            ))}
-                        </select>
+
+                        {completedTitles.length > 0 && (
+                            <div style={{ marginTop: 24 }}>
+                                <div style={{ marginBottom: 12 }}>
+                                    <SvLabel>Processed [{completedTitles.length}]</SvLabel>
+                                </div>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: 8, opacity: 0.55 }}>
+                                    {completedTitles.map(title => (
+                                        <div
+                                            key={title.id}
+                                            style={{
+                                                ...monoLabelStyle,
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: 16,
+                                                padding: '12px 14px',
+                                                background: sv.bg1,
+                                                border: `1px solid ${sv.line}`,
+                                            }}
+                                        >
+                                            <SvBadge size="sm" tone={sv.inkFaint} dot={false}>#{title.title_index}</SvBadge>
+                                            <span style={{ ...truncateStyle, flex: 1 }}>
+                                                {titleDisplayName(title)}
+                                            </span>
+                                            <span>{title.matched_episode || '—'}</span>
+                                            <SvBadge
+                                                size="sm"
+                                                state={title.state === 'completed' ? 'complete' : 'error'}
+                                                dot={false}
+                                            >
+                                                {title.state.toUpperCase()}
+                                            </SvBadge>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
 
-                    {/* Action buttons */}
-                    <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
-                        <SvActionButton
-                            tone={titleAction === 'extra' ? 'cyan' : 'neutral'}
-                            size="sm"
-                            onClick={() => onTitleAction(title.id, 'extra')}
-                            title="Keep as extra content"
-                        >
-                            Extra
-                        </SvActionButton>
-                        <SvActionButton
-                            tone={titleAction === 'discard' ? 'red' : 'neutral'}
-                            size="sm"
-                            onClick={() => onTitleAction(title.id, 'discard')}
-                            title="Discard this title"
-                            ariaLabel="Discard"
-                        >
-                            <Trash2 size={11} />
-                        </SvActionButton>
-                        <SvActionButton
-                            tone="neutral"
-                            size="sm"
-                            onClick={() => onTitleAction(title.id, 'skip')}
-                            title="Skip for now"
-                            ariaLabel="Skip"
-                        >
-                            <SkipForward size={11} />
-                        </SvActionButton>
-                        {/* Source toggle — switch between DiscDB and Engram when both exist */}
-                        {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
-                            <SvActionButton
-                                tone="magenta"
-                                size="sm"
-                                onClick={() => onRematch(title.id, title.match_source === 'discdb' ? 'engram' : 'discdb')}
-                                title={`Switch to ${title.match_source === 'discdb' ? 'Engram' : 'DiscDB'} match`}
-                                ariaLabel="Toggle match source"
-                            >
-                                <IcoRetry size={11} />
-                            </SvActionButton>
-                        )}
-                        {/* Re-match button — only DiscDB source, no Engram data yet */}
-                        {FEATURES.DISCDB && title.match_source === 'discdb' && !title.match_details && (
-                            <SvActionButton
-                                tone="magenta"
-                                size="sm"
-                                onClick={() => onRematch(title.id, 'engram')}
-                                title="Re-match with Engram audio matching"
-                                ariaLabel="Re-match"
-                            >
-                                <IcoRetry size={11} />
-                            </SvActionButton>
+                    {/* Right: inspector */}
+                    <div>
+                        <div style={{ marginBottom: 12 }}>
+                            <SvLabel>Inspector{selectedTitle ? ` — title #${selectedTitle.title_index}` : ''}</SvLabel>
+                        </div>
+                        {selectedTitle ? (
+                            <Inspector
+                                title={selectedTitle}
+                                job={job}
+                                candidates={candidates}
+                                suggestion={inspectorSuggestion}
+                                selection={selectedEpisodes[selectedTitle.id]}
+                                action={titleActions[selectedTitle.id]}
+                                episodes={rosterEpisodes}
+                                coverage={coverage}
+                                holders={holders}
+                                titleIndexById={titleIndexById}
+                                isRematching={isRematching}
+                                onAssign={(code) => handleEpisodeChange(selectedTitle.id, code)}
+                                onAction={(a) => handleTitleAction(selectedTitle.id, a)}
+                                onRematch={handleRematch}
+                            />
+                        ) : (
+                            <SvPanel pad={24}>
+                                <div style={{ ...monoLabelStyle, textAlign: 'center' }}>
+                                    No titles awaiting review.
+                                </div>
+                            </SvPanel>
                         )}
                     </div>
                 </div>
-
-                {/* Expanded details */}
-                {isExpanded && (
-                    <div
-                        style={{
-                            marginTop: 16,
-                            paddingTop: 12,
-                            borderTop: `1px solid ${sv.line}`,
-                        }}
-                    >
-                        {isConflict && details.message && (
-                            <div style={{ marginBottom: 12 }}>
-                                <SvNotice tone="warn">{details.message}</SvNotice>
-                            </div>
-                        )}
-                        <div style={{ marginBottom: 12 }}>
-                            <SvLabel>Competing matches</SvLabel>
-                        </div>
-
-                        {/* Match stats */}
-                        {details.vote_count !== undefined && (
-                            <div
-                                style={{
-                                    ...monoLabelStyle,
-                                    display: 'flex',
-                                    gap: 24,
-                                    marginBottom: 12,
-                                }}
-                            >
-                                <span>Votes: <span style={{ color: sv.ink }}>{details.vote_count}</span></span>
-                                <span>Coverage: <span style={{ color: sv.ink }}>{Math.round((details.file_cov || 0) * 100)}%</span></span>
-                                <span>Gap: <span style={{ color: sv.ink }}>{details.score_gap !== undefined ? `+${Math.round(details.score_gap * 100)}%` : '—'}</span></span>
-                            </div>
-                        )}
-
-                        <table style={{ width: '100%', fontFamily: sv.mono, fontSize: 11, borderCollapse: 'collapse' }}>
-                            <thead>
-                                <tr style={{ borderBottom: `1px solid ${sv.line}` }}>
-                                    {(['Rank', 'Episode', 'Score', 'Votes', 'Assessment'] as const).map((h) => (
-                                        <th
-                                            key={h}
-                                            style={{
-                                                ...tableCellStyle,
-                                                textAlign: 'left',
-                                                color: sv.inkFaint,
-                                                letterSpacing: '0.18em',
-                                                textTransform: 'uppercase',
-                                                fontSize: 9,
-                                                fontWeight: 700,
-                                            }}
-                                        >
-                                            {h}
-                                        </th>
-                                    ))}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {title.matched_episode && (
-                                    <tr style={{ borderBottom: `1px solid ${sv.line}` }}>
-                                        <td style={{ ...tableCellStyle, color: sv.green }}>1st</td>
-                                        <td style={{ ...tableCellStyle, color: sv.green, fontWeight: 700 }}>
-                                            {title.matched_episode}
-                                        </td>
-                                        <td style={{ ...tableCellStyle, color: sv.green }}>
-                                            {Math.round(title.match_confidence * 100)}%
-                                        </td>
-                                        <td style={{ ...tableCellStyle, color: sv.green }}>{details.vote_count || '?'}</td>
-                                        <td style={{ padding: '6px 0' }}>
-                                            <SvBadge size="sm" state="complete" dot={false}>BEST</SvBadge>
-                                        </td>
-                                    </tr>
-                                )}
-                                {alternatives.map((alt, idx) => (
-                                    <tr key={idx} style={{ borderBottom: `1px solid ${sv.line}`, color: sv.inkDim }}>
-                                        <td style={tableCellStyle}>
-                                            {idx + 2}{idx === 0 ? 'nd' : idx === 1 ? 'rd' : 'th'}
-                                        </td>
-                                        <td style={tableCellStyle}>{alt.episode}</td>
-                                        <td style={tableCellStyle}>{Math.round(alt.confidence * 100)}%</td>
-                                        <td style={tableCellStyle}>{alt.vote_count || '?'}</td>
-                                        <td style={{ padding: '6px 0' }}>
-                                            <SvBadge size="sm" tone={sv.inkDim} dot={false}>
-                                                {alt.confidence > MATCHING_CONFIG.MIN_CONFIDENCE ? 'POSSIBLE' : 'UNLIKELY'}
-                                            </SvBadge>
-                                        </td>
-                                    </tr>
-                                ))}
-                                {!title.matched_episode && alternatives.length === 0 && (
-                                    <tr>
-                                        <td
-                                            colSpan={5}
-                                            style={{ padding: '14px 0', textAlign: 'center', color: sv.inkFaint }}
-                                        >
-                                            No match data available
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                )}
-            </SvPanel>
-        </motion.div>
+            </div>
+        </SvAtmosphere>
     );
 }
 

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -9,7 +9,7 @@ import { formatDuration, formatSize, titleDisplayName } from './ReviewQueue/util
 import { MATCHING_CONFIG } from '../config/constants';
 import { SvActionButton, SvAtmosphere, SvBadge, SvLabel, SvNotice, SvPageHeader, SvPanel, sv } from '../app/components/synapse';
 import { useSeasonRoster } from '../hooks/useSeasonRoster';
-import { assignmentsByCode, buildCandidates, collidingCodes, computeCoverage, suggestGapCode } from './ReviewQueue/coverage';
+import { assignmentsByCode, buildCandidates, collidingCodes, computeCoverage, normalizeEpisodeCode, suggestGapCode } from './ReviewQueue/coverage';
 import { SeasonRosterStrip } from './ReviewQueue/SeasonRosterStrip';
 import { TitleList } from './ReviewQueue/TitleList';
 import { Inspector } from './ReviewQueue/Inspector';
@@ -197,7 +197,9 @@ function ReviewQueue() {
                 const actions: Record<number, TitleAction> = {};
                 titlesData.forEach((title: DiscTitle) => {
                     if (title.matched_episode) {
-                        episodes[title.id] = title.matched_episode;
+                        // Canonicalize so unpadded matcher output (e.g. "S1E14")
+                        // dedupes/collides against padded codes and the roster.
+                        episodes[title.id] = normalizeEpisodeCode(title.matched_episode);
                         actions[title.id] = 'episode';
                     }
                 });
@@ -224,7 +226,7 @@ function ReviewQueue() {
     }, [titles, selectedTitleId]);
 
     const handleEpisodeChange = (titleId: number, episodeCode: string) => {
-        setSelectedEpisodes(prev => ({ ...prev, [titleId]: episodeCode }));
+        setSelectedEpisodes(prev => ({ ...prev, [titleId]: normalizeEpisodeCode(episodeCode) }));
         setTitleActions(prev => ({ ...prev, [titleId]: 'episode' }));
     };
 

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -170,7 +170,7 @@ function ReviewQueue() {
     const [titleActions, setTitleActions] = useState<Record<number, TitleAction>>({});
     const [selectedTitleId, setSelectedTitleId] = useState<number | null>(null);
 
-    const { roster, episodeName } = useSeasonRoster(jobId);
+    const { roster, error: rosterError, episodeName } = useSeasonRoster(jobId);
 
     useEffect(() => {
         fetchJobDetails();
@@ -417,22 +417,23 @@ function ReviewQueue() {
     const candidates = selectedTitle ? buildCandidates(selectedTitle, episodeName) : [];
 
     // Suggest the disc's remaining gap for the selected title when it is
-    // unassigned or its current pick collides with another title.
-    let inspectorSuggestion: { code: string; name: string } | null = null;
-    let suggestedForSelected: string | null = null;
-    if (selectedTitle) {
+    // unassigned or its current pick collides with another title. Memoized so
+    // the extra computeCoverage pass inside suggestGapCode only runs when the
+    // inputs actually change, not on every render.
+    const { inspectorSuggestion, suggestedForSelected } = useMemo<{
+        inspectorSuggestion: { code: string; name: string } | null;
+        suggestedForSelected: string | null;
+    }>(() => {
+        if (!selectedTitle) return { inspectorSuggestion: null, suggestedForSelected: null };
         const currentSel = selectedEpisodes[selectedTitle.id];
         const needsHelp = !currentSel || collisions.has(currentSel);
-        if (needsHelp) {
-            const others = { ...selectedEpisodes };
-            delete others[selectedTitle.id];
-            const gap = suggestGapCode(others, rosterEpisodes);
-            if (gap) {
-                inspectorSuggestion = { code: gap, name: episodeName(gap) };
-                suggestedForSelected = gap;
-            }
-        }
-    }
+        if (!needsHelp) return { inspectorSuggestion: null, suggestedForSelected: null };
+        const others = { ...selectedEpisodes };
+        delete others[selectedTitle.id];
+        const gap = suggestGapCode(others, rosterEpisodes);
+        if (!gap) return { inspectorSuggestion: null, suggestedForSelected: null };
+        return { inspectorSuggestion: { code: gap, name: episodeName(gap) }, suggestedForSelected: gap };
+    }, [selectedTitle, selectedEpisodes, collisions, rosterEpisodes, episodeName]);
 
     const assignedCount = Object.keys(selectedEpisodes).length;
 
@@ -652,6 +653,11 @@ function ReviewQueue() {
                 {job.subtitle_status === 'failed' && !job.error_message?.includes('Subtitle') && (
                     <SvNotice tone="warn">
                         › SUBTITLE DOWNLOAD FAILED. MANUAL FETCH MAY BE REQUIRED.
+                    </SvNotice>
+                )}
+                {rosterError && (
+                    <SvNotice tone="warn">
+                        › SEASON ROSTER UNAVAILABLE — RELOAD TO RETRY.
                     </SvNotice>
                 )}
 

--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -44,6 +44,7 @@ export function Inspector({
     onAssign,
     onAction,
     onRematch,
+    onDeepRematch,
 }: {
     title: DiscTitle;
     job: Job;
@@ -60,6 +61,7 @@ export function Inspector({
     onAssign: (code: string) => void;
     onAction: (action: TitleAction) => void;
     onRematch: (titleId: number, source: string) => void;
+    onDeepRematch: (episodeCode: string) => void;
 }) {
     const details = parseMatchDetails(title);
     const fileExists = details.error === 'file_exists';
@@ -69,6 +71,11 @@ export function Inspector({
     // season roster is unavailable.
     const takenByOther = (code: string): number[] =>
         (holders.get(code) ?? []).filter((id) => id !== title.id);
+
+    // This title's current pick collides with another title's pick.
+    const selectionIsCode = !!selection && /^S\d+E\d+$/i.test(selection);
+    const conflictWith = selectionIsCode ? takenByOther(selection as string) : [];
+    const inConflict = conflictWith.length > 0;
 
     const stateBadge = fileExists ? (
         <SvBadge state="warn" dot>File exists</SvBadge>
@@ -102,6 +109,29 @@ export function Inspector({
                 {fileExists && details.message && (
                     <div style={{ marginBottom: 14 }}>
                         <SvNotice tone="warn">{details.message}</SvNotice>
+                    </div>
+                )}
+
+                {/* Conflict → deep re-match all titles claiming this episode */}
+                {inConflict && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', marginBottom: 14, border: `1px solid ${sv.red}`, background: `${sv.red}12` }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div style={{ fontFamily: sv.display, fontSize: 13, color: sv.red }}>
+                                ⚠ {selection} also claimed by {conflictWith.map((id) => `#${titleIndexById[id] ?? id}`).join(', ')}
+                            </div>
+                            <div style={{ ...monoFaint, marginTop: 2, fontSize: 10.5 }}>
+                                Deep re-match re-runs every claiming title with denser sampling + stricter votes to break the tie.
+                            </div>
+                        </div>
+                        <SvActionButton
+                            tone="magenta"
+                            size="sm"
+                            onClick={() => onDeepRematch(selection as string)}
+                            disabled={isRematching}
+                        >
+                            <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                            <span style={{ marginLeft: 6 }}>{isRematching ? 'Re-matching…' : 'Deep re-match'}</span>
+                        </SvActionButton>
                     </div>
                 )}
 

--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -1,0 +1,295 @@
+import type { CSSProperties } from 'react';
+import { Trash2, SkipForward } from 'lucide-react';
+import { IcoRetry } from '../../app/components/icons';
+import { SvActionButton, SvBadge, SvLabel, SvNotice, SvPanel, sv } from '../../app/components/synapse';
+import { FEATURES, EPISODE_CONFIG } from '../../config/constants';
+import type { DiscTitle, Job } from '../../types';
+import type { Candidate, CoverageEntry } from './coverage';
+import type { RosterEpisode } from './types';
+import {
+    confidenceColor,
+    formatDuration,
+    formatSize,
+    generateEpisodeOptions,
+    parseMatchDetails,
+    titleDisplayName,
+} from './utils';
+
+type TitleAction = 'episode' | 'extra' | 'discard' | 'skip';
+
+const monoFaint: CSSProperties = { fontFamily: sv.mono, fontSize: 11, color: sv.inkFaint };
+
+function pct(value: number): string {
+    return `${Math.round(value * 100)}%`;
+}
+
+/**
+ * Focused decision panel for one title: the disc-aware suggestion, the ranked
+ * candidates with their evidence (votes, coverage, score gap) and conflict/gap
+ * tags, plus a manual override. Assigning here updates the parent selection;
+ * the header Save/Process persists it.
+ */
+export function Inspector({
+    title,
+    job,
+    candidates,
+    suggestion,
+    selection,
+    action,
+    episodes,
+    coverage,
+    holders,
+    titleIndexById,
+    isRematching,
+    onAssign,
+    onAction,
+    onRematch,
+}: {
+    title: DiscTitle;
+    job: Job;
+    candidates: Candidate[];
+    suggestion: { code: string; name: string } | null;
+    selection: string | undefined;
+    action: TitleAction | undefined;
+    episodes: RosterEpisode[];
+    coverage: Record<string, CoverageEntry>;
+    /** Episode code → title ids claiming it (roster-independent collision source). */
+    holders: Map<string, number[]>;
+    titleIndexById: Record<number, number>;
+    isRematching: boolean;
+    onAssign: (code: string) => void;
+    onAction: (action: TitleAction) => void;
+    onRematch: (titleId: number, source: string) => void;
+}) {
+    const details = parseMatchDetails(title);
+    const fileExists = details.error === 'file_exists';
+
+    // The set of episode codes held by OTHER titles → conflict source. Derived
+    // from live selections (not the roster) so collisions surface even when the
+    // season roster is unavailable.
+    const takenByOther = (code: string): number[] =>
+        (holders.get(code) ?? []).filter((id) => id !== title.id);
+
+    const stateBadge = fileExists ? (
+        <SvBadge state="warn" dot>File exists</SvBadge>
+    ) : !selection ? (
+        <SvBadge state="review" dot>Needs review</SvBadge>
+    ) : selection === 'extra' ? (
+        <SvBadge tone={sv.cyan}>Extra</SvBadge>
+    ) : selection === 'skip' ? (
+        <SvBadge tone={sv.inkFaint}>Discarded</SvBadge>
+    ) : (
+        <SvBadge state="matched" dot>Assigned</SvBadge>
+    );
+
+    return (
+        <SvPanel pad={0} accent={`${sv.yellow}55`} style={{ position: 'sticky', top: 88 }}>
+            {/* header */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '14px 16px', borderBottom: `1px solid ${sv.line}` }}>
+                <div style={{ minWidth: 0 }}>
+                    <div style={{ fontFamily: sv.display, fontSize: 15, color: sv.ink, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {titleDisplayName(title)}
+                    </div>
+                    <div style={{ ...monoFaint, marginTop: 3 }}>
+                        {formatDuration(title.duration_seconds)} · {formatSize(title.file_size_bytes)}
+                        {title.video_resolution ? ` · ${title.video_resolution}` : ''} · {title.chapter_count} chapters
+                    </div>
+                </div>
+                {stateBadge}
+            </div>
+
+            <div style={{ padding: 16 }}>
+                {fileExists && details.message && (
+                    <div style={{ marginBottom: 14 }}>
+                        <SvNotice tone="warn">{details.message}</SvNotice>
+                    </div>
+                )}
+
+                {/* disc-aware suggestion */}
+                {suggestion && selection !== suggestion.code && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', marginBottom: 14, border: `1px solid ${sv.yellow}`, background: `${sv.yellow}12` }}>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div style={{ fontFamily: sv.display, fontSize: 13, color: sv.yellow }}>
+                                ↳ Suggested: {suggestion.code}{suggestion.name ? ` — ${suggestion.name}` : ''}
+                            </div>
+                            <div style={{ ...monoFaint, marginTop: 2, fontSize: 10.5 }}>
+                                Only unfilled gap left on this disc.
+                            </div>
+                        </div>
+                        <SvActionButton tone="yellow" size="sm" onClick={() => onAssign(suggestion.code)}>
+                            Accept
+                        </SvActionButton>
+                    </div>
+                )}
+
+                {/* ranked candidates */}
+                <SvLabel>Ranked candidates</SvLabel>
+                <div style={{ marginTop: 10, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {candidates.length === 0 && (
+                        <div style={{ ...monoFaint, padding: '12px 0', textAlign: 'center' }}>
+                            No match data — use manual assignment below.
+                        </div>
+                    )}
+                    {candidates.map((cand) => {
+                        const others = takenByOther(cand.episodeCode);
+                        const isGap = coverage[cand.episodeCode]?.status === 'missing';
+                        const isSelected = selection === cand.episodeCode;
+                        const barColor = confidenceColor(cand.score);
+                        const accent = others.length
+                            ? `${sv.red}88`
+                            : isSelected
+                              ? sv.cyan
+                              : isGap
+                                ? `${sv.yellow}88`
+                                : sv.lineMid;
+                        return (
+                            <div
+                                key={cand.episodeCode}
+                                style={{
+                                    border: `1px solid ${accent}`,
+                                    background: others.length ? `${sv.red}0d` : isGap ? `${sv.yellow}0d` : sv.bg0,
+                                    padding: '11px 13px',
+                                }}
+                            >
+                                <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 10 }}>
+                                    <div style={{ minWidth: 0 }}>
+                                        <div style={{ fontFamily: sv.mono, fontSize: 13, fontWeight: 600, color: sv.ink }}>
+                                            {cand.episodeCode}
+                                            {cand.episodeName && (
+                                                <span style={{ color: sv.inkDim, fontWeight: 400, fontSize: 11.5 }}> — {cand.episodeName}</span>
+                                            )}
+                                        </div>
+                                    </div>
+                                    <span style={{ fontFamily: sv.display, fontSize: 20, fontWeight: 600, lineHeight: 1, color: barColor }}>
+                                        {pct(cand.score)}
+                                    </span>
+                                </div>
+
+                                {/* tags */}
+                                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginTop: 8 }}>
+                                    {cand.isBest && <SvBadge size="sm" tone={sv.inkDim} dot={false}>top score</SvBadge>}
+                                    {others.length > 0 && (
+                                        <SvBadge size="sm" state="error" dot>
+                                            conflict · #{titleIndexById[others[0]] ?? others[0]}
+                                        </SvBadge>
+                                    )}
+                                    {isGap && others.length === 0 && (
+                                        <SvBadge size="sm" tone={sv.yellow} dot>fills gap</SvBadge>
+                                    )}
+                                    {isSelected && others.length === 0 && (
+                                        <SvBadge size="sm" tone={sv.cyan} dot>selected</SvBadge>
+                                    )}
+                                </div>
+
+                                {/* score bar */}
+                                <div style={{ height: 5, background: sv.bg3, marginTop: 9, position: 'relative', overflow: 'hidden' }}>
+                                    <div style={{ position: 'absolute', inset: '0 auto 0 0', width: `${Math.round(cand.score * 100)}%`, background: barColor }} />
+                                </div>
+
+                                {/* evidence + assign */}
+                                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, marginTop: 9 }}>
+                                    <div style={{ ...monoFaint, fontSize: 10, display: 'flex', gap: 14, letterSpacing: '0.04em' }}>
+                                        {cand.voteCount != null && (
+                                            <span>
+                                                <span style={{ color: sv.inkDim }}>{cand.voteCount}</span>
+                                                {cand.targetVotes ? `/${cand.targetVotes}` : ''} votes
+                                            </span>
+                                        )}
+                                        {cand.isBest && details.file_cov != null && (
+                                            <span><span style={{ color: sv.inkDim }}>{pct(details.file_cov)}</span> coverage</span>
+                                        )}
+                                        {cand.isBest && details.score_gap != null && (
+                                            <span>gap <span style={{ color: sv.inkDim }}>+{pct(details.score_gap)}</span></span>
+                                        )}
+                                    </div>
+                                    <SvActionButton
+                                        tone={isGap && others.length === 0 ? 'yellow' : 'neutral'}
+                                        size="sm"
+                                        onClick={() => onAssign(cand.episodeCode)}
+                                    >
+                                        {others.length > 0 ? 'Assign anyway' : isSelected ? 'Selected' : 'Assign'}
+                                    </SvActionButton>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {/* manual override */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 14, paddingTop: 14, borderTop: `1px dashed ${sv.lineMid}` }}>
+                    <span style={{ ...monoFaint, fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase' }}>Manual</span>
+                    <select
+                        value={selection && /^S\d+E\d+$/i.test(selection) ? selection : ''}
+                        onChange={(e) => e.target.value && onAssign(e.target.value)}
+                        aria-label={`Manual episode for title ${title.title_index}`}
+                        style={{
+                            flex: 1,
+                            background: sv.bg0,
+                            border: `1px solid ${sv.lineMid}`,
+                            color: sv.ink,
+                            fontFamily: sv.mono,
+                            fontSize: 12,
+                            padding: '7px 9px',
+                            outline: 'none',
+                            cursor: 'pointer',
+                        }}
+                    >
+                        <option value="">Pick episode…</option>
+                        {episodes.length > 0
+                            ? episodes.map((ep) => (
+                                  <option key={ep.episode_code} value={ep.episode_code}>
+                                      {`E${String(ep.episode_number).padStart(2, '0')}`}
+                                      {ep.name ? ` — ${ep.name}` : ''}
+                                  </option>
+                              ))
+                            : generateEpisodeOptions(
+                                  job.detected_season || 1,
+                                  EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON,
+                              ).map((code) => (
+                                  <option key={code} value={code}>
+                                      {code}
+                                  </option>
+                              ))}
+                    </select>
+                    <SvActionButton
+                        tone={action === 'extra' ? 'cyan' : 'neutral'}
+                        size="sm"
+                        onClick={() => onAction('extra')}
+                        title="Keep as extra content"
+                    >
+                        Extra
+                    </SvActionButton>
+                    <SvActionButton
+                        tone={action === 'discard' ? 'red' : 'neutral'}
+                        size="sm"
+                        onClick={() => onAction('discard')}
+                        title="Discard this title"
+                        ariaLabel="Discard"
+                    >
+                        <Trash2 size={11} />
+                    </SvActionButton>
+                    <SvActionButton
+                        tone="neutral"
+                        size="sm"
+                        onClick={() => onAction('skip')}
+                        title="Skip for now"
+                        ariaLabel="Skip"
+                    >
+                        <SkipForward size={11} />
+                    </SvActionButton>
+                    {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
+                        <SvActionButton
+                            tone="magenta"
+                            size="sm"
+                            onClick={() => onRematch(title.id, title.match_source === 'discdb' ? 'engram' : 'discdb')}
+                            title="Toggle match source"
+                            ariaLabel="Toggle match source"
+                        >
+                            <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                        </SvActionButton>
+                    )}
+                </div>
+            </div>
+        </SvPanel>
+    );
+}

--- a/frontend/src/components/ReviewQueue/SeasonRosterStrip.tsx
+++ b/frontend/src/components/ReviewQueue/SeasonRosterStrip.tsx
@@ -1,0 +1,100 @@
+import type { CSSProperties } from 'react';
+import { sv } from '../../app/components/synapse';
+import type { CoverageEntry, EpisodeStatus } from './coverage';
+import type { RosterEpisode } from './types';
+
+const STATUS_COLOR: Record<EpisodeStatus, string> = {
+    assigned: sv.cyan,
+    duplicate: sv.red,
+    missing: sv.yellow,
+    off: sv.inkFaint,
+};
+
+const truncate: CSSProperties = {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+};
+
+/**
+ * Disc-level coverage at a glance: the season's episodes as slots, colored by
+ * live status — assigned (cyan), doubled (red), gap inside the disc range
+ * (dashed yellow), or not on this disc (ghost). The suggested gap glows.
+ */
+export function SeasonRosterStrip({
+    episodes,
+    coverage,
+    suggestedCode,
+    titleIndexById,
+}: {
+    episodes: RosterEpisode[];
+    coverage: Record<string, CoverageEntry>;
+    suggestedCode: string | null;
+    titleIndexById: Record<number, number>;
+}) {
+    return (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {episodes.map((ep) => {
+                const entry = coverage[ep.episode_code];
+                const status: EpisodeStatus = entry?.status ?? 'off';
+                const color = STATUS_COLOR[status];
+                const isSuggested = ep.episode_code === suggestedCode;
+
+                let who: string;
+                if (entry && entry.titleIds.length > 0) {
+                    who = entry.titleIds.map((id) => `#${titleIndexById[id] ?? id}`).join(' ');
+                } else if (status === 'missing') {
+                    who = '— gap —';
+                } else {
+                    who = 'other disc';
+                }
+
+                return (
+                    <div
+                        key={ep.episode_code}
+                        title={`${ep.episode_code} — ${ep.name}`}
+                        style={{
+                            position: 'relative',
+                            flex: '1 1 78px',
+                            minWidth: 78,
+                            padding: '8px 8px 9px',
+                            background: sv.bg0,
+                            border: `1px solid ${color}${status === 'off' ? '55' : 'aa'}`,
+                            borderStyle: status === 'missing' ? 'dashed' : 'solid',
+                            opacity: status === 'off' ? 0.5 : 1,
+                            boxShadow: isSuggested ? `0 0 0 1px ${sv.yellow}, 0 0 16px ${sv.yellow}40` : undefined,
+                        }}
+                    >
+                        {isSuggested && (
+                            <span
+                                style={{
+                                    position: 'absolute',
+                                    top: -7,
+                                    right: -1,
+                                    fontFamily: sv.mono,
+                                    fontSize: 8,
+                                    letterSpacing: '0.1em',
+                                    fontWeight: 700,
+                                    padding: '1px 5px',
+                                    background: sv.yellow,
+                                    color: sv.bg0,
+                                }}
+                            >
+                                SUGGEST
+                            </span>
+                        )}
+                        <div style={{ fontFamily: sv.mono, fontSize: 11, fontWeight: 700, color }}>
+                            {`E${String(ep.episode_number).padStart(2, '0')}`}
+                        </div>
+                        <div style={{ ...truncate, fontFamily: sv.sans, fontSize: 10, color: sv.inkDim, marginTop: 3 }}>
+                            {ep.name || '—'}
+                        </div>
+                        <div style={{ ...truncate, fontFamily: sv.mono, fontSize: 9, color: sv.inkFaint, marginTop: 5, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                            {who}
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/ReviewQueue/TitleList.tsx
+++ b/frontend/src/components/ReviewQueue/TitleList.tsx
@@ -1,0 +1,114 @@
+import type { CSSProperties } from 'react';
+import { SvBadge, sv } from '../../app/components/synapse';
+import type { DiscTitle } from '../../types';
+import { confidenceColor, formatDuration, formatSize, titleDisplayName } from './utils';
+
+const truncate: CSSProperties = {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+};
+
+/** What the user has currently chosen for a title (selection beats raw match). */
+function assignmentLabel(
+    selection: string | undefined,
+    episodeName: (code: string) => string,
+): { text: string; color: string } {
+    if (!selection) return { text: 'needs review', color: sv.yellow };
+    if (selection === 'extra') return { text: 'extra', color: sv.cyan };
+    if (selection === 'skip') return { text: 'discarded', color: sv.inkFaint };
+    const name = episodeName(selection);
+    return { text: name ? `${selection} · ${name}` : selection, color: sv.cyan };
+}
+
+/**
+ * Compact, scannable list of the disc's titles. Selecting a row opens it in the
+ * inspector. Each row shows the current assignment, confidence, and any
+ * needs-review / conflict flags so the whole disc reads at a glance.
+ */
+export function TitleList({
+    titles,
+    selectedTitleId,
+    selections,
+    collisions,
+    episodeName,
+    onSelect,
+}: {
+    titles: DiscTitle[];
+    selectedTitleId: number | null;
+    selections: Record<number, string>;
+    collisions: Set<string>;
+    episodeName: (code: string) => string;
+    onSelect: (titleId: number) => void;
+}) {
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {titles.map((title) => {
+                const selection = selections[title.id];
+                const assignment = assignmentLabel(selection, episodeName);
+                const inConflict = !!selection && collisions.has(selection);
+                const isActive = title.id === selectedTitleId;
+                const needsReview = !selection;
+                const accent = inConflict ? sv.red : needsReview ? sv.yellow : sv.line;
+
+                return (
+                    <button
+                        key={title.id}
+                        type="button"
+                        onClick={() => onSelect(title.id)}
+                        aria-pressed={isActive}
+                        style={{
+                            position: 'relative',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 12,
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '12px 14px',
+                            background: isActive ? 'rgba(94,234,212,0.06)' : sv.bg1,
+                            border: `1px solid ${accent}${accent === sv.line ? '' : '66'}`,
+                            color: sv.ink,
+                            cursor: 'pointer',
+                            boxShadow: isActive ? `0 0 0 1px ${sv.cyan}, 0 0 18px ${sv.cyan}28` : undefined,
+                            transition: 'border-color 120ms, box-shadow 120ms, background 120ms',
+                        }}
+                    >
+                        <SvBadge size="sm" tone={sv.inkDim} dot={false}>
+                            #{title.title_index}
+                        </SvBadge>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div style={{ ...truncate, fontFamily: sv.mono, fontSize: 12.5, color: sv.cyanHi }}>
+                                {titleDisplayName(title)}
+                            </div>
+                            <div style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginTop: 3, letterSpacing: '0.06em' }}>
+                                {formatDuration(title.duration_seconds)} · {formatSize(title.file_size_bytes)}
+                            </div>
+                        </div>
+                        <div style={{ ...truncate, maxWidth: 200, textAlign: 'right', fontFamily: sv.mono, fontSize: 11, color: assignment.color }}>
+                            {assignment.text}
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+                            {inConflict && (
+                                <SvBadge size="sm" state="error" dot>
+                                    conflict
+                                </SvBadge>
+                            )}
+                            <span
+                                style={{
+                                    fontFamily: sv.display,
+                                    fontSize: 14,
+                                    fontWeight: 600,
+                                    minWidth: 44,
+                                    textAlign: 'right',
+                                    color: title.match_confidence > 0 ? confidenceColor(title.match_confidence) : sv.inkFaint,
+                                }}
+                            >
+                                {title.match_confidence > 0 ? `${Math.round(title.match_confidence * 100)}%` : '—'}
+                            </span>
+                        </div>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/components/ReviewQueue/coverage.test.ts
+++ b/frontend/src/components/ReviewQueue/coverage.test.ts
@@ -79,4 +79,31 @@ describe('buildCandidates', () => {
         expect(cands[0].episodeName).toBe('Seven Minutes of Terror');
         expect(cands[1].voteCount).toBe(4);
     });
+
+    it('normalizes unpadded codes to canonical zero-padded form', () => {
+        const title = {
+            matched_episode: 'S3E5',
+            match_confidence: 0.18,
+            match_details: JSON.stringify({ runner_ups: [{ episode: 'S3E4', confidence: 0.1 }] }),
+        } as unknown as DiscTitle;
+        const names: Record<string, string> = { S03E05: 'Charity Drive' };
+        const cands = buildCandidates(title, (code) => names[code] ?? '');
+        expect(cands[0].episodeCode).toBe('S03E05');
+        expect(cands[0].episodeName).toBe('Charity Drive'); // name lookup uses padded code
+        expect(cands[1].episodeCode).toBe('S03E04');
+    });
+});
+
+describe('episode-code normalization across padding', () => {
+    it('treats unpadded and padded selections as the same episode (collision)', () => {
+        // Real-world: matcher emitted "S3E5" for one title, "S03E05" for another.
+        const cov = computeCoverage({ 10: 'S3E5', 11: 'S03E05' }, episodes);
+        expect(cov['S03E05'].status).toBe('duplicate');
+        expect([...cov['S03E05'].titleIds].sort()).toEqual([10, 11]);
+    });
+
+    it('collidingCodes flags the collision regardless of padding', () => {
+        const set = collidingCodes({ 10: 'S3E5', 11: 'S03E05' });
+        expect(set.has('S03E05')).toBe(true);
+    });
 });

--- a/frontend/src/components/ReviewQueue/coverage.test.ts
+++ b/frontend/src/components/ReviewQueue/coverage.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import type { DiscTitle } from '../../types';
+import {
+    computeCoverage,
+    suggestGapCode,
+    collidingCodes,
+    buildCandidates,
+    type RosterEpisode,
+} from './coverage';
+
+const episodes: RosterEpisode[] = [
+    { episode_code: 'S03E01', episode_number: 1, name: 'Polaris' },
+    { episode_code: 'S03E02', episode_number: 2, name: 'Game Changer' },
+    { episode_code: 'S03E03', episode_number: 3, name: 'All In' },
+    { episode_code: 'S03E04', episode_number: 4, name: 'Happy Valley' },
+    { episode_code: 'S03E05', episode_number: 5, name: 'Seven Minutes of Terror' },
+    { episode_code: 'S03E06', episode_number: 6, name: 'New Eden' },
+];
+
+describe('computeCoverage', () => {
+    it('marks assigned, duplicate, missing-in-range, and off', () => {
+        const cov = computeCoverage(
+            { 10: 'S03E01', 11: 'S03E02', 12: 'S03E05', 13: 'S03E05' },
+            episodes,
+        );
+        expect(cov['S03E01'].status).toBe('assigned');
+        expect(cov['S03E05'].status).toBe('duplicate');
+        expect([...cov['S03E05'].titleIds].sort()).toEqual([12, 13]);
+        expect(cov['S03E03'].status).toBe('missing'); // gap inside range 1..5
+        expect(cov['S03E04'].status).toBe('missing');
+        expect(cov['S03E06'].status).toBe('off'); // outside covered range
+    });
+
+    it('ignores extra/skip pseudo-selections', () => {
+        const cov = computeCoverage({ 10: 'extra', 11: 'skip', 12: 'S03E02' }, episodes);
+        expect(cov['S03E02'].status).toBe('assigned');
+        expect(cov['S03E01'].status).toBe('off'); // only E02 present → range 2..2
+    });
+});
+
+describe('suggestGapCode', () => {
+    it('returns the lowest missing episode inside the covered range', () => {
+        expect(suggestGapCode({ 10: 'S03E01', 12: 'S03E05' }, episodes)).toBe('S03E02');
+    });
+    it('returns null when there is no gap', () => {
+        expect(suggestGapCode({ 10: 'S03E01', 11: 'S03E02' }, episodes)).toBeNull();
+    });
+});
+
+describe('collidingCodes', () => {
+    it('flags episodes claimed by more than one title', () => {
+        const set = collidingCodes({ 10: 'S03E05', 11: 'S03E05', 12: 'S03E01' });
+        expect(set.has('S03E05')).toBe(true);
+        expect(set.has('S03E01')).toBe(false);
+    });
+});
+
+describe('buildCandidates', () => {
+    it('orders best match first then runner_ups, attaching episode names', () => {
+        const title = {
+            matched_episode: 'S03E05',
+            match_confidence: 0.54,
+            match_details: JSON.stringify({
+                vote_count: 4,
+                runner_ups: [
+                    { episode: 'S03E04', confidence: 0.49, vote_count: 4 },
+                    { episode: 'S03E03', confidence: 0.31, vote_count: 2 },
+                ],
+            }),
+        } as unknown as DiscTitle;
+        const names: Record<string, string> = {
+            S03E05: 'Seven Minutes of Terror',
+            S03E04: 'Happy Valley',
+            S03E03: 'All In',
+        };
+        const cands = buildCandidates(title, (code) => names[code] ?? '');
+        expect(cands.map((c) => c.episodeCode)).toEqual(['S03E05', 'S03E04', 'S03E03']);
+        expect(cands[0].isBest).toBe(true);
+        expect(cands[0].episodeName).toBe('Seven Minutes of Terror');
+        expect(cands[1].voteCount).toBe(4);
+    });
+});

--- a/frontend/src/components/ReviewQueue/coverage.ts
+++ b/frontend/src/components/ReviewQueue/coverage.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure coverage/conflict logic for the disc review screen.
+ *
+ * The matcher already ranks candidates per title; this module turns the user's
+ * *current, unsaved* episode selections into disc-level coverage — which
+ * episodes are assigned, doubled (collision), or missing (a gap inside the
+ * disc's covered range) — and surfaces the obvious gap to suggest for an
+ * unmatched title. Kept free of React so it can be unit-tested directly.
+ */
+
+import type { DiscTitle } from '../../types';
+import { parseMatchDetails } from './utils';
+
+export type { RosterEpisode } from './types';
+import type { RosterEpisode } from './types';
+
+export type EpisodeStatus = 'assigned' | 'duplicate' | 'missing' | 'off';
+
+export interface CoverageEntry {
+    status: EpisodeStatus;
+    titleIds: number[];
+}
+
+export interface Candidate {
+    episodeCode: string;
+    episodeName: string;
+    score: number;
+    voteCount?: number;
+    targetVotes?: number;
+    isBest: boolean;
+}
+
+const CODE_RE = /^S(\d+)E(\d+)$/i;
+
+/** Real "S03E05"-style codes only — excludes pseudo values like extra/skip/''. */
+function isRealCode(code: string): boolean {
+    return CODE_RE.test(code);
+}
+
+function episodeNumber(code: string): number | null {
+    const m = CODE_RE.exec(code);
+    return m ? parseInt(m[2], 10) : null;
+}
+
+/** Group the live selections by episode code → the title ids claiming it. */
+export function assignmentsByCode(selections: Record<number, string>): Map<string, number[]> {
+    const map = new Map<string, number[]>();
+    for (const [titleId, code] of Object.entries(selections)) {
+        if (!code || !isRealCode(code)) continue;
+        const ids = map.get(code) ?? [];
+        ids.push(Number(titleId));
+        map.set(code, ids);
+    }
+    return map;
+}
+
+/**
+ * Per-episode coverage keyed by episode code. "missing" applies only inside the
+ * covered range [min..max] of assigned episodes — episodes outside that range
+ * are "off" (i.e. on another disc), matching the server's snapshot logic.
+ */
+export function computeCoverage(
+    selections: Record<number, string>,
+    episodes: RosterEpisode[],
+): Record<string, CoverageEntry> {
+    const byCode = assignmentsByCode(selections);
+
+    const presentNums: number[] = [];
+    for (const code of byCode.keys()) {
+        const n = episodeNumber(code);
+        if (n != null) presentNums.push(n);
+    }
+    const lo = presentNums.length ? Math.min(...presentNums) : 0;
+    const hi = presentNums.length ? Math.max(...presentNums) : -1;
+
+    const out: Record<string, CoverageEntry> = {};
+    for (const ep of episodes) {
+        const ids = byCode.get(ep.episode_code) ?? [];
+        let status: EpisodeStatus;
+        if (ids.length > 1) status = 'duplicate';
+        else if (ids.length === 1) status = 'assigned';
+        else if (ep.episode_number >= lo && ep.episode_number <= hi) status = 'missing';
+        else status = 'off';
+        out[ep.episode_code] = { status, titleIds: ids };
+    }
+    return out;
+}
+
+/** The lowest unfilled episode inside the covered range — the gap to suggest. */
+export function suggestGapCode(
+    selections: Record<number, string>,
+    episodes: RosterEpisode[],
+): string | null {
+    const cov = computeCoverage(selections, episodes);
+    const gaps = episodes
+        .filter((ep) => cov[ep.episode_code]?.status === 'missing')
+        .sort((a, b) => a.episode_number - b.episode_number);
+    return gaps.length ? gaps[0].episode_code : null;
+}
+
+/** Episode codes claimed by more than one title — the collisions to resolve. */
+export function collidingCodes(selections: Record<number, string>): Set<string> {
+    const set = new Set<string>();
+    for (const [code, ids] of assignmentsByCode(selections)) {
+        if (ids.length > 1) set.add(code);
+    }
+    return set;
+}
+
+/** Ranked candidates for a title: best match first, then runner-ups, named. */
+export function buildCandidates(
+    title: DiscTitle,
+    nameOf: (code: string) => string,
+): Candidate[] {
+    const details = parseMatchDetails(title);
+    const out: Candidate[] = [];
+    const seen = new Set<string>();
+
+    if (title.matched_episode) {
+        out.push({
+            episodeCode: title.matched_episode,
+            episodeName: nameOf(title.matched_episode),
+            score: title.match_confidence ?? 0,
+            voteCount: details.vote_count,
+            targetVotes: details.target_votes,
+            isBest: true,
+        });
+        seen.add(title.matched_episode);
+    }
+
+    for (const alt of details.runner_ups ?? []) {
+        if (!alt.episode || seen.has(alt.episode)) continue;
+        seen.add(alt.episode);
+        out.push({
+            episodeCode: alt.episode,
+            episodeName: nameOf(alt.episode),
+            score: alt.confidence ?? 0,
+            voteCount: alt.vote_count,
+            targetVotes: alt.target_votes,
+            isBest: false,
+        });
+    }
+
+    return out;
+}

--- a/frontend/src/components/ReviewQueue/coverage.ts
+++ b/frontend/src/components/ReviewQueue/coverage.ts
@@ -42,14 +42,28 @@ function episodeNumber(code: string): number | null {
     return m ? parseInt(m[2], 10) : null;
 }
 
+/**
+ * Canonicalize an episode code to zero-padded `SxxExx`. The matcher's main path
+ * emits padded codes, but a fallback path can produce unpadded ones (e.g.
+ * "S1E14"); without normalizing, "S1E14" and "S01E14" wouldn't dedupe/collide
+ * against each other or the (always-padded) season roster. Non-codes
+ * ('extra'/'skip'/'') pass through unchanged.
+ */
+export function normalizeEpisodeCode(code: string): string {
+    const m = CODE_RE.exec(code);
+    if (!m) return code;
+    return `S${m[1].padStart(2, '0')}E${m[2].padStart(2, '0')}`;
+}
+
 /** Group the live selections by episode code → the title ids claiming it. */
 export function assignmentsByCode(selections: Record<number, string>): Map<string, number[]> {
     const map = new Map<string, number[]>();
     for (const [titleId, code] of Object.entries(selections)) {
         if (!code || !isRealCode(code)) continue;
-        const ids = map.get(code) ?? [];
+        const key = normalizeEpisodeCode(code);
+        const ids = map.get(key) ?? [];
         ids.push(Number(titleId));
-        map.set(code, ids);
+        map.set(key, ids);
     }
     return map;
 }
@@ -117,23 +131,26 @@ export function buildCandidates(
     const seen = new Set<string>();
 
     if (title.matched_episode) {
+        const code = normalizeEpisodeCode(title.matched_episode);
         out.push({
-            episodeCode: title.matched_episode,
-            episodeName: nameOf(title.matched_episode),
+            episodeCode: code,
+            episodeName: nameOf(code),
             score: title.match_confidence ?? 0,
             voteCount: details.vote_count,
             targetVotes: details.target_votes,
             isBest: true,
         });
-        seen.add(title.matched_episode);
+        seen.add(code);
     }
 
     for (const alt of details.runner_ups ?? []) {
-        if (!alt.episode || seen.has(alt.episode)) continue;
-        seen.add(alt.episode);
+        if (!alt.episode) continue;
+        const code = normalizeEpisodeCode(alt.episode);
+        if (seen.has(code)) continue;
+        seen.add(code);
         out.push({
-            episodeCode: alt.episode,
-            episodeName: nameOf(alt.episode),
+            episodeCode: code,
+            episodeName: nameOf(code),
             score: alt.confidence ?? 0,
             voteCount: alt.vote_count,
             targetVotes: alt.target_votes,

--- a/frontend/src/components/ReviewQueue/types.ts
+++ b/frontend/src/components/ReviewQueue/types.ts
@@ -6,6 +6,7 @@ import { DiscTitle } from '../../types';
 
 export interface MatchDetails {
     vote_count?: number;
+    target_votes?: number;
     file_cov?: number;
     score?: number;
     score_gap?: number;
@@ -13,12 +14,32 @@ export interface MatchDetails {
         episode: string;
         confidence: number;
         vote_count?: number;
+        target_votes?: number;
     }>;
     error?: string;
     message?: string;
     matches_found?: number;
     conflict_reason?: string;
     auto_sorted?: string;
+}
+
+/** One episode slot from GET /api/jobs/{id}/season-roster. */
+export interface RosterEpisode {
+    episode_code: string;
+    episode_number: number;
+    name: string;
+    /** Persisted coverage from the server; the UI recomputes live while editing. */
+    status?: 'assigned' | 'duplicate' | 'missing' | 'off';
+    assigned_title_ids?: number[];
+}
+
+/** Response shape of the season-roster endpoint. */
+export interface SeasonRoster {
+    available: boolean;
+    season_number: number | null;
+    show_id: number | null;
+    episodes: RosterEpisode[];
+    reason: string | null;
 }
 
 export type { DiscTitle };

--- a/frontend/src/components/ReviewQueue/utils.ts
+++ b/frontend/src/components/ReviewQueue/utils.ts
@@ -6,6 +6,7 @@ import { DiscTitle } from '../../types';
 import { MatchDetails } from './types';
 import { MATCHING_CONFIG } from '../../config/constants';
 import { formatSizeGB, formatDurationLong } from '../../utils/formatting';
+import { sv } from '../../app/components/synapse';
 
 /**
  * Format file size in bytes to human-readable format.
@@ -54,6 +55,24 @@ export function getReviewReasons(title: DiscTitle): string[] {
     }
 
     return reasons;
+}
+
+/**
+ * Display name for a title — filename basename, or a generic fallback.
+ */
+export function titleDisplayName(title: DiscTitle): string {
+    return title.output_filename
+        ? title.output_filename.split(/[/\\]/).pop() ?? `Title ${title.title_index}`
+        : `Title ${title.title_index}`;
+}
+
+/**
+ * Color a confidence score: green (auto-match), yellow (plausible), red (weak).
+ */
+export function confidenceColor(confidence: number): string {
+    if (confidence >= MATCHING_CONFIG.AUTO_MATCH_THRESHOLD) return sv.green;
+    if (confidence >= MATCHING_CONFIG.MIN_CONFIDENCE) return sv.yellow;
+    return sv.red;
 }
 
 /**

--- a/frontend/src/hooks/useSeasonRoster.ts
+++ b/frontend/src/hooks/useSeasonRoster.ts
@@ -11,18 +11,31 @@ import type { SeasonRoster } from '../components/ReviewQueue/types';
 export function useSeasonRoster(jobId: string | undefined) {
     const [roster, setRoster] = useState<SeasonRoster | null>(null);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         if (!jobId) return;
         let cancelled = false;
         setLoading(true);
+        setError(null);
         fetch(`/api/jobs/${jobId}/season-roster`)
-            .then((r) => (r.ok ? r.json() : null))
-            .then((data: SeasonRoster | null) => {
+            .then((r) => {
+                // The endpoint returns 200 with available:false when there's no
+                // TMDB data, so a non-OK status is a genuine failure — except a
+                // 404 (job gone), which we treat as "no roster" rather than an
+                // error worth surfacing.
+                if (r.ok) return r.json() as Promise<SeasonRoster>;
+                if (r.status === 404) return null;
+                throw new Error(`season-roster ${r.status}`);
+            })
+            .then((data) => {
                 if (!cancelled) setRoster(data);
             })
-            .catch(() => {
-                if (!cancelled) setRoster(null);
+            .catch((e) => {
+                if (!cancelled) {
+                    setRoster(null);
+                    setError(e instanceof Error ? e.message : 'season-roster failed');
+                }
             })
             .finally(() => {
                 if (!cancelled) setLoading(false);
@@ -38,5 +51,5 @@ export function useSeasonRoster(jobId: string | undefined) {
         [roster],
     );
 
-    return { roster, loading, episodeName };
+    return { roster, loading, error, episodeName };
 }

--- a/frontend/src/hooks/useSeasonRoster.ts
+++ b/frontend/src/hooks/useSeasonRoster.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { SeasonRoster } from '../components/ReviewQueue/types';
+
+/**
+ * Loads the detected season's episode list (code + name) plus persisted
+ * coverage for a job. Powers the review roster strip and labels bare episode
+ * codes with real titles. Degrades gracefully: an unavailable roster (no TMDB
+ * id yet, or a fetch failure) leaves `roster.available === false` and
+ * `episodeName` returning ''.
+ */
+export function useSeasonRoster(jobId: string | undefined) {
+    const [roster, setRoster] = useState<SeasonRoster | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!jobId) return;
+        let cancelled = false;
+        setLoading(true);
+        fetch(`/api/jobs/${jobId}/season-roster`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data: SeasonRoster | null) => {
+                if (!cancelled) setRoster(data);
+            })
+            .catch(() => {
+                if (!cancelled) setRoster(null);
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [jobId]);
+
+    const episodeName = useCallback(
+        (code: string): string =>
+            roster?.episodes.find((e) => e.episode_code === code)?.name ?? '',
+        [roster],
+    );
+
+    return { roster, loading, episodeName };
+}


### PR DESCRIPTION
## Summary

Reworks the TV disc-review UX so manually correcting matches is easier, with full visibility into the matcher's ranking data and disc-level awareness of conflicts and gaps.

The pain this addresses: corrections are *interdependent*. Slotting in an unmatched title often collides with another title's auto-match (episodes are mutually exclusive), so you have to reconcile the whole disc — the old per-row UI had no concept of that.

Built mockups-first: four direction mockups were produced and the **Inspector panel** direction was chosen, then implemented.

## What changed

- **Backend** — new `GET /api/jobs/{id}/season-roster` ([routes.py](backend/app/api/routes.py)) returning the detected season's episodes (code **+ name** from TMDB) plus per-episode coverage across the job's titles (`assigned` / `duplicate` / `missing` gap / `off`). Reuses the existing season endpoint via a new `fetch_season_episodes()` helper ([tmdb_client.py](backend/app/matcher/tmdb_client.py)). `discdb_flagged`/`runner_ups` were already exposed, so no other API churn.
- **Frontend** — `ReviewQueue` TV path rebuilt into a compact title list + sticky **Inspector** (ranked candidates with evidence: votes `x/target`, coverage, score gap; episode names; conflict/gap tags; disc-aware "fill the gap" suggestion; manual override) + a **season roster strip**. New `useSeasonRoster` hook and a pure, unit-tested `coverage.ts` for live collision/gap/suggestion logic. Movie review path untouched.
- **Docs** — four static, brand-accurate direction mockups under `docs/design_handoff_synapse/explorations/review-redesign-*.html` (kept as design reference).

## Reviewer notes

- **Collision detection is roster-independent**: it derives from the live selections, so two titles claiming the same episode are flagged inline and **Save/Process are blocked** even when TMDB is unavailable. The season roster strip, episode-name labels, and the gap suggestion are the TMDB-dependent parts (need a configured token + resolved `tmdb_id`).
- One shared data/logic layer drives all four mockups and the final build, so the layout choice never touched the backend.

## Test plan

- [x] Backend unit suite: `cd backend && uv run pytest tests/unit` — 707 passed (incl. new `test_season_roster.py`, mocked TMDB)
- [x] Frontend unit suite: `cd frontend && npx vitest run` — 66 passed (incl. `coverage.test.ts`)
- [x] `npm run build`, `npm run lint`, `uv run ruff check` — all clean
- [x] Live browser run (simulated TV disc): inspector layout, selection, candidate display, **live collision detection** (banner + red badges + Save gated), inspector "Assign anyway", and resolving into the gap re-enables Save — 0 console errors
- [ ] Confirm the season roster strip + suggestion populate on a real TV job (needs a configured TMDB token; not available in the test environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)