### PR TITLE
fix(movies): stop flagging long bonus tracks as needing review

### DIFF
--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -110,6 +110,115 @@ class DiscAnalysisResult:
     is_ambiguous_movie: bool = False
 
 
+# Main-feature selection tuning. A movie disc only needs review when 2+ titles
+# genuinely qualify as the feature (alternate versions / obfuscation); long bonus
+# tracks must not be mistaken for the feature.
+MOVIE_MIN_FEATURE_DURATION = 80 * 60  # floor (seconds) for a title to be feature-eligible
+MOVIE_RUNTIME_TOLERANCE_MIN = 10  # minutes a title may fall short of the TMDB runtime
+MOVIE_EXTENDED_ALLOWANCE_MIN = 45  # minutes a title may exceed runtime (extended/director's cut)
+MOVIE_FALLBACK_PROXIMITY = 0.75  # no-runtime: candidate if >= 75% of the longest eligible title
+MOVIE_CANDIDATE_BITRATE_FLOOR = 0.4  # drop candidates below 40% of the top candidate's bitrate
+
+
+@dataclass
+class MainFeatureDecision:
+    """Outcome of choosing the main feature among a movie disc's titles."""
+
+    feature_index: int | None
+    extra_indices: list[int] = field(default_factory=list)
+    candidate_indices: list[int] = field(default_factory=list)
+    needs_review: bool = False
+    review_reason: str | None = None
+
+
+def _bitrate(title: TitleInfo) -> float:
+    """Bytes per second — a proxy for video quality used to tell features from docs."""
+    if not title.duration_seconds:
+        return 0.0
+    return (title.size_bytes or 0) / title.duration_seconds
+
+
+def select_movie_main_feature(
+    titles: list[TitleInfo],
+    runtime_minutes: int | None,
+    *,
+    min_feature_duration: int = MOVIE_MIN_FEATURE_DURATION,
+) -> MainFeatureDecision:
+    """Pick the main feature among a movie disc's titles.
+
+    Uses the movie's TMDB runtime when available to identify the feature, falling
+    back to duration proximity. A low-bitrate filter rejects long documentaries
+    that happen to sit near the runtime. Review is only required when 2+ titles
+    remain plausible features (theatrical vs. extended cut, or copy-protection
+    playlist duplication); everything else is tagged as an extra.
+    """
+    if not titles:
+        return MainFeatureDecision(feature_index=None)
+
+    eligible = [t for t in titles if (t.duration_seconds or 0) >= min_feature_duration]
+
+    # No title clears the feature floor — pick the longest and move on (no review).
+    if not eligible:
+        feature = max(titles, key=lambda t: t.duration_seconds or 0)
+        return _single_feature(titles, feature)
+
+    if runtime_minutes and runtime_minutes > 0:
+        low = (runtime_minutes - MOVIE_RUNTIME_TOLERANCE_MIN) * 60
+        high = (runtime_minutes + MOVIE_EXTENDED_ALLOWANCE_MIN) * 60
+        candidates = [t for t in eligible if low <= t.duration_seconds <= high]
+        if not candidates:
+            # Runtime wildly off (e.g. wrong TMDB id) — ignore it and use duration.
+            candidates = _proximity_candidates(eligible)
+    else:
+        candidates = _proximity_candidates(eligible)
+
+    candidates = _filter_by_bitrate(candidates)
+    if not candidates:
+        candidates = [max(eligible, key=lambda t: t.duration_seconds or 0)]
+
+    if len(candidates) == 1:
+        return _single_feature(titles, candidates[0])
+
+    candidate_indices = [t.index for t in candidates]
+    extras = [t.index for t in titles if t.index not in candidate_indices]
+    return MainFeatureDecision(
+        feature_index=None,
+        extra_indices=extras,
+        candidate_indices=candidate_indices,
+        needs_review=True,
+        review_reason=(
+            "Multiple feature-length titles found. "
+            "Please select the correct version (theatrical, extended, etc.)."
+        ),
+    )
+
+
+def _single_feature(titles: list[TitleInfo], feature: TitleInfo) -> MainFeatureDecision:
+    """Build a no-review decision with one feature and everything else as extras."""
+    return MainFeatureDecision(
+        feature_index=feature.index,
+        extra_indices=[t.index for t in titles if t.index != feature.index],
+        candidate_indices=[feature.index],
+    )
+
+
+def _proximity_candidates(eligible: list[TitleInfo]) -> list[TitleInfo]:
+    """Feature candidates by duration proximity to the longest eligible title."""
+    longest = max(eligible, key=lambda t: t.duration_seconds or 0)
+    threshold = longest.duration_seconds * MOVIE_FALLBACK_PROXIMITY
+    return [t for t in eligible if (t.duration_seconds or 0) >= threshold]
+
+
+def _filter_by_bitrate(candidates: list[TitleInfo]) -> list[TitleInfo]:
+    """Drop candidates whose bitrate is far below the best — likely low-quality docs."""
+    if len(candidates) <= 1:
+        return candidates
+    top = max(_bitrate(t) for t in candidates)
+    if top <= 0:
+        return candidates
+    return [t for t in candidates if _bitrate(t) >= top * MOVIE_CANDIDATE_BITRATE_FLOOR]
+
+
 class DiscAnalyst:
     """Analyzes disc structure to classify content type."""
 

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -837,6 +837,31 @@ def fetch_movie_id(movie_name: str) -> str | None:
     return None
 
 
