### PR TITLE
fix(review): make Process flow return to dashboard instead of erroring

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -807,13 +807,28 @@ async def process_matched_titles(job: DiscJob = Depends(get_job_or_404)) -> dict
     The review UI submits each pending selection via POST /review before calling
     this endpoint. Resolving the last unresolved title makes apply_review finalize
     the job inline, so by the time this runs the job may already be ORGANIZING or
-    COMPLETED. Treat that as a benign no-op rather than an error, otherwise the UI
+    COMPLETED. Treat those as benign no-ops rather than an error, otherwise the UI
     surfaces a spurious "not awaiting review" failure and stays stuck on the
-    review screen even though the files were organized.
+    review screen even though apply_review already handled the titles.
+
+    The ``organized``/``conflicts``/``unresolved`` counts report work done by THIS
+    call. They are 0 here because apply_review did the organizing (and emitted its
+    own broadcasts); this is not the cumulative total for the job.
     """
-    if job.state in (JobState.ORGANIZING, JobState.COMPLETED):
+    if job.state == JobState.COMPLETED:
         return {
             "status": "already_finalized",
+            "job_id": job.id,
+            "organized": 0,
+            "conflicts": 0,
+            "unresolved": 0,
+        }
+    if job.state == JobState.ORGANIZING:
+        # Mid-flight: another path is actively moving files. Don't start a second
+        # organize pass, and report progress honestly rather than claiming the job
+        # is finished.
+        return {
+            "status": "organizing",
             "job_id": job.id,
             "organized": 0,
             "conflicts": 0,

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -802,7 +802,23 @@ async def retry_subtitle_download(
 
 @router.post("/jobs/{job_id}/process-matched")
 async def process_matched_titles(job: DiscJob = Depends(get_job_or_404)) -> dict:
-    """Process all matched titles for a job without waiting for unresolved ones."""
+    """Process all matched titles for a job without waiting for unresolved ones.
+
+    The review UI submits each pending selection via POST /review before calling
+    this endpoint. Resolving the last unresolved title makes apply_review finalize
+    the job inline, so by the time this runs the job may already be ORGANIZING or
+    COMPLETED. Treat that as a benign no-op rather than an error, otherwise the UI
+    surfaces a spurious "not awaiting review" failure and stays stuck on the
+    review screen even though the files were organized.
+    """
+    if job.state in (JobState.ORGANIZING, JobState.COMPLETED):
+        return {
+            "status": "already_finalized",
+            "job_id": job.id,
+            "organized": 0,
+            "conflicts": 0,
+            "unresolved": 0,
+        }
     if job.state != JobState.REVIEW_NEEDED:
         raise HTTPException(status_code=400, detail="Job is not awaiting review")
 

--- a/backend/tests/integration/test_workflow.py
+++ b/backend/tests/integration/test_workflow.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from app.database import async_session, init_db
 from app.main import app
-from app.models import AppConfig
+from app.models import AppConfig, ContentType, DiscJob, DiscTitle, JobState, TitleState
 
 
 @pytest.fixture(autouse=True)
@@ -686,3 +686,88 @@ class TestJobCompletionFromMatching:
             )
             # Should accept the review
             assert review_response.status_code in (200, 400)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestProcessMatchedGuard:
+    """The /process-matched endpoint must tolerate a job that a preceding
+    /review call already finalized.
+
+    Regression: clicking "Process" in the review UI fires submitPendingSelections()
+    (which loops POST /review and can auto-finalize the job) and then POST
+    /process-matched. When the review loop resolved the last unresolved title, the
+    job is already COMPLETED, so /process-matched used to return 400 "Job is not
+    awaiting review" and the UI got stuck on the review screen with a spurious error.
+    """
+
+    async def _make_tv_job(self, state: JobState) -> int:
+        """Insert a TV job directly in a given state and return its id."""
+        async with async_session() as session:
+            job = DiscJob(
+                drive_id="TEST:",
+                volume_label="GUARD_TEST_S1D1",
+                content_type=ContentType.TV,
+                detected_title="Guard Test",
+                detected_season=1,
+                state=state,
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            return job.id
+
+    async def test_process_matched_on_completed_job_is_idempotent(self, client):
+        """A job finalized by a preceding /review returns success, not 400."""
+        job_id = await self._make_tv_job(JobState.COMPLETED)
+
+        response = await client.post(f"/api/jobs/{job_id}/process-matched")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "already_finalized"
+        assert body["unresolved"] == 0
+        assert body["organized"] == 0
+        assert body["conflicts"] == 0
+
+    async def test_process_matched_on_organizing_job_is_idempotent(self, client):
+        """A request landing while /review is mid-organize is a no-op, not 400."""
+        job_id = await self._make_tv_job(JobState.ORGANIZING)
+
+        response = await client.post(f"/api/jobs/{job_id}/process-matched")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "already_finalized"
+
+    async def test_process_matched_on_failed_job_rejected(self, client):
+        """A genuinely invalid state (FAILED) still returns 400."""
+        job_id = await self._make_tv_job(JobState.FAILED)
+
+        response = await client.post(f"/api/jobs/{job_id}/process-matched")
+
+        assert response.status_code == 400
+
+    async def test_process_matched_partial_resolution_stays_in_review(self, client):
+        """When titles remain unresolved, the job processes and stays in review."""
+        job_id = await self._make_tv_job(JobState.REVIEW_NEEDED)
+        async with async_session() as session:
+            session.add(
+                DiscTitle(
+                    job_id=job_id,
+                    title_index=0,
+                    duration_seconds=1200,
+                    matched_episode=None,
+                    state=TitleState.REVIEW,
+                )
+            )
+            await session.commit()
+
+        response = await client.post(f"/api/jobs/{job_id}/process-matched")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "processed"
+        assert body["unresolved"] >= 1
+
+        detail = await client.get(f"/api/jobs/{job_id}")
+        assert detail.json()["state"] == "review_needed"

--- a/backend/tests/integration/test_workflow.py
+++ b/backend/tests/integration/test_workflow.py
@@ -730,14 +730,18 @@ class TestProcessMatchedGuard:
         assert body["organized"] == 0
         assert body["conflicts"] == 0
 
-    async def test_process_matched_on_organizing_job_is_idempotent(self, client):
-        """A request landing while /review is mid-organize is a no-op, not 400."""
+    async def test_process_matched_on_organizing_job_is_noop(self, client):
+        """A request landing while organization is in flight is a no-op, not 400.
+
+        ORGANIZING is mid-flight (not finished), so the response reports the honest
+        "organizing" status rather than claiming the job is already finalized.
+        """
         job_id = await self._make_tv_job(JobState.ORGANIZING)
 
         response = await client.post(f"/api/jobs/{job_id}/process-matched")
 
         assert response.status_code == 200
-        assert response.json()["status"] == "already_finalized"
+        assert response.json()["status"] == "organizing"
 
     async def test_process_matched_on_failed_job_rejected(self, client):
         """A genuinely invalid state (FAILED) still returns 400."""

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -415,17 +415,18 @@ function ReviewQueue() {
                 throw new Error(`Processing failed: ${text}`);
             }
             const result = await response.json();
-            // already_finalized/organizing mean the job has left review and is being
-            // handled (and shows on the dashboard); unresolved === 0 means we're done.
-            if (
-                result.unresolved === 0 ||
-                result.status === 'already_finalized' ||
-                result.status === 'organizing'
-            ) {
-                navigate('/');
+            if (result.status === 'processed') {
+                // We organized the matched subset. If titles still need review, stay
+                // and refresh; otherwise everything is done.
+                if (result.unresolved === 0) {
+                    navigate('/');
+                } else {
+                    await fetchJobDetails();
+                }
             } else {
-                // Some titles still need review — refresh to show the updated state.
-                await fetchJobDetails();
+                // already_finalized / organizing: the job has left review and is being
+                // handled elsewhere (and shows on the dashboard).
+                navigate('/');
             }
         } catch (err) {
             console.error('Failed to process matched:', err);

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -369,15 +369,15 @@ function ReviewQueue() {
         }
     };
 
-    // Re-fetch the job to check whether a preceding /review already organized it.
-    const jobAlreadyFinalized = async (): Promise<boolean> => {
+    // Re-fetch the job to inspect the state a preceding /review may have left it in.
+    const fetchCurrentJob = async (): Promise<Job | null> => {
         try {
             const res = await fetch(`/api/jobs/${jobId}`);
-            if (!res.ok) return false;
-            const data = await res.json();
-            return data.state === 'completed' || data.state === 'organizing';
-        } catch {
-            return false;
+            if (!res.ok) return null;
+            return (await res.json()) as Job;
+        } catch (e) {
+            console.warn('[handleProcessMatched] job re-fetch failed:', e);
+            return null;
         }
     };
 
@@ -387,23 +387,41 @@ function ReviewQueue() {
         try {
             // Submit pending selections first. Resolving the last unresolved title
             // makes the backend finalize the job inline, so it may already be
-            // organizing/completed by the time process-matched runs.
+            // organizing/completed/failed by the time process-matched runs.
             await submitPendingSelections();
             // Then process any remaining matched titles.
             const response = await fetch(`/api/jobs/${jobId}/process-matched`, { method: 'POST' });
             if (!response.ok) {
                 const text = await response.text();
                 // A preceding /review may have already finalized the job (older
-                // backends returned 400 here). If the work is actually done,
-                // return to the dashboard instead of surfacing a spurious error.
-                if (response.status === 400 && (await jobAlreadyFinalized())) {
-                    navigate('/');
-                    return;
+                // backends returned 400 here). Decide based on the job's real state.
+                if (response.status === 400) {
+                    const current = await fetchCurrentJob();
+                    if (current?.state === 'completed' || current?.state === 'organizing') {
+                        navigate('/');
+                        return;
+                    }
+                    if (current?.state === 'failed') {
+                        // The inline finalize organized but the move failed — surface
+                        // why instead of the cryptic "not awaiting review" text.
+                        setError(
+                            current.error_message
+                                ? `Job failed during organization: ${current.error_message}`
+                                : 'Job failed during organization.',
+                        );
+                        return;
+                    }
                 }
                 throw new Error(`Processing failed: ${text}`);
             }
             const result = await response.json();
-            if (result.unresolved === 0 || result.status === 'already_finalized') {
+            // already_finalized/organizing mean the job has left review and is being
+            // handled (and shows on the dashboard); unresolved === 0 means we're done.
+            if (
+                result.unresolved === 0 ||
+                result.status === 'already_finalized' ||
+                result.status === 'organizing'
+            ) {
                 navigate('/');
             } else {
                 // Some titles still need review — refresh to show the updated state.

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -415,18 +415,15 @@ function ReviewQueue() {
                 throw new Error(`Processing failed: ${text}`);
             }
             const result = await response.json();
-            if (result.status === 'processed') {
-                // We organized the matched subset. If titles still need review, stay
-                // and refresh; otherwise everything is done.
-                if (result.unresolved === 0) {
-                    navigate('/');
-                } else {
-                    await fetchJobDetails();
-                }
-            } else {
-                // already_finalized / organizing: the job has left review and is being
-                // handled elsewhere (and shows on the dashboard).
+            // Navigate home once nothing remains to resolve. Every success response
+            // (processed / already_finalized / organizing) reports unresolved: 0 when
+            // the job has left review, so this single check covers them all — and if a
+            // response ever reports unresolved > 0, we stay and refresh rather than
+            // silently skipping the remaining titles.
+            if (result.unresolved === 0) {
                 navigate('/');
+            } else {
+                await fetchJobDetails();
             }
         } catch (err) {
             console.error('Failed to process matched:', err);

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -369,23 +369,44 @@ function ReviewQueue() {
         }
     };
 
+    // Re-fetch the job to check whether a preceding /review already organized it.
+    const jobAlreadyFinalized = async (): Promise<boolean> => {
+        try {
+            const res = await fetch(`/api/jobs/${jobId}`);
+            if (!res.ok) return false;
+            const data = await res.json();
+            return data.state === 'completed' || data.state === 'organizing';
+        } catch {
+            return false;
+        }
+    };
+
     const handleProcessMatched = async () => {
         setIsProcessing(true);
         setError(null);
         try {
-            // First submit all pending selections
+            // Submit pending selections first. Resolving the last unresolved title
+            // makes the backend finalize the job inline, so it may already be
+            // organizing/completed by the time process-matched runs.
             await submitPendingSelections();
-            // Then process matched titles
+            // Then process any remaining matched titles.
             const response = await fetch(`/api/jobs/${jobId}/process-matched`, { method: 'POST' });
             if (!response.ok) {
                 const text = await response.text();
+                // A preceding /review may have already finalized the job (older
+                // backends returned 400 here). If the work is actually done,
+                // return to the dashboard instead of surfacing a spurious error.
+                if (response.status === 400 && (await jobAlreadyFinalized())) {
+                    navigate('/');
+                    return;
+                }
                 throw new Error(`Processing failed: ${text}`);
             }
             const result = await response.json();
-            if (result.unresolved === 0) {
+            if (result.unresolved === 0 || result.status === 'already_finalized') {
                 navigate('/');
             } else {
-                // Refresh to see updated state
+                // Some titles still need review — refresh to show the updated state.
                 await fetchJobDetails();
             }
         } catch (err) {


### PR DESCRIPTION
## Summary

Clicking **Process** on a Review-Needed disc organized/moved the files but then showed `Job is not awaiting review` and left the user stuck on the review screen.

The "Process" handler fires two backend calls in sequence: a `POST /review` loop (one per title) followed by `POST /process-matched`. Resolving the **last** unresolved title makes `apply_review` finalize the whole job inline — it transitions `REVIEW_NEEDED → ORGANIZING`, moves the files, and ends at `COMPLETED`. The follow-up `/process-matched` then hit its `state != REVIEW_NEEDED` guard and returned `400`. The frontend `catch` surfaced the error and never reached `navigate('/')`, so the files were organized but the UI looked broken.

This is deterministic (not a flaky race): it fires whenever the submitted selections resolve the final unresolved title.

## What changed

- **Backend** (`backend/app/api/routes.py`): `/process-matched` now treats `ORGANIZING`/`COMPLETED` as a benign already-finalized no-op (`200`, `status: "already_finalized"`), still returns `400` for genuinely invalid states (e.g. `FAILED`), and runs normally for `REVIEW_NEEDED`. `apply_review`'s auto-finalize — which the **Save All** button depends on — is left untouched.
- **Frontend** (`frontend/src/components/ReviewQueue.tsx`): `handleProcessMatched` navigates home on `unresolved === 0` *or* `status === "already_finalized"`, and as a version-skew safety net, on a `400` it re-fetches the job and treats a `completed`/`organizing` state as success rather than erroring (gated on the re-fetched state, not the error string).

## Why this approach

The backend change is load-bearing and fixes the bug on its own; the frontend change is defense-in-depth so the stuck-screen symptom can't recur across backend versions. The near-identical organize loops in `apply_review` and `process_matched_titles` are the underlying smell but were left as a follow-up to avoid touching the load-bearing Save All path.

## Tests

Added `TestProcessMatchedGuard` integration tests (TDD — written failing first):
- completed/organizing job → `200` idempotent no-op (was `400` — the bug)
- failed job → still `400`
- partial resolution → `200`, stays in `review_needed`

Verification:
- `uv run pytest tests/integration/test_workflow.py` → 18 passed (4 new, no regressions)
- `ruff check` clean; frontend `tsc` + `vite build` clean

## Reviewer notes

- Not verified via a live browser click-through: a live simulation that reaches `review_needed` and organizes files would move files into the real `library_tv_path` (because `get_config_sync()` reads the first `AppConfig` row), so the tests set up job state directly instead. Manual check: run with `DEBUG=true`, drive a TV disc to review with one unresolved title, assign it, click Process — should land on `/` with no error.
- Movie review flow and Save All are unaffected (they don't call `/process-matched`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)