### PR TITLE
fix(extractor): drain MakeMKV subprocesses on shutdown + matching lifecycle fixes

### DIFF
--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -57,6 +57,33 @@ def _safe_callback(cb: Callable, *args, label: str) -> None:
         logger.exception(f"Error in {label}: {e}")
 
 
+def _terminate_proc(proc: subprocess.Popen, timeout: float = 5.0, *, label: str = "") -> None:
+    """Terminate a subprocess, escalating to SIGKILL if it ignores SIGTERM.
+
+    Blocking (calls ``proc.wait``) — run via ``asyncio.to_thread`` from async
+    callers so the event loop is never blocked. Guarantees a hung makemkvcon
+    cannot be left orphaned.
+    """
+    name = label or f"pid {proc.pid}"
+    try:
+        proc.terminate()
+    except (ProcessLookupError, PermissionError) as e:
+        logger.debug(f"terminate() failed for {name}: {e}")
+        return
+    try:
+        proc.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning(f"Process {name} did not exit within {timeout}s; sending SIGKILL")
+    try:
+        proc.kill()
+        proc.wait(timeout=timeout)
+    except (ProcessLookupError, PermissionError) as e:
+        logger.debug(f"kill() failed for {name}: {e}")
+    except subprocess.TimeoutExpired:
+        logger.error(f"Process {name} survived SIGKILL after {timeout}s")
+
+
 @dataclass
 class RipProgress:
     """Progress information during ripping."""
@@ -793,6 +820,29 @@ class MakeMKVExtractor:
                 proc.terminate()
             except (ProcessLookupError, PermissionError) as e:
                 logger.debug(f"Could not terminate MakeMKV process for job {job_id}: {e}")
+
+    async def shutdown(self, grace: float = 5.0) -> None:
+        """Drain all tracked MakeMKV subprocesses on server shutdown.
+
+        Marks every active job cancelled, then terminates (escalating to SIGKILL)
+        each subprocess off the event loop so no makemkvcon survives shutdown.
+        """
+        # Snapshot first: the rip thread's finally-block pops from _processes
+        # concurrently, and its .pop(..., None) already tolerates a missing key.
+        procs = list(self._processes.items())
+        if not procs:
+            return
+        logger.info(f"Draining {len(procs)} MakeMKV subprocess(es) on shutdown")
+        for job_id, _ in procs:
+            self._cancelled_jobs.add(job_id)
+        await asyncio.gather(
+            *(
+                asyncio.to_thread(_terminate_proc, proc, grace, label=f"job {job_id}")
+                for job_id, proc in procs
+            )
+        )
+        self._processes.clear()
+        self._cancelled_jobs.clear()
 
     def _parse_disc_info(self, output: str) -> tuple[list[TitleInfo], str]:
         """Parse MakeMKV robot-mode output to extract title information and disc name.

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -209,6 +209,10 @@ class JobManager:
             logger.info(f"Cancelled job {job_id}")
 
         self._active_jobs.clear()
+
+        # Drain any MakeMKV subprocesses so none survive shutdown as orphans.
+        await self._extractor.shutdown()
+
         logger.info("Job manager stopped")
 
     # --- Drive/Staging Event Handlers ---

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -67,6 +67,10 @@ class MatchingCoordinator:
         """
         self._episode_runtimes.pop(job_id, None)
         self._discdb_mappings.pop(job_id, None)
+        self._subtitle_ready.pop(job_id, None)
+        task = self._subtitle_tasks.pop(job_id, None)
+        if task is not None and not task.done():
+            task.cancel()
 
     def get_discdb_mappings(self, job_id: int) -> list:
         """Get DiscDB mappings for a job."""
@@ -559,7 +563,17 @@ class MatchingCoordinator:
                             match_progress=percent,
                             match_details=details,
                         )