+def fetch_movie_runtime(movie_id: str) -> int | None:
+    """Fetch a movie's canonical runtime (minutes) from TMDB.
+
+    Used to identify the main feature among a disc's titles. Returns None when
+    the key is missing, the request fails, or TMDB reports no runtime (0/null).
+    """
+    from app.services.config_service import get_config_sync
+
+    tmdb_api_key = get_config_sync().tmdb_api_key
+    if not tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return None
+
+    url = f"https://api.themoviedb.org/3/movie/{movie_id}"
+    data = _tmdb_get_json(url, tmdb_api_key)
+    if not data:
+        return None
+    runtime = data.get("runtime") or 0
+    if runtime <= 0:
+        logger.info(f"TMDB reports no runtime for movie {movie_id}")
+        return None
+    logger.info(f"TMDB runtime for movie {movie_id}: {runtime} min")
+    return int(runtime)
+
+
 def clear_caches() -> None:
     """Clear all TMDB caches — both in-process LRU and the on-disk SQLite layer.
 

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -842,12 +842,19 @@ def fetch_movie_runtime(movie_id: str, api_key: str) -> int | None:
 
     Used to identify the main feature among a disc's titles. The caller supplies
     the TMDB key (avoids importing the config service from the matcher layer, the
-    same pattern as ``fetch_season_episodes``). Returns None when the key is
+    same pattern as ``fetch_season_episodes``). Positive results are cached in the
+    persistent SQLite layer with a long TTL (runtimes are stable) so re-rips don't
+    re-hit the API; failures/None are not cached. Returns None when the key is
     missing, the request fails, or TMDB reports no runtime (0/null).
     """
     if not api_key:
         logger.warning("TMDB API key not configured")
         return None
+
+    persistent_key = f"movie_runtime:{movie_id}"
+    cached = tmdb_persistent_cache.get(persistent_key)
+    if cached is not None:
+        return cached
 
     url = f"https://api.themoviedb.org/3/movie/{movie_id}"
     data = _tmdb_get_json(url, api_key)
@@ -857,8 +864,10 @@ def fetch_movie_runtime(movie_id: str, api_key: str) -> int | None:
     if runtime <= 0:
         logger.info(f"TMDB reports no runtime for movie {movie_id}")
         return None
+    runtime = int(runtime)
+    tmdb_persistent_cache.put(persistent_key, runtime, tmdb_persistent_cache.TTL_MOVIE)
     logger.info(f"TMDB runtime for movie {movie_id}: {runtime} min")
-    return int(runtime)
+    return runtime
 
 
 def clear_caches() -> None:

--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -837,21 +837,20 @@ def fetch_movie_id(movie_name: str) -> str | None:
     return None
 
 
-def fetch_movie_runtime(movie_id: str) -> int | None:
+def fetch_movie_runtime(movie_id: str, api_key: str) -> int | None:
     """Fetch a movie's canonical runtime (minutes) from TMDB.
 
-    Used to identify the main feature among a disc's titles. Returns None when
-    the key is missing, the request fails, or TMDB reports no runtime (0/null).
+    Used to identify the main feature among a disc's titles. The caller supplies
+    the TMDB key (avoids importing the config service from the matcher layer, the
+    same pattern as ``fetch_season_episodes``). Returns None when the key is
+    missing, the request fails, or TMDB reports no runtime (0/null).
     """
-    from app.services.config_service import get_config_sync
-
-    tmdb_api_key = get_config_sync().tmdb_api_key
-    if not tmdb_api_key:
+    if not api_key:
         logger.warning("TMDB API key not configured")
         return None
 
     url = f"https://api.themoviedb.org/3/movie/{movie_id}"
-    data = _tmdb_get_json(url, tmdb_api_key)
+    data = _tmdb_get_json(url, api_key)
     if not data:
         return None
     runtime = data.get("runtime") or 0

--- a/backend/app/matcher/tmdb_persistent_cache.py
+++ b/backend/app/matcher/tmdb_persistent_cache.py
@@ -38,6 +38,7 @@ TTL_SHOW_ID = 90 * 86400
 TTL_SHOW_DETAILS = 7 * 86400
 TTL_SEASON = 7 * 86400
 TTL_DISCOVER = 86400
