### PR TITLE
test: fix unit conftest session binding for terminal-state callbacks

### DIFF
--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -88,10 +88,19 @@ async def isolate_database(monkeypatch):
 
     _config_mod = importlib.import_module("app.services.config_service")
     _jm_mod = importlib.import_module("app.services.job_manager")
+    # Terminal-state callbacks (registered on the JobStateMachine) open their own
+    # sessions through these modules' own `async_session` bindings. They must be
+    # patched too, or the callbacks hit the real engine on COMPLETED/FAILED.
+    _cleanup_mod = importlib.import_module("app.services.cleanup_service")
+    _final_mod = importlib.import_module("app.services.finalization_coordinator")
+    _match_mod = importlib.import_module("app.services.matching_coordinator")
 
     monkeypatch.setattr(_db_mod, "async_session", _unit_session_factory)
     monkeypatch.setattr(_config_mod, "async_session", _unit_session_factory)
     monkeypatch.setattr(_jm_mod, "async_session", _unit_session_factory)
+    monkeypatch.setattr(_cleanup_mod, "async_session", _unit_session_factory)
+    monkeypatch.setattr(_final_mod, "async_session", _unit_session_factory)
+    monkeypatch.setattr(_match_mod, "async_session", _unit_session_factory)
 
     # Redirect the cached sync engine in config_service so get_config_sync()
     # uses the in-memory test database instead of connecting to engram.db.

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -88,9 +88,10 @@ async def isolate_database(monkeypatch):
 
     _config_mod = importlib.import_module("app.services.config_service")
     _jm_mod = importlib.import_module("app.services.job_manager")
-    # Terminal-state callbacks (registered on the JobStateMachine) open their own
-    # sessions through these modules' own `async_session` bindings. They must be
-    # patched too, or the callbacks hit the real engine on COMPLETED/FAILED.
+    # cleanup_service and finalization_coordinator open DB sessions inside their
+    # terminal callbacks — patch so they hit the in-memory engine, not engram.db.
+    # matching_coordinator.clear_job_caches is in-memory only; patched defensively
+    # in case it gains DB access in the future.
     _cleanup_mod = importlib.import_module("app.services.cleanup_service")
     _final_mod = importlib.import_module("app.services.finalization_coordinator")
     _match_mod = importlib.import_module("app.services.matching_coordinator")


### PR DESCRIPTION
## Summary

Unit tests that drive a `DiscJob` to a terminal state (`COMPLETED`/`FAILED`) logged non-fatal `sqlalchemy.exc.OperationalError: no such table: disc_jobs` ERRORs from `app/services/job_state_machine.py:155` (the terminal-state callback loop).

**Root cause:** the `isolate_database` autouse fixture in `backend/tests/unit/conftest.py` monkeypatched `async_session` on only three modules — `app.database`, `config_service`, and `job_manager`. But the registered terminal-state callbacks open their own sessions through *separate* module-level bindings that were never patched:

- `cleanup_service.on_job_terminal` → `from app.database import async_session`
- `finalization_coordinator.on_terminal_clear_conflicts` → same (always opens a session on terminal transition)
- `matching_coordinator` → same binding (its `clear_job_caches` callback only touches in-memory dicts, but the binding is patched defensively for consistency)

Because these bindings pointed at the real engine instead of the in-memory `_unit_session_factory`, the callbacks queried a database without the test tables. The errors were non-fatal only because of the defensive try/except at `job_state_machine.py:151-157`, so they surfaced as log noise rather than failures.

## Fix

Extend the fixture to also patch `async_session` on `cleanup_service`, `finalization_coordinator`, and `matching_coordinator`, pointing them at `_unit_session_factory` — mirroring the existing `importlib.import_module(...)` pattern used for `job_manager` (needed because `app.services.__init__` shadows the submodule names).

## Verification

- A temporary test drove the shared `state_machine` singleton's job to `COMPLETED` (firing the registered terminal callbacks). With the fix reverted it **failed** with two `no such table: disc_jobs` ERRORs from `job_state_machine.py:155` (from the cleanup and finalization callbacks) — exactly the reported symptom. With the fix applied it **passed** with no errors. The temp test was then removed.
- Full unit suite: **1071 passed**, with **0** `no such table` occurrences in the run output.

## Notes for reviewers

- The `TestRunRippingSessionScoping` class / PR #185 workaround (stubbing `state_machine._on_terminal_callbacks = []` in `rip_env`) referenced in the issue is **not in this branch** — it lives in unmerged PR #185. Once that merges, the workaround can be dropped so the terminal callbacks are exercised against the now-correctly-isolated session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)