### PR TITLE
feat(diagnostics): include MakeMKV/FFmpeg versions in bug report

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -13,7 +13,7 @@ from typing import Literal
 from urllib.parse import quote
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1369,6 +1369,7 @@ async def get_recent_logs(
 
 @router.get("/diagnostics/report")
 async def generate_bug_report(
+    request: Request,
     job_id: int | None = Query(default=None),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
@@ -1377,6 +1378,12 @@ async def generate_bug_report(
     from app.services.config_service import get_config
 
     config = await get_config()
+
+    # Tool versions are detected once at startup and cached on app.state, so the
+    # bug report never re-runs the (slow) MakeMKV probe per request. getattr keeps
+    # this resilient if startup detection was skipped or the attr is missing.
+    makemkv_version = getattr(request.app.state, "makemkv_version", None)
+    ffmpeg_version = getattr(request.app.state, "ffmpeg_version", None)
 
     # --- Job summary (optional) ---
     job_summary = None
@@ -1421,6 +1428,8 @@ async def generate_bug_report(
         "app_version": __version__,
         "python_version": sys.version.split()[0],
         "os": f"{platform.system()} {platform.release()}",
+        "makemkv_version": makemkv_version,
+        "ffmpeg_version": ffmpeg_version,
         "job": job_summary,
         "recent_errors": recent_errors,
         "config": redacted_config,
@@ -1433,6 +1442,8 @@ async def generate_bug_report(
         f"**Engram version**: {__version__}",
         f"**OS**: {report['os']}",
         f"**Python**: {report['python_version']}",
+        f"**MakeMKV**: {makemkv_version or 'not detected'}",
+        f"**FFmpeg**: {ffmpeg_version or 'not detected'}",
         "",
     ]
     if job_summary:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,6 +67,10 @@ async def lifespan(app: FastAPI):
         else:
             logger.warning(f"Configured MakeMKV path not working: {makemkv_result.error}")
 
+    # Cache the detected version so the diagnostics report can include it
+    # without re-running the (potentially slow) detection probe per request.
+    app.state.makemkv_version = makemkv_result.version if makemkv_result.found else None
+
     # Auto-detect FFmpeg if path is empty
     if not config.ffmpeg_path:
         ffmpeg_result = detect_ffmpeg()
@@ -87,6 +91,8 @@ async def lifespan(app: FastAPI):
             logger.info(f"FFmpeg validated: {ffmpeg_result.version}")
         else:
             logger.warning(f"Configured FFmpeg path not working: {ffmpeg_result.error}")
+
+    app.state.ffmpeg_version = ffmpeg_result.version if ffmpeg_result.found else None
 
     await job_manager.start()
     logger.info("Job manager started")

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -4,6 +4,8 @@ Tests the REST API endpoints including job management, configuration,
 and validation. Uses async client with in-memory DB (patched via conftest.py).
 """
 
+from urllib.parse import unquote
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -253,3 +255,39 @@ class TestErrorHandling:
         list_resp = await client.get("/api/jobs")
         job_ids = [j["id"] for j in list_resp.json()]
         assert job.id not in job_ids
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics report
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsReport:
+    """Test the bug-report/diagnostics endpoint."""
+
+    async def test_report_includes_cached_makemkv_version(self, client):
+        """The cached MakeMKV version appears in both the report dict and issue body."""
+        app.state.makemkv_version = "MakeMKV v1.18.3 win(x64-release)"
+        try:
+            response = await client.get("/api/diagnostics/report")
+        finally:
+            del app.state.makemkv_version
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["makemkv_version"] == "MakeMKV v1.18.3 win(x64-release)"
+        # The version is embedded in the pre-filled GitHub issue body (url-encoded).
+        assert "MakeMKV v1.18.3 win(x64-release)" in unquote(data["github_url"])
+
+    async def test_report_handles_missing_version(self, client):
+        """A missing cached version never breaks the report; it reads 'not detected'."""
+        # Ensure no version is cached (other tests may have left state behind).
+        if hasattr(app.state, "makemkv_version"):
+            del app.state.makemkv_version
+
+        response = await client.get("/api/diagnostics/report")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["makemkv_version"] is None
+        assert "**MakeMKV**: not detected" in unquote(data["github_url"])

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -25,6 +25,7 @@ import {
   formatDurationCoarse,
   formatDurationShort,
 } from "../utils/formatting";
+import type { DiagnosticsReport } from "../types";
 
 interface HistoryJob {
   id: number;
@@ -374,6 +375,24 @@ function JobDetailPanel({
   onClose: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const [diagnostics, setDiagnostics] = useState<DiagnosticsReport | null>(null);
+
+  // Fetch environment/tool info once the panel opens. These fields are
+  // job-independent, and tool versions are cached server-side, so the request
+  // is cheap. Failures are swallowed — the Environment section just hides.
+  useEffect(() => {
+    if (!detail) return;
+    let cancelled = false;
+    fetch("/api/diagnostics/report")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: DiagnosticsReport | null) => {
+        if (!cancelled) setDiagnostics(data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [detail]);
 
   // Close on click outside or Escape key
   useEffect(() => {
@@ -753,6 +772,24 @@ function JobDetailPanel({
                   <div style={{ display: "flex", flexDirection: "column", gap: 6, fontFamily: sv.mono, fontSize: 11 }}>
                     {detail.staging_path && <KvRow label="Staging" value={detail.staging_path} truncate />}
                     {detail.final_path && <KvRow label="Library" value={detail.final_path} truncate />}
+                  </div>
+                </SvPanel>
+              </div>
+            </div>
+          )}
+
+          {/* Environment — tool/runtime versions from the diagnostics report */}
+          {diagnostics && (
+            <div>
+              <SvLabel>Environment</SvLabel>
+              <div style={{ marginTop: 8 }}>
+                <SvPanel pad={12}>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 6, fontFamily: sv.mono, fontSize: 11 }}>
+                    <KvRow label="Engram" value={diagnostics.app_version} />
+                    <KvRow label="OS" value={diagnostics.os} />
+                    <KvRow label="Python" value={diagnostics.python_version} />
+                    <KvRow label="MakeMKV" value={diagnostics.makemkv_version ?? "not detected"} truncate />
+                    <KvRow label="FFmpeg" value={diagnostics.ffmpeg_version ?? "not detected"} truncate />
                   </div>
                 </SvPanel>
               </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -160,3 +160,12 @@ export interface Config {
     library_tv_path: string;
     tmdb_api_key: string;
 }
+
+export interface DiagnosticsReport {
+    app_version: string;
+    python_version: string;
+    os: string;
+    makemkv_version: string | null;
+    ffmpeg_version: string | null;
+    github_url: string;
+}


### PR DESCRIPTION
## Summary
- Wire the startup-detected **MakeMKV** (and **FFmpeg**) version into the diagnostics/bug-report feature so it shows up in the generated GitHub issue and the UI.
- Versions are detected once in `main.py`'s `lifespan` and cached on `app.state`, so `GET /api/diagnostics/report` reads cached values instead of re-running the (potentially slow) MakeMKV detection probe on every request.
- The report endpoint reads the cached values defensively (`getattr(..., None)`); a missing/failed value degrades to `not detected` and can never break the report.
- A new **Environment** panel in the History page job-detail slide-out surfaces Engram / OS / Python / MakeMKV / FFmpeg, fetched once from the diagnostics endpoint when the panel opens.

## Why
The MakeMKV version detector was fixed to return a real version string, but the bug-report flow didn't include it. Adding it gives maintainers the tool versions they need for triage directly in filed issues — without paying the detection cost (or risking spinning up a loaded disc) on every diagnostics request.

## Changes
- `backend/app/main.py` — cache `app.state.makemkv_version` / `app.state.ffmpeg_version` after startup detection.
- `backend/app/api/routes.py` — `generate_bug_report()` adds `makemkv_version` / `ffmpeg_version` to the report dict and `**MakeMKV**:` / `**FFmpeg**:` lines to the GitHub issue body.
- `backend/tests/unit/test_api_routes.py` — new `TestDiagnosticsReport` (cached version surfaced; missing version → `not detected`, no error).
- `frontend/src/types/index.ts` — new `DiagnosticsReport` interface.
- `frontend/src/components/HistoryPage.tsx` — Environment panel in the job detail slide-out.

## Test plan
- [x] `cd backend && uv run pytest tests/unit/ -q` → 794 passed
- [x] `cd backend && uv run ruff check .` → all checks passed
- [x] `cd frontend && npm run build` → tsc + vite build succeeded
- [ ] Manual UI check: open History → a job's detail panel → confirm the **Environment** panel renders the MakeMKV/FFmpeg versions (not done in this session; change is additive and uses existing primitives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)