-                        asyncio.run_coroutine_threadsafe(coro, loop)
+                        fut = asyncio.run_coroutine_threadsafe(coro, loop)
+
+                        def _log_broadcast_error(f) -> None:
+                            try:
+                                f.result()
+                            except Exception as exc:
+                                logger.warning(
+                                    f"[MATCH] Title {title_id}: progress broadcast failed: {exc}"
+                                )
+
+                        fut.add_done_callback(_log_broadcast_error)
                     except Exception as e:
                         logger.warning(f"[MATCH] Title {title_id}: progress callback error: {e}")
 

--- a/backend/tests/unit/test_extractor_shutdown.py
+++ b/backend/tests/unit/test_extractor_shutdown.py
@@ -1,0 +1,81 @@
+"""Tests for MakeMKV subprocess lifecycle: terminate/kill escalation and shutdown drain.
+
+Guards against orphaned makemkvcon processes — the #1 documented operational
+hazard. No real subprocesses are spawned; processes are MagicMock stand-ins.
+"""
+
+import subprocess
+from unittest.mock import MagicMock
+
+from app.core.extractor import MakeMKVExtractor, _terminate_proc
+
+
+def _fake_proc(pid: int = 1234) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = pid
+    proc.wait.return_value = 0
+    return proc
+
+
+class TestTerminateProc:
+    def test_graceful_exit_does_not_kill(self):
+        proc = _fake_proc()
+        _terminate_proc(proc, timeout=0.01)
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once()
+        proc.kill.assert_not_called()
+
+    def test_escalates_to_kill_on_timeout(self):
+        proc = _fake_proc()
+        # First wait (after terminate) times out; second wait (after kill) returns.
+        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="makemkvcon", timeout=0.01), 0]
+        _terminate_proc(proc, timeout=0.01)
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+
+    def test_already_dead_process_is_swallowed(self):
+        proc = _fake_proc()
+        proc.terminate.side_effect = ProcessLookupError()
+        _terminate_proc(proc, timeout=0.01)  # must not raise
+        proc.kill.assert_not_called()
+
+
+class TestExtractorShutdown:
+    async def test_drains_all_processes_with_escalation(self):
+        extractor = MakeMKVExtractor()
+        graceful = _fake_proc(pid=1)
+        stubborn = _fake_proc(pid=2)
+        stubborn.wait.side_effect = [subprocess.TimeoutExpired(cmd="x", timeout=0.01), 0]
+        extractor._processes = {1: graceful, 2: stubborn}
+
+        await extractor.shutdown(grace=0.01)
+
+        graceful.terminate.assert_called_once()
+        graceful.kill.assert_not_called()
+        stubborn.terminate.assert_called_once()
+        stubborn.kill.assert_called_once()
+        assert extractor._processes == {}
+        assert extractor._cancelled_jobs == set()
+
+    async def test_no_processes_is_noop(self):
+        extractor = MakeMKVExtractor()
+        await extractor.shutdown(grace=0.01)  # must not raise
+        assert extractor._processes == {}
+
+
+class TestCancelIsNonBlocking:
+    def test_cancel_flags_and_terminates_without_waiting(self):
+        extractor = MakeMKVExtractor()
+        proc = _fake_proc()
+        extractor._processes = {7: proc}
+        extractor.cancel(7)
+        assert 7 in extractor._cancelled_jobs
+        proc.terminate.assert_called_once()
+        proc.wait.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_cancel_unknown_job_is_safe(self):
+        extractor = MakeMKVExtractor()
+        extractor.cancel(999)  # must not raise
+        assert 999 in extractor._cancelled_jobs

