### PR TITLE
feat(scripts): verify episode labels against the matcher

### DIFF
--- a/backend/scripts/verify_episode_labels.py
+++ b/backend/scripts/verify_episode_labels.py
@@ -239,12 +239,19 @@ def _ensure_references(
     downloads real subtitles for the whole season — needed for reliable
     verification when the precomputed cache covers only some episodes.
     """
+    # Import is intentionally outside the try: a missing app package is a setup
+    # error that should surface as a traceback, not a per-season "unverifiable".
     from app.matcher.testing_service import download_subtitles
 
     try:
         result = download_subtitles(show_name, season, use_precomputed=not full_references)
-    except Exception as e:  # ValueError (TMDB miss) or network/provider failure
-        return False, str(e)
+    except Exception as e:
+        # Broad on purpose: a TMDB miss (ValueError), a provider network error, or
+        # any other download failure should mark THIS season unverifiable and let
+        # the run continue to other seasons (and still write the CSV) rather than
+        # abort everything. Surface the exception type so unexpected failures are
+        # still debuggable from the printed message.
+        return False, f"{type(e).__name__}: {e}"
 
     episodes = result.get("episodes", [])
     ok = sum(1 for ep in episodes if ep["status"] in ("downloaded", "cached", "precomputed"))
@@ -312,10 +319,8 @@ def build_apply_plan(
     return plan, net
 
 
-def execute_plan(plan: RenamePlan, directory: Path) -> Path:
-    """Run the rename steps and write an undo log; returns the log path."""
-    for src, dst in plan.steps:
-        src.rename(dst)
+def _write_undo_log(plan: RenamePlan, directory: Path) -> Path:
+    """Persist the full rename plan so it can be replayed/reverted."""
     ts = datetime.now().strftime("%Y%m%d-%H%M%S")
     log_path = directory / f"engram_label_undo_{ts}.json"
     log_path.write_text(
@@ -331,9 +336,24 @@ def execute_plan(plan: RenamePlan, directory: Path) -> Path:
     return log_path
 
 
+def execute_plan(plan: RenamePlan, directory: Path) -> Path:
+    """Write the undo log FIRST, then run the rename steps; returns the log path.
+
+    Logging before mutating is deliberate: if a ``rename`` fails midway (disk full,
+    permission error, killed process), the log already on disk lets ``--undo``
+    recover any files left stranded under ``.engram-tmp``.
+    """
+    log_path = _write_undo_log(plan, directory)
+    for src, dst in plan.steps:
+        src.rename(dst)
+    return log_path
+
+
 def undo_from_log(log_path: Path) -> int:
     """Reverse a previous --apply run. Returns the number of files moved back."""
     data = json.loads(log_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "steps" not in data:
+        raise ValueError(f"Not a valid undo log (missing 'steps'): {log_path}")
     steps = [(Path(s), Path(d)) for s, d in data["steps"]]
     moved = 0
     for src, dst in reversed(steps):
@@ -444,6 +464,17 @@ def write_csv(csv_path: Path, all_results: list[tuple[int, FileResult]]) -> None
 # --------------------------------------------------------------------------- #
 
 
+def default_csv_path(plan: ScopePlan, override: str | None) -> Path:
+    """Where to write the CSV: explicit override, else show root (show mode) or
+    the season directory (season mode)."""
+    if override:
+        return Path(override)
+    if plan.mode == "show":
+        # targets are Season subdirs of the show root; write to the root itself.
+        return plan.targets[0].directory.parent / "engram_label_check.csv"
+    return plan.targets[0].directory / "engram_label_check.csv"
+
+
 def _process(plan: ScopePlan, show_name: str, args: argparse.Namespace) -> None:
     all_results: list[tuple[int, FileResult]] = []
 
@@ -497,11 +528,7 @@ def _process(plan: ScopePlan, show_name: str, args: argparse.Namespace) -> None:
         all_results.extend((season, r) for r in results)
 
     if all_results:
-        csv_path = (
-            Path(args.csv)
-            if args.csv
-            else Path(plan.targets[0].directory) / ("engram_label_check.csv")
-        )
+        csv_path = default_csv_path(plan, args.csv)
         write_csv(csv_path, all_results)
         print(f"\nCSV written: {csv_path}")
 
@@ -530,7 +557,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.undo:
-        moved = undo_from_log(Path(args.undo))
+        undo_path = Path(args.undo)
+        if not undo_path.is_file():
+            parser.error(f"undo log not found: {undo_path}")
+        moved = undo_from_log(undo_path)
         print(f"Reverted {moved} file(s) from {args.undo}")
         return 0
 

--- a/backend/scripts/verify_episode_labels.py
+++ b/backend/scripts/verify_episode_labels.py
@@ -1,0 +1,555 @@
+"""Verify TV episode labels against Engram's audio matcher.
+
+Point this at an existing library folder (a single ``Season NN`` folder or a whole
+show folder) and it checks whether each ``.mkv`` is named with the correct episode
+by transcribing a few audio chunks and matching them against reference subtitles —
+the same matcher the live pipeline uses. Mislabeled / out-of-order files are
+flagged, and can optionally be renamed (collision-safe, with an undo log).
+
+Usage (from ``backend/``):
+
+    uv run python scripts/verify_episode_labels.py "C:\\Media\\TV\\Show\\Season 03"
+    uv run python scripts/verify_episode_labels.py "C:\\Media\\TV\\Show" --show "Show"
+    uv run python scripts/verify_episode_labels.py "...\\Season 03" --apply
+    uv run python scripts/verify_episode_labels.py --undo "...\\engram_label_undo_*.json"
+
+Default is a dry run: it reports and proposes renames but changes nothing. Pass
+``--apply`` to actually rename.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+# Allow ``import app...`` when run as a standalone script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Windows consoles default to cp1252; force UTF-8 so table glyphs (→, —, ✓) and
+# show titles with accents don't raise UnicodeEncodeError when piped/redirected.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
+TEMP_SUFFIX = ".engram-tmp"
+DEFAULT_MIN_CONFIDENCE = 0.7
+
+
+class Status:
+    OK = "OK"
+    MISMATCH = "MISMATCH"
+    LOW_CONF = "LOW_CONF"
+    NO_MATCH = "NO_MATCH"
+    UNPARSEABLE = "UNPARSEABLE"
+
+
+_CLAIM_PATTERNS = (
+    r"S(\d+)E(\d+)",
+    r"(\d+)x(\d+)",
+    r"Season\s*(\d+)\s*Episode\s*(\d+)",
+)
+_SEASON_DIR_RE = re.compile(r"^season\s*0*(\d+)$", re.IGNORECASE)
+
+
+# --------------------------------------------------------------------------- #
+# Pure logic (unit-tested; no I/O, no matcher)
+# --------------------------------------------------------------------------- #
+
+
+def parse_claim(name: str) -> tuple[int, int] | None:
+    """Parse the (season, episode) a filename *claims* to be."""
+    for pattern in _CLAIM_PATTERNS:
+        m = re.search(pattern, name, re.IGNORECASE)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    return None
+
+
+def compute_target_name(name: str, season: int, episode: int) -> str:
+    """Rewrite the episode code in ``name`` to ``season``/``episode``.
+
+    Preserves the original style (``SxxEyy`` vs ``NxNN``) and zero-padding widths.
+    """
+    m = re.search(r"S(\d+)E(\d+)", name, re.IGNORECASE)
+    if m:
+        sw, ew = len(m.group(1)), len(m.group(2))
+        repl = f"S{season:0{sw}d}E{episode:0{ew}d}"
+        return name[: m.start()] + repl + name[m.end() :]
+
+    m = re.search(r"(\d+)x(\d+)", name)
+    if m:
+        ew = len(m.group(2))
+        repl = f"{season}x{episode:0{ew}d}"
+        return name[: m.start()] + repl + name[m.end() :]
+
+    m = re.search(r"(Season\s*)(\d+)(\s*Episode\s*)(\d+)", name, re.IGNORECASE)
+    if m:
+        repl = f"{m.group(1)}{season}{m.group(3)}{episode}"
+        return name[: m.start()] + repl + name[m.end() :]
+
+    raise ValueError(f"No episode code to rewrite in {name!r}")
+
+
+def classify(
+    claim: tuple[int, int] | None,
+    predicted: tuple[int, int] | None,
+    confidence: float,
+    threshold: float,
+) -> str:
+    """Bucket one file by comparing its claimed label to the matcher's guess."""
+    if predicted is None:
+        return Status.NO_MATCH
+    if claim is None:
+        return Status.UNPARSEABLE
+    if confidence < threshold:
+        return Status.LOW_CONF
+    return Status.OK if predicted == claim else Status.MISMATCH
+
+
+@dataclass
+class SeasonTarget:
+    season: int | None
+    directory: Path
+
+
+@dataclass
+class ScopePlan:
+    mode: str  # "season" | "show"
+    show_name: str
+    targets: list[SeasonTarget]
+
+
+def detect_scope(path: Path) -> ScopePlan:
+    """Decide whether ``path`` is a single season folder or a whole show folder."""
+    season_subdirs = [
+        d for d in sorted(path.iterdir()) if d.is_dir() and _SEASON_DIR_RE.match(d.name)
+    ]
+    if season_subdirs:
+        targets = [
+            SeasonTarget(int(_SEASON_DIR_RE.match(d.name).group(1)), d) for d in season_subdirs
+        ]
+        return ScopePlan(mode="show", show_name=path.name, targets=targets)
+
+    # No season subdirs: treat this folder as a single season.
+    season = _season_from_dir_name(path.name)
+    if season is None:
+        season = _dominant_season([p.name for p in path.glob("*.mkv")])
+    return ScopePlan(
+        mode="season",
+        show_name=path.parent.name,
+        targets=[SeasonTarget(season, path)],
+    )
+
+
+def _season_from_dir_name(name: str) -> int | None:
+    m = _SEASON_DIR_RE.match(name)
+    return int(m.group(1)) if m else None
+
+
+def _dominant_season(filenames: list[str]) -> int | None:
+    counts: dict[int, int] = {}
+    for fn in filenames:
+        claim = parse_claim(fn)
+        if claim:
+            counts[claim[0]] = counts.get(claim[0], 0) + 1
+    if not counts:
+        return None
+    return max(counts, key=counts.get)
+
+
+def expand_sidecars(mapping: dict[Path, Path], listing: list[Path]) -> dict[Path, Path]:
+    """Extend an mkv rename mapping to carry along same-stem sidecar files."""
+    result = dict(mapping)
+    for src, dst in mapping.items():
+        prefix = src.stem + "."
+        for f in listing:
+            if f == src or f in result:
+                continue
+            if f.name.startswith(prefix):
+                new_name = dst.stem + f.name[len(src.stem) :]
+                result[f] = f.with_name(new_name)
+    return result
+
+
+@dataclass
+class RenamePlan:
+    steps: list[tuple[Path, Path]]
+    conflicts: list[Path]
+
+
+def plan_two_phase(mapping: dict[Path, Path], existing: set[Path]) -> RenamePlan:
+    """Order renames so cyclic swaps never clobber.
+
+    Every participant is first moved to a unique temp name, then from the temp to
+    its final name. A target that points at an existing file which is *not* itself
+    being moved is a conflict (would destroy a non-participant) and aborts.
+    """
+    sources = set(mapping.keys())
+    conflicts = [dst for src, dst in mapping.items() if dst in existing and dst not in sources]
+    if conflicts:
+        return RenamePlan(steps=[], conflicts=conflicts)
+
+    used = set(existing)
+    temps: dict[Path, Path] = {}
+    for src in mapping:
+        temp = src.with_name(src.name + TEMP_SUFFIX)
+        counter = 1
+        while temp in used:
+            temp = src.with_name(f"{src.name}{TEMP_SUFFIX}.{counter}")
+            counter += 1
+        used.add(temp)
+        temps[src] = temp
+
+    steps = [(src, temps[src]) for src in mapping]
+    steps += [(temps[src], dst) for src, dst in mapping.items()]
+    return RenamePlan(steps=steps, conflicts=[])
+
+
+# --------------------------------------------------------------------------- #
+# Matcher orchestration (lazy app imports)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class FileResult:
+    path: Path
+    claim: tuple[int, int] | None
+    predicted: tuple[int, int] | None
+    confidence: float
+    status: str = ""
+    runner_ups: list[dict] = field(default_factory=list)
+    target_name: str | None = None
+
+
+def _ensure_references(
+    show_name: str, season: int, full_references: bool = False
+) -> tuple[bool, str]:
+    """Make sure reference subtitles/vectors exist for show+season.
+
+    ``full_references`` bypasses the (possibly sparse) precomputed vector cache and
+    downloads real subtitles for the whole season — needed for reliable
+    verification when the precomputed cache covers only some episodes.
+    """
+    from app.matcher.testing_service import download_subtitles
+
+    try:
+        result = download_subtitles(show_name, season, use_precomputed=not full_references)
+    except Exception as e:  # ValueError (TMDB miss) or network/provider failure
+        return False, str(e)
+
+    episodes = result.get("episodes", [])
+    ok = sum(1 for ep in episodes if ep["status"] in ("downloaded", "cached", "precomputed"))
+    if ok == 0:
+        return False, "no reference subtitles found"
+    return True, f"{ok}/{len(episodes)} references ready"
+
+
+async def _match_season(
+    files: list[Path],
+    show_name: str,
+    season: int,
+    threshold: float,
+    num_points: int | None,
+) -> list[FileResult]:
+    from app.core.curator import EpisodeCurator
+
+    curator = EpisodeCurator()
+    results: list[FileResult] = []
+    for f in sorted(files):
+        claim = parse_claim(f.name)
+        match = await curator.match_single_file(f, show_name, season, num_points=num_points)
+        predicted = parse_claim(match.episode_code) if match.episode_code else None
+        # match_single_file falls back to filename parsing when the matcher
+        # produces nothing; treat that as "no real match" for verification.
+        details = match.match_details or {}
+        is_real_match = bool(details) and "vote_count" in details
+        if not is_real_match and match.confidence <= 0.3:
+            predicted = None
+        results.append(
+            FileResult(
+                path=f,
+                claim=claim,
+                predicted=predicted,
+                confidence=match.confidence,
+                status=classify(claim, predicted, match.confidence, threshold),
+                runner_ups=details.get("runner_ups", []) or [],
+            )
+        )
+    return results
+
+
+# --------------------------------------------------------------------------- #
+# Rename application + undo
+# --------------------------------------------------------------------------- #
+
+
+def build_apply_plan(
+    results: list[FileResult], threshold: float
+) -> tuple[RenamePlan | None, dict[Path, Path]]:
+    """Build a collision-safe plan from MISMATCH results above the threshold."""
+    net: dict[Path, Path] = {}
+    for r in results:
+        if r.status == Status.MISMATCH and r.confidence >= threshold and r.predicted:
+            target = r.path.with_name(compute_target_name(r.path.name, *r.predicted))
+            net[r.path] = target
+            r.target_name = target.name
+    if not net:
+        return None, {}
+
+    directory = next(iter(net)).parent
+    listing = [p for p in directory.iterdir() if p.is_file()]
+    full = expand_sidecars(net, listing)
+    plan = plan_two_phase(full, set(listing))
+    return plan, net
+
+
+def execute_plan(plan: RenamePlan, directory: Path) -> Path:
+    """Run the rename steps and write an undo log; returns the log path."""
+    for src, dst in plan.steps:
+        src.rename(dst)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_path = directory / f"engram_label_undo_{ts}.json"
+    log_path.write_text(
+        json.dumps(
+            {
+                "created": ts,
+                "steps": [[str(s), str(d)] for s, d in plan.steps],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return log_path
+
+
+def undo_from_log(log_path: Path) -> int:
+    """Reverse a previous --apply run. Returns the number of files moved back."""
+    data = json.loads(log_path.read_text(encoding="utf-8"))
+    steps = [(Path(s), Path(d)) for s, d in data["steps"]]
+    moved = 0
+    for src, dst in reversed(steps):
+        if dst.exists():
+            dst.rename(src)
+            moved += 1
+    return moved
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_ep(ep: tuple[int, int] | None) -> str:
+    return f"S{ep[0]:02d}E{ep[1]:02d}" if ep else "—"
+
+
+def _fmt_runner_ups(runner_ups: list[dict]) -> str:
+    parts = []
+    for ru in runner_ups[:3]:
+        code = ru.get("episode", "?")
+        conf = ru.get("confidence")
+        parts.append(f"{code}({conf:.2f})" if isinstance(conf, (int, float)) else str(code))
+    return ", ".join(parts)
+
+
+def render_results(show_name: str, season: int, results: list[FileResult]) -> None:
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console()
+        color = {
+            Status.OK: "green",
+            Status.MISMATCH: "bold red",
+            Status.LOW_CONF: "yellow",
+            Status.NO_MATCH: "dim",
+            Status.UNPARSEABLE: "magenta",
+        }
+        table = Table(title=f"{show_name} — Season {season:02d}", title_style="bold")
+        table.add_column("File")
+        table.add_column("Claimed")
+        table.add_column("Matched")
+        table.add_column("Conf", justify="right")
+        table.add_column("Status")
+        table.add_column("Rename →")
+        for r in results:
+            rename = r.target_name or ""
+            table.add_row(
+                r.path.name,
+                _fmt_ep(r.claim),
+                _fmt_ep(r.predicted),
+                f"{r.confidence:.0%}",
+                f"[{color.get(r.status, 'white')}]{r.status}[/]",
+                rename,
+            )
+        console.print(table)
+    except ImportError:
+        print(f"\n{show_name} — Season {season:02d}")
+        for r in results:
+            rename = f"  ->  {r.target_name}" if r.target_name else ""
+            print(
+                f"  {r.status:11} {_fmt_ep(r.claim):>7} -> {_fmt_ep(r.predicted):>7}"
+                f"  {r.confidence:5.0%}  {r.path.name}{rename}"
+            )
+
+
+def _summary(results: list[FileResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    return counts
+
+
+def write_csv(csv_path: Path, all_results: list[tuple[int, FileResult]]) -> None:
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "season",
+                "file",
+                "claimed",
+                "matched",
+                "confidence",
+                "status",
+                "proposed_rename",
+                "runner_ups",
+            ]
+        )
+        for season, r in all_results:
+            writer.writerow(
+                [
+                    season,
+                    str(r.path),
+                    _fmt_ep(r.claim),
+                    _fmt_ep(r.predicted),
+                    f"{r.confidence:.4f}",
+                    r.status,
+                    r.target_name or "",
+                    _fmt_runner_ups(r.runner_ups),
+                ]
+            )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _process(plan: ScopePlan, show_name: str, args: argparse.Namespace) -> None:
+    all_results: list[tuple[int, FileResult]] = []
+
+    for target in plan.targets:
+        season = args.season if (plan.mode == "season" and args.season) else target.season
+        if season is None:
+            print(f"! Could not determine season for {target.directory} — pass --season N")
+            continue
+
+        files = sorted(target.directory.glob("*.mkv"))
+        if not files:
+            print(f"! No .mkv files in {target.directory}")
+            continue
+
+        print(f"\n=> {show_name} Season {season:02d}: {len(files)} file(s). Preparing references…")
+        ok, note = _ensure_references(show_name, season, args.full_references)
+        if not ok:
+            print(f"! Reference setup failed ({note}). Marking season unverifiable.")
+            results = [
+                FileResult(f, parse_claim(f.name), None, 0.0, Status.NO_MATCH) for f in files
+            ]
+        else:
+            print(f"   {note}. Matching (this transcribes audio — a few seconds per file)…")
+            results = asyncio.run(
+                _match_season(files, show_name, season, args.min_confidence, args.num_points)
+            )
+
+        plan_obj, net = build_apply_plan(results, args.min_confidence)
+        # Display is best-effort; never let a rendering hiccup lose the CSV data.
+        try:
+            render_results(show_name, season, results)
+        except Exception as e:
+            print(f"   (table render skipped: {e})")
+
+        counts = _summary(results)
+        print("   " + "  ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+
+        if net:
+            if plan_obj.conflicts:
+                print(
+                    "   ! Unsafe rename: would overwrite non-participant file(s): "
+                    + ", ".join(p.name for p in plan_obj.conflicts)
+                )
+                print("     Skipping rename for this season; resolve manually.")
+            elif args.apply:
+                log = execute_plan(plan_obj, target.directory)
+                print(f'   ✓ Renamed {len(net)} file(s). Undo: --undo "{log}"')
+            else:
+                print(f"   (dry run) Would rename {len(net)} file(s). Re-run with --apply.")
+
+        all_results.extend((season, r) for r in results)
+
+    if all_results:
+        csv_path = (
+            Path(args.csv)
+            if args.csv
+            else Path(plan.targets[0].directory) / ("engram_label_check.csv")
+        )
+        write_csv(csv_path, all_results)
+        print(f"\nCSV written: {csv_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify TV episode labels with Engram's matcher.")
+    parser.add_argument("path", nargs="?", help="season folder or show folder")
+    parser.add_argument("--show", help="override inferred show name")
+    parser.add_argument("--season", type=int, help="override inferred season (season-folder mode)")
+    parser.add_argument("--apply", action="store_true", help="perform renames (default: dry run)")
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=DEFAULT_MIN_CONFIDENCE,
+        help=f"confidence gate for auto-rename (default {DEFAULT_MIN_CONFIDENCE})",
+    )
+    parser.add_argument("--num-points", type=int, help="denser audio scan for accuracy")
+    parser.add_argument(
+        "--full-references",
+        action="store_true",
+        help="bypass the precomputed cache and download real subtitles for the whole "
+        "season (uses OpenSubtitles quota; needed when the cache covers only some episodes)",
+    )
+    parser.add_argument("--csv", help="CSV output path (default: alongside target)")
+    parser.add_argument("--undo", help="revert a previous --apply run from its undo log")
+    args = parser.parse_args(argv)
+
+    if args.undo:
+        moved = undo_from_log(Path(args.undo))
+        print(f"Reverted {moved} file(s) from {args.undo}")
+        return 0
+
+    if not args.path:
+        parser.error("path is required (or use --undo)")
+
+    root = Path(args.path).expanduser()
+    if not root.is_dir():
+        parser.error(f"not a directory: {root}")
+
+    plan = detect_scope(root)
+    show_name = args.show or plan.show_name
+    print(
+        f"Scope: {plan.mode}  Show: {show_name}  Seasons: "
+        + ", ".join(str(t.season) for t in plan.targets)
+    )
+    _process(plan, show_name, args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verify_episode_labels.py
+++ b/backend/scripts/verify_episode_labels.py
@@ -38,6 +38,8 @@ for _stream in (sys.stdout, sys.stderr):
     try:
         _stream.reconfigure(encoding="utf-8")
     except (AttributeError, ValueError):
+        # Stream is already UTF-8, or is a wrapped/captured stream (e.g. pytest,
+        # a pipe) that doesn't support reconfigure() — safe to leave as-is.
         pass
 
 TEMP_SUFFIX = ".engram-tmp"
@@ -312,6 +314,8 @@ def build_apply_plan(
     if not net:
         return None, {}
 
+    # net is non-empty here (guarded above) and, since build_apply_plan runs once
+    # per SeasonTarget, every MISMATCH file shares the same season directory.
     directory = next(iter(net)).parent
     listing = [p for p in directory.iterdir() if p.is_file()]
     full = expand_sidecars(net, listing)

--- a/backend/tests/unit/test_verify_episode_labels.py
+++ b/backend/tests/unit/test_verify_episode_labels.py
@@ -182,3 +182,59 @@ class TestPlanTwoPhase:
 
         assert a.read_text() == "content-B"
         assert b.read_text() == "content-A"
+
+
+class TestDefaultCsvPath:
+    def test_season_mode_uses_target_dir(self, tmp_path):
+        season_dir = tmp_path / "Show" / "Season 03"
+        plan = vel.ScopePlan("season", "Show", [vel.SeasonTarget(3, season_dir)])
+        assert vel.default_csv_path(plan, None) == season_dir / "engram_label_check.csv"
+
+    def test_show_mode_uses_show_root(self, tmp_path):
+        show_dir = tmp_path / "Show"
+        targets = [
+            vel.SeasonTarget(1, show_dir / "Season 01"),
+            vel.SeasonTarget(2, show_dir / "Season 02"),
+        ]
+        plan = vel.ScopePlan("show", "Show", targets)
+        # CSV should land at the show root, not inside Season 01
+        assert vel.default_csv_path(plan, None) == show_dir / "engram_label_check.csv"
+
+    def test_override_wins(self, tmp_path):
+        plan = vel.ScopePlan("season", "Show", [vel.SeasonTarget(3, tmp_path)])
+        assert vel.default_csv_path(plan, "X:/out/custom.csv") == Path("X:/out/custom.csv")
+
+
+class TestUndoLog:
+    def test_rejects_log_without_steps(self, tmp_path):
+        import json
+
+        bad = tmp_path / "bad_undo.json"
+        bad.write_text(json.dumps({"created": "20260523-000000"}), encoding="utf-8")
+        try:
+            vel.undo_from_log(bad)
+            raise AssertionError("expected ValueError for malformed log")
+        except ValueError:
+            pass
+
+    def test_recovers_files_stranded_after_partial_apply(self, tmp_path):
+        # Simulate a crash after phase 1: the log (written first) must let --undo
+        # recover the .engram-tmp files.
+        a = tmp_path / "a.mkv"
+        b = tmp_path / "b.mkv"
+        a.write_text("A")
+        b.write_text("B")
+
+        plan = vel.plan_two_phase({a: b, b: a}, existing={a, b})
+        log_path = vel._write_undo_log(plan, tmp_path)
+
+        # Execute ONLY phase 1 (everyone -> temp), then "crash".
+        phase1 = plan.steps[: len(plan.steps) // 2]
+        for src, dst in phase1:
+            src.rename(dst)
+
+        moved = vel.undo_from_log(log_path)
+
+        assert moved == 2
+        assert a.read_text() == "A"
+        assert b.read_text() == "B"

--- a/backend/tests/unit/test_verify_episode_labels.py
+++ b/backend/tests/unit/test_verify_episode_labels.py
@@ -1,0 +1,184 @@
+"""Unit tests for the verify_episode_labels script's pure logic.
+
+These cover only the no-I/O, no-matcher helpers so they run fast and offline:
+filename parsing, target-name computation, status classification, scope
+auto-detection, sidecar expansion, and the collision-safe rename planner.
+"""
+
+import sys
+from pathlib import Path
+
+# The script lives in backend/scripts, which isn't on the package path.
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import verify_episode_labels as vel  # noqa: E402
+
+
+class TestParseClaim:
+    def test_standard_sxxeyy(self):
+        assert vel.parse_claim("Breaking Bad - S01E03.mkv") == (1, 3)
+
+    def test_lowercase_and_single_digits(self):
+        assert vel.parse_claim("show s1e3.mkv") == (1, 3)
+
+    def test_xform(self):
+        assert vel.parse_claim("Show 2x07.mkv") == (2, 7)
+
+    def test_season_episode_words(self):
+        assert vel.parse_claim("Show - Season 4 Episode 11.mkv") == (4, 11)
+
+    def test_no_code_returns_none(self):
+        assert vel.parse_claim("Show - the one with no code.mkv") is None
+
+
+class TestComputeTargetName:
+    def test_swaps_episode_preserving_padding(self):
+        assert vel.compute_target_name("Show - S01E05.mkv", 1, 3) == "Show - S01E03.mkv"
+
+    def test_changes_season_too(self):
+        assert vel.compute_target_name("Show - S02E05.mkv", 1, 3) == "Show - S01E03.mkv"
+
+    def test_preserves_xform_style(self):
+        assert vel.compute_target_name("Show 1x05.mkv", 1, 3) == "Show 1x03.mkv"
+
+    def test_single_digit_padding_preserved(self):
+        # original used single-digit episode width, keep it
+        assert vel.compute_target_name("Show S1E5.mkv", 1, 3) == "Show S1E3.mkv"
+
+
+class TestClassify:
+    THRESHOLD = 0.7
+
+    def test_ok_when_match_and_confident(self):
+        assert vel.classify((1, 3), (1, 3), 0.9, self.THRESHOLD) == vel.Status.OK
+
+    def test_mismatch_when_confident_and_different(self):
+        assert vel.classify((1, 5), (1, 3), 0.9, self.THRESHOLD) == vel.Status.MISMATCH
+
+    def test_low_conf_below_threshold(self):
+        assert vel.classify((1, 5), (1, 3), 0.5, self.THRESHOLD) == vel.Status.LOW_CONF
+
+    def test_low_conf_even_when_agreeing(self):
+        assert vel.classify((1, 3), (1, 3), 0.4, self.THRESHOLD) == vel.Status.LOW_CONF
+
+    def test_no_match_when_predicted_none(self):
+        assert vel.classify((1, 3), None, 0.0, self.THRESHOLD) == vel.Status.NO_MATCH
+
+    def test_no_match_takes_priority_over_unparseable(self):
+        assert vel.classify(None, None, 0.0, self.THRESHOLD) == vel.Status.NO_MATCH
+
+    def test_unparseable_when_claim_none_but_predicted_exists(self):
+        assert vel.classify(None, (1, 3), 0.9, self.THRESHOLD) == vel.Status.UNPARSEABLE
+
+
+class TestDetectScope:
+    def test_season_folder_uses_dir_name(self, tmp_path):
+        season_dir = tmp_path / "Breaking Bad" / "Season 03"
+        season_dir.mkdir(parents=True)
+        (season_dir / "Breaking Bad - S03E01.mkv").touch()
+        (season_dir / "Breaking Bad - S03E02.mkv").touch()
+
+        plan = vel.detect_scope(season_dir)
+
+        assert plan.mode == "season"
+        assert plan.show_name == "Breaking Bad"
+        assert [t.season for t in plan.targets] == [3]
+        assert plan.targets[0].directory == season_dir
+
+    def test_season_folder_falls_back_to_filename_season(self, tmp_path):
+        # Directory name doesn't say "Season N"; infer from the files.
+        disc_dir = tmp_path / "MyShow" / "Disc1"
+        disc_dir.mkdir(parents=True)
+        (disc_dir / "MyShow - S02E01.mkv").touch()
+        (disc_dir / "MyShow - S02E02.mkv").touch()
+
+        plan = vel.detect_scope(disc_dir)
+
+        assert plan.mode == "season"
+        assert [t.season for t in plan.targets] == [2]
+
+    def test_show_folder_lists_seasons(self, tmp_path):
+        show_dir = tmp_path / "Breaking Bad"
+        s1 = show_dir / "Season 01"
+        s2 = show_dir / "Season 02"
+        s1.mkdir(parents=True)
+        s2.mkdir(parents=True)
+        (s1 / "Breaking Bad - S01E01.mkv").touch()
+        (s2 / "Breaking Bad - S02E01.mkv").touch()
+
+        plan = vel.detect_scope(show_dir)
+
+        assert plan.mode == "show"
+        assert plan.show_name == "Breaking Bad"
+        assert sorted(t.season for t in plan.targets) == [1, 2]
+        dirs = {t.season: t.directory for t in plan.targets}
+        assert dirs[1] == s1
+        assert dirs[2] == s2
+
+
+class TestExpandSidecars:
+    def test_includes_same_stem_sidecars(self, tmp_path):
+        src = tmp_path / "Show - S01E05.mkv"
+        dst = tmp_path / "Show - S01E03.mkv"
+        listing = [
+            tmp_path / "Show - S01E05.mkv",
+            tmp_path / "Show - S01E05.srt",
+            tmp_path / "Show - S01E05.en.srt",
+            tmp_path / "Show - S01E01.mkv",  # unrelated, must not move
+        ]
+
+        expanded = vel.expand_sidecars({src: dst}, listing)
+
+        assert expanded[tmp_path / "Show - S01E05.srt"] == tmp_path / "Show - S01E03.srt"
+        assert expanded[tmp_path / "Show - S01E05.en.srt"] == tmp_path / "Show - S01E03.en.srt"
+        assert (tmp_path / "Show - S01E05.mkv") in expanded
+        assert (tmp_path / "Show - S01E01.mkv") not in expanded
+
+
+class TestPlanTwoPhase:
+    def _tmp(self, p: Path) -> Path:
+        return p.with_name(p.name + vel.TEMP_SUFFIX)
+
+    def test_simple_move_to_free_name(self, tmp_path):
+        a = tmp_path / "a.mkv"
+        z = tmp_path / "z.mkv"
+        plan = vel.plan_two_phase({a: z}, existing={a})
+
+        assert plan.conflicts == []
+        assert plan.steps == [(a, self._tmp(a)), (self._tmp(a), z)]
+
+    def test_two_cycle_swap_uses_temps(self, tmp_path):
+        a = tmp_path / "a.mkv"
+        b = tmp_path / "b.mkv"
+        plan = vel.plan_two_phase({a: b, b: a}, existing={a, b})
+
+        assert plan.conflicts == []
+        # phase 1: everyone to temp; phase 2: temps to finals
+        assert plan.steps == [
+            (a, self._tmp(a)),
+            (b, self._tmp(b)),
+            (self._tmp(a), b),
+            (self._tmp(b), a),
+        ]
+
+    def test_conflict_with_non_participant(self, tmp_path):
+        a = tmp_path / "a.mkv"
+        c = tmp_path / "c.mkv"  # exists on disk but is NOT a source we move
+        plan = vel.plan_two_phase({a: c}, existing={a, c})
+
+        assert c in plan.conflicts
+
+    def test_executing_steps_realizes_mapping(self, tmp_path):
+        # Concrete proof the swap plan is safe on a real filesystem.
+        a = tmp_path / "a.mkv"
+        b = tmp_path / "b.mkv"
+        a.write_text("content-A")
+        b.write_text("content-B")
+
+        plan = vel.plan_two_phase({a: b, b: a}, existing={a, b})
+        for src, dst in plan.steps:
+            src.rename(dst)
+
+        assert a.read_text() == "content-B"
+        assert b.read_text() == "content-A"

--- a/docs/superpowers/specs/2026-05-23-verify-episode-labels-design.md
+++ b/docs/superpowers/specs/2026-05-23-verify-episode-labels-design.md
@@ -1,0 +1,151 @@
+# Verify Episode Labels — Design
+
+**Date:** 2026-05-23
+**Status:** Approved
+**Branch:** `feat/verify-episode-labels`
+
+## Problem
+
+A user has TV library folders where episodes are already ripped and named
+(`TV/Show/Season 01/Show - S01E03.mkv`), but at least one season got mixed up so
+several episodes are out of order (mislabeled). We want a standalone script that
+points at an existing library folder and uses Engram's episode matcher to verify
+whether each file's *claimed* episode label matches what the audio actually is,
+flagging mismatches and optionally renaming them.
+
+## Goals
+
+- Point at a season folder **or** a show folder (auto-detected) and verify labels.
+- For each `.mkv`: compare the episode parsed from the filename (the *claim*)
+  against the matcher's predicted episode + calibrated confidence.
+- Surface mislabeled / out-of-order files clearly.
+- Optionally rename mismatched files to the correct code, **safely** (handles the
+  cyclic-swap collision inherent in "out of order"), with an undo log.
+- Default to a **dry run** that changes nothing.
+
+## Non-Goals
+
+- No changes to the running app, DB, or job pipeline.
+- No new web/API surface — this is a CLI utility.
+- Not a general media renamer; scoped to verifying against Engram's matcher.
+
+## Approach
+
+Reuse the production matcher path rather than reinventing it:
+
+- **Matching:** drive `EpisodeCurator.match_single_file()`
+  (`backend/app/core/curator.py:172`) — the same call the real pipeline uses. It
+  resolves the canonical show name via TMDB, initializes `EpisodeMatcher`, runs
+  `identify_episode()` in a thread, and returns a `MatchResult` with
+  `episode_code`, `confidence`, and `match_details` (including `runner_ups`).
+- **Reference setup:** before matching a season, call
+  `testing_service.download_subtitles(show, season)`
+  (`backend/app/matcher/testing_service.py:242`). This handles the precomputed
+  vector cache → OpenSubtitles → Addic7ed fallback exactly like production. The
+  matcher itself does **not** download subtitles; it returns `None` if references
+  are absent.
+- **Config:** the script imports the app package, so `get_config_sync()` supplies
+  the TMDB token, cache path, and OpenSubtitles creds straight from `engram.db`.
+  No separate API setup.
+
+Rejected alternative: calling `EpisodeMatcher.identify_episode()` raw. It would
+force duplicating curator's canonical-name resolution and cache init for no gain.
+
+## Components
+
+The script is `backend/scripts/verify_episode_labels.py`, structured so the pure
+logic is unit-testable without the matcher or network. App imports
+(`curator`, `testing_service`, `config_service`) are **lazy** (inside functions)
+so importing the module for tests is cheap and side-effect-free.
+
+### Pure functions (unit-tested)
+
+- `parse_claim(filename) -> (season, episode) | None` — `SxxEyy`, `NxNN`,
+  `Season N Episode M` patterns (mirrors `_parse_episode_from_filename`).
+- `detect_scope(path) -> ("season"|"show", seasons)` —
+  - `.mkv` files directly in `path` → season folder. Season from `Season NN`
+    dir name; fallback to the dominant `SxxEyy` season across filenames.
+  - `Season NN` subfolders present → show folder; iterate each season.
+- `classify(claim, predicted, confidence, threshold) -> Status` —
+  `OK | MISMATCH | LOW_CONF | NO_MATCH | UNPARSEABLE`.
+- `build_rename_plan(results, threshold) -> list[RenameStep]` — for `MISMATCH`
+  files at confidence ≥ threshold, compute target filenames (swap the episode
+  code, preserve the rest + extension), detect cycles/collisions, and emit a
+  **two-phase** plan (each source → unique temp name → final name) so cyclic
+  swaps (E03↔E05) never clobber. Includes same-stem sidecars (`.srt`, `.nfo`).
+
+### I/O / orchestration
+
+- `argparse` CLI (see flags below).
+- Per-season loop: resolve show name (folder name or `--show`) → ensure subtitles
+  → match each file → classify → render.
+- Console output via `rich` (`Table`, colored status); falls back to plain text
+  if `rich` import fails.
+- CSV written alongside the target with full per-file detail (path, claimed,
+  matched, confidence, status, runner-ups).
+- `--apply`: execute the rename plan, writing
+  `engram_label_undo_<timestamp>.json` (final → original). `--undo <log>` reverts.
+
+## CLI
+
+```
+verify_episode_labels.py PATH [options]
+
+  PATH                 season folder or show folder (auto-detected)
+  --show NAME          override inferred show name
+  --season N           override inferred season (season-folder mode)
+  --apply              perform renames (default: dry run, no changes)
+  --min-confidence X   confidence gate for auto-rename (default 0.7)
+  --num-points N       denser audio scan for accuracy (matcher default 10)
+  --csv PATH           CSV output path (default: alongside target)
+  --undo LOG           revert a previous --apply run from its undo log
+```
+
+Run from `backend/`:
+`uv run python scripts/verify_episode_labels.py "C:\Media\TV\Show\Season 03"`
+
+## Status classification
+
+| Status        | Condition                                              |
+|---------------|--------------------------------------------------------|
+| `OK`          | predicted == claimed, confidence ≥ threshold           |
+| `MISMATCH`    | predicted ≠ claimed, confidence ≥ threshold (rename!)  |
+| `LOW_CONF`    | confidence < threshold (can't trust either way)        |
+| `NO_MATCH`    | matcher returned `None` (no refs / no transcript hit)  |
+| `UNPARSEABLE` | no episode code in filename (still gets a suggestion)  |
+
+## Rename safety
+
+"Out of order" means swaps, so renaming a file into a name that already exists is
+expected. The plan:
+
+1. Build the full season target map; only `MISMATCH` ≥ threshold participate.
+2. Detect collisions/cycles.
+3. Two-phase rename: every participant → unique temp name first, then temp →
+   final. Cyclic swaps resolve cleanly.
+4. Same-stem sidecars (`.srt`, `.nfo`) move with their `.mkv`.
+5. Write an undo log; `--undo` reverses it.
+6. Refuse to overwrite a non-participant file (abort with a clear message).
+
+## Error handling
+
+- Subtitle setup failure for a season → mark every file `NO_MATCH`, print a clear
+  reason, continue to the next season (don't abort the whole run).
+- TMDB unreachable / show not found → caught, reported per season.
+- Missing/locked `.mkv` → reported per file, never crashes the run.
+- `--apply` aborts before touching anything if the plan has an unsafe collision
+  with a non-participant.
+
+## Testing
+
+- **Unit (`backend/tests/unit/test_verify_episode_labels.py`):** `parse_claim`,
+  `detect_scope` (via tmp dirs), `classify`, and `build_rename_plan` — especially
+  the cyclic-swap two-phase ordering and sidecar inclusion. No matcher/network.
+- **Integration:** a real dry-run on the user's known-mixed-up season is the
+  acceptance check (ASR + real references; not automated).
+
+## Performance
+
+ASR is CPU/GPU-bound: a few seconds per file, so a ~20-episode season takes a
+couple of minutes on first run (subtitle fetch + transcription). Subsequent runs
+reuse the cache.


### PR DESCRIPTION
## Summary
- Adds `backend/scripts/verify_episode_labels.py`: point it at a season folder or a whole show folder (auto-detected) and it verifies whether each `.mkv` is named with the correct episode, using the same audio matcher the live pipeline uses (`EpisodeCurator.match_single_file` + `testing_service.download_subtitles`).
- For each file it compares the *claimed* episode (parsed from the filename) against the matcher's predicted episode + calibrated confidence, classifying as `OK` / `MISMATCH` / `LOW_CONF` / `NO_MATCH` / `UNPARSEABLE`.
- **Dry-run by default**; `--apply` performs collision-safe two-phase renames (handles cyclic out-of-order swaps), carries `.srt`/`.nfo` sidecars, writes an undo log, and `--undo <log>` reverts.
- Reuses existing `engram.db` config (TMDB token, cache, OpenSubtitles creds) — no extra setup. `--full-references` bypasses the precomputed cache to download full-season subtitles when coverage is sparse. Output: `rich` console table (UTF-8 forced for Windows) + CSV with runner-up detail.

## Test plan
- [x] `uv run pytest tests/unit/test_verify_episode_labels.py` — 24 unit tests cover parsing, scope detection, status classification, sidecar expansion, and the collision-safe rename planner (incl. a real on-disk cyclic swap).
- [x] `uv run ruff check` / `ruff format --check` clean.
- [x] Real run against a known mixed-up library season (South Park S11): correctly identified a 5-episode rotation at 86–100% confidence and produced a safe rename plan.

Design spec: `docs/superpowers/specs/2026-05-23-verify-episode-labels-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)