### PR TITLE
feat(matcher): auto-escalate deep re-match for episode conflicts

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -100,6 +100,7 @@ class ConnectionManager:
         detected_title: str | None = None,
         detected_season: int | None = None,
         review_reason: str | None = None,
+        conflict_status: str | None = None,
     ) -> None:
         """Broadcast a job status update.
 
@@ -132,6 +133,8 @@ class ConnectionManager:
             data["detected_season"] = detected_season
         if review_reason is not None:
             data["review_reason"] = review_reason
+        if conflict_status is not None:
+            data["conflict_status"] = conflict_status
         await self.broadcast(data)
 
     async def broadcast_drive_event(

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -90,6 +90,7 @@ class DiscJob(SQLModel, table=True):
     cleared_at: datetime | None = Field(default=None)  # Soft-delete: hidden from dashboard
     error_message: str | None = None
     review_reason: str | None = None  # Human-readable reason why review is needed
+    conflict_status: str | None = None  # Transient note while auto-resolving episode conflicts
 
     # Title information (JSON stored as string for simplicity)
     titles_json: str | None = None  # List of titles with durations

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -6,6 +6,9 @@ Extracted from JobManager to isolate finalization concerns.
 import asyncio
 import json
 import logging
+import math
+import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlmodel import select
@@ -18,6 +21,64 @@ from app.services.event_broadcaster import EventBroadcaster
 from app.services.job_state_machine import JobStateMachine
 
 logger = logging.getLogger(__name__)
+
+# --- Automatic conflict escalation ---------------------------------------
+# When two titles match the same episode, we re-run the audio matcher on the
+# contested titles at progressively denser sampling before falling back to
+# manual review. The ladder is depth-only: scan more points (more evidence),
+# but keep the matcher's default vote gate so a genuinely-correct match on a
+# hard episode isn't demoted straight to review.
+_CHUNK_DURATION_S = 30  # mirrors EpisodeMatcher.chunk_duration
+_MAX_SCAN_POINTS = 200  # bound runtime even for very long tracks
+_CONFLICT_FIXED_DEPTHS = (25, 50)  # first two tiers; final tier is full coverage
+_EP_CODE_RE = re.compile(r"[Ss](\d+)[Ee](\d+)")
+
+
+def _normalize_episode_code(code: str | None) -> str:
+    """Canonicalize ``SxxExx`` so padded/unpadded variants collide.
+
+    The matcher's fallback path can emit unpadded codes ("S1E14") while its
+    main path emits "S01E14"; without normalizing, a real collision would be
+    grouped under two different keys and missed.
+    """
+    match = _EP_CODE_RE.search(code or "")
+    if not match:
+        return (code or "").upper()
+    return f"S{int(match.group(1)):02d}E{int(match.group(2)):02d}"
+
+
+def _detect_conflicts(titles) -> dict[str, list]:
+    """Group ``MATCHED`` titles by canonical episode code, keeping only ties."""
+    by_ep: dict[str, list] = {}
+    for t in titles:
+        if t.state == TitleState.MATCHED and t.matched_episode:
+            by_ep.setdefault(_normalize_episode_code(t.matched_episode), []).append(t)
+    return {ep: tl for ep, tl in by_ep.items() if len(tl) > 1}
+
+
+def _full_coverage_points(titles) -> int:
+    """Scan points needed to transcribe ~100% of the longest contested track."""
+    longest = max((t.duration_seconds or 0 for t in titles), default=0)
+    if longest <= 0:
+        return _MAX_SCAN_POINTS  # duration unknown: go as deep as allowed
+    return min(math.ceil(longest / _CHUNK_DURATION_S) + 1, _MAX_SCAN_POINTS)
+
+
+def _conflict_scan_ladder(titles) -> list[int]:
+    """Strictly-increasing escalation ladder, capped at full coverage.
+
+    For short episodes the fixed tiers already exceed full coverage, so the
+    ladder collapses (e.g. ``[25, 45]``); for long tracks it grows
+    (``[25, 50, 180]``). The last entry is always full coverage — there is no
+    "deeper" to go, which is the natural termination point.
+    """
+    full = _full_coverage_points(titles)
+    ladder: list[int] = []
+    for depth in (*_CONFLICT_FIXED_DEPTHS, full):
+        depth = min(depth, full)
+        if depth > 1 and (not ladder or depth > ladder[-1]):
+            ladder.append(depth)
+    return ladder
 
 
 def _merge_match_details(existing: str | None, updates: dict) -> str:
@@ -53,15 +114,115 @@ class FinalizationCoordinator:
         self._on_task_done: callable = None
         self._active_jobs: dict = None
         self._match_single_file: callable = None
+        self._rematch_conflict: callable = None
+
+        # Last scan depth attempted per job while auto-resolving a collision.
+        # Transient (in memory); cleared on resolution, exhaustion, or restart.
+        self._conflict_passes: dict[int, int] = {}
 
     def set_callbacks(
-        self, *, run_ripping, on_task_done, active_jobs, match_single_file=None
+        self,
+        *,
+        run_ripping,
+        on_task_done,
+        active_jobs,
+        match_single_file=None,
+        rematch_conflict=None,
     ) -> None:
         """Set cross-coordinator callbacks."""
         self._run_ripping = run_ripping
         self._on_task_done = on_task_done
         self._active_jobs = active_jobs
         self._match_single_file = match_single_file
+        self._rematch_conflict = rematch_conflict
+
+    def reset_conflict_passes(self, job_id: int) -> None:
+        """Forget any in-progress conflict escalation for ``job_id``."""
+        self._conflict_passes.pop(job_id, None)
+
+    async def on_terminal_clear_conflicts(self, job_id: int, _state) -> None:
+        """Terminal-state hook: drop conflict-escalation tracking for the job."""
+        self.reset_conflict_passes(job_id)
+
+    async def _clear_conflict_state(self, session, job) -> None:
+        """Drop escalation tracking and clear the transient dashboard note."""
+        self.reset_conflict_passes(job.id)
+        if job.conflict_status is not None:
+            job.conflict_status = None
+            await session.commit()
+
+    async def _maybe_escalate_conflicts(self, session, job, titles) -> bool:
+        """Deep re-match titles colliding on the same episode, escalating depth.
+
+        Returns ``True`` if a re-match was dispatched (the job is held in
+        MATCHING and the caller should return — completion re-entry will pick
+        it back up). Returns ``False`` when there is nothing to escalate
+        (no collision, ladder exhausted, or contested files missing), after
+        clearing any transient state so the normal review/organize path runs.
+        """
+        job_id = job.id
+        # Episode collisions only apply to TV; movies resolve file conflicts elsewhere.
+        if job.content_type != ContentType.TV or self._rematch_conflict is None:
+            await self._clear_conflict_state(session, job)
+            return False
+
+        conflicts = _detect_conflicts(titles)
+        if not conflicts:
+            await self._clear_conflict_state(session, job)
+            return False
+
+        contested = [t for group in conflicts.values() for t in group]
+        ladder = _conflict_scan_ladder(contested)
+        last_depth = self._conflict_passes.get(job_id, 0)
+        next_depth = next((d for d in ladder if d > last_depth), None)
+
+        if next_depth is None:
+            logger.info(
+                f"Job {job_id}: conflict re-match exhausted at {last_depth} scan points; "
+                f"{list(conflicts)} still contested — handing to review"
+            )
+            await self._clear_conflict_state(session, job)
+            return False
+
+        # Re-match every distinct raw code in each tie (padded + unpadded), so
+        # all contested titles are covered regardless of stored formatting.
+        dispatched: list[int] = []
+        for group in conflicts.values():
+            for raw_code in {t.matched_episode for t in group if t.matched_episode}:
+                result = await self._rematch_conflict(
+                    job_id, raw_code, num_points=next_depth, min_vote_count=None
+                )
+                dispatched.extend(result.get("dispatched", []))
+
+        if not dispatched:
+            logger.warning(
+                f"Job {job_id}: conflict re-match dispatched no titles (files missing); "
+                f"handing {list(conflicts)} to review"
+            )
+            await self._clear_conflict_state(session, job)
+            return False
+
+        self._conflict_passes[job_id] = next_depth
+        pass_no = ladder.index(next_depth) + 1
+        job.conflict_status = f"Resolving episode conflicts — pass {pass_no} of {len(ladder)}"
+        job.updated_at = datetime.now(UTC)
+        # Hold the disc in MATCHING so the dashboard shows live re-match progress.
+        if job.state != JobState.MATCHING:
+            job.state = JobState.MATCHING
+        await session.commit()
+        await ws_manager.broadcast_job_update(
+            job_id,
+            JobState.MATCHING.value,
+            content_type=job.content_type.value if job.content_type else None,
+            detected_title=job.detected_title,
+            detected_season=job.detected_season,
+            conflict_status=job.conflict_status,
+        )
+        logger.info(
+            f"Job {job_id}: deep re-match for conflicts {list(conflicts)} at "
+            f"{next_depth} scan points (pass {pass_no}/{len(ladder)}, titles {dispatched})"
+        )
+        return True
 
     async def _complete_tv_job(self, session, job) -> None:
         """Finalize a TV job: set progress, compute final_path, transition to COMPLETED."""
@@ -113,6 +274,14 @@ class FinalizationCoordinator:
         has_review = any(t.state == TitleState.REVIEW for t in titles)
         has_completed = any(t.state == TitleState.COMPLETED for t in titles)
         all_failed = all(t.state == TitleState.FAILED for t in titles)
+
+        # Auto-resolve same-episode collisions before any manual review: deep
+        # re-match contested titles at escalating scan density until the tie
+        # breaks or the whole track has been transcribed. Runs BEFORE the
+        # has_review short-circuit so a pass that leaves one title unmatched
+        # doesn't abort escalation of the titles still colliding.
+        if await self._maybe_escalate_conflicts(session, job, titles):
+            return
 
         # Review takes priority: while ANY title still needs manual review, do
         # not organize anything — hold the whole disc in staging until it is

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -141,8 +141,18 @@ class FinalizationCoordinator:
         self._conflict_passes.pop(job_id, None)
 
     async def on_terminal_clear_conflicts(self, job_id: int, _state) -> None:
-        """Terminal-state hook: drop conflict-escalation tracking for the job."""
+        """Terminal-state hook: drop conflict-escalation tracking for the job.
+
+        Also clears the persisted ``conflict_status`` so a job forced to a
+        terminal state mid-escalation (e.g. finalization throws on a later
+        pass) doesn't leave a stale "Resolving…" note in the DB.
+        """
         self.reset_conflict_passes(job_id)
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if job is not None and job.conflict_status is not None:
+                job.conflict_status = None
+                await session.commit()
 
     async def _clear_conflict_state(self, session, job) -> None:
         """Drop escalation tracking and clear the transient dashboard note."""
@@ -359,7 +369,12 @@ class FinalizationCoordinator:
                 candidates = {}
                 for t in titles:
                     if t.state == TitleState.MATCHED and t.matched_episode:
-                        candidates.setdefault(t.matched_episode, []).append(t)
+                        # Normalize so padded/unpadded variants of the same episode
+                        # ("S1E3" vs "S01E03") group together — otherwise a real
+                        # collision is missed and both files organize to one path.
+                        candidates.setdefault(
+                            _normalize_episode_code(t.matched_episode), []
+                        ).append(t)
 
                 conflicts = {ep: tlist for ep, tlist in candidates.items() if len(tlist) > 1}
                 if not conflicts:
@@ -410,7 +425,9 @@ class FinalizationCoordinator:
                         reassigned = False
 
                         for ru in cand["runner_ups"]:
-                            alt_ep = ru["episode"]
+                            # Canonicalize to match the normalized candidates keys
+                            # (and to store a consistent code on reassignment).
+                            alt_ep = _normalize_episode_code(ru["episode"])
                             current_claimants = candidates.get(alt_ep, [])
                             if not current_claimants:
                                 loser.matched_episode = alt_ep

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -582,6 +582,15 @@ class JobManager:
                     detected_season=job.detected_season,
                     conflict_status="",  # "" overwrites the merged-in stale value
                 )
+            elif job is not None and job.conflict_status is not None:
+                # Re-matching from a non-review state (e.g. an escalation pass is
+                # in flight): the in-memory counter was already reset above, so
+                # clear the persisted note too — "rerun starts over" must apply
+                # to the DB column, not just the counter.
+                job.conflict_status = None
+                job.updated_at = datetime.now(UTC)
+                await session.commit()
+                await ws_manager.broadcast_job_update(job_id, job.state.value, conflict_status="")
 
         if retry_args is not None:
             await self._matching.restart_subtitle_download(*retry_args)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -99,6 +99,7 @@ class JobManager:
             on_task_done=self._on_task_done,
             active_jobs=self._active_jobs,
             match_single_file=self._matching.match_single_file,
+            rematch_conflict=self._matching.rematch_conflict,
         )
         self._simulation.set_callbacks(
             subtitle_ready=self._matching._subtitle_ready,
@@ -110,6 +111,7 @@ class JobManager:
         # Register terminal job state callbacks
         state_machine.on_terminal_state(self._cleanup.on_job_terminal)
         state_machine.on_terminal_state(self._matching.clear_job_caches)
+        state_machine.on_terminal_state(self._finalization.on_terminal_clear_conflicts)
 
     async def start(self) -> None:
         """Start the job manager and begin monitoring drives."""
@@ -546,6 +548,8 @@ class JobManager:
 
     async def rerun_matching(self, job_id: int, source_preference: str | None = None) -> None:
         """Re-run episode matching for all titles in a job."""
+        # A full re-match starts conflict escalation over from the first tier.
+        self._finalization.reset_conflict_passes(job_id)
         # If a previous subtitle download failed (e.g. unresolvable label that
         # has since been corrected via re-identification), give the user a
         # recovery path: retry subtitles when they hit "Re-match all".
@@ -567,6 +571,7 @@ class JobManager:
             # this the static review page stays mounted showing only cleared matches.
             if job is not None and job.state == JobState.REVIEW_NEEDED:
                 job.state = JobState.MATCHING
+                job.conflict_status = None  # drop any stale escalation note
                 job.updated_at = datetime.now(UTC)
                 await session.commit()
                 await ws_manager.broadcast_job_update(
@@ -575,6 +580,7 @@ class JobManager:
                     content_type=job.content_type.value,
                     detected_title=job.detected_title,
                     detected_season=job.detected_season,
+                    conflict_status="",  # "" overwrites the merged-in stale value
                 )
 
         if retry_args is not None:

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -214,10 +214,13 @@ class MatchingCoordinator:
                     min_vote_count=min_vote_count,
                 )
                 dispatched.append(tid)
-            except ValueError as e:
-                # e.g. staging file missing for a title that was matched earlier
-                # but whose ripped file is no longer present — skip it rather
-                # than failing the whole conflict re-match, and report it.
+            except Exception as e:
+                # e.g. staging file missing (ValueError) or a transient DB/IO
+                # error — skip this title rather than failing the whole conflict
+                # re-match, and report it. Catching broadly (but NOT BaseException,
+                # so asyncio.CancelledError still propagates) keeps the auto-
+                # escalation caller from leaving its pass counter unset, which
+                # would otherwise re-dispatch the same depth indefinitely.
                 logger.warning(f"Conflict re-match: skipping title {tid} (job {job_id}): {e}")
                 skipped.append({"title_id": tid, "reason": str(e)})
         return {"dispatched": dispatched, "skipped": skipped}

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -272,6 +272,27 @@ class TestEscalation:
         assert result is False
         assert job_id not in coord._conflict_passes
 
+    async def test_terminal_hook_clears_db_conflict_status(self, monkeypatch):
+        # The hook opens its own session; point it at the test DB.
+        monkeypatch.setattr(
+            "app.services.finalization_coordinator.async_session", _unit_session_factory
+        )
+        job_id = await _seed_conflict()
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            job.conflict_status = "Resolving episode conflicts — pass 1 of 3"
+            await session.commit()
+
+        coord = _coord_with(None)
+        coord._conflict_passes[job_id] = 25
+
+        await coord.on_terminal_clear_conflicts(job_id, JobState.FAILED)
+
+        assert job_id not in coord._conflict_passes
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            assert job.conflict_status is None
+
     async def test_reset_conflict_passes(self):
         coord = _coord_with(None)
         coord._conflict_passes[42] = 50

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -1,0 +1,279 @@
+"""Unit tests for automatic, escalating conflict re-match.
+
+When two titles match the same episode, FinalizationCoordinator deep re-matches
+the contested titles at progressively denser sampling (depth-only — the vote
+gate stays at its default) before falling back to manual review. The audio
+matcher is stubbed here; these tests cover the escalation/termination logic and
+the pure helpers that drive it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.models import DiscJob, DiscTitle
+from app.models.disc_job import ContentType, JobState, TitleState
+from app.services.finalization_coordinator import (
+    FinalizationCoordinator,
+    _conflict_scan_ladder,
+    _detect_conflicts,
+    _full_coverage_points,
+    _normalize_episode_code,
+)
+from tests.unit.conftest import _unit_session_factory
+
+
+def _matched(episode: str, duration: int = 1380):
+    return SimpleNamespace(
+        state=TitleState.MATCHED, matched_episode=episode, duration_seconds=duration
+    )
+
+
+@pytest.mark.unit
+class TestConflictHelpers:
+    def test_normalize_pads_unpadded_codes(self):
+        assert _normalize_episode_code("S1E3") == "S01E03"
+        assert _normalize_episode_code("S01E03") == "S01E03"
+        assert _normalize_episode_code("s1e14") == "S01E14"
+        assert _normalize_episode_code(None) == ""
+
+    def test_detect_conflicts_collapses_padded_and_unpadded(self):
+        titles = [_matched("S01E03"), _matched("S1E3"), _matched("S01E07")]
+        conflicts = _detect_conflicts(titles)
+        assert list(conflicts) == ["S01E03"]
+        assert len(conflicts["S01E03"]) == 2
+
+    def test_detect_conflicts_ignores_non_matched_titles(self):
+        titles = [
+            _matched("S01E03"),
+            SimpleNamespace(
+                state=TitleState.REVIEW, matched_episode="S01E03", duration_seconds=1380
+            ),
+        ]
+        assert _detect_conflicts(titles) == {}
+
+    def test_full_coverage_points_from_duration(self):
+        # 3000s / 30s + 1 = 101 chunks to cover the whole track.
+        assert _full_coverage_points([_matched("S01E03", duration=3000)]) == 101
+
+    def test_full_coverage_points_unknown_duration_goes_max(self):
+        assert _full_coverage_points([_matched("S01E03", duration=0)]) == 200
+
+    def test_ladder_collapses_for_short_episodes(self):
+        # 23-min episode: full coverage (47) < the 50 tier, so the ladder is
+        # capped and de-duplicated to two strictly-increasing tiers.
+        assert _conflict_scan_ladder([_matched("S01E03", duration=1380)]) == [25, 47]
+
+    def test_ladder_is_three_tier_for_long_episodes(self):
+        assert _conflict_scan_ladder([_matched("S01E03", duration=3000)]) == [25, 50, 101]
+
+
+@pytest.fixture(autouse=True)
+def _quiet_ws(monkeypatch):
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_job_update", _noop)
+
+
+async def _seed_conflict(duration: int = 3000) -> int:
+    """Seed a TV job with two titles colliding on S01E05. Returns job id."""
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=ContentType.TV,
+            state=JobState.MATCHING,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path="/tmp/staging/job",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        for idx, ep in ((0, "S01E05"), (1, "S01E05"), (2, "S01E02")):
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=idx,
+                    duration_seconds=duration,
+                    matched_episode=ep,
+                    match_confidence=0.6,
+                    state=TitleState.MATCHED,
+                )
+            )
+        await session.commit()
+        return job.id
+
+
+def _coord_with(rematch):
+    coord = FinalizationCoordinator(Mock(), Mock())
+    coord._rematch_conflict = rematch
+    return coord
+
+
+async def _escalate(coord, job_id):
+    async with _unit_session_factory() as session:
+        job = await session.get(DiscJob, job_id)
+        titles = (
+            (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+            .scalars()
+            .all()
+        )
+        result = await coord._maybe_escalate_conflicts(session, job, titles)
+        return result, job.conflict_status
+
+
+@pytest.mark.unit
+class TestEscalation:
+    async def test_first_pass_dispatches_depth_only(self):
+        job_id = await _seed_conflict()
+        calls: list[tuple] = []
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            calls.append((num_points, min_vote_count))
+            return {"dispatched": [1], "skipped": []}
+
+        coord = _coord_with(fake)
+        result, status = await _escalate(coord, job_id)
+
+        assert result is True
+        assert coord._conflict_passes[job_id] == 25
+        assert calls and all(np == 25 for np, _mv in calls)
+        # Depth-only: the vote gate is never raised on the auto path.
+        assert all(mv is None for _np, mv in calls)
+        assert status and "pass 1 of 3" in status
+
+    async def test_escalates_25_50_full_then_exhausts(self):
+        job_id = await _seed_conflict(duration=3000)  # full coverage = 101
+        depths: list[int] = []
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            depths.append(num_points)
+            return {"dispatched": [1], "skipped": []}
+
+        coord = _coord_with(fake)
+
+        for expected in (25, 50, 101):
+            result, _status = await _escalate(coord, job_id)
+            assert result is True
+            assert coord._conflict_passes[job_id] == expected
+
+        # Ladder exhausted (full coverage reached): hand back to the review path.
+        result, status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._conflict_passes
+        assert status is None
+        assert {25, 50, 101}.issubset(set(depths))
+
+    async def test_resolved_conflict_clears_state(self):
+        job_id = await _seed_conflict()
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            return {"dispatched": [1], "skipped": []}
+
+        coord = _coord_with(fake)
+        await _escalate(coord, job_id)
+        assert job_id in coord._conflict_passes
+
+        # Simulate the re-match having broken the tie.
+        async with _unit_session_factory() as session:
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            titles[1].matched_episode = "S01E06"
+            await session.commit()
+
+        result, status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._conflict_passes
+        assert status is None
+
+    async def test_no_dispatch_falls_through_without_looping(self):
+        job_id = await _seed_conflict()
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            # All contested files missing from staging.
+            return {"dispatched": [], "skipped": [{"title_id": 1, "reason": "missing"}]}
+
+        coord = _coord_with(fake)
+        result, status = await _escalate(coord, job_id)
+
+        assert result is False
+        assert job_id not in coord._conflict_passes  # no progress recorded → no loop
+        assert status is None
+
+    async def test_no_conflict_returns_false(self):
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="SHOW",
+                content_type=ContentType.TV,
+                state=JobState.MATCHING,
+                staging_path="/tmp/s",
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=0,
+                    duration_seconds=1380,
+                    matched_episode="S01E01",
+                    state=TitleState.MATCHED,
+                )
+            )
+            await session.commit()
+            job_id = job.id
+
+        async def fake(*a, **k):
+            raise AssertionError("should not re-match without a conflict")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_movie_job_never_escalates(self):
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="INCEPTION_2010",
+                content_type=ContentType.MOVIE,
+                state=JobState.MATCHING,
+                staging_path="/tmp/s",
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            for idx in (0, 1):
+                session.add(
+                    DiscTitle(
+                        job_id=job.id,
+                        title_index=idx,
+                        duration_seconds=8400,
+                        matched_episode="Inception",
+                        state=TitleState.MATCHED,
+                    )
+                )
+            await session.commit()
+            job_id = job.id
+
+        async def fake(*a, **k):
+            raise AssertionError("movies must not trigger episode re-match")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._conflict_passes
+
+    async def test_reset_conflict_passes(self):
+        coord = _coord_with(None)
+        coord._conflict_passes[42] = 50
+        coord.reset_conflict_passes(42)
+        assert 42 not in coord._conflict_passes

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -293,6 +293,37 @@ class TestEscalation:
             job = await session.get(DiscJob, job_id)
             assert job.conflict_status is None
 
