### PR TITLE
feat(matcher): calibrate episode-match confidence to an interpretable 0-1 scale

### DIFF
--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -216,6 +216,166 @@ def _is_watermark_block(block_text: str, block_lines: list[str], subtitle_start:
     return False
 
 
+# --- Confidence calibration --------------------------------------------------
+#
+# The matcher's raw ``ranked_voting_score`` is the mean TF-IDF cosine of the
+# chunks that voted for the winning episode. Comparing a 30s ASR snippet to a
+# full ~22-minute subtitle file ("teaspoon vs bucket") keeps that cosine small
+# (~0.15-0.21) even for a correct match, so it is uninterpretable as a
+# percentage. ``calibrate_confidence`` translates the raw signals into a 0-1
+# confidence a human reviewer can read. It answers "how sure are we this is the
+# right episode?" rather than "how much text overlapped?".
+#
+# Rationale for the constants lives in
+# docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md.
+
+# Cosine at which a matched chunk counts as full-quality. Votes require >0.15
+# and observed-correct chunks cluster ~0.15-0.21, so the discriminative band is
+# razor-thin; normalized_score is a mild guard, mostly reported for transparency.
+QUALITY_REF_COSINE = 0.18
+# Processed fraction treated as full coverage. ~22-min episodes sample ~0.23, so
+# typical TV reads 1.0 while longer episodes (covered proportionally less) read
+# lower -- the correct direction (the rejected score/coverage design did the
+# opposite, leaking episode length into confidence).
+COVERAGE_REF = 0.15
+# Evidence is a weighted blend of the three independent reported metrics.
+# Consensus (how many sampled chunks agreed) is the strongest, so it dominates.
+W_CONSENSUS = 0.5
+W_NORMALIZED_SCORE = 0.25
+W_COVERAGE = 0.25
+# Floor so a decisive sweep with thin evidence still reads meaningfully, while
+# minimal evidence lands just under the 0.7 review gate.
+EVIDENCE_FLOOR = 0.30
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def calibrate_confidence(
+    *,
+    score: float,
+    score_gap: float,
+    vote_count: int,
+    target_votes: int,
+    processed_coverage: float,
+) -> tuple[float, dict[str, float]]:
+    """Translate raw match signals into a 0-1 reviewer-facing confidence.
+
+    Args:
+        score: winner's ranked_voting_score (mean matched-chunk cosine).
+        score_gap: top1 - top2 (decisiveness; == score when uncontested).
+        vote_count: chunks that voted for the winner.
+        target_votes: total chunks sampled.
+        processed_coverage: fraction of the file run through the matcher
+            (samples * chunk_len / video_duration), NOT the matched fraction.
+
+    Returns:
+        (confidence, components) where components reports the three independent
+        metrics (separation, consensus, normalized_score, coverage) plus the
+        derived evidence term, each in [0, 1].
+
+    Formula:
+        confidence = separation * evidence
+        evidence   = EVIDENCE_FLOOR + (1-FLOOR) * (
+                         W_CONSENSUS*consensus
+                       + W_NORMALIZED_SCORE*normalized_score
+                       + W_COVERAGE*coverage_norm)
+
+    Separation is the safety gate: a near-tie (two plausible episodes) craters
+    confidence regardless of how strong the evidence is, because none of the
+    evidence metrics looks at the runner-up.
+    """
+    eps = 1e-9
+    separation = _clamp01(score_gap / score) if score > eps else 0.0
+    consensus = _clamp01(vote_count / target_votes) if target_votes > 0 else 0.0
+    normalized_score = _clamp01(score / QUALITY_REF_COSINE)
+    coverage_norm = _clamp01(processed_coverage / COVERAGE_REF)
+
+    evidence_raw = (
+        W_CONSENSUS * consensus + W_NORMALIZED_SCORE * normalized_score + W_COVERAGE * coverage_norm
+    )
+    evidence = EVIDENCE_FLOOR + (1.0 - EVIDENCE_FLOOR) * evidence_raw
+    confidence = _clamp01(separation * evidence)
+
+    components = {
+        "separation": separation,
+        "consensus": consensus,
+        "normalized_score": normalized_score,
+        # Report the actual processed fraction (the metric), not the normalized
+        # form used inside the formula.
+        "coverage": _clamp01(processed_coverage),
+        "evidence": evidence,
+    }
+    return confidence, components
+
+
+def _attach_calibrated_confidence(
+    best_match: dict,
+    results_summary: list[dict],
+    video_duration: float,
+    chunk_len: int = 30,
+) -> None:
+    """Mutate ``best_match`` in place with calibrated confidence + leaderboard.
+
+    Sets ``best_match["confidence"]`` to the calibrated value (this is what flows
+    to ``DiscTitle.match_confidence``) while leaving ``best_match["score"]`` and
+    ``match_details["score"]`` as the raw ranked_voting_score that the accept-vs-
+    fallback gate and conflict resolution depend on. Adds the reported metrics to
+    ``match_details`` and builds ``runner_ups`` where each entry keeps its raw
+    ``score`` (for cascading reassignment) and gains a calibrated ``confidence``
+    scaled to the winner so the winner's leaderboard entry equals the headline.
+    """
+    if not results_summary:
+        return
+
+    # results_summary is sorted by score descending by the caller.
+    top1 = results_summary[0]["score"]
+    if len(results_summary) >= 2:
+        score_gap = top1 - results_summary[1]["score"]
+    else:
+        score_gap = top1
+
+    md = best_match.setdefault("match_details", {})
+    target_votes = md.get("target_votes", 0)
+    vote_count = md.get("vote_count", 0)
+    processed_coverage = (target_votes * chunk_len / video_duration) if video_duration > 0 else 0.0
+
+    confidence, components = calibrate_confidence(
+        score=best_match.get("score", 0.0),
+        score_gap=score_gap,
+        vote_count=vote_count,
+        target_votes=target_votes,
+        processed_coverage=processed_coverage,
+    )
+
+    best_match["confidence"] = confidence
+    md["confidence"] = confidence
+    md["score_gap"] = score_gap
+    md["separation"] = components["separation"]
+    md["normalized_score"] = components["normalized_score"]
+    md["consensus"] = components["consensus"]
+    md["coverage"] = components["coverage"]
+
+    runner_ups = []
+    for r in results_summary:
+        if r["score"] <= 0:
+            continue
+        ru_confidence = _clamp01(confidence * (r["score"] / top1)) if top1 > 0 else 0.0
+        runner_ups.append(
+            {
+                "episode": r["episode"],
+                "score": r["score"],  # raw, for conflict resolution
+                "confidence": ru_confidence,  # calibrated, for display
+                "vote_count": r["vote_count"],
+                "target_votes": r.get("target_votes", target_votes),
+            }
+        )
+    runner_ups = runner_ups[:5]
+    best_match["runner_ups"] = runner_ups
+    md["runner_ups"] = runner_ups
+
+
 class TfidfMatcher:
     """
     Episode matcher using TF-IDF cosine similarity.
@@ -1007,46 +1167,31 @@ class EpisodeMatcher:
                     "runner_ups": [],
                 }
 
-            # Add ALL candidates (including the best match) so the UI can display
-            # the full voting leaderboard. Previously excluded the best match, but
-            # for decisive matches with a single candidate this left runner_ups empty.
-            runner_ups = []
-            if results_summary:
-                results_summary.sort(key=lambda x: x["score"], reverse=True)
-                runner_ups = [
-                    {
-                        "episode": r["episode"],
-                        "score": r["score"],
-                        "vote_count": r["vote_count"],
-                        "target_votes": len(scan_points),
-                    }
-                    for r in results_summary
-                    if r["score"] > 0
-                ][:5]
-                best_match["runner_ups"] = runner_ups
-
-            # Merge stats into match_details
+            # Merge stats into match_details before calibration so the helper
+            # operates on the full per-winner detail dict.
             best_match["match_details"].update(match_stats)
-            best_match["match_details"]["runner_ups"] = runner_ups
 
-            # Log top candidates with voting details and score gap analysis
+            # Sort candidates so the calibrator sees top1/top2 in order, then
+            # translate the raw signals into a 0-1 reviewer-facing confidence and
+            # build the runner-up leaderboard. This sets best_match["confidence"]
+            # (calibrated, -> DiscTitle.match_confidence) while leaving
+            # best_match["score"] raw for the accept-gate and conflict resolution.
+            # All candidates (incl. the winner) appear in runner_ups so the UI can
+            # show the full leaderboard. See calibrate_confidence for rationale.
+            results_summary.sort(key=lambda x: x["score"], reverse=True)
+            _attach_calibrated_confidence(best_match, results_summary, video_duration)
+
+            score_gap = best_match["match_details"].get("score_gap", 0.0)
+
+            # Log top candidates with voting + calibration analysis
             voting_method = "ranked voting" if self.use_ranked_voting else "weighted score"
             logger.info(f"{voting_method.capitalize()} results for {video_file.name}:")
-
-            # Compute score gap between top-1 and top-2 (strong correctness signal)
-            score_gap = 0.0
-            if len(results_summary) >= 2:
-                score_gap = results_summary[0]["score"] - results_summary[1]["score"]
-                logger.info(
-                    f"  Score gap (top1-top2): {score_gap:.4f} {'(decisive)' if score_gap > 0.01 else '(LOW - uncertain match)'}"
-                )
-            elif len(results_summary) == 1:
-                # Only one candidate, gap equals its score
-                score_gap = results_summary[0]["score"]
-
-            # Add score_gap to match_details for UI transparency
-            if best_match and best_match.get("match_details"):
-                best_match["match_details"]["score_gap"] = score_gap
+            logger.info(
+                f"  Calibrated confidence: {best_match['confidence']:.3f} "
+                f"(raw score={best_match['score']:.3f}, "
+                f"score_gap={score_gap:.4f} "
+                f"{'decisive' if score_gap > 0.01 else 'LOW-uncertain'})"
+            )
 
             for i, result in enumerate(results_summary[:5], 1):
                 logger.info(

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -341,8 +341,12 @@ def _attach_calibrated_confidence(
     vote_count = md.get("vote_count", 0)
     processed_coverage = (target_votes * chunk_len / video_duration) if video_duration > 0 else 0.0
 
+    # Use top1 (not best_match["score"]) as the denominator so separation
+    # (score_gap / score) is self-consistent: both derive from results_summary.
+    # They are equal by construction (best_match is the top-scoring candidate),
+    # but sourcing both here removes the implicit cross-reference invariant.
     confidence, components = calibrate_confidence(
-        score=best_match.get("score", 0.0),
+        score=top1,
         score_gap=score_gap,
         vote_count=vote_count,
         target_votes=target_votes,
@@ -372,8 +376,10 @@ def _attach_calibrated_confidence(
             }
         )
     runner_ups = runner_ups[:5]
+    # Distinct list objects: curator shallow-copies match_details but not the
+    # inner list, so a shared reference could let one mutation corrupt the other.
     best_match["runner_ups"] = runner_ups
-    md["runner_ups"] = runner_ups
+    md["runner_ups"] = runner_ups[:]
 
 
 class TfidfMatcher:
@@ -1240,6 +1246,11 @@ class EpisodeMatcher:
             match = self._match_full_file(video_file, model_config, reference_files, video_duration)
 
             if match:
+                # Intentional exception to calibration: the full-file fallback
+                # compares whole transcription vs whole subtitle ("bucket vs
+                # bucket"), so its cosine lands on a higher scale than chunk
+                # cosines and is already > min_confidence by construction. We pass
+                # it through uncalibrated; curator's review gate reads it directly.
                 match["score"] = match[
                     "confidence"
                 ]  # Full file score is just confidence (coverage=1.0)

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -234,7 +234,10 @@ class FinalizationCoordinator:
                             current_claimants = candidates.get(alt_ep, [])
                             if not current_claimants:
                                 loser.matched_episode = alt_ep
-                                loser.match_confidence = ru["score"]
+                                # Ranking uses raw score; the stored confidence is
+                                # the calibrated value (falls back to raw for old
+                                # match_details that predate calibration).
+                                loser.match_confidence = ru.get("confidence", ru["score"])
                                 candidates.setdefault(alt_ep, []).append(loser)
                                 reassigned = True
                                 reassigned_any = True
@@ -248,7 +251,7 @@ class FinalizationCoordinator:
                                 claimant_score, _, _, _ = _get_metrics(claimant)
                                 if ru["score"] > claimant_score:
                                     loser.matched_episode = alt_ep
-                                    loser.match_confidence = ru["score"]
+                                    loser.match_confidence = ru.get("confidence", ru["score"])
                                     candidates[alt_ep].append(loser)
                                     reassigned = True
                                     reassigned_any = True

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -171,6 +171,12 @@ class FinalizationCoordinator:
                     except (json.JSONDecodeError, KeyError, TypeError) as e:
                         logger.debug(f"Could not parse match_details JSON: {e}")
                 if score == 0.0:
+                    # Fallback only fires for titles WITHOUT a raw ranked_voting
+                    # score in match_details — i.e. DiscDB-assigned (match_confidence
+                    # is a hardcoded 0.99 sentinel, intentionally outranking engram)
+                    # or filename-parsed titles. Engram matches always carry a raw
+                    # details["score"] (> match_threshold), so a calibrated
+                    # match_confidence never reaches this comparison.
                     score = t.match_confidence
                 return score, vote_count, file_cov, runner_ups
 

--- a/backend/tests/unit/test_confidence_calibration.py
+++ b/backend/tests/unit/test_confidence_calibration.py
@@ -209,6 +209,22 @@ def test_attach_runner_up_confidence_scaled_below_winner():
     assert runner_ups[1]["confidence"] < runner_ups[0]["confidence"]
 
 
+def test_attach_runner_ups_not_shared_between_keys():
+    """best_match['runner_ups'] and match_details['runner_ups'] must be distinct
+    list objects so a downstream in-place mutation of one cannot corrupt the
+    other (curator shallow-copies match_details but not the inner list)."""
+    best = _make_best_match(0.18, 6)
+    rs = _results_summary(("S1E13", 0.18, 6), ("S1E07", 0.09, 2))
+    _attach_calibrated_confidence(best, rs, video_duration=1320)
+
+    top_level = best["runner_ups"]
+    nested = best["match_details"]["runner_ups"]
+    assert top_level == nested  # same contents
+    assert top_level is not nested  # but independent objects
+    nested.append({"episode": "X", "score": 0.0, "confidence": 0.0})
+    assert len(best["runner_ups"]) == 2  # unaffected by mutating the nested list
+
+
 def test_attach_reports_independent_metrics():
     best = _make_best_match(0.165, 8)
     rs = _results_summary(("S1E13", 0.165, 8))

--- a/backend/tests/unit/test_confidence_calibration.py
+++ b/backend/tests/unit/test_confidence_calibration.py
@@ -1,0 +1,218 @@
+"""Unit tests for episode-match confidence calibration.
+
+The matcher's raw ``ranked_voting_score`` is a TF-IDF cosine magnitude
+(~0.15-0.21 even for a correct match) and is uninterpretable as a percentage.
+``calibrate_confidence`` translates the raw signals (separation, consensus,
+normalized score, processed coverage) into a 0-1 confidence that a human
+reviewer can read. These tests pin that behavior, anchored to real
+Arrested Development S1 matcher runs.
+
+Real AD S1 runs (from ~/.engram/engram.log), all CORRECT matches that
+previously displayed as ~18%:
+
+    Episode  raw_score  score_gap  votes/samples
+    S01E13   0.165      0.1652     8/10
+    S01E12   0.180      0.1795     5/10
+    S01E14   0.180      0.1804     4/10
+
+In every case score_gap == score (top2 == 0): the winner swept the field.
+"""
+
+import pytest
+
+from app.matcher.episode_identification import (
+    _attach_calibrated_confidence,
+    calibrate_confidence,
+)
+
+# ~22 min episode -> 10 samples * 30s / 1320s ~= 0.227 processed coverage
+AD_COVERAGE = 10 * 30 / 1320
+
+
+def _calibrate(score, score_gap, votes, target=10, coverage=AD_COVERAGE):
+    conf, _ = calibrate_confidence(
+        score=score,
+        score_gap=score_gap,
+        vote_count=votes,
+        target_votes=target,
+        processed_coverage=coverage,
+    )
+    return conf
+
+
+# --- Real-data anchors: correct decisive matches must read clearly high -------
+
+
+def test_decisive_high_vote_match_reads_high():
+    """S01E13: swept the field, 8/10 votes -> should auto-organize (>= 0.85)."""
+    conf = _calibrate(0.165, 0.1652, 8)
+    assert conf >= 0.85, f"E13 should read high, got {conf:.3f}"
+
+
+def test_decisive_mid_vote_match_reads_high():
+    """S01E12: swept, 5/10 votes -> clearly high (>= 0.75), above review gate."""
+    conf = _calibrate(0.180, 0.1795, 5)
+    assert conf >= 0.75, f"E12 should clear review, got {conf:.3f}"
+
+
+def test_decisive_low_vote_match_reads_high():
+    """S01E14: swept, 4/10 votes -> still above the 0.7 review gate."""
+    conf = _calibrate(0.180, 0.1804, 4)
+    assert conf >= 0.70, f"E14 should clear review, got {conf:.3f}"
+
+
+def test_all_real_ad_cases_far_above_raw():
+    """Every real correct match must read far higher than its raw ~18%."""
+    for score, gap, votes in [(0.165, 0.1652, 8), (0.180, 0.1795, 5), (0.180, 0.1804, 4)]:
+        conf = _calibrate(score, gap, votes)
+        assert conf > 0.5, f"raw≈{score} correct match still low: {conf:.3f}"
+
+
+# --- The dangerous cases: ambiguity must stay in review -----------------------
+
+
+def test_near_tie_needs_review():
+    """Two episodes neck-and-neck (top1 0.18 vs top2 0.16) -> low confidence."""
+    conf = _calibrate(0.18, 0.18 - 0.16, votes=6)
+    assert conf < 0.3, f"near-tie must read low, got {conf:.3f}"
+
+
+def test_two_x_contest_needs_review():
+    """Winner beats #2 by 2x but #2 is real -> below auto/review gate (0.7)."""
+    conf = _calibrate(0.20, 0.20 - 0.10, votes=7)
+    assert conf < 0.7, f"2x contest should need review, got {conf:.3f}"
+
+
+def test_weak_uncontested_sweep_is_borderline():
+    """Barely-above-threshold sweep with minimal votes -> at/under review gate."""
+    conf = _calibrate(0.15, 0.15, votes=2)
+    assert conf < 0.75, f"weak thin sweep should be modest, got {conf:.3f}"
+
+
+# --- Monotonicity: the formula must move the right way ------------------------
+
+
+def test_more_votes_increases_confidence():
+    base = _calibrate(0.18, 0.18, votes=3)
+    more = _calibrate(0.18, 0.18, votes=8)
+    assert more > base
+
+
+def test_bigger_separation_increases_confidence():
+    """Same score/votes, a more decisive win reads more confident."""
+    contested = _calibrate(0.20, 0.04, votes=6)  # top2 = 0.16
+    decisive = _calibrate(0.20, 0.18, votes=6)  # top2 = 0.02
+    assert decisive > contested
+
+
+def test_longer_file_not_more_confident():
+    """Guards the rejected score/coverage design: dividing by coverage made
+    longer episodes (lower coverage) read MORE confident. Same score/gap/votes,
+    a longer file (less processed) must read <= a shorter file."""
+    short = _calibrate(0.18, 0.18, votes=6, coverage=10 * 30 / 1320)  # 22 min
+    long = _calibrate(0.18, 0.18, votes=6, coverage=10 * 30 / 2640)  # 44 min
+    assert long <= short
+
+
+# --- Components & edges -------------------------------------------------------
+
+
+def test_components_reported_and_in_range():
+    conf, comp = calibrate_confidence(
+        score=0.18, score_gap=0.18, vote_count=8, target_votes=10, processed_coverage=AD_COVERAGE
+    )
+    for key in ("separation", "consensus", "normalized_score", "coverage", "evidence"):
+        assert key in comp, f"missing component {key}"
+        assert 0.0 <= comp[key] <= 1.0, f"{key} out of range: {comp[key]}"
+    assert 0.0 <= conf <= 1.0
+
+
+def test_zero_target_votes_is_safe():
+    """No scan points -> no division-by-zero; consensus is 0 and conf stays valid.
+
+    In practice zero votes means score is 0 too (score is the mean of voting
+    chunks), so the realistic degenerate state yields 0 confidence; the point of
+    this test is that target_votes=0 never raises.
+    """
+    conf, comp = calibrate_confidence(
+        score=0.0, score_gap=0.0, vote_count=0, target_votes=0, processed_coverage=0.0
+    )
+    assert comp["consensus"] == 0.0
+    assert 0.0 <= conf <= 1.0
+    assert conf == 0.0
+
+
+def test_zero_score_is_safe():
+    conf, _ = calibrate_confidence(
+        score=0.0, score_gap=0.0, vote_count=0, target_votes=10, processed_coverage=0.0
+    )
+    assert conf == 0.0
+
+
+# --- _attach_calibrated_confidence wiring ------------------------------------
+
+
+def _make_best_match(score, vote_count, target_votes=10):
+    return {
+        "season": 1,
+        "episode": 13,
+        "confidence": score,  # raw, pre-calibration
+        "score": score,  # raw ranked_voting_score (must stay raw)
+        "match_details": {
+            "episode": "S1E13",
+            "score": score,
+            "vote_count": vote_count,
+            "target_votes": target_votes,
+        },
+    }
+
+
+def _results_summary(*pairs):
+    """pairs = (episode_str, score, vote_count)."""
+    return [{"episode": ep, "score": s, "vote_count": v, "target_votes": 10} for ep, s, v in pairs]
+
+
+def test_attach_sets_calibrated_confidence_keeps_raw_score():
+    best = _make_best_match(0.165, 8)
+    rs = _results_summary(("S1E13", 0.165, 8))
+    _attach_calibrated_confidence(best, rs, video_duration=1320)
+
+    assert best["confidence"] >= 0.85  # calibrated headline
+    assert best["score"] == 0.165  # raw signal preserved for accept-gate
+    assert best["match_details"]["score"] == 0.165  # raw preserved for conflict resolution
+    assert best["match_details"]["confidence"] == pytest.approx(best["confidence"])
+
+
+def test_attach_winner_runner_up_equals_headline():
+    """The winner's leaderboard entry confidence must equal the headline."""
+    best = _make_best_match(0.18, 6)
+    rs = _results_summary(("S1E13", 0.18, 6), ("S1E07", 0.05, 1))
+    _attach_calibrated_confidence(best, rs, video_duration=1320)
+
+    runner_ups = best["match_details"]["runner_ups"]
+    winner_entry = runner_ups[0]
+    assert winner_entry["episode"] == "S1E13"
+    assert winner_entry["confidence"] == pytest.approx(best["confidence"])
+    # raw score still present for conflict resolution / cascading reassignment
+    assert winner_entry["score"] == 0.18
+
+
+def test_attach_runner_up_confidence_scaled_below_winner():
+    best = _make_best_match(0.18, 6)
+    rs = _results_summary(("S1E13", 0.18, 6), ("S1E07", 0.09, 2))
+    _attach_calibrated_confidence(best, rs, video_duration=1320)
+
+    runner_ups = best["match_details"]["runner_ups"]
+    assert runner_ups[1]["score"] == 0.09
+    # half the winner's raw score -> ~half the winner's calibrated confidence
+    assert runner_ups[1]["confidence"] == pytest.approx(best["confidence"] * 0.5, abs=0.02)
+    assert runner_ups[1]["confidence"] < runner_ups[0]["confidence"]
+
+
+def test_attach_reports_independent_metrics():
+    best = _make_best_match(0.165, 8)
+    rs = _results_summary(("S1E13", 0.165, 8))
+    _attach_calibrated_confidence(best, rs, video_duration=1320)
+    md = best["match_details"]
+    for key in ("separation", "normalized_score", "consensus", "coverage", "score_gap"):
+        assert key in md, f"missing reported metric {key}"

--- a/docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md
+++ b/docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md
@@ -1,0 +1,134 @@
+# Match-confidence calibration — design
+
+**Date:** 2026-05-22
+**Status:** Approved (design); implementation in progress
+
+## Problem
+
+The episode-match "confidence" shown in the review UI is the raw
+`ranked_voting_score` from `app/matcher/episode_identification.py`
+(`MatchCoverage.ranked_voting_score`): the weighted mean cosine of the chunks
+that voted for the winning episode. Because each vote is a TF-IDF cosine between
+a 30-second ASR snippet and a full ~22-minute subtitle file ("teaspoon vs
+bucket"), a *correct* match scores only ~0.15–0.21. Stored verbatim in
+`DiscTitle.match_confidence` and rendered as a percentage, a correct top match
+reads **~18%**, and the review gates (curator `0.7`, frontend `0.85/0.7/0.5`)
+are effectively unreachable, so every match looks low-confidence.
+
+The raw score answers *"how much text overlapped"* (a magnitude). The UI slot
+asks *"how sure are we this is the right episode"* (a probability-like
+judgment). The fix is a **translation** between the two, not a rescale.
+
+## Signals (grounded in real AD S1 logs)
+
+| File | Episode (correct) | raw `score` | `score_gap` (top1−top2) | votes/samples |
+|------|------|------|------|------|
+| B1_t06 | S01E13 | 0.165 | 0.1652 | 8/10 |
+| B1_t05 | S01E12 | 0.180 | 0.1795 | 5/10 |
+| C1_t07 | S01E14 | 0.180 | 0.1804 | 4/10 |
+
+Key observation: in every correct case `score_gap ≈ score`, i.e. **top2 ≈ 0**.
+Since a chunk only votes at cosine > 0.15, top2 ≈ 0 means *no other episode got a
+single vote* — the winner swept the field. The certainty lives in the
+**separation**, not the magnitude.
+
+## Three independent reported metrics (each 0–1)
+
+1. **normalized_score** = `clamp(score / 0.18, 0, 1)` — magnitude normalized
+   against the *vote threshold band* (votes need >0.15; correct ≈ 0.15–0.21),
+   **not** against coverage. Normalizing by coverage was rejected: `score` is
+   already a mean over *matched* chunks (not diluted by misses), and
+   `score/coverage` is algebraically `score × duration / 300`, leaking episode
+   length into confidence (a 44-min episode would read *more* confident than a
+   22-min one at the same cosine). Discriminative power is small (the cosine band
+   is razor-thin) — this is a mild guard, kept mostly for transparency.
+2. **consensus** = `clamp(votes / samples, 0, 1)` — of the chunks examined, how
+   many agreed with the winner.
+3. **coverage** = `clamp(samples × 30 / video_duration, 0, 1)` — the fraction of
+   the file actually run through the matcher (processed, *not* matched). This is
+   independent of consensus: coverage is "how much we looked at," consensus is
+   "of what we looked at, how much agreed." Currently not computed (the code only
+   has *matched* coverage `file_cov`/`total_weight`); we add it.
+
+## The missing signal: separation
+
+None of the three metrics above looks at the runner-up, so a **decisive sweep**
+(top2 = 0) and a **near-tie** (top1 0.18 vs top2 0.16) produce identical numbers
+— yet the near-tie is the dangerous case (two-parters, recaps, wrong episode in
+the reference set). We add a separation term:
+
+```
+separation = clamp(score_gap / max(score, eps), 0, 1)   # ≈1.0 when uncontested
+```
+
+## Calibration formula
+
+```
+evidence_raw = 0.50·consensus + 0.25·normalized_score + 0.25·coverage
+evidence     = EVIDENCE_FLOOR + (1 − EVIDENCE_FLOOR)·evidence_raw   # FLOOR=0.30
+confidence   = separation · evidence
+```
+
+`confidence = decisiveness × evidence-strength`. Separation is the safety gate
+(near-ties crater regardless of evidence); the three user metrics form the
+evidence term, with consensus weighted highest. Constants:
+`QUALITY_REF_COSINE=0.18`, `COVERAGE_REF` handled by the `/0.15`-style band via
+`clamp(coverage/0.15,…)` is folded into `coverage` above (REF=0.15 → typical TV
+≈1.0, longer episodes lower — the correct direction).
+
+### Behavior on real + synthetic cases
+
+| Case | separation | consensus | conf | outcome |
+|------|------|------|------|------|
+| S01E13 (8/10, swept) | 1.0 | 0.8 | **0.92** | auto-organize |
+| S01E12 (5/10, swept) | 1.0 | 0.5 | **0.83** | auto-organize |
+| S01E14 (4/10, swept) | 1.0 | 0.4 | **0.79** | auto-organize |
+| near-tie 0.18/0.16, 6/10 | 0.11 | 0.6 | **~0.09** | review |
+| 2× contest 0.20/0.10, 7/10 | 0.50 | 0.7 | **~0.45** | review |
+| weak uncontested 0.15, 2/10 | 1.0 | 0.2 | **~0.69** | review (borderline) |
+
+Correct decisive matches move from ~18% to **79–92%**; contested/thin matches
+stay in review. A longer episode at the same score/gap/votes reads *lower* (less
+coverage), eliminating the length artifact.
+
+## Wiring (keep raw `score` intact)
+
+`match_details["score"]` and `runner_ups[].score` are raw signals the matcher's
+accept-vs-fallback gate AND `finalization_coordinator` conflict resolution
+depend on — so calibration is added as a **new** field, never an overwrite.
+
+- **`episode_identification.py`**: add pure `calibrate_confidence(...)` (returns
+  `(confidence, components)`) + a `_attach_calibrated_confidence(best_match,
+  results_summary, video_duration, chunk_len)` helper (testable without ASR).
+  Set `best_match["confidence"]` = calibrated (flows to `match_confidence`);
+  keep `best_match["score"]` raw. Add `confidence/separation/normalized_score/
+  consensus/coverage` to `match_details`. Each runner-up gets
+  `confidence = winner_conf · (ru_score / top1)` (keeps raw `score`), so the
+  winner's leaderboard entry equals the headline and near-ties degrade
+  gracefully.
+- **`curator.py`**: unchanged logic — `confidence` is now calibrated, so
+  `needs_review = confidence < 0.7` finally means something.
+- **`finalization_coordinator.py`**: conflict ranking/reassignment stays on raw
+  `score`; reassignment writes `loser.match_confidence = ru["confidence"]`
+  (calibrated, falling back to `ru["score"]`) so reassigned titles also show a
+  meaningful percentage.
+- **frontend `adapters.ts`**: `extractMatchCandidates` and
+  `extractFinalMatchInfo` prefer `confidence ?? score`.
+
+## Thresholds
+
+- **Accept-vs-fallback gate stays on raw `score`** (`> 0.10`, votes ≥ 2) — proven,
+  don't destabilize which discs match.
+- **needs_review / auto-organize moves to the calibrated scale** (curator `0.7`,
+  frontend `0.85/0.7/0.5` unchanged numerically, now meaningful).
+
+## Tests (`backend/tests/unit/test_confidence_calibration.py`)
+
+- Real AD cases → high (E13 ≥ 0.85; E12, E14 ≥ 0.75).
+- Near-tie / 2× contest → review band (< 0.7).
+- Monotonic in votes and in score_gap.
+- Length-artifact guard: same score/gap/votes, longer file (lower coverage) →
+  confidence not higher.
+- Components in [0,1]; winner runner-up confidence == headline; edge cases
+  (single candidate, zero target_votes, score 0).
+- Frontend `adapters.test.ts`: runner-up + final confidence prefer calibrated.

--- a/docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md
+++ b/docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md
@@ -1,7 +1,7 @@
 # Match-confidence calibration — design
 
 **Date:** 2026-05-22
-**Status:** Approved (design); implementation in progress
+**Status:** Implemented (PR #169)
 
 ## Problem
 

--- a/frontend/src/types/__tests__/adapters.test.ts
+++ b/frontend/src/types/__tests__/adapters.test.ts
@@ -203,4 +203,46 @@ describe("extractMatchCandidates (via track transform)", () => {
     const result = transformJobToDiscData(job, [title]);
     expect(result.tracks![0].matchCandidates).toBeUndefined();
   });
+
+  it("prefers calibrated confidence over raw score for runner_ups", () => {
+    // Backend now ships both raw `score` (small cosine) and calibrated
+    // `confidence` (reviewer-facing). The UI must show the calibrated value.
+    const matchDetails = JSON.stringify({
+      score: 0.18,
+      confidence: 0.92,
+      vote_count: 8,
+      runner_ups: [
+        { episode: "S01E13", score: 0.18, confidence: 0.92, vote_count: 8, target_votes: 10 },
+        { episode: "S01E07", score: 0.0, confidence: 0.0, vote_count: 0, target_votes: 10 },
+      ],
+    });
+    const title = makeTitle({
+      state: "matched",
+      matched_episode: "S01E13",
+      match_confidence: 0.92,
+      match_details: matchDetails,
+    });
+    const track = transformJobToDiscData(makeJob(), [title]).tracks![0];
+
+    expect(track.matchCandidates![0].confidence).toBe(0.92); // not 0.18
+    expect(track.matchCandidates![1].confidence).toBe(0); // zero-vote loser stays 0
+  });
+
+  it("uses calibrated confidence for the headline finalMatchConfidence", () => {
+    const matchDetails = JSON.stringify({
+      score: 0.165,
+      confidence: 0.9,
+      vote_count: 8,
+      target_votes: 10,
+    });
+    const title = makeTitle({
+      state: "matched",
+      matched_episode: "S01E13",
+      match_confidence: 0.9,
+      match_details: matchDetails,
+    });
+    const track = transformJobToDiscData(makeJob(), [title]).tracks![0];
+
+    expect(track.finalMatchConfidence).toBe(0.9); // not the raw 0.165
+  });
 });

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -88,10 +88,12 @@ function extractFinalMatchInfo(title: DiscTitle): { confidence: number; votes: n
 
   const details = parseMatchDetails(title);
 
-  // For matched tracks, the winning match info is at the top level
+  // For matched tracks, the winning match info is at the top level. Prefer the
+  // calibrated `confidence` (0-1, reviewer-facing); fall back to raw `score` for
+  // match_details that predate calibration.
   if (details.score !== undefined && details.vote_count !== undefined) {
     return {
-      confidence: details.score || 0,
+      confidence: details.confidence ?? details.score ?? 0,
       votes: details.vote_count ?? 0,
       targetVotes: details.target_votes ?? details.total_chunks ?? 5
     };
@@ -168,7 +170,8 @@ interface RunnerUp {
 
 interface MatchDetails {
   runner_ups?: RunnerUp[];
-  score?: number;
+  score?: number;        // raw ranked_voting_score
+  confidence?: number;   // calibrated 0-1, reviewer-facing
   vote_count?: number;
   target_votes?: number;
   total_chunks?: number;
@@ -190,7 +193,9 @@ function extractMatchCandidates(title: DiscTitle): MatchCandidate[] | undefined 
   if (details.runner_ups && Array.isArray(details.runner_ups) && details.runner_ups.length > 0) {
     return details.runner_ups.map((ru: RunnerUp) => ({
       episode: ru.episode || 'Unknown',
-      confidence: ru.score || ru.confidence || 0,     // Backend uses 'score'
+      // Prefer calibrated `confidence` (?? keeps a legitimate 0 for zero-vote
+      // losers); fall back to raw `score` for pre-calibration match_details.
+      confidence: ru.confidence ?? ru.score ?? 0,
       votes: ru.vote_count ?? Math.floor((ru.score || 0) * 5),  // Use actual vote_count (0 is valid!)
       targetVotes: ru.target_votes ?? details.target_votes ?? details.total_chunks ?? 5
     }));
@@ -202,7 +207,7 @@ function extractMatchCandidates(title: DiscTitle): MatchCandidate[] | undefined 
   if (details.score !== undefined && details.vote_count !== undefined) {
     return [{
       episode: details.episode || title.matched_episode || 'Matching...',
-      confidence: details.score || 0,
+      confidence: details.confidence ?? details.score ?? 0,
       votes: details.vote_count ?? 0,
       targetVotes: details.target_votes ?? details.total_chunks ?? 5
     }];


### PR DESCRIPTION
## Summary

The review UI showed the matcher's raw `ranked_voting_score` as a percentage. That score is the mean TF-IDF cosine of the chunks that voted for the winning episode; comparing a 30s ASR snippet to a full ~22-min subtitle file ("teaspoon vs bucket") keeps it structurally small (~0.15–0.21) **even for a correct match**. So a correct top match on a real disc (Arrested Development S1) read **~18%**, and the review gates (curator `0.7`, frontend `0.85/0.7/0.5`) were effectively unreachable — every match looked low-confidence.

The raw score answers *"how much text overlapped"* (a magnitude); the UI slot asks *"how sure are we this is the right episode"* (a probability-like judgment). This PR adds a **calibration** that translates between the two.

## Formula

`confidence = separation · evidence`

- **separation** = `score_gap / score` — decisiveness gate. In real correct matches `score_gap ≈ score` (top2 ≈ 0: no other episode got a vote), so an uncontested sweep → ~1.0; a near-tie → ~0.
- **evidence** = `FLOOR + (1−FLOOR)·(0.5·consensus + 0.25·normalized_score + 0.25·coverage)`
  - **consensus** = `votes / samples`
  - **normalized_score** = cosine normalized against the 0.15 vote band (deliberately *not* `score/coverage`, which leaks episode length into confidence)
  - **coverage** = *processed* fraction of the file (`samples·30 / duration`), independent of consensus

Separation is the safety gate: a near-tie (two-parter, recap, wrong episode in the reference set) craters confidence regardless of how strong the evidence is, because none of the evidence metrics looks at the runner-up.

## Results (anchored to real AD S1 logs)

| Episode (correct) | raw score | votes | before | after |
|---|---|---|---|---|
| S01E13 | 0.165 | 8/10 | ~17% | **92%** |
| S01E12 | 0.180 | 5/10 | ~18% | **83%** |
| S01E14 | 0.180 | 4/10 | ~18% | **79%** |
| near-tie 0.18/0.16 | — | 6/10 | — | **~9% (review)** |
| 2× contest 0.20/0.10 | — | 7/10 | — | **~45% (review)** |

## Reviewer notes

- **Raw score is preserved.** `match_details["score"]` and `runner_ups[].score` are unchanged — the matcher's accept-vs-fallback gate (`score > 0.10`, votes ≥ 2) and the `finalization_coordinator` conflict-resolution / cascading-reassignment logic still key off the raw value. Calibration is added as **new** fields.
- **`DiscTitle.match_confidence`** now carries the calibrated value, so the needs-review / auto-organize gates move onto a meaningful scale (thresholds unchanged numerically).
- **Latent bug fixed:** the review UI read `runner_ups[].confidence`, but the backend never set it (alternatives rendered `NaN%`). It's now populated, scaled to the winner so the winner's leaderboard entry equals the headline.
- Rationale + rejected alternatives documented in `docs/superpowers/specs/2026-05-22-match-confidence-calibration-design.md`.

## Test plan

- [x] `backend/tests/unit/test_confidence_calibration.py` — 17 new tests anchored to the real AD signals (decisive→high, near-tie/contest→review, monotonic in votes & separation, a length-artifact regression guard, edge cases, and the `_attach` wiring incl. winner==headline).
- [x] Full backend unit suite: 722 pass; ruff clean.
- [x] Frontend: 62 unit tests pass (incl. 2 new adapter tests proving calibrated `confidence` is preferred over raw `score`); `tsc` + eslint clean.
- [ ] Not run: real end-to-end disc rip (needs MKV files + Whisper) — calibration validated at the unit level against the real logged signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)