### PR TITLE
feat(diagnostics): preview bug reports and surface real tool versions

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1411,8 +1411,12 @@ async def generate_bug_report(
     config = await get_config()
 
     # --- External tool versions (detection runs subprocesses; keep off the loop) ---
-    mk = await asyncio.to_thread(detect_makemkv)
-    ff = await asyncio.to_thread(detect_ffmpeg)
+    # Run concurrently — each spawns a subprocess with up to a 10 s timeout, so
+    # serial detection would double the worst-case latency before the modal opens.
+    mk, ff = await asyncio.gather(
+        asyncio.to_thread(detect_makemkv),
+        asyncio.to_thread(detect_ffmpeg),
+    )
     makemkv_version = mk.version if mk.found else (mk.error or "not found")
     ffmpeg_version = ff.version if ff.found else (ff.error or "not found")
 
@@ -1441,6 +1445,7 @@ async def generate_bug_report(
             error_lines = [ln for ln in all_lines if "ERROR" in ln or "CRITICAL" in ln]
             recent_errors = [_sanitize_line(line) for line in error_lines[-20:]]
         except Exception:
+            logger.warning(f"Failed to read log file for bug report: {log_path}", exc_info=True)
             recent_errors = ["(could not read log file)"]
 
     # --- Redacted config ---

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1405,9 +1405,16 @@ async def generate_bug_report(
 ) -> dict:
     """Generate a sanitized bug report with optional job context."""
     from app import __version__
+    from app.api.validation import detect_ffmpeg, detect_makemkv
     from app.services.config_service import get_config
 
     config = await get_config()
+
+    # --- External tool versions (detection runs subprocesses; keep off the loop) ---
+    mk = await asyncio.to_thread(detect_makemkv)
+    ff = await asyncio.to_thread(detect_ffmpeg)
+    makemkv_version = mk.version if mk.found else (mk.error or "not found")
+    ffmpeg_version = ff.version if ff.found else (ff.error or "not found")
 
     # --- Job summary (optional) ---
     job_summary = None
@@ -1452,6 +1459,8 @@ async def generate_bug_report(
         "app_version": __version__,
         "python_version": sys.version.split()[0],
         "os": f"{platform.system()} {platform.release()}",
+        "makemkv_version": makemkv_version,
+        "ffmpeg_version": ffmpeg_version,
         "job": job_summary,
         "recent_errors": recent_errors,
         "config": redacted_config,
@@ -1464,6 +1473,8 @@ async def generate_bug_report(
         f"**Engram version**: {__version__}",
         f"**OS**: {report['os']}",
         f"**Python**: {report['python_version']}",
+        f"**MakeMKV**: {makemkv_version}",
+        f"**FFmpeg**: {ffmpeg_version}",
         "",
     ]
     if job_summary:
@@ -1504,6 +1515,7 @@ async def generate_bug_report(
     )
 
     report["github_url"] = github_url
+    report["markdown"] = issue_body
     return report
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 
+from app import __version__
 from app.api import manager as ws_manager
 from app.api import router as api_router
 from app.api import test_router
@@ -111,19 +112,12 @@ async def lifespan(app: FastAPI):
     logger.info("Shutdown complete")
 
 
-# Read version from pyproject.toml metadata (falls back for frozen builds)
-try:
-    from importlib.metadata import version as _pkg_version
-
-    _version = _pkg_version("engram-backend")
-except Exception:
-    _version = "0.0.0"
-
-# Create FastAPI application
+# Create FastAPI application (version sourced from app/__init__.py — the single
+# source of truth, which also resolves correctly in frozen builds).
 app = FastAPI(
     title="Engram API",
     description="Glass-Box automation for disc ripping and organization",
-    version=_version,
+    version=__version__,
     lifespan=lifespan,
 )
 

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -34,7 +34,12 @@ async def client():
 
 @pytest.fixture
 def fake_tools(monkeypatch):
-    """Patch tool detection so the test does not depend on installed binaries."""
+    """Patch tool detection so the test does not depend on installed binaries.
+
+    The endpoint resolves these names lazily (``from app.api.validation import
+    ...`` inside the handler), so we patch them on the source module — that is
+    where the lookup happens at call time.
+    """
     monkeypatch.setattr(
         "app.api.validation.detect_makemkv",
         lambda: ToolDetectionResult(

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -1,0 +1,119 @@
+"""Unit tests for the diagnostics / bug-report endpoint.
+
+Verifies that GET /api/diagnostics/report surfaces *real* data (app/tool
+versions, job context) rather than placeholders, and that the version source of
+truth cannot silently drift between app/__init__.py and pyproject.toml.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import app as app_pkg
+from app.api.validation import ToolDetectionResult
+from app.database import get_session
+from app.main import app
+from tests.unit.conftest import _unit_session_factory
+from tests.unit.test_api_routes import _seed_job
+
+
+@pytest.fixture
+async def client():
+    async def override_get_session():
+        async with _unit_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fake_tools(monkeypatch):
+    """Patch tool detection so the test does not depend on installed binaries."""
+    monkeypatch.setattr(
+        "app.api.validation.detect_makemkv",
+        lambda: ToolDetectionResult(
+            found=True, path="/usr/bin/makemkvcon", version="MakeMKV v1.17.7"
+        ),
+    )
+    monkeypatch.setattr(
+        "app.api.validation.detect_ffmpeg",
+        lambda: ToolDetectionResult(
+            found=True, path="/usr/bin/ffmpeg", version="ffmpeg version 6.1.1"
+        ),
+    )
+
+
+class TestBugReport:
+    async def test_report_contains_real_versions(self, client, fake_tools):
+        resp = await client.get("/api/diagnostics/report")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # App version is the real package version, never the frozen-build fallback.
+        assert data["app_version"] == app_pkg.__version__
+        assert data["app_version"] != "0.0.0"
+
+        assert data["python_version"]
+        assert data["os"]
+        assert data["makemkv_version"] == "MakeMKV v1.17.7"
+        assert data["ffmpeg_version"] == "ffmpeg version 6.1.1"
+
+        # The copy-to-clipboard payload mirrors the GitHub issue body.
+        assert "## Bug Report" in data["markdown"]
+        assert "MakeMKV v1.17.7" in data["markdown"]
+        assert "ffmpeg version 6.1.1" in data["markdown"]
+        assert data["github_url"].startswith("https://github.com/")
+
+    async def test_report_includes_job_context(self, client, fake_tools):
+        from app.models.disc_job import JobState
+
+        job = await _seed_job(
+            volume_label="INCEPTION_2010",
+            state=JobState.FAILED,
+            error_message="boom during ripping",
+        )
+
+        resp = await client.get(f"/api/diagnostics/report?job_id={job.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert data["job"] is not None
+        assert data["job"]["id"] == job.id
+        assert data["job"]["volume_label"] == "INCEPTION_2010"
+        assert data["job"]["state"] == "failed"
+        assert data["job"]["error"] == "boom during ripping"
+        assert "Job Context" in data["markdown"]
+        assert "boom during ripping" in data["markdown"]
+
+    async def test_report_reports_missing_tools(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "app.api.validation.detect_makemkv",
+            lambda: ToolDetectionResult(found=False, error="MakeMKV not found"),
+        )
+        monkeypatch.setattr(
+            "app.api.validation.detect_ffmpeg",
+            lambda: ToolDetectionResult(found=False, error="FFmpeg not found"),
+        )
+
+        resp = await client.get("/api/diagnostics/report")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["makemkv_version"] == "MakeMKV not found"
+        assert data["ffmpeg_version"] == "FFmpeg not found"
+
+
+def test_version_source_of_truth_is_consistent():
+    """pyproject.toml must match app.__version__ so the reported version is real."""
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject.open("rb") as fh:
+        declared = tomllib.load(fh)["project"]["version"]
+    assert declared == app_pkg.__version__, (
+        f"pyproject.toml version {declared!r} != app.__version__ "
+        f"{app_pkg.__version__!r} — bump them together."
+    )

--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -1,0 +1,393 @@
+import { useState, useEffect, useCallback } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Bug, X, Copy, Check, ArrowRight, Loader2 } from "lucide-react";
+import { SvPanel, SvLabel, SvNotice, sv } from "../app/components/synapse";
+
+interface BugReport {
+  app_version: string;
+  python_version: string;
+  os: string;
+  makemkv_version: string;
+  ffmpeg_version: string;
+  job: {
+    id: number;
+    volume_label: string;
+    content_type: string;
+    state: string;
+    error: string | null;
+    created_at: string | null;
+    completed_at: string | null;
+  } | null;
+  recent_errors: string[];
+  config: Record<string, string | number | boolean>;
+  github_url: string;
+  markdown: string;
+}
+
+interface BugReportModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** When set, the report includes context for this specific job. */
+  jobId?: number;
+}
+
+// GitHub silently truncates issues opened via a prefilled `?body=` URL beyond
+// roughly 8 KB. Past this threshold we steer the user toward copy-and-paste.
+const URL_LENGTH_LIMIT = 7500;
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <SvLabel size={10}>{title}</SvLabel>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>{children}</div>
+    </div>
+  );
+}
+
+function KvRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+      <span
+        style={{
+          flexShrink: 0,
+          width: 120,
+          fontFamily: sv.mono,
+          fontSize: 11,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: sv.inkFaint,
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          minWidth: 0,
+          fontFamily: sv.mono,
+          fontSize: 12,
+          color: sv.cyanHi,
+          wordBreak: "break-word",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export default function BugReportModal({ open, onClose, jobId }: BugReportModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<BugReport | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      // Reset so the next open re-fetches fresh diagnostics.
+      setReport(null);
+      setError(null);
+      setCopied(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const url =
+      jobId != null
+        ? `/api/diagnostics/report?job_id=${jobId}`
+        : "/api/diagnostics/report";
+
+    fetch(url)
+      .then(async (resp) => {
+        if (!resp.ok) throw new Error(`Request failed (${resp.status})`);
+        return (await resp.json()) as BugReport;
+      })
+      .then((data) => {
+        if (!cancelled) setReport(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load report");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, jobId]);
+
+  const handleCopy = useCallback(async () => {
+    if (!report) return;
+    try {
+      await navigator.clipboard.writeText(report.markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setError("Could not copy to clipboard.");
+    }
+  }, [report]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const tooLargeForUrl = report != null && report.github_url.length > URL_LENGTH_LIMIT;
+
+  const buttonBase: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    padding: "10px 16px",
+    fontFamily: sv.mono,
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: "0.18em",
+    textTransform: "uppercase",
+    cursor: "pointer",
+    transition: "all 0.18s",
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bug-report-title"
+        >
+          <motion.div
+            className="absolute inset-0"
+            style={{ background: `${sv.bg0}d9`, backdropFilter: "blur(4px)" }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            onClick={onClose}
+          />
+
+          <motion.div
+            className="relative w-full max-w-2xl"
+            initial={{ opacity: 0, scale: 0.94, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 20 }}
+            transition={{ type: "spring", stiffness: 400, damping: 30 }}
+          >
+            <SvPanel
+              glow
+              pad={0}
+              style={{
+                background: `linear-gradient(180deg, ${sv.bg2}, ${sv.bg1})`,
+                boxShadow: `0 0 40px ${sv.red}26, inset 0 0 30px ${sv.red}0a`,
+                maxHeight: "85vh",
+                display: "flex",
+                flexDirection: "column",
+              }}
+              data-testid="bug-report-modal"
+            >
+              {/* Header */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "20px 24px",
+                  borderBottom: `1px solid ${sv.line}`,
+                }}
+              >
+                <Bug size={20} color={sv.red} style={{ filter: `drop-shadow(0 0 6px ${sv.red}99)` }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <h2
+                    id="bug-report-title"
+                    style={{
+                      fontFamily: sv.display,
+                      fontWeight: 700,
+                      fontSize: 16,
+                      letterSpacing: "0.2em",
+                      textTransform: "uppercase",
+                      color: sv.cyanHi,
+                      margin: 0,
+                    }}
+                  >
+                    Diagnostic Report
+                  </h2>
+                  <p
+                    style={{
+                      margin: "4px 0 0",
+                      fontFamily: sv.mono,
+                      fontSize: 11,
+                      letterSpacing: "0.06em",
+                      color: sv.inkFaint,
+                    }}
+                  >
+                    Exactly what will be attached to your bug report — review before sending.
+                  </p>
+                </div>
+                <button
+                  onClick={onClose}
+                  aria-label="Close"
+                  style={{
+                    display: "inline-flex",
+                    background: "transparent",
+                    border: "none",
+                    color: sv.inkDim,
+                    cursor: "pointer",
+                  }}
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              {/* Body (scrolls) */}
+              <div
+                style={{
+                  padding: 24,
+                  overflowY: "auto",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 20,
+                }}
+              >
+                {loading && (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 10,
+                      color: sv.inkDim,
+                      fontFamily: sv.mono,
+                      fontSize: 12,
+                    }}
+                  >
+                    <Loader2 size={16} className="animate-spin" />
+                    Collecting diagnostics…
+                  </div>
+                )}
+
+                {error && <SvNotice tone="error">{error}</SvNotice>}
+
+                {report && (
+                  <>
+                    <Section title="Environment">
+                      <KvRow label="Engram" value={report.app_version} />
+                      <KvRow label="OS" value={report.os} />
+                      <KvRow label="Python" value={report.python_version} />
+                    </Section>
+
+                    <Section title="Tools">
+                      <KvRow label="MakeMKV" value={report.makemkv_version} />
+                      <KvRow label="FFmpeg" value={report.ffmpeg_version} />
+                    </Section>
+
+                    {report.job && (
+                      <Section title="Job Context">
+                        <KvRow label="ID" value={report.job.id} />
+                        <KvRow label="Label" value={report.job.volume_label} />
+                        <KvRow label="Type" value={report.job.content_type} />
+                        <KvRow label="State" value={report.job.state} />
+                        {report.job.error && <KvRow label="Error" value={report.job.error} />}
+                      </Section>
+                    )}
+
+                    <Section title="Config">
+                      {Object.entries(report.config).map(([k, v]) => (
+                        <KvRow key={k} label={k} value={String(v)} />
+                      ))}
+                    </Section>
+
+                    <Section title="Recent Errors">
+                      <pre
+                        style={{
+                          margin: 0,
+                          maxHeight: 180,
+                          overflow: "auto",
+                          background: sv.bg0,
+                          border: `1px solid ${sv.lineMid}`,
+                          padding: 12,
+                          fontFamily: sv.mono,
+                          fontSize: 11,
+                          lineHeight: 1.5,
+                          color: sv.inkDim,
+                          whiteSpace: "pre-wrap",
+                          wordBreak: "break-word",
+                        }}
+                      >
+                        {report.recent_errors.length > 0
+                          ? report.recent_errors.join("\n")
+                          : "No recent errors logged."}
+                      </pre>
+                    </Section>
+
+                    {tooLargeForUrl && (
+                      <SvNotice tone="warn">
+                        This report is large — the prefilled GitHub link may be truncated. Copy the
+                        report and paste it into a new issue instead.
+                      </SvNotice>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {/* Footer actions */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "flex-end",
+                  gap: 12,
+                  padding: "16px 24px",
+                  borderTop: `1px solid ${sv.line}`,
+                }}
+              >
+                <button
+                  onClick={handleCopy}
+                  disabled={!report}
+                  style={{
+                    ...buttonBase,
+                    color: copied ? sv.green : sv.cyan,
+                    border: `1px solid ${copied ? sv.green : sv.cyan}80`,
+                    background: tooLargeForUrl ? `${sv.cyan}1f` : "transparent",
+                    boxShadow: tooLargeForUrl ? `0 0 14px ${sv.cyan}4d` : "none",
+                    opacity: report ? 1 : 0.4,
+                    cursor: report ? "pointer" : "not-allowed",
+                  }}
+                >
+                  {copied ? <Check size={14} /> : <Copy size={14} />}
+                  {copied ? "Copied" : "Copy Report"}
+                </button>
+
+                <button
+                  onClick={() => report && window.open(report.github_url, "_blank", "noopener")}
+                  disabled={!report}
+                  style={{
+                    ...buttonBase,
+                    color: sv.red,
+                    border: `1px solid ${sv.red}80`,
+                    background: tooLargeForUrl ? "transparent" : `${sv.red}1f`,
+                    boxShadow: tooLargeForUrl ? "none" : `0 0 14px ${sv.red}4d`,
+                    opacity: report ? 1 : 0.4,
+                    cursor: report ? "pointer" : "not-allowed",
+                  }}
+                >
+                  Open GitHub Issue
+                  <ArrowRight size={14} />
+                </button>
+              </div>
+            </SvPanel>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -18,6 +18,7 @@ import {
 import { IcoMovie, IcoTv, IcoError, IcoDisc } from "../app/components/icons";
 import { FEATURES } from "../config/constants";
 import { SvActionButton, SvAtmosphere, SvBadge, type SvBadgeState, SvBarChart, SvLabel, SvNotice, SvPageHeader, SvPanel, sv } from "../app/components/synapse";
+import BugReportModal from "./BugReportModal";
 import {
   formatBytesScaled,
   formatDateTime,
@@ -368,10 +369,12 @@ function JobDetailPanel({
   detail,
   loading,
   onClose,
+  onReportBug,
 }: {
   detail: JobDetail | null;
   loading: boolean;
   onClose: () => void;
+  onReportBug: (jobId: number) => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -761,22 +764,9 @@ function JobDetailPanel({
 
           {/* Bug Report for this specific job */}
           <div style={{ paddingTop: 8, borderTop: `1px solid ${sv.line}` }}>
-            <a
-              href={`/api/diagnostics/report?job_id=${detail.id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={async (e) => {
-                e.preventDefault();
-                try {
-                  const resp = await fetch(`/api/diagnostics/report?job_id=${detail.id}`);
-                  if (resp.ok) {
-                    const data = await resp.json();
-                    window.open(data.github_url, "_blank");
-                  }
-                } catch {
-                  // silently fail
-                }
-              }}
+            <button
+              type="button"
+              onClick={() => onReportBug(detail.id)}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -785,14 +775,17 @@ function JobDetailPanel({
                 fontSize: 11,
                 letterSpacing: "0.06em",
                 color: sv.inkDim,
-                textDecoration: "none",
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
                 transition: "color 120ms",
               }}
               {...hoverProps({ color: sv.red }, { color: sv.inkDim })}
             >
               <Bug size={12} />
               Report bug for this job
-            </a>
+            </button>
           </div>
         </div>
       ) : null}
@@ -971,7 +964,8 @@ export default function HistoryPage() {
   const [filterType, setFilterType] = useState<string>("");
   const [filterState, setFilterState] = useState<string>("");
   const [hasMore, setHasMore] = useState(true);
-  const [reportLoading, setReportLoading] = useState(false);
+  const [bugModalOpen, setBugModalOpen] = useState(false);
+  const [bugModalJobId, setBugModalJobId] = useState<number | undefined>(undefined);
   const [selectedJobId, setSelectedJobId] = useState<number | null>(
     urlJobId ? parseInt(urlJobId, 10) : null
   );
@@ -1045,19 +1039,10 @@ export default function HistoryPage() {
     navigate("/history", { replace: true });
   }, [navigate]);
 
-  const handleReportBug = async () => {
-    setReportLoading(true);
-    try {
-      const resp = await fetch("/api/diagnostics/report");
-      if (!resp.ok) throw new Error("Failed to generate report");
-      const data = await resp.json();
-      window.open(data.github_url, "_blank");
-    } catch {
-      alert("Could not generate bug report. Is the backend running?");
-    } finally {
-      setReportLoading(false);
-    }
-  };
+  const openBugReport = useCallback((jobId?: number) => {
+    setBugModalJobId(jobId);
+    setBugModalOpen(true);
+  }, []);
 
   return (
     <SvAtmosphere>
@@ -1067,8 +1052,7 @@ export default function HistoryPage() {
         onBack={() => navigate("/")}
         right={
           <button
-            onClick={handleReportBug}
-            disabled={reportLoading}
+            onClick={() => openBugReport()}
             style={{
               display: "inline-flex",
               alignItems: "center",
@@ -1083,13 +1067,11 @@ export default function HistoryPage() {
               fontWeight: 700,
               letterSpacing: "0.20em",
               textTransform: "uppercase",
-              cursor: reportLoading ? "wait" : "pointer",
-              opacity: reportLoading ? 0.5 : 1,
+              cursor: "pointer",
               boxShadow: `0 0 8px ${sv.red}33`,
               transition: "border-color 120ms, color 120ms, box-shadow 120ms",
             }}
             onMouseEnter={(e) => {
-              if (reportLoading) return;
               e.currentTarget.style.borderColor = sv.red;
               e.currentTarget.style.boxShadow = `0 0 14px ${sv.red}66`;
             }}
@@ -1099,7 +1081,7 @@ export default function HistoryPage() {
             }}
           >
             <Bug size={14} />
-            <span>{reportLoading ? "Generating…" : "Report Bug"}</span>
+            <span>Report Bug</span>
           </button>
         }
       />
@@ -1315,10 +1297,17 @@ export default function HistoryPage() {
               detail={jobDetail}
               loading={detailLoading}
               onClose={handleCloseDetail}
+              onReportBug={openBugReport}
             />
           </>
         )}
       </AnimatePresence>
+
+      <BugReportModal
+        open={bugModalOpen}
+        onClose={() => setBugModalOpen(false)}
+        jobId={bugModalJobId}
+      />
     </SvAtmosphere>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,10 +5,10 @@ import path from 'path'
 import fs from 'fs'
 import { fileURLToPath } from 'url'
 
-// Read version from backend pyproject.toml (single source of truth)
-const pyprojectPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../backend/pyproject.toml')
-const pyprojectContent = fs.readFileSync(pyprojectPath, 'utf-8')
-const versionMatch = pyprojectContent.match(/^version\s*=\s*"(.+?)"/m)
+// Read version from backend app/__init__.py:__version__ (single source of truth)
+const versionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../backend/app/__init__.py')
+const versionContent = fs.readFileSync(versionPath, 'utf-8')
+const versionMatch = versionContent.match(/__version__\s*=\s*"(.+?)"/)
 const APP_VERSION = versionMatch ? versionMatch[1] : 'dev'
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
## Summary

The **Report Bug** feature looked like a mock-up: clicking it opened a prefilled GitHub issue immediately, so you could never see the collected data and couldn't tell whether the version numbers and diagnostics were real or fabricated. They *were* real — the problem was opacity, plus a few genuine gaps. This makes the feature transparent, complete, and trustworthy.

## What changed

- **Preview modal** — New `BugReportModal` shows exactly what will be attached before anything is sent: Environment (Engram/OS/Python), Tools (MakeMKV/ffmpeg), Job context, redacted Config, and sanitized Recent Errors. Two actions: **Copy Report** (clipboard) and **Open GitHub Issue**, with a guard that steers users to copy-paste when the prefilled URL would exceed GitHub's ~8 KB limit. Both entry points in `HistoryPage` (header button + per-job link) open it.
- **Real tool versions** — `GET /api/diagnostics/report` now includes MakeMKV and ffmpeg versions, reusing the existing `detect_*` helpers run via `asyncio.to_thread` so the blocking subprocess calls don't stall the event loop. The endpoint also returns the rendered issue `markdown` so Copy mirrors the GitHub issue exactly.
- **One version source of truth** — Consolidated on `app/__init__.py:__version__`:
  - `main.py` imports it directly, removing the `importlib.metadata` lookup that fell back to `0.0.0` in frozen PyInstaller builds.
  - `vite.config.ts` reads `__version__` from `app/__init__.py` instead of `pyproject.toml`.
  - A new test fails CI if `pyproject.toml` drifts from `__version__`.

## Why

The user couldn't trust the feature because the data was invisible. Showing it (and adding the disc-ripper's most relevant tool versions) turns "is this made up?" into something you can verify at a glance.

## Testing

- Backend: 48 unit tests pass, incl. 4 new in `tests/unit/test_diagnostics.py` (real versions, tool versions, job context, missing-tool handling, version consistency). `ruff` clean.
- Frontend: `tsc` + production build pass.
- **Browser**: drove the modal end-to-end on an isolated stack — it renders all real data (real ffmpeg build string, redacted paths, genuine error-log lines) with **0 console errors**; Copy Report works.

## Reviewer notes

- **MakeMKV version** currently displays `MakeMKV (version not detectable)` on some setups. The value is honest (not fabricated) — the existing detector's parser is weak. A follow-up to fix the shared parser in `validation.py` is tracked separately to keep this PR focused.

## Test plan

- [ ] Open History → **Report Bug** → modal shows real environment/tools/config/errors
- [ ] **Copy Report** copies the markdown; **Open GitHub Issue** opens a prefilled issue
- [ ] Open a job's **Report bug for this job** → modal includes that job's context
- [ ] Confirm reported Engram version matches the splash/status version (not `0.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)