+    async def test_rerun_matching_clears_db_note_from_matching(self, monkeypatch):
+        """rerun_matching must clear the persisted note even from MATCHING, not
+        just REVIEW_NEEDED — "rerun starts over" applies to the DB column too."""
+        from app.services.job_manager import job_manager
+
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="SHOW",
+                content_type=ContentType.TV,
+                state=JobState.MATCHING,
+                conflict_status="Resolving episode conflicts — pass 2 of 3",
+                staging_path="/tmp/s",
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+
+        async def _noop(*a, **k):
+            return None
+
+        monkeypatch.setattr(job_manager, "_rerun_matching", _noop)
+        monkeypatch.setattr(job_manager._matching, "restart_subtitle_download", _noop)
+
+        await job_manager.rerun_matching(job_id)
+
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            assert job.conflict_status is None
+
     async def test_reset_conflict_passes(self):
         coord = _coord_with(None)
         coord._conflict_passes[42] = 50

--- a/backend/tests/unit/test_defer_organization.py
+++ b/backend/tests/unit/test_defer_organization.py
@@ -95,6 +95,36 @@ class TestDeferOrganization:
             assert w.organized_to is None
             assert ll.state == TitleState.REVIEW
 
+    async def test_detects_padded_unpadded_collision(self, monkeypatch, tmp_path):
+        """S01E14 vs S1E14 are the same episode and must be treated as a conflict.
+
+        finalize_disc_job groups by normalized code, so the unpadded loser is
+        detected, sent to REVIEW (no runner-up), and the disc is held — without
+        normalization both files would organize to the same path.
+        """
+        wfile = tmp_path / "winner.mkv"
+        wfile.write_bytes(b"x")
+        job = await _seed_job()
+        await _seed_title(job.id, 7, "S01E14", 0.9, votes=9, output=str(wfile))
+        loser = await _seed_title(job.id, 8, "S1E14", 0.5, votes=4)  # unpadded, no runner_ups
+
+        from app.services.job_manager import job_manager
+
+        calls: list = []
+        monkeypatch.setattr(
+            "app.core.organizer.tv_organizer.organize",
+            lambda *a, **k: calls.append(a) or {"success": True, "final_path": "/lib/x.mkv"},
+        )
+
+        await job_manager._finalization.finalize_disc_job(job.id)
+
+        assert calls == []  # collision detected → deferred, nothing organized
+        async with _unit_session_factory() as s:
+            j = await s.get(DiscJob, job.id)
+            ll = await s.get(DiscTitle, loser.id)
+            assert j.state == JobState.REVIEW_NEEDED
+            assert ll.state == TitleState.REVIEW
+
     async def test_organizes_everything_when_disc_is_clean(self, monkeypatch, tmp_path):
         """No conflicts / no review → organize all in one pass → COMPLETED."""
         f0 = tmp_path / "t00.mkv"