--- a/backend/tests/unit/test_matching_coordinator_lifecycle.py
+++ b/backend/tests/unit/test_matching_coordinator_lifecycle.py
@@ -1,0 +1,56 @@
+"""Tests for MatchingCoordinator per-job cache lifecycle (leak prevention)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.matching_coordinator import MatchingCoordinator
+
+
+def _coordinator() -> MatchingCoordinator:
+    return MatchingCoordinator(MagicMock(), MagicMock())
+
+
+class TestClearJobCaches:
+    async def test_clears_all_per_job_state_and_cancels_subtitle_task(self):
+        mc = _coordinator()
+        job_id = 5
+        mc._episode_runtimes[job_id] = [1, 2]
+        mc._discdb_mappings[job_id] = ["mapping"]
+        mc._subtitle_ready[job_id] = asyncio.Event()
+
+        async def _never():
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_never())
+        mc._subtitle_tasks[job_id] = task
+
+        await mc.clear_job_caches(job_id, None)
+
+        assert job_id not in mc._episode_runtimes
+        assert job_id not in mc._discdb_mappings
+        assert job_id not in mc._subtitle_ready
+        assert job_id not in mc._subtitle_tasks
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_unknown_job_is_safe(self):
+        mc = _coordinator()
+        await mc.clear_job_caches(999, None)  # must not raise
+
+    async def test_completed_subtitle_task_not_recancelled(self):
+        mc = _coordinator()
+        job_id = 7
+
+        async def _done():
+            return None
+
+        task = asyncio.create_task(_done())
+        await task
+        mc._subtitle_tasks[job_id] = task
+
+        await mc.clear_job_caches(job_id, None)
+        assert job_id not in mc._subtitle_tasks
+        assert not task.cancelled()


### PR DESCRIPTION
## Summary

Workstream **A** (P0 backend stability) of the stabilization roadmap (analysis in #179). Closes the highest-priority operational hazards around process and async lifecycle.

- **Orphaned `makemkvcon` drain (A1)** — the #1 documented hazard (orphans cause duplicate jobs + drive conflicts). Adds `_terminate_proc` (`terminate → wait(timeout) → kill` escalation) and an async `MakeMKVExtractor.shutdown()` that drains all tracked subprocesses **off the event loop** (`asyncio.to_thread`). Wired into `JobManager.stop()`, which the FastAPI lifespan already calls on shutdown. `cancel()` stays non-blocking.
- **Subtitle cache leak (A3)** — `MatchingCoordinator.clear_job_caches` now also clears `_subtitle_ready` and cancels/pops `_subtitle_tasks` on terminal states.
- **Silent broadcast errors (A4)** — the matching progress `run_coroutine_threadsafe` future is now tracked with a done-callback that logs failures instead of dropping them.

New unit tests cover the kill escalation, the shutdown drain (incl. a stubborn process that ignores SIGTERM), the non-blocking `cancel`, and the cache-clear lifecycle. Full backend unit suite: **817 passed** (807 baseline + 10 new); ruff clean.

## Deliberately deferred — A2 (long-held DB session)

The audit's A2 finding is real: the `async with async_session()` in `_run_ripping` (job_manager.py:~707) wraps the **entire** multi-hour rip, holding an aiosqlite connection and risking `SQLITE_BUSY` under concurrent multi-drive jobs. The fix is a ~525-line restructure (scope the setup session, capture scalars as locals, re-fetch the job in fresh sessions for each post-rip transition, route the `except` handlers through a `_fail_job` helper to avoid `DetachedInstanceError`).

`_run_ripping` has **no automated coverage of the real rip path** (it drives real `makemkvcon`; simulation uses a separate path), so a restructure that large can't be safely verified in CI alone. Splitting it into its own PR with hardware verification — tracked as a follow-up — rather than bundling a high-blast-radius change here.

## Test plan
- [x] `uv run pytest tests/unit` — 817 passed
- [x] `uv run ruff check . && ruff format --check` — clean
- [ ] Manual (real disc): start a rip, kill the backend, confirm `ps` shows no orphan `makemkvcon`
- [ ] Manual: cancel a job mid-rip, confirm clean termination

https://claude.ai/code/session_01JZ7GhDc8CNhPopFAj6FozP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ7GhDc8CNhPopFAj6FozP)_