### PR TITLE
Improve backend test coverage + close CI coverage blind spots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,16 +74,22 @@ jobs:
         run: |
           set -o pipefail
           uv run pytest tests/unit/ -v --tb=short \
-            --cov=app --cov-report=xml --cov-report=term \
+            --cov=app --cov-report=term \
             -m "not requires_audio" 2>&1 | tee pytest-unit-output.txt
         env:
           DEBUG: "true"
-      - name: Upload coverage artifact
+      # Stash the raw coverage data (Linux only) so the backend-coverage job can
+      # combine it with the integration run for a full-suite coverage gate.
+      - name: Stash coverage data
+        if: matrix.os == 'ubuntu-latest'
+        run: mv .coverage .coverage.unit
+      - name: Upload coverage data
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7
         with:
-          name: backend-coverage
-          path: backend/coverage.xml
+          name: coverage-data-unit
+          path: backend/.coverage.unit
+          include-hidden-files: true
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v7
@@ -118,15 +124,69 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          uv run pytest tests/integration/ tests/pipeline/ -v --tb=long 2>&1 | tee pytest-integration-output.txt
+          uv run pytest tests/integration/ tests/pipeline/ -v --tb=long \
+            --cov=app --cov-report=term 2>&1 | tee pytest-integration-output.txt
         env:
           DEBUG: "true"
+      - name: Stash coverage data
+        run: mv .coverage .coverage.integration
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-data-integration
+          path: backend/.coverage.integration
+          include-hidden-files: true
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: pytest-integration-output
           path: backend/pytest-integration-output.txt