+TTL_MOVIE = 90 * 86400  # a released movie's runtime is effectively immutable
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS tmdb_cache (

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1132,44 +1132,10 @@ class JobManager:
                     ripped_titles = [t for t in disc_titles if t.is_selected]
 
                     if len(ripped_titles) > 1:
-                        discdb_maps = self._matching.get_discdb_mappings(job_id)
-                        main_movie_idx = None
-                        for m in discdb_maps:
-                            if m.title_type == "MainMovie":
-                                main_movie_idx = m.index
-                                break
-
-                        if main_movie_idx is not None:
-                            for dt in ripped_titles:
-                                if dt.title_index == main_movie_idx:
-                                    dt.is_selected = True
-                                else:
-                                    dt.is_selected = False
-                                session.add(dt)
-                            await session.commit()
-                            ripped_titles = [
-                                t for t in ripped_titles if t.title_index == main_movie_idx
-                            ]
-                            logger.info(
-                                f"Job {job_id}: TheDiscDB auto-selected MainMovie "
-                                f"title index {main_movie_idx}, skipping review"
-                            )
-                        else:
-                            await state_machine.transition_to_review(
-                                job,
-                                session,
-                                reason="Multiple versions ripped. Please select the correct one.",
-                                broadcast=False,
-                            )
-                            await ws_manager.broadcast_job_update(
-                                job_id,
-                                JobState.REVIEW_NEEDED.value,
-                                error="Multiple versions ripped. Please select the correct one.",
-                            )
-                            logger.info(
-                                f"Job {job_id}: Multiple movie versions ripped. "
-                                f"Waiting for user selection."
-                            )
+                        sent_to_review = await self._resolve_multi_title_movie(
+                            job, job_id, ripped_titles, session
+                        )
+                        if sent_to_review:
                             return
 
                     # Single title flow (Standard Movie)
@@ -1226,6 +1192,101 @@ class JobManager:
             except Exception as e:
                 logger.exception(f"Error ripping job {job_id}")
                 await state_machine.transition_to_failed(job, session, error_message=str(e))
+
+    async def _resolve_multi_title_movie(
+        self,
+        job: DiscJob,
+        job_id: int,
+        ripped_titles: list[DiscTitle],
+        session,
+    ) -> bool:
+        """Decide what to do when a movie rip produced more than one title.
+
+        Prefers a TheDiscDB ``MainMovie`` tag; otherwise distinguishes the real
+        feature from long bonus tracks via the movie's TMDB runtime (with a
+        duration/bitrate fallback). Tags non-feature titles as extras. Only
+        genuinely competing features (alternate cuts / obfuscation playlists)
+        require a review.
+
+        Returns True when the job was sent to REVIEW_NEEDED (caller should stop).
+        """
+        discdb_maps = self._matching.get_discdb_mappings(job_id)
+        main_movie_idx = next((m.index for m in discdb_maps if m.title_type == "MainMovie"), None)
+        if main_movie_idx is not None:
+            for dt in ripped_titles:
+                dt.is_selected = dt.title_index == main_movie_idx
+                dt.is_extra = dt.title_index != main_movie_idx
+                session.add(dt)
+            await session.commit()
+            logger.info(
+                f"Job {job_id}: TheDiscDB auto-selected MainMovie "
+                f"title index {main_movie_idx}, skipping review"
+            )
+            return False
+
+        decision = await self._resolve_movie_feature(job, ripped_titles)
+
+        for dt in ripped_titles:
+            if dt.title_index in decision.extra_indices:
+                dt.is_extra = True
+                if decision.needs_review:
+                    # Keep extras out of the version picker.
+                    dt.is_selected = False
+                session.add(dt)
+        await session.commit()
+
+        if decision.needs_review:
+            reason = (
+                decision.review_reason
+                or "Multiple feature-length titles found. Please select the correct version."
+            )
+            await state_machine.transition_to_review(job, session, reason=reason, broadcast=False)
+            await ws_manager.broadcast_job_update(
+                job_id, JobState.REVIEW_NEEDED.value, error=reason
+            )
+            logger.info(
+                f"Job {job_id}: {len(decision.candidate_indices)} feature candidates "
+                f"{decision.candidate_indices} ripped — waiting for user selection."
+            )
+            return True
+
+        logger.info(
+            f"Job {job_id}: auto-selected feature title {decision.feature_index}; "
+            f"tagged {decision.extra_indices} as extras (no review)."
+        )
+        return False
+
+    async def _resolve_movie_feature(self, job: DiscJob, ripped_titles: list[DiscTitle]):
+        """Decide which ripped title is the movie's main feature.
+
+        Uses the movie's TMDB runtime (when available) plus a duration/bitrate
+        fallback so long bonus tracks aren't mistaken for the feature. Returns a
+        ``MainFeatureDecision`` (see ``select_movie_main_feature``).
+        """
+        from app.core.analyst import TitleInfo, select_movie_main_feature
+        from app.matcher.tmdb_client import fetch_movie_runtime
+        from app.services.config_service import get_config
+
+        runtime = None
+        if job.tmdb_id:
+            try:
+                runtime = await asyncio.to_thread(fetch_movie_runtime, str(job.tmdb_id))
+            except Exception as e:
+                logger.warning(f"Job {job.id}: movie runtime lookup failed: {e}")
+
+        config = await get_config()
+        infos = [
+            TitleInfo(
+                index=t.title_index,
+                duration_seconds=t.duration_seconds or 0,
+                size_bytes=t.file_size_bytes or 0,
+                chapter_count=t.chapter_count or 0,
+            )
+            for t in ripped_titles
+        ]
+        return select_movie_main_feature(
+            infos, runtime, min_feature_duration=config.analyst_movie_min_duration
+        )
 
     async def _on_title_ripped(
         self, job_id: int, rip_index: int, path: Path, sorted_titles: list[DiscTitle]

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1218,10 +1218,11 @@ class JobManager:
                 dt.is_extra = dt.title_index != main_movie_idx
                 session.add(dt)
             await session.commit()
-            safe_main_idx = sanitize_log_value(main_movie_idx)
+            # int() coerces the disc-derived index to a number — a numeric value
+            # cannot carry CR/LF, so it is not a log-injection vector.
             logger.info(
                 f"Job {job_id}: TheDiscDB auto-selected MainMovie "
-                f"title index {safe_main_idx}, skipping review"
+                f"title index {int(main_movie_idx)}, skipping review"
             )
             return False
 
@@ -1245,18 +1246,17 @@ class JobManager:
             await ws_manager.broadcast_job_update(
                 job_id, JobState.REVIEW_NEEDED.value, error=reason
             )
-            safe_candidates = sanitize_log_value(decision.candidate_indices)
+            # Log counts only — the raw indices are disc-derived; counts (len) and
+            # int-coerced ids below are numeric and cannot carry log-injection.
             logger.info(
                 f"Job {job_id}: {len(decision.candidate_indices)} feature candidates "
-                f"{safe_candidates} ripped — waiting for user selection."
+                f"ripped — waiting for user selection."
             )
             return True
 
-        safe_feature = sanitize_log_value(decision.feature_index)
-        safe_extras = sanitize_log_value(decision.extra_indices)
         logger.info(
-            f"Job {job_id}: auto-selected feature title {safe_feature}; "
-            f"tagged {safe_extras} as extras (no review)."
+            f"Job {job_id}: auto-selected feature title {int(decision.feature_index)}; "
+            f"tagged {len(decision.extra_indices)} extras (no review)."
         )
         return False
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1210,6 +1210,10 @@ class JobManager:
 
         Returns True when the job was sent to REVIEW_NEEDED (caller should stop).
         """
+        # job_id reaches this method from the /jobs/{job_id}/... review path param
+        # (apply_review -> _run_ripping), so it is user-provided — sanitize before
+        # logging to prevent CR/LF log forging (py/log-injection).
+        safe_job = sanitize_log_value(job_id)
         discdb_maps = self._matching.get_discdb_mappings(job_id)
         main_movie_idx = next((m.index for m in discdb_maps if m.title_type == "MainMovie"), None)
         if main_movie_idx is not None:
@@ -1218,11 +1222,9 @@ class JobManager:
                 dt.is_extra = dt.title_index != main_movie_idx
                 session.add(dt)
             await session.commit()
-            # int() coerces the disc-derived index to a number — a numeric value
-            # cannot carry CR/LF, so it is not a log-injection vector.
             logger.info(
-                f"Job {job_id}: TheDiscDB auto-selected MainMovie "
-                f"title index {int(main_movie_idx)}, skipping review"
+                f"Job {safe_job}: TheDiscDB auto-selected MainMovie "
+                f"title index {main_movie_idx}, skipping review"
             )
             return False
 
@@ -1246,17 +1248,15 @@ class JobManager:
             await ws_manager.broadcast_job_update(
                 job_id, JobState.REVIEW_NEEDED.value, error=reason
             )
-            # Log counts only — the raw indices are disc-derived; counts (len) and
-            # int-coerced ids below are numeric and cannot carry log-injection.
             logger.info(
-                f"Job {job_id}: {len(decision.candidate_indices)} feature candidates "
-                f"ripped — waiting for user selection."
+                f"Job {safe_job}: {len(decision.candidate_indices)} feature candidates "
+                f"{decision.candidate_indices} ripped — waiting for user selection."
             )
             return True
 
         logger.info(
-            f"Job {job_id}: auto-selected feature title {int(decision.feature_index)}; "
-            f"tagged {len(decision.extra_indices)} extras (no review)."
+            f"Job {safe_job}: auto-selected feature title {decision.feature_index}; "
+            f"tagged {decision.extra_indices} as extras (no review)."
         )
         return False
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1220,7 +1220,7 @@ class JobManager:
             await session.commit()
             logger.info(
                 f"Job {job_id}: TheDiscDB auto-selected MainMovie "
-                f"title index {main_movie_idx}, skipping review"
+                f"title index {sanitize_log_value(main_movie_idx)}, skipping review"
             )
             return False
 
@@ -1246,13 +1246,15 @@ class JobManager:
             )
             logger.info(
                 f"Job {job_id}: {len(decision.candidate_indices)} feature candidates "
-                f"{decision.candidate_indices} ripped — waiting for user selection."
+                f"{sanitize_log_value(decision.candidate_indices)} ripped — "
+                f"waiting for user selection."
             )
             return True
 
         logger.info(
-            f"Job {job_id}: auto-selected feature title {decision.feature_index}; "
-            f"tagged {decision.extra_indices} as extras (no review)."
+            f"Job {job_id}: auto-selected feature title "
+            f"{sanitize_log_value(decision.feature_index)}; "
+            f"tagged {sanitize_log_value(decision.extra_indices)} as extras (no review)."
         )
         return False
 
@@ -1267,14 +1269,17 @@ class JobManager:
         from app.matcher.tmdb_client import fetch_movie_runtime
         from app.services.config_service import get_config
 
+        config = await get_config()
+
         runtime = None
-        if job.tmdb_id:
+        if job.tmdb_id and config.tmdb_api_key:
             try:
-                runtime = await asyncio.to_thread(fetch_movie_runtime, str(job.tmdb_id))
+                runtime = await asyncio.to_thread(
+                    fetch_movie_runtime, str(job.tmdb_id), config.tmdb_api_key
+                )
             except Exception as e:
                 logger.warning(f"Job {job.id}: movie runtime lookup failed: {e}")
 
-        config = await get_config()
         infos = [
             TitleInfo(
                 index=t.title_index,

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1218,9 +1218,10 @@ class JobManager:
                 dt.is_extra = dt.title_index != main_movie_idx
                 session.add(dt)
             await session.commit()
+            safe_main_idx = sanitize_log_value(main_movie_idx)
             logger.info(
                 f"Job {job_id}: TheDiscDB auto-selected MainMovie "
-                f"title index {sanitize_log_value(main_movie_idx)}, skipping review"
+                f"title index {safe_main_idx}, skipping review"
             )
             return False
 
@@ -1228,10 +1229,10 @@ class JobManager:
 
         for dt in ripped_titles:
             if dt.title_index in decision.extra_indices:
+                # Extras are never the selected feature, in either path: deselected so
+                # the version picker (review) and downstream state stay consistent.
                 dt.is_extra = True
-                if decision.needs_review:
-                    # Keep extras out of the version picker.
-                    dt.is_selected = False
+                dt.is_selected = False
                 session.add(dt)
         await session.commit()
 
@@ -1244,17 +1245,18 @@ class JobManager:
             await ws_manager.broadcast_job_update(
                 job_id, JobState.REVIEW_NEEDED.value, error=reason
             )
+            safe_candidates = sanitize_log_value(decision.candidate_indices)
             logger.info(
                 f"Job {job_id}: {len(decision.candidate_indices)} feature candidates "
-                f"{sanitize_log_value(decision.candidate_indices)} ripped — "
-                f"waiting for user selection."
+                f"{safe_candidates} ripped — waiting for user selection."
             )
             return True
 
+        safe_feature = sanitize_log_value(decision.feature_index)
+        safe_extras = sanitize_log_value(decision.extra_indices)
         logger.info(
-            f"Job {job_id}: auto-selected feature title "
-            f"{sanitize_log_value(decision.feature_index)}; "
-            f"tagged {sanitize_log_value(decision.extra_indices)} as extras (no review)."
+            f"Job {job_id}: auto-selected feature title {safe_feature}; "
+            f"tagged {safe_extras} as extras (no review)."
         )
         return False
 
@@ -1278,7 +1280,7 @@ class JobManager:
                     fetch_movie_runtime, str(job.tmdb_id), config.tmdb_api_key
                 )
             except Exception as e:
-                logger.warning(f"Job {job.id}: movie runtime lookup failed: {e}")
+                logger.warning(f"Job {job.id}: movie runtime lookup failed: {e}", exc_info=True)
 
         infos = [
             TitleInfo(

--- a/backend/tests/integration/test_movie_feature_resolution.py
+++ b/backend/tests/integration/test_movie_feature_resolution.py
@@ -1,0 +1,121 @@
+"""Integration tests for the post-rip movie gate (_resolve_multi_title_movie).
+
+Verifies that a movie with long bonus tracks auto-selects the feature and tags
+extras (no review), while genuinely competing features still require review.
+This is the path that previously flagged Marty Supreme as "Multiple versions
+ripped" because every ripped title counted as a candidate.
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from app.models import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.services.job_manager import JobManager
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as s:
+        yield s
+
+
+def _cfg():
+    return types.SimpleNamespace(analyst_movie_min_duration=4800)
+
+
+async def _make_movie_job(session, title_specs):
+    """title_specs: list of (minutes, mbps). Returns (job, [DiscTitle])."""
+    job = DiscJob(
+        drive_id="D:",
+        volume_label="MARTY_SUPREME",
+        content_type=ContentType.MOVIE,
+        state=JobState.RIPPING,
+        detected_title="Marty Supreme",
+        tmdb_id=1317288,
+        staging_path="/tmp/staging",
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+
+    titles = []
+    for idx, (minutes, mbps) in enumerate(title_specs):
+        dur = int(minutes * 60)
+        size = int(mbps * 1_000_000 * dur / 8)
+        t = DiscTitle(
+            job_id=job.id,
+            title_index=idx,
+            duration_seconds=dur,
+            file_size_bytes=size,
+            chapter_count=12,
+            state=TitleState.MATCHED,
+            is_selected=True,
+        )
+        session.add(t)
+        titles.append(t)
+    await session.commit()
+    for t in titles:
+        await session.refresh(t)
+    return job, titles
+
+
+@pytest.fixture
+def jm(mocker):
+    mgr = JobManager()
+    mgr._matching.get_discdb_mappings = MagicMock(return_value=[])
+    mocker.patch("app.services.job_manager.ws_manager", new=AsyncMock())
+    mocker.patch("app.services.config_service.get_config", new=AsyncMock(return_value=_cfg()))
+    return mgr
+
+
+async def test_long_bonus_tracks_no_review(jm, session, mocker):
+    """149min feature + short bonus tracks → no review, extras tagged."""
+    mocker.patch("app.matcher.tmdb_client.fetch_movie_runtime", return_value=149)
+    job, titles = await _make_movie_job(session, [(149.7, 38), (20, 19), (4, 17), (4, 18)])
+
+    sent_to_review = await jm._resolve_multi_title_movie(job, job.id, titles, session)
+
+    assert sent_to_review is False
+    assert job.state == JobState.RIPPING  # not pushed to review
+    assert titles[0].is_extra is False
+    assert all(t.is_extra for t in titles[1:])
+
+
+async def test_two_real_features_needs_review(jm, session, mocker):
+    """Theatrical + extended cut → review with both kept as candidates."""
+    mocker.patch("app.matcher.tmdb_client.fetch_movie_runtime", return_value=120)
+    job, titles = await _make_movie_job(session, [(120, 36), (145, 35), (5, 18)])
+
+    sent_to_review = await jm._resolve_multi_title_movie(job, job.id, titles, session)
+
+    assert sent_to_review is True
+    assert job.state == JobState.REVIEW_NEEDED
+    # Competing features stay selected; the short extra is dropped from the picker.
+    assert titles[0].is_selected and titles[1].is_selected
+    assert titles[2].is_extra and titles[2].is_selected is False
+
+
+async def test_discdb_mainmovie_skips_review(jm, session, mocker):
+    """A TheDiscDB MainMovie tag selects the feature and skips review."""
+    mocker.patch("app.matcher.tmdb_client.fetch_movie_runtime", return_value=149)
+    jm._matching.get_discdb_mappings = MagicMock(
+        return_value=[types.SimpleNamespace(index=1, title_type="MainMovie")]
+    )
+    job, titles = await _make_movie_job(session, [(149, 38), (149, 37), (4, 18)])
+
+    sent_to_review = await jm._resolve_multi_title_movie(job, job.id, titles, session)
+
+    assert sent_to_review is False
+    assert job.state == JobState.RIPPING
+    assert titles[1].is_selected and titles[1].is_extra is False
+    assert all(t.is_extra and t.is_selected is False for t in (titles[0], titles[2]))

--- a/backend/tests/integration/test_movie_feature_resolution.py
+++ b/backend/tests/integration/test_movie_feature_resolution.py
@@ -30,7 +30,7 @@ async def session():
 
 
 def _cfg():
-    return types.SimpleNamespace(analyst_movie_min_duration=4800)
+    return types.SimpleNamespace(analyst_movie_min_duration=4800, tmdb_api_key="test_key")
 
 
 async def _make_movie_job(session, title_specs):

--- a/backend/tests/integration/test_movie_feature_resolution.py
+++ b/backend/tests/integration/test_movie_feature_resolution.py
@@ -87,8 +87,9 @@ async def test_long_bonus_tracks_no_review(jm, session, mocker):
 
     assert sent_to_review is False
     assert job.state == JobState.RIPPING  # not pushed to review
-    assert titles[0].is_extra is False
-    assert all(t.is_extra for t in titles[1:])
+    assert titles[0].is_extra is False and titles[0].is_selected is True
+    # Extras are tagged and deselected so they never read as the feature.
+    assert all(t.is_extra and t.is_selected is False for t in titles[1:])
 
 
 async def test_two_real_features_needs_review(jm, session, mocker):

--- a/backend/tests/unit/test_movie_feature.py
+++ b/backend/tests/unit/test_movie_feature.py
@@ -1,0 +1,122 @@
+"""Unit tests for select_movie_main_feature.
+
+Distinguishes the real movie feature from long bonus tracks so that a disc only
+goes to review when 2+ titles genuinely qualify as the feature (alternate
+versions / obfuscation), not when it merely carries long extras.
+"""
+
+from app.core.analyst import TitleInfo, select_movie_main_feature
+
+
+def _title(index: int, minutes: float, mbps: float, chapters: int = 12) -> TitleInfo:
+    """Build a TitleInfo from a duration (minutes) and a bitrate (Mbps)."""
+    duration = int(minutes * 60)
+    size = int(mbps * 1_000_000 * duration / 8)
+    return TitleInfo(
+        index=index,
+        duration_seconds=duration,
+        size_bytes=size,
+        chapter_count=chapters,
+    )
+
+
+class TestSingleFeature:
+    def test_marty_supreme_shape_no_review(self):
+        """149min feature + short bonus tracks → 1 feature, rest extras, no review."""
+        titles = [
+            _title(0, 149.7, 38, chapters=16),
+            _title(1, 20.0, 19, chapters=1),
+            _title(2, 4.1, 17, chapters=1),
+            _title(3, 3.9, 18, chapters=2),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=149)
+        assert decision.needs_review is False
+        assert decision.feature_index == 0
+        assert sorted(decision.extra_indices) == [1, 2, 3]
+
+    def test_long_low_bitrate_bonus_is_extra(self):
+        """100min feature + 90min low-bitrate making-of → bonus is an extra, no review."""
+        titles = [
+            _title(0, 100, 38),  # feature, high bitrate
+            _title(1, 90, 4),  # long documentary, low bitrate
+            _title(2, 5, 15),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=100)
+        assert decision.needs_review is False
+        assert decision.feature_index == 0
+        assert 1 in decision.extra_indices
+
+    def test_no_runtime_single_long_title_no_review(self):
+        """Fallback (no TMDB runtime): one long title + short extras → no review."""
+        titles = [
+            _title(0, 130, 35),
+            _title(1, 8, 20),
+            _title(2, 3, 18),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=None)
+        assert decision.needs_review is False
+        assert decision.feature_index == 0
+
+    def test_runtime_wildly_off_falls_back_to_longest(self):
+        """Wrong/garbage runtime → fall back to longest eligible, no false review."""
+        titles = [
+            _title(0, 142, 36),
+            _title(1, 6, 20),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=600)
+        assert decision.needs_review is False
+        assert decision.feature_index == 0
+
+
+class TestAmbiguousFeatures:
+    def test_theatrical_plus_extended_needs_review(self):
+        """Two large near-runtime cuts → review with both as candidates."""
+        titles = [
+            _title(0, 120, 36),  # theatrical
+            _title(1, 145, 35),  # extended
+            _title(2, 6, 18),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=120)
+        assert decision.needs_review is True
+        assert sorted(decision.candidate_indices) == [0, 1]
+        assert 2 in decision.extra_indices
+
+    def test_obfuscation_identical_titles_needs_review(self):
+        """Two identical-duration high-bitrate titles → review."""
+        titles = [
+            _title(0, 107, 30),
+            _title(1, 107, 30),
+            _title(2, 4, 18),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=107)
+        assert decision.needs_review is True
+        assert sorted(decision.candidate_indices) == [0, 1]
+
+    def test_no_runtime_two_long_high_bitrate_titles_review(self):
+        """Fallback with two long, similar, high-bitrate titles → review."""
+        titles = [
+            _title(0, 118, 34),
+            _title(1, 122, 35),
+            _title(2, 5, 18),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=None)
+        assert decision.needs_review is True
+        assert sorted(decision.candidate_indices) == [0, 1]
+
+
+class TestEdgeCases:
+    def test_empty_titles(self):
+        decision = select_movie_main_feature([], runtime_minutes=120)
+        assert decision.feature_index is None
+        assert decision.needs_review is False
+
+    def test_no_long_titles_picks_longest(self):
+        """No title clears the feature floor → pick the longest, no review."""
+        titles = [
+            _title(0, 40, 20),
+            _title(1, 55, 22),
+            _title(2, 10, 18),
+        ]
+        decision = select_movie_main_feature(titles, runtime_minutes=None)
+        assert decision.needs_review is False
+        assert decision.feature_index == 1

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+from app.matcher import tmdb_client
 from app.matcher.tmdb_client import (
     _fetch_show_id_cached,
     clear_caches,
@@ -500,3 +501,45 @@ class TestVariationEdgeCases:
         queries = [call[1]["params"]["query"] for call in mock_get.call_args_list]
         # Should try with spaces instead of underscores
         assert any(" " in q and "_" not in q for q in queries)
+
+
+@pytest.mark.unit
+class TestFetchMovieRuntime:
+    """fetch_movie_runtime supplies the canonical runtime used to pick a movie's
+    main feature apart from its long bonus tracks."""
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_returns_runtime_minutes(self, mock_get):
+        mock_get.return_value = Mock(
+            status_code=200, json=lambda: {"runtime": 149}, raise_for_status=Mock()
+        )
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test_key"
+            assert tmdb_client.fetch_movie_runtime("1317288") == 149
+        assert "/movie/1317288" in mock_get.call_args[0][0]
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_zero_runtime_returns_none(self, mock_get):
+        """TMDB returns 0/None runtime when unknown — treat as no signal."""
+        mock_get.return_value = Mock(
+            status_code=200, json=lambda: {"runtime": 0}, raise_for_status=Mock()
+        )
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test_key"
+            assert tmdb_client.fetch_movie_runtime("123") is None
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_no_api_key_returns_none(self, mock_get):
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = ""
+            assert tmdb_client.fetch_movie_runtime("123") is None
+        assert mock_get.call_count == 0
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_api_error_returns_none(self, mock_get):
+        err = Mock(status_code=500)
+        err.raise_for_status = Mock(side_effect=requests.exceptions.HTTPError("500 Server Error"))
+        mock_get.return_value = err
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test_key"
+            assert tmdb_client.fetch_movie_runtime("123") is None

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -513,9 +513,7 @@ class TestFetchMovieRuntime:
         mock_get.return_value = Mock(
             status_code=200, json=lambda: {"runtime": 149}, raise_for_status=Mock()
         )
-        with patch("app.services.config_service.get_config_sync") as cfg:
-            cfg.return_value.tmdb_api_key = "test_key"
-            assert tmdb_client.fetch_movie_runtime("1317288") == 149
+        assert tmdb_client.fetch_movie_runtime("1317288", "test_key") == 149
         assert "/movie/1317288" in mock_get.call_args[0][0]
 
     @patch("app.matcher.tmdb_client.requests.get")
@@ -524,15 +522,11 @@ class TestFetchMovieRuntime:
         mock_get.return_value = Mock(
             status_code=200, json=lambda: {"runtime": 0}, raise_for_status=Mock()
         )
-        with patch("app.services.config_service.get_config_sync") as cfg:
-            cfg.return_value.tmdb_api_key = "test_key"
-            assert tmdb_client.fetch_movie_runtime("123") is None
+        assert tmdb_client.fetch_movie_runtime("123", "test_key") is None
 
     @patch("app.matcher.tmdb_client.requests.get")
     def test_no_api_key_returns_none(self, mock_get):
-        with patch("app.services.config_service.get_config_sync") as cfg:
-            cfg.return_value.tmdb_api_key = ""
-            assert tmdb_client.fetch_movie_runtime("123") is None
+        assert tmdb_client.fetch_movie_runtime("123", "") is None
         assert mock_get.call_count == 0
 
     @patch("app.matcher.tmdb_client.requests.get")
@@ -540,6 +534,4 @@ class TestFetchMovieRuntime:
         err = Mock(status_code=500)
         err.raise_for_status = Mock(side_effect=requests.exceptions.HTTPError("500 Server Error"))
         mock_get.return_value = err
-        with patch("app.services.config_service.get_config_sync") as cfg:
-            cfg.return_value.tmdb_api_key = "test_key"
-            assert tmdb_client.fetch_movie_runtime("123") is None
+        assert tmdb_client.fetch_movie_runtime("123", "test_key") is None


### PR DESCRIPTION
## Summary

A movie disc carrying long bonus tracks (e.g. **Marty Supreme**) was incorrectly marked `REVIEW_NEEDED` with *"Multiple versions ripped. Please select the correct one."* The extras were being mistaken for alternate versions of the feature.

Root cause (verified against the live job): the **post-rip movie gate** in `job_manager.py` counted every selected title as a candidate version — and since `DiscTitle.is_selected` defaults to `True`, the short/low-bitrate extras competed with the real feature. The analyst was *not* at fault here (Marty Supreme had a single title ≥80 min and classified cleanly).

This makes the gate identify the main feature using the movie's **TMDB runtime**, with a duration-proximity + bitrate fallback. Extras are tagged `is_extra`, and the disc only goes to review when **2+ titles genuinely qualify as the feature** (alternate cuts / copy-protection obfuscation playlists) — the case the flag was originally meant for.

## What changed

- `fetch_movie_runtime(movie_id)` in `matcher/tmdb_client.py` — fetches canonical runtime via `/movie/{id}`, mirroring the existing TV runtime fetcher.
- `select_movie_main_feature(titles, runtime)` in `core/analyst.py` — runtime-primary selector with a duration/bitrate fallback (bitrate separates a long low-bitrate making-of from a real cut).
- `JobManager._resolve_multi_title_movie` / `_resolve_movie_feature` — the post-rip gate now uses the selector; one feature → tag the rest as extras and organize (no review), 2+ candidates → review. The TheDiscDB `MainMovie` short-circuit is preserved.

Calibrated to the real disc: feature 149.7 min @ 38 Mbps vs. bonus 20 min @ 19 Mbps + two ~4-min extras → resolved to 1 feature + 3 extras, no review.

## Reviewer notes

- The planned pre-rip tagging and `_detect_movie` softening were **dropped** as redundant once the gate became authoritative — both failure modes (clear-movie+extras and genuine 2-feature discs) converge at that gate. Existing THE TERMINATOR analyst tests are unaffected.
- The organizer still picks the main file by largest size (`organizer.py`), which agrees with the selector for realistic discs; tightening that to use the selector's explicit choice is a possible follow-up.

## Test plan

- [x] `uv run pytest tests/unit/` → 805 passed
- [x] `uv run pytest tests/integration/ tests/pipeline/` → 181 passed (matches CI's split invocations)
- [x] `uv run ruff check` / `ruff format` clean
- [x] 16 new tests: selector decision matrix, `fetch_movie_runtime`, and the three post-rip gate branches (no-review / review / DiscDB MainMovie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)