--- a/backend/tests/unit/test_rematch_conflict.py
+++ b/backend/tests/unit/test_rematch_conflict.py
@@ -131,6 +131,32 @@ class TestRematchConflict:
         assert [s["title_id"] for s in body["skipped"]] == [t2.id]
         assert "not found" in body["skipped"][0]["reason"].lower()
 
+    async def test_non_value_error_is_skipped_not_raised(self, client, monkeypatch):
+        """A non-ValueError (e.g. transient DB/IO error) must be reported as
+        skipped, not escape the loop — otherwise the auto-escalation caller never
+        records its pass and re-dispatches the same depth indefinitely."""
+        job = await _seed_job()
+        t1 = await _seed_title(job.id, 0, "S01E05")
+        t2 = await _seed_title(job.id, 1, "S01E05")
+
+        from app.services.job_manager import job_manager
+
+        async def fake_rematch_single(job_id, title_id, source_preference=None, **kw):
+            if title_id == t2.id:
+                raise RuntimeError("db lock timeout")
+
+        monkeypatch.setattr(job_manager._matching, "rematch_single_title", fake_rematch_single)
+
+        resp = await client.post(
+            f"/api/jobs/{job.id}/rematch-conflict", json={"episode_code": "S01E05"}
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["title_ids"] == [t1.id]
+        assert [s["title_id"] for s in body["skipped"]] == [t2.id]
+        assert "lock timeout" in body["skipped"][0]["reason"].lower()
+
     async def test_404_when_no_title_claims_the_episode(self, client, monkeypatch):
         job = await _seed_job()
         await _seed_title(job.id, 0, "S01E01")

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -69,6 +69,7 @@ export interface DiscData {
   subtitleStatus?: string;
   startedAt?: string;
   needsReview?: boolean;
+  conflictStatus?: string;
 }
 
 interface DiscCardProps {
@@ -436,6 +437,18 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   >
                     › MATCHING EPISODES…
                   </PulseCaption>
+                  {disc.conflictStatus && (
+                    <div
+                      style={{
+                        fontFamily: sv.mono,
+                        fontSize: 11,
+                        color: sv.amber,
+                        letterSpacing: "0.04em",
+                      }}
+                    >
+                      {disc.conflictStatus}
+                    </div>
+                  )}
                   <div
                     style={{
                       display: "grid",

--- a/frontend/src/types/__tests__/adapters.test.ts
+++ b/frontend/src/types/__tests__/adapters.test.ts
@@ -137,6 +137,21 @@ describe("transformJobToDiscData", () => {
 
     expect(result.mediaType).toBe("unknown");
   });
+
+  it("carries conflict_status through to the disc view model", () => {
+    const job = makeJob({
+      state: "matching",
+      conflict_status: "Resolving episode conflicts — pass 2 of 3",
+    });
+    const result = transformJobToDiscData(job, []);
+
+    expect(result.conflictStatus).toBe("Resolving episode conflicts — pass 2 of 3");
+  });
+
+  it("leaves conflictStatus undefined when absent", () => {
+    const result = transformJobToDiscData(makeJob(), []);
+    expect(result.conflictStatus).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -62,6 +62,7 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     currentSpeed: job.current_speed,
     etaSeconds: job.eta_seconds,
     subtitleStatus: job.subtitle_status || undefined,
+    conflictStatus: job.conflict_status || undefined,
     startedAt: job.created_at
       ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')
       : undefined,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,6 +35,7 @@ export interface Job {
     subtitles_total?: number;
     subtitles_failed?: number;
     review_reason?: string | null;
+    conflict_status?: string | null;
     created_at?: string;
 }
 
@@ -92,6 +93,7 @@ export interface JobUpdate {
     detected_title?: string;
     detected_season?: number;
     review_reason?: string | null;
+    conflict_status?: string | null;
 }
 
 export interface TitleUpdate {


### PR DESCRIPTION
## Summary

Follow-up to #165. That PR added a **manual** "Deep re-match" button to break a same-episode collision; this makes the resolution **automatic and escalating**. When two TV titles match the same episode, Engram now deep re-matches the contested titles at progressively denser sampling **until the tie breaks or ~100% of the track has been transcribed** — only then falling back to the existing review/inspector flow, which is **unchanged**.

## How it works

- The escalation gate lives at the top of `check_job_completion`, **before** the `has_review` short-circuit #165 introduced — so a pass that leaves one title unmatched doesn't abort escalation of the titles still colliding.
- No recursion / no inline `await` of ASR: each pass fires the deep re-match fire-and-forget; when those tasks finish, the existing completion re-entry re-evaluates. A per-job in-memory counter tracks the last scan depth tried.
- **Depth-only ladder `25 → 50 → full-coverage`**: more scan points, but the matcher's default vote gate is kept so a genuinely-correct match on a hard episode isn't demoted straight to review. Full coverage = one 30s chunk per 30s of runtime, so the ladder self-terminates; for short episodes it collapses (e.g. `[25, 47]`).
- Episode collisions are **TV-only** — movie jobs no-op.
- The manual "Deep re-match" button and the entire review/inspector UI are untouched. The runner-up reassignment + review fallback in `finalize_disc_job` now runs only after escalation is exhausted.

## Visibility

A transient `conflict_status` ("Resolving episode conflicts — pass N of M") is added to `DiscJob` and carried on `job_update`; the dashboard's matching block renders it so the disc doesn't look stalled during ASR passes. Cleared on resolution, exhaustion, terminal state, and full re-match. (Nullable column — auto-added by `_add_missing_columns()`, no Alembic migration.)

## Files

- `services/finalization_coordinator.py` — escalation gate (`_maybe_escalate_conflicts`) + helpers (`_detect_conflicts`, `_full_coverage_points`, `_conflict_scan_ladder`, `_normalize_episode_code`) + per-job tracker
- `services/job_manager.py` — wires `rematch_conflict` into finalization, resets escalation on `rerun_matching`, registers terminal cleanup
- `models/disc_job.py` + `api/websocket.py` — `conflict_status` field + broadcast param
- frontend `types/index.ts`, `types/adapters.ts`, `app/components/DiscCard.tsx` — carry + render the status

## Test plan

- [x] Backend unit: `uv run pytest tests/unit` — **759 passed** (incl. new `test_auto_conflict_escalation.py`: helpers, 25→50→full escalation, exhaustion→review, mid-ladder resolve, no-progress, depth-only, movie no-op, reset)
- [x] Frontend unit: `npx vitest run` — **73 passed** (incl. adapter `conflict_status` mapping)
- [x] `npm run build` (tsc), `npm run lint`, `uv run ruff check/format` — all clean
- [ ] **Live disc**: a real audio collision can't be forced via the DEBUG simulation endpoints, so end-to-end with actual ASR is verified by unit tests + logic only. On a disc that genuinely collides, watch `~/.engram/engram.log` for "Resolving episode conflicts — pass N" and confirm the disc enters review only after the ladder is exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)