+
+  backend-coverage:
+    name: Backend Coverage
+    runs-on: ubuntu-latest
+    needs: [backend-test-unit, backend-test-integration]
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "backend/uv.lock"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - run: uv sync --no-install-project
+      # Both artifacts hold a single `.coverage.*` file; dropping them in the
+      # working dir lets `coverage combine` merge unit + integration + pipeline.
+      - name: Download unit coverage data
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-data-unit
+          path: backend
+      - name: Download integration coverage data
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage-data-integration
+          path: backend
+      # Floor is set ~2pts below the measured full-suite line rate. It lives here
+      # (not in pyproject's [coverage.report] fail_under) so that local subset
+      # runs like `pytest --cov=app tests/unit/test_x.py` aren't failed by it.
+      - name: Combine coverage and enforce floor
+        run: |
+          uv run coverage combine
+          uv run coverage report --show-missing --fail-under=58
+          uv run coverage xml
+      - name: Upload combined coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: backend-coverage
+          path: backend/coverage.xml
 
   backend-smoke:
     name: Backend Smoke Test

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -75,7 +75,14 @@ quote-style = "double"
 source = ["app"]
 branch = true
 omit = [
-    "app/matcher/*",
+    # Investigation/evaluation scripts — not part of the runtime pipeline.
+    "app/matcher/scripts/*",
+    # ASR / model-registry modules require audio libs + downloaded ML models,
+    # which CI cannot exercise (it runs `-m "not requires_audio"`). Measuring
+    # them would peg the floor to code the test suite can never reach.
+    "app/matcher/asr_models.py",
+    "app/matcher/asr_provider.py",
+    "app/matcher/model_registry.py",
     "tests/*",
 ]
 

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -1,0 +1,281 @@
+"""Unit tests for EpisodeCurator (matcher integration glue).
+
+The audio matcher itself is stubbed; these tests cover the filename-fallback
+helpers, confidence-threshold routing, lazy initialization branches, and the
+batch driver.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.core.curator import EpisodeCurator, MatchResult
+
+
+@pytest.mark.unit
+class TestParseEpisodeFromFilename:
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("Show.S01E03.mkv", "S01E03"),
+            ("Show S1E3.mkv", "S01E03"),
+            ("Show.1x05.mkv", "S01E05"),
+            ("Season 2 Episode 4.mkv", "S02E04"),
+            ("random_movie.mkv", None),
+        ],
+    )
+    def test_patterns(self, name, expected):
+        assert EpisodeCurator()._parse_episode_from_filename(name) == expected
+
+
+@pytest.mark.unit
+class TestFallbackResult:
+    def test_parses_filename_with_code(self, tmp_path):
+        result = EpisodeCurator()._fallback_result(tmp_path / "Show.S02E05.mkv")
+        assert result.episode_code == "S02E05"
+        assert result.confidence == 0.3
+        assert result.needs_review is True
+
+    def test_no_code_is_zero_confidence(self, tmp_path):
+        result = EpisodeCurator()._fallback_result(tmp_path / "movie.mkv")
+        assert result.episode_code is None
+        assert result.confidence == 0.0
+
+    def test_parse_disabled_passes_details_through(self, tmp_path):
+        result = EpisodeCurator()._fallback_result(
+            tmp_path / "Show.S02E05.mkv", parse_filename=False, match_details={"k": 1}
+        )
+        assert result.episode_code is None
+        assert result.match_details == {"k": 1}
+
+
+@pytest.mark.unit
+class TestClassifyResults:
+    def test_splits_high_confidence_from_review(self, tmp_path):
+        hi = MatchResult(tmp_path / "a", "S01E01", None, 0.9, False)
+        lo = MatchResult(tmp_path / "b", "S01E02", None, 0.6, True)
+        # High score but flagged for review still goes to the review bucket.
+        flagged = MatchResult(tmp_path / "c", "S01E03", None, 0.8, True)
+
+        high, review = EpisodeCurator().classify_results([hi, lo, flagged])
+        assert high == [hi]
+        assert lo in review and flagged in review
+
+
+@pytest.mark.unit
+class TestMatchSingleFile:
+    async def test_fallback_when_matcher_unavailable(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        f = tmp_path / "Show.S01E04.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: False)
+
+        result = await curator.match_single_file(f, "Show", 1)
+        assert result.needs_review is True
+        assert result.episode_code == "S01E04"  # recovered from filename
+
+    async def test_fallback_when_no_season(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._matcher = Mock()
+        f = tmp_path / "Show.S01E04.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        result = await curator.match_single_file(f, "Show", None)
+        assert result.needs_review is True
+
+    async def test_high_confidence_match(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        mock_matcher = Mock()
+        mock_matcher.identify_episode.return_value = {
+            "season": 1,
+            "episode": 3,
+            "confidence": 0.95,
+            "match_details": {"votes": 10},
+            "runner_ups": [{"episode": "S01E04"}],
+        }
+        curator._matcher = mock_matcher
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        result = await curator.match_single_file(f, "Show", 1)
+        assert result.episode_code == "S01E03"
+        assert result.confidence == 0.95
+        assert result.needs_review is False
+        assert result.match_details["votes"] == 10
+        assert result.match_details["runner_ups"] == [{"episode": "S01E04"}]
+
+    async def test_low_confidence_match_needs_review(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        mock_matcher = Mock()
+        mock_matcher.identify_episode.return_value = {
+            "season": 1,
+            "episode": 2,
+            "confidence": 0.6,
+        }
+        curator._matcher = mock_matcher
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        result = await curator.match_single_file(f, "Show", 1)
+        assert result.episode_code == "S01E02"
+        assert result.needs_review is True
+
+    async def test_no_match_falls_back_preserving_details(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        mock_matcher = Mock()
+        mock_matcher.identify_episode.return_value = {
+            "episode": None,
+            "match_details": {"reason": "no votes"},
+        }
+        curator._matcher = mock_matcher
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        result = await curator.match_single_file(f, "Show", 1)
+        assert result.needs_review is True
+        assert result.match_details == {"reason": "no votes"}
+
+    async def test_matcher_exception_falls_back(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        f = tmp_path / "Show.S03E07.mkv"
+        f.write_text("")
+        mock_matcher = Mock()
+        mock_matcher.identify_episode.side_effect = RuntimeError("boom")
+        curator._matcher = mock_matcher
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        result = await curator.match_single_file(f, "Show", 3)
+        assert result.needs_review is True
+        assert result.episode_code == "S03E07"  # filename fallback
+
+
+@pytest.mark.unit
+class TestMatchFiles:
+    async def test_no_series_name_all_fallback(self, tmp_path):
+        files = [tmp_path / "Show.S01E01.mkv", tmp_path / "Show.S01E02.mkv"]
+        results = await EpisodeCurator().match_files(files, series_name=None)
+        assert len(results) == 2
+        assert all(r.needs_review for r in results)
+
+    async def test_matcher_unavailable_uses_fallback_and_reports_progress(
+        self, tmp_path, monkeypatch
+    ):
+        curator = EpisodeCurator()
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: False)
+        files = [tmp_path / "a.mkv", tmp_path / "b.mkv"]
+        seen: list[tuple[int, int]] = []
+
+        results = await curator.match_files(
+            files, series_name="Show", progress_callback=lambda c, t: seen.append((c, t))
+        )
+        assert len(results) == 2
+        assert seen == [(1, 2), (2, 2)]
+
+    async def test_success_path_reports_progress(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        async def fake_single(fp, series, season):
+            return MatchResult(fp, "S01E01", None, 0.9, False)
+
+        monkeypatch.setattr(curator, "match_single_file", fake_single)
+        seen: list[tuple[int, int]] = []
+
+        results = await curator.match_files(
+            [tmp_path / "a.mkv"], "Show", 1, progress_callback=lambda c, t: seen.append((c, t))
+        )
+        assert results[0].confidence == 0.9
+        assert seen == [(1, 1)]
+
+    async def test_per_file_exception_falls_back(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        async def boom(fp, series, season):
+            raise RuntimeError("x")
+
+        monkeypatch.setattr(curator, "match_single_file", boom)
+        results = await curator.match_files([tmp_path / "a.mkv"], "Show", 1)
+        assert len(results) == 1
+        assert results[0].needs_review is True
+
+
+@pytest.mark.unit
+class TestEnsureInitialized:
+    def test_short_circuit_when_show_unchanged(self):
+        curator = EpisodeCurator()
+        curator._initialized = True
+        curator._current_show = "Show"
+        curator._matcher = object()
+        assert curator._ensure_initialized("Show") is True
+
+        curator._matcher = None
+        assert curator._ensure_initialized("Show") is False
+
+    def test_init_success_resolves_canonical_name(self, tmp_path):
+        curator = EpisodeCurator()
+        with (
+            patch("app.matcher.episode_identification.EpisodeMatcher") as MockMatcher,
+            patch("app.matcher.tmdb_client.fetch_show_id", return_value=123),
+            patch(
+                "app.matcher.tmdb_client.fetch_show_details",
+                return_value={"name": "Canonical Show"},
+            ),
+            patch(
+                "app.services.config_service.get_config_sync",
+                return_value=SimpleNamespace(subtitles_cache_path=str(tmp_path / "cache")),
+            ),
+        ):
+            ok = curator._ensure_initialized("Show")
+
+        assert ok is True
+        assert curator._matcher is not None
+        _, kwargs = MockMatcher.call_args
+        assert kwargs["show_name"] == "Canonical Show"
+
+    def test_init_default_cache_when_no_config(self, tmp_path):
+        curator = EpisodeCurator()
+        with (
+            patch("app.matcher.episode_identification.EpisodeMatcher"),
+            patch("app.matcher.tmdb_client.fetch_show_id", return_value=None),
+            patch("app.services.config_service.get_config_sync", return_value=None),
+            patch("app.core.curator.Path.home", return_value=tmp_path),
+        ):
+            ok = curator._ensure_initialized("Show")
+
+        assert ok is True
+        assert curator._cache_dir == tmp_path / ".engram" / "cache"
+
+    def test_init_failure_returns_false(self, tmp_path):
+        curator = EpisodeCurator()
+        with (
+            patch(
+                "app.matcher.episode_identification.EpisodeMatcher",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("app.matcher.tmdb_client.fetch_show_id", return_value=None),
+            patch(
+                "app.services.config_service.get_config_sync",
+                return_value=SimpleNamespace(subtitles_cache_path=str(tmp_path)),
+            ),
+        ):
+            ok = curator._ensure_initialized("Show")
+
+        assert ok is False
+        assert curator._matcher is None
+
+    def test_import_error_returns_false(self):
+        curator = EpisodeCurator()
+        with patch.dict(sys.modules, {"app.matcher.episode_identification": None}):
+            ok = curator._ensure_initialized("Show")
+        assert ok is False

--- a/backend/tests/unit/test_errors.py
+++ b/backend/tests/unit/test_errors.py
@@ -1,0 +1,174 @@
+"""Unit tests for the error-handling framework (decorator + context manager).
+
+CLAUDE.md documents @handle_errors / error_context as the backbone of error
+handling, so this locks in their wrap/reraise/swallow contract.
+"""
+
+import pytest
+
+from app.core.errors import (
+    ConfigurationError,
+    DatabaseError,
+    EngramError,
+    MakeMKVError,
+    MatchingError,
+    OrganizationError,
+    SubtitleError,
+    error_context,
+    handle_errors,
+)
+
+
+@pytest.mark.unit
+class TestExceptionHierarchy:
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            MakeMKVError,
+            MatchingError,
+            ConfigurationError,
+            OrganizationError,
+            SubtitleError,
+            DatabaseError,
+        ],
+    )
+    def test_subclasses_are_engram_errors(self, exc_cls):
+        assert issubclass(exc_cls, EngramError)
+        assert isinstance(exc_cls("boom"), EngramError)
+
+
+@pytest.mark.unit
+class TestHandleErrorsSync:
+    def test_returns_value_on_success(self):
+        @handle_errors(error_types=(ValueError,), default_message="nope")
+        def add(a, b):
+            return a + b
+
+        assert add(2, 3) == 5
+
+    def test_does_not_catch_unlisted_exception(self):
+        @handle_errors(error_types=(ValueError,), default_message="nope")
+        def boom():
+            raise KeyError("unlisted")
+
+        with pytest.raises(KeyError):
+            boom()
+
+    def test_reraises_original_by_default(self):
+        @handle_errors(error_types=(ValueError,), default_message="bad input")
+        def boom():
+            raise ValueError("orig")
+
+        with pytest.raises(ValueError, match="orig"):
+            boom()
+
+    def test_wrap_as_wraps_and_chains(self):
+        @handle_errors(
+            error_types=(ValueError,),
+            default_message="bad input",
+            wrap_as=ConfigurationError,
+        )
+        def boom():
+            raise ValueError("orig")
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            boom()
+        assert "bad input: orig" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    def test_swallows_when_not_reraising_and_no_wrap(self):
+        @handle_errors(
+            error_types=(ValueError,),
+            default_message="ignored",
+            reraise=False,
+        )
+        def boom():
+            raise ValueError("orig")
+
+        assert boom() is None
+
+    def test_respects_log_level(self, caplog):
+        @handle_errors(
+            error_types=(ValueError,),
+            default_message="warned",
+            log_level="warning",
+            reraise=False,
+        )
+        def boom():
+            raise ValueError("orig")
+
+        with caplog.at_level("WARNING"):
+            boom()
+        assert any("warned: orig" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+class TestHandleErrorsAsync:
+    async def test_returns_value_on_success(self):
+        @handle_errors(error_types=(ValueError,), default_message="nope")
+        async def add(a, b):
+            return a + b
+
+        assert await add(2, 3) == 5
+
+    async def test_wrap_as_wraps_and_chains(self):
+        @handle_errors(
+            error_types=(RuntimeError,),
+            default_message="rip failed",
+            wrap_as=MakeMKVError,
+        )
+        async def boom():
+            raise RuntimeError("orig")
+
+        with pytest.raises(MakeMKVError) as exc_info:
+            await boom()
+        assert "rip failed: orig" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    async def test_swallows_when_not_reraising(self):
+        @handle_errors(
+            error_types=(RuntimeError,),
+            default_message="ignored",
+            reraise=False,
+        )
+        async def boom():
+            raise RuntimeError("orig")
+
+        assert await boom() is None
+
+    async def test_does_not_catch_unlisted(self):
+        @handle_errors(error_types=(ValueError,), default_message="nope")
+        async def boom():
+            raise KeyError("unlisted")
+
+        with pytest.raises(KeyError):
+            await boom()
+
+
+@pytest.mark.unit
+class TestErrorContext:
+    def test_noop_on_clean_exit(self):
+        with error_context(error_types=(ValueError,), default_message="x"):
+            value = 1 + 1
+        assert value == 2
+
+    def test_reraises_when_no_wrap(self):
+        with pytest.raises(ValueError, match="orig"):
+            with error_context(error_types=(ValueError,), default_message="failed"):
+                raise ValueError("orig")
+
+    def test_wrap_as_wraps_and_chains(self):
+        with pytest.raises(OrganizationError) as exc_info:
+            with error_context(
+                error_types=(FileNotFoundError,),
+                default_message="move failed",
+                wrap_as=OrganizationError,
+            ):
+                raise FileNotFoundError("missing")
+        assert "move failed: missing" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+    def test_ignores_unlisted_exception(self):
+        with pytest.raises(KeyError):
+            with error_context(error_types=(ValueError,), default_message="x"):
+                raise KeyError("unlisted")

--- a/backend/tests/unit/test_extractor.py
+++ b/backend/tests/unit/test_extractor.py
@@ -1,0 +1,333 @@
+"""Unit tests for MakeMKVExtractor pure parsing + helper functions.
+
+Covers robot-mode output parsing, duration/size/resolution parsing, drive-spec
+normalization, content-hash computation, and process bookkeeping — none of which
+require launching a real makemkvcon. The subprocess-driven scan/rip orchestration
+is left to integration tests.
+"""
+
+import hashlib
+import struct
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+
+from app.core.extractor import (
+    MakeMKVExtractor,
+    _extract_created_mkv,
+    _find_linux_mount_point,
+    _safe_callback,
+    _save_makemkv_log,
+    _to_drive_spec,
+    compute_content_hash,
+)
+
+
+def _extractor() -> MakeMKVExtractor:
+    return MakeMKVExtractor(makemkv_path=Path("/usr/bin/makemkvcon"))
+
+
+@pytest.mark.unit
+class TestToDriveSpec:
+    @pytest.mark.parametrize(
+        "drive, expected",
+        [
+            ("E:", "dev:E:"),
+            ("/dev/sr0", "dev:/dev/sr0"),
+            ("disc:0", "disc:0"),
+        ],
+    )
+    def test_normalization(self, drive, expected):
+        assert _to_drive_spec(drive) == expected
+
+
+@pytest.mark.unit
+class TestExtractCreatedMkv:
+    def test_extracts_basename_into_output_dir(self, tmp_path):
+        line = 'something created "/disc/path/Movie_t01.mkv" done'
+        assert _extract_created_mkv(line, tmp_path) == tmp_path / "Movie_t01.mkv"
+
+    def test_returns_none_without_created_keyword(self, tmp_path):
+        assert _extract_created_mkv('saved "Movie_t01.mkv"', tmp_path) is None
+
+    def test_returns_none_without_mkv(self, tmp_path):
+        assert _extract_created_mkv("created something else", tmp_path) is None
+
+    def test_returns_none_when_no_quoted_name(self, tmp_path):
+        assert _extract_created_mkv("created a .mkv but unquoted", tmp_path) is None
+
+
+@pytest.mark.unit
+class TestSafeCallback:
+    def test_invokes_callback(self):
+        cb = Mock()
+        _safe_callback(cb, 1, 2, label="x")
+        cb.assert_called_once_with(1, 2)
+
+    def test_swallows_exceptions(self):
+        cb = Mock(side_effect=ValueError("boom"))
+        # Must not raise.
+        _safe_callback(cb, label="x")
+        cb.assert_called_once()
+
+
+@pytest.mark.unit
+class TestSaveMakemkvLog:
+    def test_writes_content(self, tmp_path):
+        log = tmp_path / "logs" / "scan.log"
+        _save_makemkv_log(log, "hello")
+        assert log.read_text() == "hello"
+
+    def test_oserror_is_swallowed(self, tmp_path):
+        # Passing a directory as the log path makes write_text raise OSError.
+        _save_makemkv_log(tmp_path, "hello")  # must not raise
+
+
+@pytest.mark.unit
+class TestFindLinuxMountPoint:
+    def test_returns_mount_point(self):
+        mounts = "/dev/sda1 / ext4 rw 0 0\n/dev/sr0 /media/disc iso9660 ro 0 0\n"
+        with patch("builtins.open", mock_open(read_data=mounts)):
+            assert _find_linux_mount_point("/dev/sr0") == Path("/media/disc")
+
+    def test_returns_none_when_not_found(self):
+        with patch("builtins.open", mock_open(read_data="/dev/sda1 / ext4 rw 0 0\n")):
+            assert _find_linux_mount_point("/dev/sr0") is None
+
+    def test_returns_none_on_read_error(self):
+        with patch("builtins.open", side_effect=OSError("nope")):
+            assert _find_linux_mount_point("/dev/sr0") is None
+
+
+@pytest.mark.unit
+class TestComputeContentHash:
+    @staticmethod
+    def _expected(sizes_by_name_sorted):
+        md5 = hashlib.md5()
+        for size in sizes_by_name_sorted:
+            md5.update(struct.pack("<q", size))
+        return md5.hexdigest().upper()
+
+    def test_bluray_hash(self, tmp_path):
+        stream = tmp_path / "BDMV" / "STREAM"
+        stream.mkdir(parents=True)
+        (stream / "a.m2ts").write_bytes(b"x" * 100)
+        (stream / "b.m2ts").write_bytes(b"x" * 200)
+        with patch("app.core.extractor._find_linux_mount_point", return_value=tmp_path):
+            result = compute_content_hash("/dev/sr0")
+        assert result == self._expected([100, 200])
+
+    def test_dvd_hash(self, tmp_path):
+        video_ts = tmp_path / "VIDEO_TS"
+        video_ts.mkdir()
+        (video_ts / "VTS_01_1.VOB").write_bytes(b"x" * 50)
+        with patch("app.core.extractor._find_linux_mount_point", return_value=tmp_path):
+            result = compute_content_hash("/dev/sr0")
+        assert result == self._expected([50])
+
+    def test_not_mounted_returns_none(self):
+        with patch("app.core.extractor._find_linux_mount_point", return_value=None):
+            assert compute_content_hash("/dev/sr0") is None
+
+    def test_no_disc_structure_returns_none(self, tmp_path):
+        with patch("app.core.extractor._find_linux_mount_point", return_value=tmp_path):
+            assert compute_content_hash("/dev/sr0") is None
+
+    def test_empty_stream_dir_returns_none(self, tmp_path):
+        (tmp_path / "BDMV" / "STREAM").mkdir(parents=True)
+        with patch("app.core.extractor._find_linux_mount_point", return_value=tmp_path):
+            assert compute_content_hash("/dev/sr0") is None
+
+    def test_windows_branch_without_structure_returns_none(self):
+        with patch("app.core.extractor.sys.platform", "win32"):
+            assert compute_content_hash("Z:") is None
+
+
+@pytest.mark.unit
+class TestParseDiscInfo:
+    SAMPLE = "\n".join(
+        [
+            'CINFO:1,6209,"ignored attr"',
+            'CINFO:2,0,"INCEPTION"',
+            'TINFO:0,2,0,"Inception"',
+            'TINFO:0,9,0,"2:28:00"',
+            'TINFO:0,10,0,"30.1 GB"',
+            'TINFO:0,8,0,"24"',
+            'TINFO:0,16,0,"00800.m2ts"',
+            'TINFO:0,19,0,"1920x1080"',
+            'TINFO:0,25,0,"1"',
+            'TINFO:0,26,0,"1,2,3"',
+            'TINFO:0,27,0,"Inception_t00.mkv"',
+            'TINFO:0,28,0,"eng"',
+            'TINFO:1,2,0,"Extra"',
+            'TINFO:1,9,0,"0:05:00"',
+            'TINFO:1,8,0,"notanumber"',  # ValueError path for chapters
+            'TINFO:1,25,0,"bad"',  # ValueError path for segment count
+        ]
+    )
+
+    def test_parses_disc_name_and_title_attrs(self):
+        titles, disc_name = _extractor()._parse_disc_info(self.SAMPLE)
+        assert disc_name == "INCEPTION"
+        by_idx = {t.index: t for t in titles}
+        assert set(by_idx) == {0, 1}
+
+        t0 = by_idx[0]
+        assert t0.name == "Inception"
+        assert t0.duration_seconds == 2 * 3600 + 28 * 60
+        assert t0.size_bytes == int(30.1 * 1000**3)
+        assert t0.chapter_count == 24
+        assert t0.source_filename == "00800.m2ts"
+        assert t0.video_resolution == "1080p"
+        assert t0.segment_count == 1
+        assert t0.segment_map == "1,2,3"
+        assert t0.disc_title == "Inception_t00.mkv"
+
+    def test_invalid_numeric_attrs_are_ignored(self):
+        titles, _ = _extractor()._parse_disc_info(self.SAMPLE)
+        t1 = {t.index: t for t in titles}[1]
+        assert t1.chapter_count == 0  # "notanumber" left default
+        assert t1.segment_count == 0  # "bad" left default
+
+    def test_empty_output(self):
+        titles, disc_name = _extractor()._parse_disc_info("")
+        assert titles == []
+        assert disc_name == ""
+
+    def test_cinfo_other_than_attr_2_is_ignored(self):
+        titles, disc_name = _extractor()._parse_disc_info('CINFO:1,0,"foo"')
+        assert disc_name == ""
+        assert titles == []
+
+
+@pytest.mark.unit
+class TestParseDuration:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("1:30:45", 5445),
+            ("30:45", 1845),
+            ("90", 90),
+            ("garbage", 0),
+        ],
+    )
+    def test_parse(self, value, expected):
+        assert _extractor()._parse_duration(value) == expected
+
+
+@pytest.mark.unit
+class TestParseSize:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("12.5 GB", int(12.5 * 1000**3)),
+            ("500 MB", 500 * 1000**2),
+            ("2 KB", 2000),
+            ("100 B", 100),
+            ("12 gb", 12 * 1000**3),
+            ("garbage", 0),
+        ],
+    )
+    def test_parse(self, value, expected):
+        assert _extractor()._parse_size(value) == expected
+
+
+@pytest.mark.unit
+class TestParseResolution:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("3840x2160", "4K"),
+            ("1920x1080 (16:9)", "1080p"),
+            ("1280x720", "720p"),
+            ("720x480", "480p"),
+            ("", ""),
+            ("no-numbers", "Unknown"),
+        ],
+    )
+    def test_parse(self, value, expected):
+        assert _extractor()._parse_resolution(value) == expected
+
+
+@pytest.mark.unit
+class TestDriveLock:
+    def test_same_lock_for_equivalent_drive_specs(self):
+        ex = _extractor()
+        assert ex._get_drive_lock("F:") is ex._get_drive_lock("dev:F:")
+
+    def test_different_drives_get_different_locks(self):
+        ex = _extractor()
+        assert ex._get_drive_lock("F:") is not ex._get_drive_lock("disc:0")
+
+
+@pytest.mark.unit
+class TestCancel:
+    def test_cancel_marks_job_and_terminates_process(self):
+        ex = _extractor()
+        proc = Mock()
+        ex._processes[5] = proc
+        ex.cancel(5)
+        assert 5 in ex._cancelled_jobs
+        proc.terminate.assert_called_once()
+
+    def test_cancel_without_process_is_safe(self):
+        ex = _extractor()
+        ex.cancel(99)  # must not raise
+        assert 99 in ex._cancelled_jobs
+
+    def test_cancel_swallows_terminate_error(self):
+        ex = _extractor()
+        proc = Mock()
+        proc.terminate.side_effect = ProcessLookupError()
+        ex._processes[7] = proc
+        ex.cancel(7)  # must not raise
+        assert 7 in ex._cancelled_jobs
+
+
+@pytest.mark.unit
+class TestMakemkvPathProperty:
+    def test_override_is_returned(self):
+        ex = MakeMKVExtractor(makemkv_path=Path("/custom/makemkvcon"))
+        assert ex.makemkv_path == Path("/custom/makemkvcon")
+
+    def test_lazy_loads_from_config(self):
+        ex = MakeMKVExtractor()
+        with patch(
+            "app.services.config_service.get_config_sync",
+            return_value=SimpleNamespace(makemkv_path="/usr/bin/makemkvcon"),
+        ):
+            assert ex.makemkv_path == Path("/usr/bin/makemkvcon")
+
+
+@pytest.mark.unit
+class TestScanDiscSubprocessParsing:
+    """scan_disc with the subprocess stubbed — exercises the parse + error paths."""
+
+    async def test_successful_scan_parses_titles(self):
+        ex = _extractor()
+        completed = subprocess.CompletedProcess(
+            args=["makemkvcon"],
+            returncode=0,
+            stdout=TestParseDiscInfo.SAMPLE,
+            stderr="",
+        )
+        with patch("app.core.extractor.subprocess.Popen") as popen:
+            proc = popen.return_value
+            proc.communicate.return_value = (completed.stdout, "")
+            proc.returncode = 0
+            titles, disc_name = await ex.scan_disc("/dev/sr0")
+        assert disc_name == "INCEPTION"
+        assert len(titles) == 2
+
+    async def test_nonzero_returncode_returns_empty(self):
+        ex = _extractor()
+        with patch("app.core.extractor.subprocess.Popen") as popen:
+            proc = popen.return_value
+            proc.communicate.return_value = ("", "fatal error")
+            proc.returncode = 1
+            titles, disc_name = await ex.scan_disc("/dev/sr0")
+        assert titles == []
+        assert disc_name == ""

--- a/backend/tests/unit/test_extractor.py
+++ b/backend/tests/unit/test_extractor.py
@@ -111,6 +111,13 @@ class TestComputeContentHash:
             md5.update(struct.pack("<q", size))
         return md5.hexdigest().upper()
 
+    @pytest.fixture(autouse=True)
+    def _force_linux(self, monkeypatch):
+        # These tests drive the mount-point (Linux) code path; on a Windows
+        # runner compute_content_hash would otherwise take the drive-letter
+        # branch and ignore the _find_linux_mount_point patch.
+        monkeypatch.setattr("app.core.extractor.sys.platform", "linux")
+
     def test_bluray_hash(self, tmp_path):
         stream = tmp_path / "BDMV" / "STREAM"
         stream.mkdir(parents=True)

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -1,0 +1,303 @@
+"""Unit tests for FinalizationCoordinator's conflict resolution + completion routing.
+
+The escalation ladder and conflict helpers are covered by
+test_auto_conflict_escalation.py; this file targets finalize_disc_job's
+ranking/reassignment loop and organize routing, plus check_job_completion's
+decision branches. The organizer and websocket layers are stubbed.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.finalization_coordinator import FinalizationCoordinator
+from app.services.job_state_machine import JobStateMachine
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture(autouse=True)
+def _patch_session_and_ws(monkeypatch):
+    # finalize_disc_job opens its own session; point it at the test DB.
+    monkeypatch.setattr(
+        "app.services.finalization_coordinator.async_session", _unit_session_factory
+    )
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_job_update", _noop)
+    monkeypatch.setattr(ws_manager, "broadcast_title_update", _noop)
+
+
+@pytest.fixture
+def mock_organize(monkeypatch):
+    """Stub tv_organizer.organize to a success result by default."""
+    import app.core.organizer as org
+
+    m = Mock(return_value={"success": True, "final_path": "/lib/tv/Show/ep.mkv"})
+    monkeypatch.setattr(org.tv_organizer, "organize", m)
+    return m
+
+
+def _make_coord() -> FinalizationCoordinator:
+    broadcaster = MagicMock()
+    broadcaster.broadcast_job_completed = AsyncMock()
+    broadcaster.broadcast_job_failed = AsyncMock()
+    broadcaster.broadcast_job_state_changed = AsyncMock()
+    return FinalizationCoordinator(broadcaster, JobStateMachine(broadcaster))
+
+
+async def _seed_job(
+    titles,
+    staging,
+    *,
+    content_type=ContentType.TV,
+    state=JobState.MATCHING,
+    match_details_by_idx=None,
+) -> int:
+    """Seed a job with the given (title_index, episode, output_filename, title_state) titles."""
+    md = match_details_by_idx or {}
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=content_type,
+            state=state,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path=staging,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        for idx, ep, outfn, tstate in titles:
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=idx,
+                    duration_seconds=1380,
+                    matched_episode=ep,
+                    match_confidence=0.8,
+                    state=tstate,
+                    output_filename=outfn,
+                    match_details=md.get(idx),
+                )
+            )
+        await session.commit()
+        return job.id
+
+
+async def _load(job_id):
+    async with _unit_session_factory() as session:
+        job = await session.get(DiscJob, job_id)
+        titles = (
+            (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+            .scalars()
+            .all()
+        )
+        return job, {t.title_index: t for t in titles}
+
+
+@pytest.mark.unit
+class TestFinalizeDiscJob:
+    async def test_no_conflict_organizes_all_and_completes(self, tmp_path, mock_organize):
+        f0 = tmp_path / "show_t00.mkv"
+        f1 = tmp_path / "show_t01.mkv"
+        f0.write_text("")
+        f1.write_text("")
+        job_id = await _seed_job(
+            [
+                (0, "S01E01", str(f0), TitleState.MATCHED),
+                (1, "S01E02", str(f1), TitleState.MATCHED),
+            ],
+            staging=str(tmp_path),
+        )
+
+        await _make_coord().finalize_disc_job(job_id)
+
+        job, titles = await _load(job_id)
+        assert job.state == JobState.COMPLETED
+        assert all(t.state == TitleState.COMPLETED for t in titles.values())
+        assert mock_organize.call_count == 2
+
+    async def test_conflict_reassigns_loser_via_runner_up(self, tmp_path, mock_organize):
+        f0 = tmp_path / "show_t00.mkv"
+        f1 = tmp_path / "show_t01.mkv"
+        f0.write_text("")
+        f1.write_text("")
+        job_id = await _seed_job(
+            [
+                (0, "S01E05", str(f0), TitleState.MATCHED),
+                (1, "S01E05", str(f1), TitleState.MATCHED),
+            ],
+            staging=str(tmp_path),
+            match_details_by_idx={
+                0: json.dumps({"score": 0.9, "vote_count": 10, "file_cov": 0.9, "runner_ups": []}),
+                1: json.dumps(
+                    {
+                        "score": 0.5,
+                        "vote_count": 2,
+                        "file_cov": 0.5,
+                        "runner_ups": [{"episode": "S01E06", "score": 0.8, "confidence": 0.85}],
+                    }
+                ),
+            },
+        )
+
+        await _make_coord().finalize_disc_job(job_id)
+
+        job, titles = await _load(job_id)
+        # Lower-voted title is bumped to its runner-up episode and both organize.
+        assert titles[0].matched_episode == "S01E05"
+        assert titles[1].matched_episode == "S01E06"
+        assert titles[1].match_confidence == 0.85
+        assert all(t.state == TitleState.COMPLETED for t in titles.values())
+        assert job.state == JobState.COMPLETED
+
+    async def test_conflict_without_runner_up_defers_to_review(self, tmp_path, mock_organize):
+        f0 = tmp_path / "show_t00.mkv"
+        f1 = tmp_path / "show_t01.mkv"
+        f0.write_text("")
+        f1.write_text("")
+        job_id = await _seed_job(
+            [
+                (0, "S01E05", str(f0), TitleState.MATCHED),
+                (1, "S01E05", str(f1), TitleState.MATCHED),
+            ],
+            staging=str(tmp_path),
+            match_details_by_idx={
+                0: json.dumps({"vote_count": 10, "score": 0.9, "runner_ups": []}),
+                1: json.dumps({"vote_count": 2, "score": 0.5, "runner_ups": []}),
+            },
+        )
+
+        await _make_coord().finalize_disc_job(job_id)
+
+        job, titles = await _load(job_id)
+        assert titles[1].state == TitleState.REVIEW
+        # Winner is held (not organized) while the disc has an unresolved title.
+        assert titles[0].state == TitleState.MATCHED
+        assert job.state == JobState.REVIEW_NEEDED
+        mock_organize.assert_not_called()
+
+    async def test_missing_source_file_marks_review(self, tmp_path, mock_organize):
+        job_id = await _seed_job(
+            [(0, "S01E01", None, TitleState.MATCHED)],
+            staging=str(tmp_path),  # empty dir, no glob match
+        )
+
+        await _make_coord().finalize_disc_job(job_id)
+
+        job, titles = await _load(job_id)
+        assert titles[0].state == TitleState.REVIEW
+        assert job.state == JobState.REVIEW_NEEDED
+        mock_organize.assert_not_called()
+
+    async def test_organize_failure_marks_review(self, tmp_path, monkeypatch):
+        import app.core.organizer as org
+
+        monkeypatch.setattr(
+            org.tv_organizer,
+            "organize",
+            Mock(return_value={"success": False, "error": "disk full"}),
+        )
+        f0 = tmp_path / "show_t00.mkv"
+        f0.write_text("")
+        job_id = await _seed_job(
+            [(0, "S01E01", str(f0), TitleState.MATCHED)], staging=str(tmp_path)
+        )
+
+        await _make_coord().finalize_disc_job(job_id)
+
+        job, titles = await _load(job_id)
+        assert titles[0].state == TitleState.REVIEW
+        assert job.state == JobState.REVIEW_NEEDED
+
+
+@pytest.mark.unit
+class TestCheckJobCompletion:
+    async def test_active_title_returns_without_finalizing(self, tmp_path):
+        job_id = await _seed_job([(0, "S01E01", None, TitleState.RIPPING)], staging=str(tmp_path))
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.MATCHING  # unchanged
+        coord.finalize_disc_job.assert_not_called()
+
+    async def test_review_title_transitions_to_review(self, tmp_path):
+        job_id = await _seed_job(
+            [
+                (0, "S01E01", None, TitleState.MATCHED),
+                (1, None, None, TitleState.REVIEW),
+            ],
+            staging=str(tmp_path),
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        coord.finalize_disc_job.assert_not_called()
+
+    async def test_all_matched_invokes_finalize(self, tmp_path):
+        job_id = await _seed_job([(0, "S01E01", None, TitleState.MATCHED)], staging=str(tmp_path))
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        coord.finalize_disc_job.assert_awaited_once_with(job_id)
+
+    async def test_all_failed_transitions_to_failed(self, tmp_path):
+        job_id = await _seed_job(
+            [
+                (0, None, None, TitleState.FAILED),
+                (1, None, None, TitleState.FAILED),
+            ],
+            staging=str(tmp_path),
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.FAILED
+        coord.finalize_disc_job.assert_not_called()
+
+    async def test_conflict_escalation_short_circuits_finalize(self, tmp_path):
+        job_id = await _seed_job(
+            [
+                (0, "S01E05", None, TitleState.MATCHED),
+                (1, "S01E05", None, TitleState.MATCHED),
+            ],
+            staging=str(tmp_path),
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async def fake_rematch(jid, ep, num_points=None, min_vote_count=None):
+            return {"dispatched": [1], "skipped": []}
+
+        coord._rematch_conflict = fake_rematch
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        # Escalation dispatched a re-match, so finalization is deferred.
+        coord.finalize_disc_job.assert_not_called()
+        assert coord._conflict_passes.get(job_id) == 25

--- a/backend/tests/unit/test_identification_coordinator.py
+++ b/backend/tests/unit/test_identification_coordinator.py
@@ -1,0 +1,210 @@
+"""Unit tests for IdentificationCoordinator._run_classification branch routing.
+
+The classifier backends (DiscDB / TMDB / AI) and the analyst are stubbed so the
+test isolates the merge/override logic: which signal wins, how low-confidence
+DiscDB supplements, and the AI re-query fallback. The method does not touch the
+DB session, so a transient DiscJob and session=None are sufficient.
+"""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from app.core.analyst import DiscAnalysisResult
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType
+from app.services.identification_coordinator import IdentificationCoordinator
+
+
+def _make_coord(analyst):
+    coord = IdentificationCoordinator(analyst, MagicMock(), MagicMock(), MagicMock())
+    coord._set_discdb_mappings = Mock()
+    return coord
+
+
+def _analysis(**kw):
+    base = dict(
+        content_type=ContentType.UNKNOWN,
+        detected_name=None,
+        confidence=0.0,
+        needs_review=True,
+    )
+    base.update(kw)
+    return DiscAnalysisResult(**base)
+
+
+def _config(**kw):
+    base = dict(
+        tmdb_api_key=None,
+        discdb_enabled=False,
+        ai_identification_enabled=False,
+        ai_api_key=None,
+        ai_provider="anthropic",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _job(volume_label="THE_OFFICE_S1D1"):
+    return DiscJob(
+        drive_id="E:",
+        volume_label=volume_label,
+        content_type=ContentType.UNKNOWN,
+        state=JobState.IDENTIFYING,
+        staging_path="/tmp/staging",
+    )
+
+
+def _patch_config(monkeypatch, config):
+    monkeypatch.setattr("app.services.config_service.get_config", AsyncMock(return_value=config))
+
+
+@pytest.mark.unit
+class TestRunClassification:
+    async def test_discdb_high_confidence_overrides_analysis(self, monkeypatch):
+        analyst = MagicMock()
+        analyst.analyze.return_value = _analysis(detected_name=None)
+        coord = _make_coord(analyst)
+        _patch_config(monkeypatch, _config(discdb_enabled=True))
+        monkeypatch.setattr("app.core.features.DISCDB_ENABLED", True)
+
+        @dataclass
+        class _Mapping:
+            index: int
+            season: int
+            episode: int
+
+        signal = SimpleNamespace(
+            content_type=ContentType.TV,
+            confidence=0.95,
+            matched_title="The Office",
+            source="hash",
+            disc_slug="the-office-s1d1",
+            tmdb_id=2316,
+            title_mappings=[_Mapping(0, 1, 1)],
+        )
+        monkeypatch.setattr(
+            "app.core.discdb_classifier.classify_from_discdb", Mock(return_value=signal)
+        )
+
+        analysis = await coord._run_classification(_job(), 1, [], None, is_staging=True)
+
+        assert analysis.content_type == ContentType.TV
+        assert analysis.confidence == 0.95
+        assert analysis.classification_source == "discdb_hash"
+        assert analysis.detected_name == "The Office"
+        assert analysis.needs_review is False
+        assert analysis.tmdb_id == 2316
+        coord._set_discdb_mappings.assert_called_once()
+
+    async def test_discdb_low_confidence_supplements_name_only(self, monkeypatch):
+        analyst = MagicMock()
+        analyst.analyze.return_value = _analysis(detected_name=None)
+        coord = _make_coord(analyst)
+        _patch_config(monkeypatch, _config(discdb_enabled=True))
+        monkeypatch.setattr("app.core.features.DISCDB_ENABLED", True)
+
+        signal = SimpleNamespace(
+            content_type=ContentType.TV,
+            confidence=0.5,
+            matched_title="The Office",
+            source="fuzzy",
+            disc_slug="x",
+            tmdb_id=None,
+            title_mappings=[],
+        )
+        monkeypatch.setattr(
+            "app.core.discdb_classifier.classify_from_discdb", Mock(return_value=signal)
+        )
+
+        analysis = await coord._run_classification(_job(), 1, [], None, is_staging=True)
+
+        # Low-confidence DiscDB does not override the type, only fills a blank name.
+        assert analysis.content_type == ContentType.UNKNOWN
+        assert analysis.detected_name == "The Office"
+        assert analysis._discdb_signal is signal
+
+    async def test_tmdb_signal_is_passed_to_analyst(self, monkeypatch):
+        analyst = MagicMock()
+        analyst.analyze.return_value = _analysis(detected_name="The Office")
+        coord = _make_coord(analyst)
+        _patch_config(monkeypatch, _config(tmdb_api_key="key"))
+
+        tmdb_signal = SimpleNamespace(
+            content_type=ContentType.TV, confidence=0.8, tmdb_name="The Office"
+        )
+        monkeypatch.setattr(
+            "app.core.tmdb_classifier.classify_from_tmdb", Mock(return_value=tmdb_signal)
+        )
+
+        analysis = await coord._run_classification(_job(), 1, [], None, is_staging=True)
+
+        assert analysis._tmdb_signal is tmdb_signal
+        _, kwargs = analyst.analyze.call_args
+        assert kwargs["tmdb_signal"] is tmdb_signal
+
+    async def test_ai_fallback_requeries_tmdb(self, monkeypatch):
+        analyst = MagicMock()
+        analyst.analyze.return_value = _analysis(detected_name=None)
+        coord = _make_coord(analyst)
+        _patch_config(
+            monkeypatch,
+            _config(tmdb_api_key="key", ai_identification_enabled=True, ai_api_key="aikey"),
+        )
+
+        ai_tmdb = SimpleNamespace(
+            content_type=ContentType.MOVIE, confidence=0.9, tmdb_name="Inception"
+        )
+        # First TMDB lookup (from the label) fails; re-query with AI name succeeds.
+        monkeypatch.setattr(
+            "app.core.tmdb_classifier.classify_from_tmdb", Mock(side_effect=[None, ai_tmdb])
+        )
+        monkeypatch.setattr(
+            "app.core.ai_identifier.identify_from_label",
+            AsyncMock(return_value={"title": "Inception"}),
+        )
+
+        analysis = await coord._run_classification(
+            _job("INCEPTION_2010"), 1, [], None, is_staging=False
+        )
+
+        assert analysis._tmdb_signal is ai_tmdb
+
+    async def test_ai_name_used_when_tmdb_requery_also_fails(self, monkeypatch):
+        analyst = MagicMock()
+        analyst.analyze.return_value = _analysis(detected_name=None)
+        coord = _make_coord(analyst)
+        _patch_config(
+            monkeypatch,
+            _config(tmdb_api_key="key", ai_identification_enabled=True, ai_api_key="aikey"),
+        )
+
+        monkeypatch.setattr("app.core.tmdb_classifier.classify_from_tmdb", Mock(return_value=None))
+        monkeypatch.setattr(
+            "app.core.ai_identifier.identify_from_label",
+            AsyncMock(return_value={"title": "Inception"}),
+        )
+
+        analysis = await coord._run_classification(
+            _job("INCEPTION_2010"), 1, [], None, is_staging=False
+        )
+
+        assert analysis.detected_name == "Inception"
+        assert analysis.classification_source == "ai"
+
+    async def test_no_signals_returns_analyst_result_unchanged(self, monkeypatch):
+        analyst = MagicMock()
+        result = _analysis(
+            content_type=ContentType.MOVIE, detected_name="Some Movie", confidence=0.6
+        )
+        analyst.analyze.return_value = result
+        coord = _make_coord(analyst)
+        _patch_config(monkeypatch, _config())
+
+        analysis = await coord._run_classification(_job(), 1, [], None, is_staging=True)
+
+        assert analysis is result
+        assert analysis._discdb_signal is None
+        assert analysis._tmdb_signal is None

--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -1,0 +1,165 @@
+"""Unit tests for JobManager's mockable handlers.
+
+Targets _on_title_ripped (per-title completion routing) and _rerun_matching
+(re-match dispatch + DiscDB restore). The heavy _run_ripping orchestration is
+intentionally left to integration tests. The matching/finalization collaborators
+and websocket layer are stubbed.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.websocket import manager as ws_manager
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.job_manager import job_manager
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture(autouse=True)
+def _quiet_ws(monkeypatch):
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_title_update", _noop)
+
+
+async def _seed(content_type=ContentType.TV, staging="/tmp/staging", **title_kwargs):
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=content_type,
+            state=JobState.RIPPING,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path=staging,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        defaults = dict(
+            job_id=job.id, title_index=0, duration_seconds=1380, state=TitleState.RIPPING
+        )
+        defaults.update(title_kwargs)
+        title = DiscTitle(**defaults)
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+        return job, title
+
+
+async def _get_title(title_id):
+    async with _unit_session_factory() as session:
+        return await session.get(DiscTitle, title_id)
+
+
+@pytest.mark.unit
+class TestOnTitleRipped:
+    async def test_movie_title_becomes_matched_without_dispatch(self, tmp_path, monkeypatch):
+        job, title = await _seed(content_type=ContentType.MOVIE)
+        dispatch = AsyncMock()
+        monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
+        path = tmp_path / "movie_t00.mkv"
+        path.write_text("")
+
+        await job_manager._on_title_ripped(job.id, 1, path, [title])
+
+        t = await _get_title(title.id)
+        assert t.state == TitleState.MATCHED
+        assert t.output_filename == str(path)
+        dispatch.assert_not_called()
+
+    async def test_tv_title_dispatches_match_when_no_discdb(self, tmp_path, monkeypatch):
+        job, title = await _seed(content_type=ContentType.TV)
+        monkeypatch.setattr(
+            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=False)
+        )
+        dispatch = AsyncMock()
+        monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
+        monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
+        path = tmp_path / "show_t00.mkv"
+        path.write_text("")
+
+        await job_manager._on_title_ripped(job.id, 1, path, [title])
+        await asyncio.sleep(0)  # let the dispatched task run
+
+        t = await _get_title(title.id)
+        assert t.state == TitleState.MATCHING
+        dispatch.assert_awaited_once()
+
+    async def test_tv_title_with_discdb_checks_completion(self, tmp_path, monkeypatch):
+        job, title = await _seed(content_type=ContentType.TV)
+        monkeypatch.setattr(
+            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=True)
+        )
+        dispatch = AsyncMock()
+        monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
+        completion = AsyncMock()
+        monkeypatch.setattr(job_manager._finalization, "check_job_completion", completion)
+        path = tmp_path / "show_t00.mkv"
+        path.write_text("")
+
+        await job_manager._on_title_ripped(job.id, 1, path, [title])
+
+        completion.assert_awaited_once()
+        dispatch.assert_not_called()
+
+    async def test_unresolvable_file_is_noop(self, tmp_path):
+        job, title = await _seed(content_type=ContentType.TV)
+        path = tmp_path / "unrelated.mkv"
+        path.write_text("")
+
+        # No sorted_titles to map to → resolve returns None → early return.
+        await job_manager._on_title_ripped(job.id, 1, path, [])
+
+        t = await _get_title(title.id)
+        assert t.state == TitleState.RIPPING  # unchanged
+
+
+@pytest.mark.unit
+class TestRerunMatching:
+    async def test_discdb_preference_restores_matches(self):
+        job, title = await _seed(
+            content_type=ContentType.TV,
+            is_selected=True,
+            discdb_match_details=json.dumps({"matched_episode": "S01E04"}),
+        )
+
+        await job_manager._rerun_matching(job.id, source_preference="discdb")
+
+        t = await _get_title(title.id)
+        assert t.state == TitleState.MATCHED
+        assert t.matched_episode == "S01E04"
+        assert t.match_source == "discdb"
+        assert t.match_confidence == 0.99
+
+    async def test_engram_resets_and_dispatches(self, tmp_path, monkeypatch):
+        f = tmp_path / "show_t00.mkv"
+        f.write_text("")
+        job, title = await _seed(
+            content_type=ContentType.TV,
+            staging=str(tmp_path),
+            is_selected=True,
+            output_filename=str(f),
+            state=TitleState.MATCHED,
+            matched_episode="S01E01",
+        )
+        dispatch = AsyncMock()
+        monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
+        monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
+
+        await job_manager._rerun_matching(job.id)
+        await asyncio.sleep(0)
+
+        t = await _get_title(title.id)
+        assert t.state == TitleState.MATCHING
+        assert t.matched_episode is None
+        dispatch.assert_awaited_once()
+
+    async def test_missing_job_is_noop(self):
+        # Must not raise for an unknown job id.
+        await job_manager._rerun_matching(999999)

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -1,0 +1,231 @@
+"""Unit tests for MatchingCoordinator's extras policy and rematch source routing.
+
+The audio matcher / subtitle pipeline are not exercised here; these tests target
+the branchy decision logic: _handle_extras' skip/ask/keep policies and
+rematch_single_title's discdb-vs-engram routing. DB + websocket + organizer are
+stubbed.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from app.api.websocket import manager as ws_manager
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.job_state_machine import JobStateMachine
+from app.services.matching_coordinator import MatchingCoordinator
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture(autouse=True)
+def _patch_session_and_ws(monkeypatch):
+    monkeypatch.setattr("app.services.matching_coordinator.async_session", _unit_session_factory)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_title_update", _noop)
+
+
+def _make_coord() -> MatchingCoordinator:
+    broadcaster = MagicMock()
+    broadcaster.broadcast_job_completed = AsyncMock()
+    broadcaster.broadcast_job_failed = AsyncMock()
+    broadcaster.broadcast_job_state_changed = AsyncMock()
+    coord = MatchingCoordinator(broadcaster, JobStateMachine(broadcaster))
+    coord._check_job_completion = AsyncMock()
+    return coord
+
+
+async def _seed(session, **title_kwargs):
+    job = DiscJob(
+        drive_id="E:",
+        volume_label="SHOW_S1D1",
+        content_type=ContentType.TV,
+        state=JobState.MATCHING,
+        detected_title="Some Show",
+        detected_season=1,
+        disc_number=1,
+        staging_path="/tmp/staging",
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    defaults = dict(job_id=job.id, title_index=0, duration_seconds=600, state=TitleState.MATCHING)
+    defaults.update(title_kwargs)
+    title = DiscTitle(**defaults)
+    session.add(title)
+    await session.commit()
+    await session.refresh(title)
+    return job, title
+
+
+def _patch_config(monkeypatch, policy: str):
+    monkeypatch.setattr(
+        "app.services.config_service.get_config",
+        AsyncMock(return_value=SimpleNamespace(extras_policy=policy)),
+    )
+
+
+@pytest.mark.unit
+class TestHandleExtras:
+    async def test_skip_policy_completes_and_discards(self, monkeypatch, tmp_path):
+        _patch_config(monkeypatch, "skip")
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            handled = await coord._handle_extras(
+                job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
+            )
+            assert handled is True
+            assert title.state == TitleState.COMPLETED
+            assert title.is_extra is True
+            assert json.loads(title.match_details)["action"] == "skipped"
+        coord._check_job_completion.assert_awaited_once()
+
+    async def test_ask_policy_sends_to_review(self, monkeypatch, tmp_path):
+        _patch_config(monkeypatch, "ask")
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            handled = await coord._handle_extras(
+                job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
+            )
+            assert handled is True
+            assert title.state == TitleState.REVIEW
+            assert title.is_extra is True
+            assert json.loads(title.match_details)["action"] == "review"
+
+    async def test_keep_policy_organizes_to_extras(self, monkeypatch, tmp_path):
+        _patch_config(monkeypatch, "keep")
+        import app.core.organizer as org
+
+        monkeypatch.setattr(
+            org,
+            "organize_tv_extras",
+            Mock(return_value={"success": True, "final_path": "/lib/tv/Show/Extras/x.mkv"}),
+        )
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            handled = await coord._handle_extras(
+                job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
+            )
+            assert handled is True
+            assert title.state == TitleState.COMPLETED
+            assert title.is_extra is True
+            assert title.organized_to == "/lib/tv/Show/Extras/x.mkv"
+            assert json.loads(title.match_details)["action"] == "kept"
+
+    async def test_keep_policy_records_organize_error(self, monkeypatch, tmp_path):
+        _patch_config(monkeypatch, "keep")
+        import app.core.organizer as org
+
+        monkeypatch.setattr(
+            org,
+            "organize_tv_extras",
+            Mock(return_value={"success": False, "error": "boom"}),
+        )
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            await coord._handle_extras(
+                job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
+            )
+            assert title.state == TitleState.COMPLETED
+            assert json.loads(title.match_details)["organize_error"] == "boom"
+
+
+@pytest.mark.unit
+class TestRematchSingleTitle:
+    async def test_discdb_restores_from_stored_details(self):
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(
+                session,
+                discdb_match_details=json.dumps({"matched_episode": "S01E03"}),
+            )
+            job_id, title_id = job.id, title.id
+
+        await coord.rematch_single_title(job_id, title_id, source_preference="discdb")
+
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.MATCHED
+            assert t.matched_episode == "S01E03"
+            assert t.match_source == "discdb"
+            assert t.match_confidence == 0.99
+
+    async def test_discdb_falls_back_to_in_memory_mappings(self):
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(
+                session,
+                title_index=2,
+                discdb_match_details=json.dumps({"some": "data"}),  # no matched_episode
+            )
+            job_id, title_id = job.id, title.id
+
+        coord.set_discdb_mappings(job_id, [SimpleNamespace(index=2, season=1, episode=7)])
+
+        await coord.rematch_single_title(job_id, title_id, source_preference="discdb")
+
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.matched_episode == "S01E07"
+            assert t.state == TitleState.MATCHED
+
+    async def test_engram_resets_and_dispatches_match(self, tmp_path):
+        coord = _make_coord()
+        dispatched: dict = {}
+
+        async def fake_match(job_id, title_id, file_path, num_points=None, min_vote_count=None):
+            dispatched["args"] = (job_id, title_id, file_path)
+
+        coord.match_single_file = fake_match
+        coord.on_match_task_done = lambda *a, **k: None
+
+        f = tmp_path / "show_t00.mkv"
+        f.write_text("")
+        async with _unit_session_factory() as session:
+            job, title = await _seed(
+                session,
+                output_filename=str(f),
+                state=TitleState.MATCHED,
+                matched_episode="S01E01",
+            )
+            job.staging_path = str(tmp_path)
+            session.add(job)
+            await session.commit()
+            job_id, title_id = job.id, title.id
+
+        await coord.rematch_single_title(job_id, title_id, source_preference="engram")
+        await asyncio.sleep(0)  # let the dispatched task run
+
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.MATCHING
+            assert t.matched_episode is None
+            assert t.match_source is None
+        assert dispatched["args"][1] == title_id
+
+    async def test_engram_missing_file_raises(self, tmp_path):
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            job.staging_path = str(tmp_path)  # empty dir
+            session.add(job)
+            await session.commit()
+            job_id, title_id = job.id, title.id
+
+        with pytest.raises(ValueError, match="Staging file not found"):
+            await coord.rematch_single_title(job_id, title_id, source_preference="engram")
+
+    async def test_unknown_title_raises(self):
+        coord = _make_coord()
+        with pytest.raises(ValueError):
+            await coord.rematch_single_title(9999, 9999, source_preference="discdb")

--- a/backend/tests/unit/test_upc_lookup.py
+++ b/backend/tests/unit/test_upc_lookup.py
@@ -1,0 +1,167 @@
+"""Unit tests for the UPC product lookup service.
+
+Covers the pure confidence-scoring helper and the async upcitemdb lookup,
+with httpx stubbed via AsyncMock (mirrors tests/unit/test_ai_identifier.py).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.core.upc_lookup import (
+    UPCLookupResult,
+    compute_match_confidence,
+    lookup_upc,
+)
+
+
+def _make_mock_client(*, json_data: dict | None = None, raise_exc: Exception | None = None):
+    """Build a mock httpx.AsyncClient usable as an async context manager.
+
+    httpx.Response.json() / raise_for_status() are sync, so the response is a
+    MagicMock while the client itself is an AsyncMock.
+    """
+    mock_response = MagicMock()
+    mock_response.json.return_value = json_data or {}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    if raise_exc is not None:
+        mock_client.get = AsyncMock(side_effect=raise_exc)
+    else:
+        mock_client.get = AsyncMock(return_value=mock_response)
+    return mock_client
+
+
+@pytest.mark.unit
+class TestComputeMatchConfidence:
+    @pytest.mark.parametrize(
+        "product, detected, expected",
+        [
+            # Direct substring matches -> high
+            ("Inception (2010) Blu-ray", "Inception", "high"),
+            ("Inception", "Inception (2010) Blu-ray", "high"),
+            # Word overlap >= 0.5 (not a substring) -> high
+            ("Breaking Bad Complete", "Breaking Bad Marathon", "high"),
+            # 0 < ratio < 0.5 -> low
+            ("alpha beta gamma delta", "alpha wun too three", "low"),
+            # Zero overlap -> none
+            ("foo bar", "baz qux", "none"),
+        ],
+    )
+    def test_scoring(self, product, detected, expected):
+        assert compute_match_confidence(product, detected) == expected
+
+    @pytest.mark.parametrize(
+        "product, detected",
+        [
+            (None, "Inception"),
+            ("Inception", None),
+            ("", "Inception"),
+            ("Inception", ""),
+            (None, None),
+        ],
+    )
+    def test_missing_inputs_return_none(self, product, detected):
+        assert compute_match_confidence(product, detected) == "none"
+
+    def test_filler_only_words_return_none(self):
+        # Both titles collapse to empty sets after filler removal, and neither
+        # is a substring of the other.
+        assert compute_match_confidence("The Season", "A Disc") == "none"
+
+    def test_overlap_ratio_uses_smaller_set(self):
+        # Not a substring; overlap {quest}=1, min(|{galaxy,quest,special}|,
+        # |{quest,bonus}|)=2 -> ratio 0.5 -> high.
+        assert compute_match_confidence("Galaxy Quest Special", "Quest Bonus") == "high"
+
+
+@pytest.mark.unit
+class TestLookupUpc:
+    async def test_blank_upc_returns_error_without_request(self):
+        result = await lookup_upc("   ")
+        assert result.success is False
+        assert result.error == "UPC code is required"
+
+    async def test_successful_lookup_extracts_fields_and_dedupes_asins(self):
+        json_data = {
+            "items": [
+                {
+                    "title": "Inception",
+                    "brand": "Warner",
+                    "description": "A dream heist.",
+                    "images": ["http://img/1.jpg"],
+                    "asin": "B0TOP",
+                    "offers": [
+                        {"asin": "B0OFFER1"},
+                        {"asin": "B0OFFER1"},  # duplicate, should collapse
+                        {"asin": "B0OFFER2"},
+                        {},  # no asin key
+                    ],
+                }
+            ]
+        }
+        mock_client = _make_mock_client(json_data=json_data)
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("  012345678905  ")
+
+        assert result.success is True
+        assert result.product_title == "Inception"
+        assert result.brand == "Warner"
+        assert result.description == "A dream heist."
+        assert result.images == ["http://img/1.jpg"]
+        # Top-level asin is inserted first, offer asins follow, no duplicates.
+        assert result.asins == ["B0TOP", "B0OFFER1", "B0OFFER2"]
+        # UPC was stripped before the request.
+        _, kwargs = mock_client.get.call_args
+        assert kwargs["params"] == {"upc": "012345678905"}
+
+    async def test_lookup_without_top_level_asin(self):
+        json_data = {"items": [{"title": "Foo", "offers": [{"asin": "B0OFFER1"}]}]}
+        mock_client = _make_mock_client(json_data=json_data)
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("012345678905")
+        assert result.success is True
+        assert result.asins == ["B0OFFER1"]
+
+    async def test_no_items_returns_error(self):
+        mock_client = _make_mock_client(json_data={"items": []})
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("000000000000")
+        assert result.success is False
+        assert "No product found" in result.error
+
+    async def test_rate_limit_returns_friendly_message(self):
+        response = httpx.Response(429, request=httpx.Request("GET", "http://x"))
+        exc = httpx.HTTPStatusError("429", request=response.request, response=response)
+        mock_client = _make_mock_client(raise_exc=exc)
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("012345678905")
+        assert result.success is False
+        assert "rate limit" in result.error.lower()
+
+    async def test_other_http_status_returns_generic_message(self):
+        response = httpx.Response(500, request=httpx.Request("GET", "http://x"))
+        exc = httpx.HTTPStatusError("500", request=response.request, response=response)
+        mock_client = _make_mock_client(raise_exc=exc)
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("012345678905")
+        assert result.success is False
+        assert "HTTP 500" in result.error
+
+    async def test_network_error_returns_message(self):
+        exc = httpx.ConnectError("boom", request=httpx.Request("GET", "http://x"))
+        mock_client = _make_mock_client(raise_exc=exc)
+        with patch("app.core.upc_lookup.httpx.AsyncClient", return_value=mock_client):
+            result = await lookup_upc("012345678905")
+        assert result.success is False
+        assert "network error" in result.error.lower()
+
+    def test_result_defaults(self):
+        result = UPCLookupResult()
+        assert result.success is False
+        assert result.asins == []
+        assert result.images == []

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -578,3 +578,352 @@ class TestDetectionOffloadsBlockingWork:
         # Both detections ran on worker threads, never the event loop thread.
         assert observed["makemkv"] != loop_thread
         assert observed["ffmpeg"] != loop_thread
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+class TestFfmpegBinaryValidation:
+    """Direct tests for the FFmpeg binary validator (subprocess stubbed)."""
+
+    @staticmethod
+    def _fake_run(returncode=0, stdout="ffmpeg version 6.0\nbuilt with gcc\n"):
+        def run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = returncode
+            m.stdout = stdout
+            m.stderr = ""
+            return m
+
+        return run
+
+    def test_success_returns_first_stdout_line_as_version(self):
+        from app.api.validation import _validate_ffmpeg_binary
+
+        with patch("app.api.validation.subprocess.run", side_effect=self._fake_run()):
+            result = _validate_ffmpeg_binary("/usr/bin/ffmpeg")
+        assert result.found is True
+        assert result.version == "ffmpeg version 6.0"
+        assert result.path == "/usr/bin/ffmpeg"
+
+    def test_non_zero_exit_is_not_found(self):
+        from app.api.validation import _validate_ffmpeg_binary
+
+        with patch("app.api.validation.subprocess.run", side_effect=self._fake_run(returncode=1)):
+            result = _validate_ffmpeg_binary("/usr/bin/ffmpeg")
+        assert result.found is False
+        assert result.error == "Non-zero exit code"
+
+    def test_timeout(self):
+        import subprocess
+
+        from app.api.validation import _validate_ffmpeg_binary
+
+        with patch(
+            "app.api.validation.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=10),
+        ):
+            result = _validate_ffmpeg_binary("/usr/bin/ffmpeg")
+        assert result.found is False
+        assert result.error == "Command timeout (10s)"
+
+    def test_execution_failure(self):
+        from app.api.validation import _validate_ffmpeg_binary
+
+        with patch("app.api.validation.subprocess.run", side_effect=OSError("boom")):
+            result = _validate_ffmpeg_binary("/usr/bin/ffmpeg")
+        assert result.found is False
+        assert "Execution failed" in result.error
+
+
+class TestToolDetection:
+    """Auto-detection across PATH and common install locations."""
+
+    def test_detect_makemkv_found_on_path(self):
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult
+
+        with (
+            patch.object(validation.shutil, "which", return_value="/usr/bin/makemkvcon64"),
+            patch.object(
+                validation,
+                "_validate_makemkv_binary",
+                return_value=ToolDetectionResult(
+                    found=True, path="/usr/bin/makemkvcon64", version="MakeMKV v1.18.3"
+                ),
+            ),
+        ):
+            result = validation.detect_makemkv()
+        assert result.found is True
+        assert result.version == "MakeMKV v1.18.3"
+
+    def test_detect_makemkv_found_in_common_location(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult
+
+        exe = tmp_path / "makemkvcon64"
+        exe.write_text("")
+        with (
+            patch.object(validation.shutil, "which", return_value=None),
+            patch.object(validation, "_get_makemkv_search_paths", return_value=[str(exe)]),
+            patch.object(
+                validation,
+                "_validate_makemkv_binary",
+                return_value=ToolDetectionResult(found=True, path=str(exe), version="v"),
+            ),
+        ):
+            result = validation.detect_makemkv()
+        assert result.found is True
+
+    def test_detect_makemkv_not_found(self):
+        from app.api import validation
+
+        with (
+            patch.object(validation.shutil, "which", return_value=None),
+            patch.object(validation, "_get_makemkv_search_paths", return_value=[]),
+        ):
+            result = validation.detect_makemkv()
+        assert result.found is False
+        assert "not found" in result.error.lower()
+
+    def test_detect_ffmpeg_found_on_path(self):
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult
+
+        with (
+            patch.object(validation.shutil, "which", return_value="/usr/bin/ffmpeg"),
+            patch.object(
+                validation,
+                "_validate_ffmpeg_binary",
+                return_value=ToolDetectionResult(
+                    found=True, path="/usr/bin/ffmpeg", version="ffmpeg 6.0"
+                ),
+            ),
+        ):
+            result = validation.detect_ffmpeg()
+        assert result.found is True
+        assert result.version == "ffmpeg 6.0"
+
+    def test_detect_ffmpeg_found_in_common_location(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult
+
+        exe = tmp_path / "ffmpeg"
+        exe.write_text("")
+        with (
+            patch.object(validation.shutil, "which", return_value=None),
+            patch.object(validation, "_get_ffmpeg_search_paths", return_value=[str(exe)]),
+            patch.object(
+                validation,
+                "_validate_ffmpeg_binary",
+                return_value=ToolDetectionResult(found=True, path=str(exe), version="v"),
+            ),
+        ):
+            result = validation.detect_ffmpeg()
+        assert result.found is True
+
+    def test_detect_ffmpeg_not_found(self):
+        from app.api import validation
+
+        with (
+            patch.object(validation.shutil, "which", return_value=None),
+            patch.object(validation, "_get_ffmpeg_search_paths", return_value=[]),
+        ):
+            result = validation.detect_ffmpeg()
+        assert result.found is False
+        assert "not found" in result.error.lower()
+
+
+class TestSearchPaths:
+    """Platform-specific search path lists."""
+
+    def test_linux_paths_nonempty(self):
+        from app.api import validation
+
+        with patch.object(validation.sys, "platform", "linux"):
+            assert validation._get_makemkv_search_paths()
+            assert validation._get_ffmpeg_search_paths()
+
+    def test_windows_paths(self):
+        from app.api import validation
+
+        with patch.object(validation.sys, "platform", "win32"):
+            mk = validation._get_makemkv_search_paths()
+            ff = validation._get_ffmpeg_search_paths()
+        assert any("makemkvcon64.exe" in p for p in mk)
+        assert any("ffmpeg.exe" in p for p in ff)
+
+
+class TestValidateMakemkvEndpoint:
+    """The /validate/makemkv endpoint's existence + relabel branches."""
+
+    def test_file_not_found(self):
+        from app.api.validation import ValidationRequest, validate_makemkv
+
+        result = _run(validate_makemkv(ValidationRequest(path="/nope/makemkvcon64.exe")))
+        assert result.valid is False
+        assert "File not found" in result.error
+
+    def test_path_is_not_a_file(self, tmp_path):
+        from app.api.validation import ValidationRequest, validate_makemkv
+
+        d = tmp_path / "makemkvcon"  # allowed basename, but a directory
+        d.mkdir()
+        result = _run(validate_makemkv(ValidationRequest(path=str(d))))
+        assert result.valid is False
+        assert "not a file" in result.error.lower()
+
+    def test_success_omits_path(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import (
+            ToolDetectionResult,
+            ValidationRequest,
+            validate_makemkv,
+        )
+
+        exe = tmp_path / "makemkvcon64.exe"
+        exe.write_text("")
+        with patch.object(
+            validation,
+            "_validate_makemkv_binary",
+            return_value=ToolDetectionResult(found=True, version="MakeMKV v1.18.3"),
+        ):
+            result = _run(validate_makemkv(ValidationRequest(path=str(exe))))
+        assert result.valid is True
+        assert result.version == "MakeMKV v1.18.3"
+        assert result.path is None
+
+    def test_timeout_is_relabeled(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import (
+            ToolDetectionResult,
+            ValidationRequest,
+            validate_makemkv,
+        )
+
+        exe = tmp_path / "makemkvcon64.exe"
+        exe.write_text("")
+        with patch.object(
+            validation,
+            "_validate_makemkv_binary",
+            return_value=ToolDetectionResult(found=False, error="Command timeout (10s)"),
+        ):
+            result = _run(validate_makemkv(ValidationRequest(path=str(exe))))
+        assert result.valid is False
+        assert result.error == "MakeMKV command timeout (10s)"
+
+
+class TestValidateFfmpegEndpoint:
+    """The /validate/ffmpeg endpoint, including the empty-path PATH lookup."""
+
+    def test_empty_path_found_on_system_path(self):
+        from app.api import validation
+        from app.api.validation import (
+            ToolDetectionResult,
+            ValidationRequest,
+            validate_ffmpeg,
+        )
+
+        with (
+            patch.object(validation.shutil, "which", return_value="/usr/bin/ffmpeg"),
+            patch.object(
+                validation,
+                "_validate_ffmpeg_binary",
+                return_value=ToolDetectionResult(
+                    found=True, path="/usr/bin/ffmpeg", version="ffmpeg 6.0"
+                ),
+            ),
+        ):
+            result = _run(validate_ffmpeg(ValidationRequest(path="")))
+        assert result.valid is True
+        assert result.path == "/usr/bin/ffmpeg"
+
+    def test_empty_path_not_on_system_path(self):
+        from app.api import validation
+        from app.api.validation import ValidationRequest, validate_ffmpeg
+
+        with patch.object(validation.shutil, "which", return_value=None):
+            result = _run(validate_ffmpeg(ValidationRequest(path="")))
+        assert result.valid is False
+        assert "PATH" in result.error
+
+    def test_file_path_not_found(self):
+        from app.api.validation import ValidationRequest, validate_ffmpeg
+
+        result = _run(validate_ffmpeg(ValidationRequest(path="/nope/ffmpeg")))
+        assert result.valid is False
+        assert "File not found" in result.error
+
+    def test_non_zero_is_relabeled(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import (
+            ToolDetectionResult,
+            ValidationRequest,
+            validate_ffmpeg,
+        )
+
+        exe = tmp_path / "ffmpeg"
+        exe.write_text("")
+        with patch.object(
+            validation,
+            "_validate_ffmpeg_binary",
+            return_value=ToolDetectionResult(found=False, error="Non-zero exit code"),
+        ):
+            result = _run(validate_ffmpeg(ValidationRequest(path=str(exe))))
+        assert result.valid is False
+        assert result.error == "FFmpeg returned non-zero exit code"
+
+    def test_timeout_is_relabeled(self, tmp_path):
+        from app.api import validation
+        from app.api.validation import (
+            ToolDetectionResult,
+            ValidationRequest,
+            validate_ffmpeg,
+        )
+
+        exe = tmp_path / "ffmpeg"
+        exe.write_text("")
+        with patch.object(
+            validation,
+            "_validate_ffmpeg_binary",
+            return_value=ToolDetectionResult(found=False, error="Command timeout (10s)"),
+        ):
+            result = _run(validate_ffmpeg(ValidationRequest(path=str(exe))))
+        assert result.valid is False
+        assert result.error == "FFmpeg command timeout (10s)"
+
+
+class TestTmdbValidationRemainingBranches:
+    """The status/timeout/generic-exception branches not covered elsewhere."""
+
+    @patch("app.api.validation.requests.get")
+    def test_unexpected_status_code(self, mock_get):
+        from app.api.validation import TmdbValidationRequest, validate_tmdb
+
+        mock_get.return_value = MagicMock(status_code=500)
+        result = _run(validate_tmdb(TmdbValidationRequest(api_key="k")))
+        assert result.valid is False
+        assert "status 500" in result.error
+
+    @patch("app.api.validation.requests.get")
+    def test_timeout(self, mock_get):
+        import requests as req_lib
+
+        from app.api.validation import TmdbValidationRequest, validate_tmdb
+
+        mock_get.side_effect = req_lib.exceptions.Timeout()
+        result = _run(validate_tmdb(TmdbValidationRequest(api_key="k")))
+        assert result.valid is False
+        assert "timeout" in result.error.lower()
+
+    @patch("app.api.validation.requests.get")
+    def test_generic_exception(self, mock_get):
+        from app.api.validation import TmdbValidationRequest, validate_tmdb
+
+        mock_get.side_effect = RuntimeError("weird")
+        result = _run(validate_tmdb(TmdbValidationRequest(api_key="k")))
+        assert result.valid is False
+        assert "Validation failed" in result.error


### PR DESCRIPTION
## Summary

A coverage analysis surfaced two structural blind spots — the entire `app/matcher/*` package (~40% of the backend) was excluded from measurement, and CI computed coverage from unit tests only with no floor — plus thin coverage on the core orchestration logic. This PR adds focused unit tests for the highest-risk modules and fixes the coverage/CI process so the matcher is measured and the full-suite line rate is gated.

### New / extended unit tests

**Quick wins (pure logic + simple mocks)**
- `test_upc_lookup.py` — `app/core/upc_lookup.py` **0% → 99%** (confidence scoring + httpx-stubbed lookup paths)
- `test_errors.py` — `@handle_errors` decorator (sync/async) + `error_context` manager **33% → 100%**
- extended `test_validation.py` — FFmpeg validator, tool detection, and endpoint relabel branches **45% → 93%**

**Core modules**
- `test_curator.py` — `EpisodeCurator` filename fallback, confidence routing, lazy init, batch driver **33% → 96%**
- `test_extractor.py` — MakeMKV robot-mode parsers, content-hash, drive-spec/lock helpers, scan parsing **30% → 47%** (rip streaming left to integration)

**Coordinators + job manager (branchy logic, mocked collaborators)**
- `test_finalization_coordinator.py` — conflict-resolution/runner-up reassignment loop + `check_job_completion` routing
- `test_matching_coordinator.py` — extras skip/ask/keep policies + rematch discdb-vs-engram routing
- `test_identification_coordinator.py` — `_run_classification` DiscDB/TMDB/AI merge & override
- `test_job_manager.py` — `_on_title_ripped` + `_rerun_matching` handlers

### CI / coverage process
- Stop omitting the whole matcher package; keep only non-runtime scripts and the audio/model modules CI can't exercise (`-m "not requires_audio"`).
- New `backend-coverage` job combines unit + integration coverage data and enforces `--fail-under=58` (~2 pts below the measured full-suite line rate of **60.18%**). The floor lives in the CI step, not `pyproject`, so local subset `--cov` runs aren't failed by it.

All new tests pass locally and are lint/format clean.

## Test plan
- [ ] `cd backend && uv run pytest tests/unit/ -q` — all unit tests green
- [ ] `uv run pytest --cov=app --cov-report=term-missing` — confirm per-module gains above
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] CI `backend-coverage` job combines unit+integration data and the `--fail-under` gate passes

https://claude.ai/code/session_011Tu45YEXnMK3x3U71boTgY

---
_Generated by [Claude Code](https://claude.ai/code/session_011Tu45YEXnMK3x3U71boTgY)_