### PR TITLE
feat(frontend): resilient API/WS error handling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -191,7 +191,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -583,7 +582,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -632,7 +630,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -644,7 +641,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
@@ -657,7 +653,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -975,6 +970,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1009,6 +1005,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1043,6 +1040,7 @@
             "os": [
                 "openharmony"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1961,7 +1959,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -6869,7 +6866,8 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -7017,7 +7015,6 @@
             "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
             }
@@ -7035,7 +7032,6 @@
             "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -7047,7 +7043,6 @@
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -7101,7 +7096,6 @@
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -7292,7 +7286,6 @@
             "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.7",
@@ -7410,7 +7403,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7659,7 +7651,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -7840,7 +7831,6 @@
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mdn-data": "2.27.1",
                 "source-map-js": "^1.2.1"
@@ -8028,7 +8018,6 @@
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
             "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -8140,7 +8129,8 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -8163,8 +8153,7 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/embla-carousel-react": {
             "version": "8.6.0",
@@ -8291,7 +8280,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -9124,7 +9112,6 @@
             "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
                 "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9572,6 +9559,7 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -10020,7 +10008,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
@@ -10053,6 +10040,7 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -10068,6 +10056,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -10128,7 +10117,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -10194,7 +10182,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -10230,7 +10217,8 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-popper": {
             "version": "2.3.0",
@@ -11001,7 +10989,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11138,7 +11125,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11298,7 +11284,6 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",
@@ -11374,7 +11359,6 @@
             "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.7",
                 "@vitest/mocker": "4.1.7",
@@ -11472,6 +11456,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11489,6 +11474,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11506,6 +11492,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11523,6 +11510,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11540,6 +11528,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11557,6 +11546,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11574,6 +11564,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11591,6 +11582,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11608,6 +11600,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11625,6 +11618,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11642,6 +11636,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11659,6 +11654,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11676,6 +11672,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11693,6 +11690,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11710,6 +11708,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11727,6 +11726,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11744,6 +11744,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11761,6 +11762,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11778,6 +11780,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11795,6 +11798,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11812,6 +11816,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11829,6 +11834,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -11846,6 +11852,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -12195,7 +12202,6 @@
             "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { apiFetch, apiFetchVoid, ApiError } from "../client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number; statusText?: string; text?: string } = {}) {
+  const ok = init.ok ?? true;
+  return {
+    ok,
+    status: init.status ?? (ok ? 200 : 500),
+    statusText: init.statusText ?? (ok ? "OK" : "Internal Server Error"),
+    json: async () => body,
+    text: async () => init.text ?? JSON.stringify(body),
+  } as Response;
+}
+
+describe("apiFetch", () => {
+  it("returns parsed JSON on ok response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ hello: "world" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await apiFetch<{ hello: string }>("/api/thing");
+
+    expect(result).toEqual({ hello: "world" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/thing", undefined);
+  });
+
+  it("throws ApiError with status + body on non-ok response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(null, { ok: false, status: 503, statusText: "Service Unavailable", text: "backend down" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiFetch("/api/thing")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+      body: "backend down",
+    });
+    await expect(apiFetch("/api/thing")).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("apiFetchVoid", () => {
+  it("resolves on ok response without parsing JSON", async () => {
+    const json = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: "No Content",
+      json,
+      text: async () => "",
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiFetchVoid("/api/thing", { method: "POST" })).resolves.toBeUndefined();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("throws ApiError on non-ok response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(null, { ok: false, status: 400, statusText: "Bad Request", text: "nope" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiFetchVoid("/api/thing", { method: "POST" })).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared fetch helpers.
+ *
+ * These wrap the native `fetch` so callers always get a thrown Error (with the
+ * HTTP status and any response body) on a non-2xx response, instead of silently
+ * receiving an unparsed/error payload. Dependency-free on purpose.
+ */
+
+/** Error thrown by {@link apiFetch}/{@link apiFetchVoid} for non-ok responses. */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, statusText: string, body: string) {
+    const detail = body ? `: ${body}` : "";
+    super(`Request failed (${status} ${statusText})${detail}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function request(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    // Read the body defensively — it may be empty or unreadable.
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      body = "";
+    }
+    throw new ApiError(res.status, res.statusText, body);
+  }
+  return res;
+}
+
+/**
+ * Fetch and parse a JSON response, typed as `T`.
+ * Throws {@link ApiError} when the response is not ok.
+ */
+export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const res = await request(input, init);
+  return (await res.json()) as T;
+}
+
+/**
+ * Fetch when the response body is not needed (e.g. POST/DELETE actions).
+ * Throws {@link ApiError} when the response is not ok.
+ */
+export async function apiFetchVoid(input: RequestInfo | URL, init?: RequestInit): Promise<void> {
+  await request(input, init);
+}

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -3,8 +3,14 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { toast } from 'sonner';
 import { useWebSocket } from '../../hooks/useWebSocket';
+import { apiFetch, apiFetchVoid } from '../../api/client';
 import type { Job, DiscTitle, WebSocketMessage } from '../../types';
+
+// Trailing-debounce window for refetches triggered by a burst of unknown
+// `job_update` messages, so we issue one fetch instead of N.
+const UNKNOWN_JOB_REFETCH_DEBOUNCE_MS = 400;
 
 // Title state ordering used when merging REST snapshots with WebSocket-derived
 // state. WebSocket state (e.g. "ripping") is more current than a stale REST
@@ -30,57 +36,115 @@ export function useJobManagement(devMode: boolean = false) {
     // When running on localhost:5173, connects to ws://localhost:5173/ws (proxied to backend)
     // In production, uses the same host as the frontend
     const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`;
-    const { isConnected, addMessageListener } = useWebSocket(wsUrl);
 
-    // Stable ref to fetchJobsAndTitles so the listener closure doesn't go stale
+    // Stable ref to fetchJobsAndTitles so the listener/onOpen closures don't go stale
     const fetchRef = useRef<() => Promise<void>>();
+    // Trailing-debounce timer for unknown-job refetches.
+    const debouncedRefetchRef = useRef<number | null>(null);
+    // Guards against the very first onOpen (initial connect) double-fetching,
+    // since the mount effect already performs the initial load.
+    const initialConnectRef = useRef(true);
+
+    // Merge a job's REST titles snapshot with any newer WebSocket-derived state.
+    const mergeTitles = useCallback((jobId: number, titlesData: DiscTitle[]) => {
+        setTitlesMap(prev => {
+            const existing = prev[jobId];
+            if (import.meta.env.DEV) {
+                console.log('🔄 fetchJobsAndTitles merge:', {
+                    job_id: jobId,
+                    restTitleStates: titlesData.map(t => `${t.id}:${t.state}`),
+                    existingTitleStates: existing?.map(t => `${t.id}:${t.state}`) ?? 'NONE',
+                });
+            }
+            if (!existing) {
+                return { ...prev, [jobId]: titlesData };
+            }
+            // Merge: for each title, keep the more-recent state.
+            const merged = titlesData.map(restTitle => {
+                const wsTitle = existing.find(t => t.id === restTitle.id);
+                if (!wsTitle) return restTitle;
+                const restPriority = STATE_PRIORITY[restTitle.state] ?? 0;
+                const wsPriority = STATE_PRIORITY[wsTitle.state] ?? 0;
+                // Keep whichever has the more advanced state
+                if (wsPriority > restPriority) {
+                    return { ...restTitle, ...wsTitle };
+                }
+                return restTitle;
+            });
+            return { ...prev, [jobId]: merged };
+        });
+    }, []);
 
     const fetchJobsAndTitles = useCallback(async () => {
         try {
             if (import.meta.env.DEV) {
                 console.log('🔄 fetchJobsAndTitles called');
             }
-            const jobsRes = await fetch('/api/jobs');
-            const jobsData: Job[] = await jobsRes.json();
+            const jobsData = await apiFetch<Job[]>('/api/jobs');
             setJobs(jobsData);
 
-            // Fetch titles for each job, merging with existing WebSocket state
-            for (const job of jobsData) {
-                const titlesRes = await fetch(`/api/jobs/${job.id}/titles`);
-                const titlesData: DiscTitle[] = await titlesRes.json();
-                setTitlesMap(prev => {
-                    const existing = prev[job.id];
-                    if (import.meta.env.DEV) {
-                        console.log('🔄 fetchJobsAndTitles merge:', {
-                            job_id: job.id,
-                            restTitleStates: titlesData.map(t => `${t.id}:${t.state}`),
-                            existingTitleStates: existing?.map(t => `${t.id}:${t.state}`) ?? 'NONE',
-                        });
-                    }
-                    if (!existing) {
-                        return { ...prev, [job.id]: titlesData };
-                    }
-                    // Merge: for each title, keep the more-recent state.
-                    const merged = titlesData.map(restTitle => {
-                        const wsTitle = existing.find(t => t.id === restTitle.id);
-                        if (!wsTitle) return restTitle;
-                        const restPriority = STATE_PRIORITY[restTitle.state] ?? 0;
-                        const wsPriority = STATE_PRIORITY[wsTitle.state] ?? 0;
-                        // Keep whichever has the more advanced state
-                        if (wsPriority > restPriority) {
-                            return { ...restTitle, ...wsTitle };
-                        }
-                        return restTitle;
-                    });
-                    return { ...prev, [job.id]: merged };
-                });
+            // Fetch titles for all jobs in parallel; merge each as it resolves.
+            const results = await Promise.allSettled(
+                jobsData.map(async (job) => {
+                    const titlesData = await apiFetch<DiscTitle[]>(`/api/jobs/${job.id}/titles`);
+                    return { jobId: job.id, titlesData };
+                }),
+            );
+
+            let failures = 0;
+            for (const result of results) {
+                if (result.status === 'fulfilled') {
+                    mergeTitles(result.value.jobId, result.value.titlesData);
+                } else {
+                    failures += 1;
+                    console.error('Failed to fetch job titles:', result.reason);
+                }
+            }
+            if (failures > 0) {
+                toast.error(
+                    `Couldn't load tracks for ${failures} job${failures === 1 ? '' : 's'}. Some details may be missing.`,
+                );
             }
         } catch (error) {
+            // Top-level failure (job list itself) — surface it; leave state intact.
             console.error('Failed to fetch jobs:', error);
+            toast.error('Failed to load jobs from the server. Retrying on the next update.');
         }
-    }, []);
+    }, [mergeTitles]);
 
     fetchRef.current = fetchJobsAndTitles;
+
+    const scheduleUnknownJobRefetch = useCallback(() => {
+        if (debouncedRefetchRef.current !== null) {
+            window.clearTimeout(debouncedRefetchRef.current);
+        }
+        debouncedRefetchRef.current = window.setTimeout(() => {
+            debouncedRefetchRef.current = null;
+            fetchRef.current?.();
+        }, UNKNOWN_JOB_REFETCH_DEBOUNCE_MS);
+    }, []);
+
+    // Resync on (re)connect so the UI recovers from any drift while disconnected.
+    const handleSocketOpen = useCallback(() => {
+        if (initialConnectRef.current) {
+            // The mount effect already performs the first load; skip it here.
+            initialConnectRef.current = false;
+            return;
+        }
+        if (import.meta.env.DEV) {
+            console.log('🔌 WebSocket reconnected — resyncing jobs');
+        }
+        fetchRef.current?.();
+    }, []);
+
+    const { isConnected, addMessageListener } = useWebSocket(wsUrl, { onOpen: handleSocketOpen });
+
+    // Clean up the debounce timer on unmount.
+    useEffect(() => () => {
+        if (debouncedRefetchRef.current !== null) {
+            window.clearTimeout(debouncedRefetchRef.current);
+        }
+    }, []);
 
     // Initial data fetch
     useEffect(() => {
@@ -91,23 +155,27 @@ export function useJobManagement(devMode: boolean = false) {
 
     async function cancelJob(jobId: string) {
         try {
-            await fetch(`/api/jobs/${jobId}/cancel`, { method: 'POST' });
+            await apiFetchVoid(`/api/jobs/${jobId}/cancel`, { method: 'POST' });
             // Job will update via WebSocket
         } catch (error) {
             console.error('Failed to cancel job:', error);
+            toast.error('Failed to cancel the job. Please try again.');
         }
     }
 
     async function clearCompleted() {
         try {
             const completedJobs = jobs.filter(j => j.state === 'completed');
-            for (const job of completedJobs) {
-                await fetch(`/api/jobs/${job.id}`, { method: 'DELETE' });
-            }
+            await Promise.all(
+                completedJobs.map(job =>
+                    apiFetchVoid(`/api/jobs/${job.id}`, { method: 'DELETE' }),
+                ),
+            );
             // Refresh jobs
             await fetchJobsAndTitles();
         } catch (error) {
             console.error('Failed to clear completed jobs:', error);
+            toast.error('Failed to clear completed jobs. Please try again.');
         }
     }
 
@@ -118,7 +186,7 @@ export function useJobManagement(devMode: boolean = false) {
         season?: number,
     ) {
         try {
-            await fetch(`/api/jobs/${jobId}/set-name`, {
+            await apiFetchVoid(`/api/jobs/${jobId}/set-name`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ name, content_type: contentType, season: season ?? null }),
@@ -126,6 +194,7 @@ export function useJobManagement(devMode: boolean = false) {
             // Job will update via WebSocket
         } catch (error) {
             console.error('Failed to set job name:', error);
+            toast.error('Failed to save the disc name. Please try again.');
         }
     }
 
@@ -137,7 +206,7 @@ export function useJobManagement(devMode: boolean = false) {
         tmdbId?: number,
     ) {
         try {
-            await fetch(`/api/jobs/${jobId}/re-identify`, {
+            await apiFetchVoid(`/api/jobs/${jobId}/re-identify`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -150,6 +219,7 @@ export function useJobManagement(devMode: boolean = false) {
             // Job will update via WebSocket
         } catch (error) {
             console.error('Failed to re-identify job:', error);
+            toast.error('Failed to re-identify the disc. Please try again.');
         }
     }
 
@@ -167,8 +237,9 @@ export function useJobManagement(devMode: boolean = false) {
                                 job.id === message.job_id ? { ...job, ...message } : job
                             );
                         }
-                        // Unknown job — trigger a fetch
-                        fetchRef.current?.();
+                        // Unknown job — trigger a (debounced) fetch so a burst
+                        // of unknown updates collapses into a single refetch.
+                        scheduleUnknownJobRefetch();
                         return prev;
                     });
                     break;
@@ -277,7 +348,7 @@ export function useJobManagement(devMode: boolean = false) {
         });
 
         return unsubscribe;
-    }, [addMessageListener, devMode]);
+    }, [addMessageListener, devMode, scheduleUnknownJobRefetch]);
 
     return {
         jobs,

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
 import { FEATURES } from '../config/constants';
 import './ConfigWizard.css';
 
@@ -282,7 +283,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
             onComplete();
         } catch (error) {
             console.error('Failed to save config:', error);
-            alert(`Failed to save configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            toast.error(`Failed to save configuration: ${error instanceof Error ? error.message : 'Unknown error'}`);
         } finally {
             setIsSaving(false);
         }

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import { motion, AnimatePresence } from "motion/react";
+import { apiFetch } from "../api/client";
 import {
   CheckCircle2,
   XCircle,
@@ -974,10 +976,12 @@ export default function HistoryPage() {
   const perPage = 20;
 
   useEffect(() => {
-    fetch("/api/jobs/stats")
-      .then((r) => r.json())
+    apiFetch<Stats>("/api/jobs/stats")
       .then(setStats)
-      .catch(() => {});
+      .catch((error) => {
+        console.error("Failed to load history stats:", error);
+        toast.error("Failed to load history statistics.");
+      });
   }, []);
 
   const fetchHistory = useCallback(() => {
@@ -988,13 +992,15 @@ export default function HistoryPage() {
     if (filterType) params.set("content_type", filterType);
     if (filterState) params.set("state", filterState);
 
-    fetch(`/api/jobs/history?${params}`)
-      .then((r) => r.json())
+    apiFetch<HistoryJob[]>(`/api/jobs/history?${params}`)
       .then((data: HistoryJob[]) => {
         setHistory(data);
         setHasMore(data.length === perPage);
       })
-      .catch(() => {});
+      .catch((error) => {
+        console.error("Failed to load job history:", error);
+        toast.error("Failed to load job history.");
+      });
   }, [page, filterType, filterState]);
 
   useEffect(() => {
@@ -1008,16 +1014,14 @@ export default function HistoryPage() {
       return;
     }
     setDetailLoading(true);
-    fetch(`/api/jobs/${selectedJobId}/detail`)
-      .then((r) => {
-        if (!r.ok) throw new Error("Not found");
-        return r.json();
-      })
+    apiFetch<JobDetail>(`/api/jobs/${selectedJobId}/detail`)
       .then((data: JobDetail) => {
         setJobDetail(data);
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("Failed to load job detail:", error);
         setJobDetail(null);
+        toast.error("Failed to load job details.");
       })
       .finally(() => {
         setDetailLoading(false);

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -30,8 +30,12 @@ export const MATCHING_CONFIG = {
  * UI behavior and timing configuration
  */
 export const UI_CONFIG = {
-  /** WebSocket reconnect delay in milliseconds */
+  /** WebSocket reconnect delay in milliseconds (legacy fixed delay; superseded by backoff) */
   WEBSOCKET_RECONNECT_DELAY_MS: 3000,
+  /** Initial WebSocket reconnect backoff delay in milliseconds */
+  WEBSOCKET_RECONNECT_BASE_DELAY_MS: 1000,
+  /** Maximum WebSocket reconnect backoff delay in milliseconds */
+  WEBSOCKET_RECONNECT_MAX_DELAY_MS: 30000,
   /** Delay before retrying poster fetch in milliseconds */
   POSTER_FETCH_RETRY_DELAY_MS: 2000,
   /** Maximum number of poster fetch retries */

--- a/frontend/src/hooks/__tests__/useJobManagement.test.ts
+++ b/frontend/src/hooks/__tests__/useJobManagement.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type {
   Job,
   DiscTitle,
@@ -6,7 +7,44 @@ import type {
   TitleUpdate,
   TitlesDiscovered,
   SubtitleEvent,
+  WebSocketMessage,
 } from "../../types";
+
+// ---------------------------------------------------------------------------
+// Mocks for the hook-level integration tests below.
+// useWebSocket is mocked so we can drive onOpen / message listeners manually,
+// and toast is mocked so we can assert error surfacing without a DOM portal.
+// ---------------------------------------------------------------------------
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
+}));
+
+let capturedOnOpen: (() => void) | undefined;
+let capturedListener: ((msg: WebSocketMessage) => void) | undefined;
+
+vi.mock("../useWebSocket", () => ({
+  useWebSocket: (
+    _url: string,
+    options?: { onOpen?: () => void },
+  ) => {
+    capturedOnOpen = options?.onOpen;
+    return {
+      isConnected: true,
+      sendMessage: vi.fn(),
+      addMessageListener: (listener: (msg: WebSocketMessage) => void) => {
+        capturedListener = listener;
+        return () => {
+          capturedListener = undefined;
+        };
+      },
+    };
+  },
+}));
+
+// Imported after the mocks so the hook picks up the mocked useWebSocket.
+import { useJobManagement } from "../../app/hooks/useJobManagement";
 
 /**
  * Tests for the job management logic extracted from useJobManagement.
@@ -252,5 +290,100 @@ describe("subtitle_event merging", () => {
     expect(result[0].subtitles_failed).toBe(1);
     // Job 2 unchanged
     expect(result[1].subtitle_status).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook integration tests: fetch error surfacing + reconnect resync.
+// These exercise the real useJobManagement hook with a stubbed fetch and a
+// mocked useWebSocket.
+// ---------------------------------------------------------------------------
+
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function errResponse(status = 500): Response {
+  return {
+    ok: false,
+    status,
+    statusText: "Server Error",
+    json: async () => ({}),
+    text: async () => "boom",
+  } as Response;
+}
+
+describe("useJobManagement hook integration", () => {
+  beforeEach(() => {
+    toastErrorMock.mockClear();
+    capturedOnOpen = undefined;
+    capturedListener = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces an error and does not corrupt state when /api/jobs is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(errResponse(503));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useJobManagement(false));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+
+    // State stays a valid empty list — never corrupted by the failed fetch.
+    expect(result.current.jobs).toEqual([]);
+    expect(result.current.titlesMap).toEqual({});
+  });
+
+  it("re-runs fetchJobsAndTitles on reconnect (onOpen) to resync", async () => {
+    const job = makeJob(1);
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const urlStr = String(input);
+      if (urlStr.endsWith("/api/jobs")) return Promise.resolve(okJson([job]));
+      if (urlStr.includes("/titles")) return Promise.resolve(okJson([]));
+      return Promise.resolve(okJson([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useJobManagement(false));
+
+    // Initial mount fetch resolves.
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(1);
+    });
+
+    const jobsCallsAfterMount = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).endsWith("/api/jobs"),
+    ).length;
+
+    // The very first onOpen is the initial connect and is intentionally skipped;
+    // a SECOND onOpen represents a reconnect and must trigger a resync.
+    expect(typeof capturedOnOpen).toBe("function");
+    act(() => {
+      capturedOnOpen?.(); // initial connect (skipped)
+    });
+    act(() => {
+      capturedOnOpen?.(); // reconnect (should resync)
+    });
+
+    await waitFor(() => {
+      const jobsCallsNow = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).endsWith("/api/jobs"),
+      ).length;
+      expect(jobsCallsNow).toBeGreaterThan(jobsCallsAfterMount);
+    });
+
+    // Sanity: the listener was registered so WS messages would be handled.
+    expect(typeof capturedListener).toBe("function");
   });
 });

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -4,17 +4,43 @@ import { UI_CONFIG } from '../config/constants';
 
 type MessageListener = (msg: WebSocketMessage) => void;
 
+interface UseWebSocketOptions {
+    /**
+     * Called every time the socket (re)connects successfully. Use this to
+     * resync state that may have drifted while disconnected.
+     */
+    onOpen?: () => void;
+}
+
 interface UseWebSocketReturn {
     isConnected: boolean;
     sendMessage: (message: string) => void;
     addMessageListener: (listener: MessageListener) => () => void;
 }
 
-export function useWebSocket(url: string): UseWebSocketReturn {
+export function useWebSocket(url: string, options: UseWebSocketOptions = {}): UseWebSocketReturn {
     const [isConnected, setIsConnected] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
     const reconnectTimeoutRef = useRef<number | null>(null);
     const listenersRef = useRef<Set<MessageListener>>(new Set());
+    // Current backoff delay; grows on each failed/closed connection, resets on open.
+    const backoffRef = useRef<number>(UI_CONFIG.WEBSOCKET_RECONNECT_BASE_DELAY_MS);
+    // Keep the latest onOpen callback without re-creating `connect` (avoids reconnect storms).
+    const onOpenRef = useRef<(() => void) | undefined>(options.onOpen);
+    onOpenRef.current = options.onOpen;
+
+    const scheduleReconnect = useCallback((connect: () => void) => {
+        const delay = backoffRef.current;
+        // Exponential backoff, capped.
+        backoffRef.current = Math.min(
+            backoffRef.current * 2,
+            UI_CONFIG.WEBSOCKET_RECONNECT_MAX_DELAY_MS,
+        );
+        reconnectTimeoutRef.current = window.setTimeout(() => {
+            console.log(`Attempting to reconnect (next backoff ${backoffRef.current}ms)...`);
+            connect();
+        }, delay);
+    }, []);
 
     const connect = useCallback(() => {
         try {
@@ -22,18 +48,16 @@ export function useWebSocket(url: string): UseWebSocketReturn {
 
             ws.onopen = () => {
                 console.log('WebSocket connected');
+                // Reset backoff on a successful connection.
+                backoffRef.current = UI_CONFIG.WEBSOCKET_RECONNECT_BASE_DELAY_MS;
                 setIsConnected(true);
+                onOpenRef.current?.();
             };
 
             ws.onclose = () => {
                 console.log('WebSocket disconnected');
                 setIsConnected(false);
-
-                // Reconnect after configured delay
-                reconnectTimeoutRef.current = window.setTimeout(() => {
-                    console.log('Attempting to reconnect...');
-                    connect();
-                }, UI_CONFIG.WEBSOCKET_RECONNECT_DELAY_MS);
+                scheduleReconnect(connect);
             };
 
             ws.onerror = (error) => {
@@ -53,8 +77,10 @@ export function useWebSocket(url: string): UseWebSocketReturn {
             wsRef.current = ws;
         } catch (error) {
             console.error('Failed to connect WebSocket:', error);
+            // Couldn't even construct the socket — retry with backoff.
+            scheduleReconnect(connect);
         }
-    }, [url]);
+    }, [url, scheduleReconnect]);
 
     useEffect(() => {
         connect();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { MotionConfig } from "motion/react";
 import { BrowserRouter } from "react-router-dom";
+import { Toaster } from "sonner";
 import App from "./app/App.tsx";
 import "./styles/index.css";
 
@@ -45,6 +46,7 @@ createRoot(document.getElementById("root")!).render(
         <ErrorBoundary>
           <App />
         </ErrorBoundary>
+        <Toaster theme="dark" position="bottom-right" richColors closeButton />
       </BrowserRouter>
     </MotionConfig>
   </StrictMode>


### PR DESCRIPTION
## Summary

Workstream C of the stability plan: make the frontend surface backend/WebSocket failures instead of silently corrupting or hiding UI state.

- **Shared fetch helper** (`frontend/src/api/client.ts`): dependency-free `apiFetch<T>`/`apiFetchVoid` that throw an `ApiError` (with HTTP status + body) on non-ok responses, instead of returning unchecked payloads.
- **Surface errors via toasts** (`sonner`): mounted `<Toaster />` in `main.tsx`. `useJobManagement`, `HistoryPage` (three former `.catch(() => {})` swallow sites), and `ConfigWizard` (former `alert(...)`) now route through `apiFetch` and show `toast.error(...)` on failure.
- **Parallelized titles fetch**: per-job `/titles` calls now run via `Promise.allSettled` instead of a sequential loop; individual failures are tolerated, surfaced, and never corrupt state.
- **Debounced refetch**: a burst of unknown `job_update` messages now collapses into a single trailing-debounced (400ms) refetch.
- **WebSocket exponential backoff + reconnect resync** (`useWebSocket.ts`): replaced the fixed 3000ms reconnect with exponential backoff (1s base, 30s cap, reset on successful open) and added an `onOpen` callback. `useJobManagement` subscribes and re-runs `fetchJobsAndTitles` on reconnect (skipping the initial connect, which the mount effect already handles).
- **Tests**: new `api/client` tests (ok + !ok paths for both helpers); extended `useJobManagement` tests to mock `useWebSocket`/`sonner` and stub `fetch`, covering (a) a non-ok response surfaces an error without corrupting state and (b) reconnect triggers a resync fetch.

## Backoff parameters

- Base delay: 1000ms (`WEBSOCKET_RECONNECT_BASE_DELAY_MS`)
- Cap: 30000ms (`WEBSOCKET_RECONNECT_MAX_DELAY_MS`)
- Doubles each failed attempt; resets to base on successful open.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` (tsc + vite) passes
- [x] `npm run test:unit` passes (79 tests)
- [ ] Playwright e2e — NOT run here (requires a live backend); needs manual verification.

https://claude.ai/code/session_01JZ7GhDc8CNhPopFAj6FozP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ7GhDc8CNhPopFAj6FozP)_