### PR TITLE
fix(test): isolate progress_callback race test from real engram.db

### DIFF
--- a/backend/tests/unit/test_progress_callback_race.py
+++ b/backend/tests/unit/test_progress_callback_race.py
@@ -27,10 +27,8 @@ force the exact interleaving:
 
 import asyncio
 
-import pytest
-
+from app import database
 from app.core.extractor import RipProgress
-from app.database import async_session, init_db
 from app.models.disc_job import (
     ContentType,
     DiscJob,
@@ -39,16 +37,18 @@ from app.models.disc_job import (
     TitleState,
 )
 
-
-@pytest.fixture(autouse=True)
-async def setup_db():
-    """Initialize DB for each test."""
-    await init_db()
+# NOTE: This test relies on the autouse `isolate_database` fixture in
+# tests/unit/conftest.py, which builds the schema in an in-memory SQLite engine
+# and monkeypatches `app.database.async_session` onto it. We must therefore
+# reach the session factory through the module (`database.async_session`) at
+# call time — a `from app.database import async_session` binding would capture
+# the real-engine factory before the patch is applied and silently read/write
+# the developer's real engram.db.
 
 
 async def _create_job_with_titles(n_titles: int = 5) -> tuple[DiscJob, list[DiscTitle]]:
     """Create a movie job with n PENDING titles."""
-    async with async_session() as session:
+    async with database.async_session() as session:
         job = DiscJob(
             drive_id="E:",
             volume_label="TEST_MOVIE",
@@ -80,7 +80,7 @@ async def _create_job_with_titles(n_titles: int = 5) -> tuple[DiscJob, list[Disc
 
 async def _count_ripping(sorted_titles: list[DiscTitle]) -> list[int]:
     """Return title_indices of all titles currently in RIPPING state."""
-    async with async_session() as sess:
+    async with database.async_session() as sess:
         ripping = []
         for t in sorted_titles:
             db_t = await sess.get(DiscTitle, t.id)
@@ -127,7 +127,7 @@ class TestProgressCallbackRaceCondition:
                 prev_list_idx = _last_title_idx - 1
                 if 0 <= prev_list_idx < len(sorted_titles):
                     prev_title = sorted_titles[prev_list_idx]
-                    async with async_session() as sess:
+                    async with database.async_session() as sess:
                         prev_db = await sess.get(DiscTitle, prev_title.id)
                         if prev_db and prev_db.state == TitleState.RIPPING:
                             prev_db.state = TitleState.MATCHED
@@ -137,7 +137,7 @@ class TestProgressCallbackRaceCondition:
 
             # Set active title to RIPPING
             if active_title and active_title.id not in _titles_marked_ripping:
-                async with async_session() as sess:
+                async with database.async_session() as sess:
                     title_db = await sess.get(DiscTitle, active_title.id)
 
                     # >>> CRITICAL INTERLEAVE POINT <<<
@@ -217,7 +217,7 @@ class TestProgressCallbackRaceCondition:
                     prev_list_idx = _last_title_idx - 1
                     if 0 <= prev_list_idx < len(sorted_titles):
                         prev_title = sorted_titles[prev_list_idx]
-                        async with async_session() as sess:
+                        async with database.async_session() as sess:
                             prev_db = await sess.get(DiscTitle, prev_title.id)
                             if prev_db and prev_db.state == TitleState.RIPPING:
                                 prev_db.state = TitleState.MATCHED
@@ -226,7 +226,7 @@ class TestProgressCallbackRaceCondition:
                 _last_title_idx = current_idx
 
                 if active_title and active_title.id not in _titles_marked_ripping:
-                    async with async_session() as sess:
+                    async with database.async_session() as sess:
                         title_db = await sess.get(DiscTitle, active_title.id)
 
                         # Barriers are inside the lock — Task B can't reach
@@ -297,7 +297,7 @@ class TestProgressCallbackRaceCondition:
                     prev_list_idx = _last_title_idx - 1
                     if 0 <= prev_list_idx < len(sorted_titles):
                         prev_title = sorted_titles[prev_list_idx]
-                        async with async_session() as sess:
+                        async with database.async_session() as sess:
                             prev_db = await sess.get(DiscTitle, prev_title.id)
                             if prev_db and prev_db.state == TitleState.RIPPING:
                                 prev_db.state = TitleState.MATCHED
@@ -306,7 +306,7 @@ class TestProgressCallbackRaceCondition:
                 _last_title_idx = current_idx
 
                 if active_title and active_title.id not in _titles_marked_ripping:
-                    async with async_session() as sess:
+                    async with database.async_session() as sess:
                         title_db = await sess.get(DiscTitle, active_title.id)
                         if title_db and title_db.state == TitleState.PENDING:
                             title_db.state = TitleState.RIPPING
@@ -336,7 +336,7 @@ class TestProgressCallbackRaceCondition:
             )
 
         # After all titles, verify progression: 4 MATCHED + 1 RIPPING
-        async with async_session() as sess:
+        async with database.async_session() as sess:
             matched = 0
             for t in sorted_titles:
                 db_t = await sess.get(DiscTitle, t.id)
@@ -371,7 +371,7 @@ class TestProgressCallbackRaceCondition:
                     prev_list_idx = _last_title_idx - 1
                     if 0 <= prev_list_idx < len(sorted_titles):
                         prev_title = sorted_titles[prev_list_idx]
-                        async with async_session() as sess:
+                        async with database.async_session() as sess:
                             prev_db = await sess.get(DiscTitle, prev_title.id)
                             if prev_db and prev_db.state == TitleState.RIPPING:
                                 prev_db.state = TitleState.MATCHED
@@ -380,7 +380,7 @@ class TestProgressCallbackRaceCondition:
                 _last_title_idx = current_idx
 
                 if active_title and active_title.id not in _titles_marked_ripping:
-                    async with async_session() as sess:
+                    async with database.async_session() as sess:
                         title_db = await sess.get(DiscTitle, active_title.id)
                         if title_db and title_db.state == TitleState.PENDING:
                             title_db.state = TitleState.RIPPING


### PR DESCRIPTION
## Summary

The 4 `TestProgressCallbackRaceCondition` tests in `backend/tests/unit/test_progress_callback_race.py` could fail with:

```
sqlalchemy.exc.IntegrityError: NOT NULL constraint failed: disc_jobs.is_transcoding_enabled
```

…on developer machines, even though the migration chain is correct.

## Root cause

This was a **test-isolation** bug, not a migration bug.

- The test did `from app.database import async_session, init_db` and ran `init_db()` in an autouse fixture.
- `conftest.py`'s `isolate_database` fixture isolates unit tests by monkeypatching `app.database.async_session` onto an in-memory engine. But a `from app.database import async_session` binding copies the **real-engine** factory into the test's namespace *before* the patch is applied, so the patch never reaches it. (Every other unit test correctly goes through the module, e.g. `db_mod.async_session`.)
- As a result the test ran Alembic against — and inserted `DiscJob` rows into — the developer's real `backend/engram.db`. Its pass/fail depended entirely on that file's schema:
  - On a db whose schema still had the legacy `is_transcoding_enabled` (NOT NULL, no server default) — because it predates the drop migration `f3a9c1e7b204`, or because `init_db()`'s broad `except Exception` silently swallowed an upgrade failure — inserting a `DiscJob` (which no longer sets that column) violated the constraint.
  - On an up-to-date db (stamped at head, column dropped) it passed.

The migration chain itself is a single linear head (`base → d9cbecac097c → bdedeca4d1be → 9b793042b934 → f3a9c1e7b204`) that correctly drops the column — no fix needed there.

## Fix

- Access the session factory through the module (`database.async_session()`) so the conftest monkeypatch lands and inserts go to the in-memory engine.
- Drop the `init_db()` fixture — `conftest.py`'s `isolate_database` already builds the in-memory schema.
- Added a comment explaining why the by-name import must be avoided here.

The tests are now deterministic regardless of `engram.db` state and no longer pollute the real db. Runtime dropped ~5x (no Alembic round-trips).

## Test plan

- [x] `uv run pytest tests/unit/test_progress_callback_race.py` — 4 passed; `engram.db` row count unchanged (proves it no longer touches the real db)
- [x] `uv run pytest tests/unit` — 705 passed, no regressions
- [x] `uv run ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)