### PR TITLE
docs(tests): clarify rip_env terminal-callback stub is for isolation

### DIFF
--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -178,11 +178,11 @@ def rip_env(monkeypatch, tmp_path):
     terminal-state callbacks (staging cleanup / cache clearing).
 
     Stubbing the terminal callbacks is purely for isolation, not error
-    avoidance: as of PR #186 conftest patches their async_session bindings to
-    the in-memory engine, so they no longer raise "no such table". They are
-    still stubbed here so completing-job tests don't trigger real staging
-    deletion (default policy is on_success) or cache clearing, which are
-    irrelevant to what these scoping tests assert."""
+    avoidance: conftest patches their async_session bindings to the in-memory
+    engine, so they no longer raise "no such table". They are still stubbed
+    here so completing-job tests don't trigger real staging deletion (default
+    policy is on_success) or cache clearing, which are irrelevant to what these
+    scoping tests assert."""
     import app.core.discdb_exporter as exporter_mod
     import app.core.sentinel as sentinel_mod
 

--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -175,7 +175,14 @@ class TestRerunMatching:
 def rip_env(monkeypatch, tmp_path):
     """Neutralize the side-effecting steps in _run_ripping that are orthogonal
     to DB-session scoping: physical eject, the makemkv log directory, and the
-    terminal-state callbacks (staging cleanup / cache clearing)."""
+    terminal-state callbacks (staging cleanup / cache clearing).
+
+    Stubbing the terminal callbacks is purely for isolation, not error
+    avoidance: as of PR #186 conftest patches their async_session bindings to
+    the in-memory engine, so they no longer raise "no such table". They are
+    still stubbed here so completing-job tests don't trigger real staging
+    deletion (default policy is on_success) or cache clearing, which are
+    irrelevant to what these scoping tests assert."""
     import app.core.discdb_exporter as exporter_mod
     import app.core.sentinel as sentinel_mod
 


### PR DESCRIPTION
## Summary

Follow-up to #186. The `rip_env` fixture in `backend/tests/unit/test_job_manager.py` stubs `state_machine._on_terminal_callbacks = []`. Before #186, that stub also happened to avoid the non-fatal `no such table: disc_jobs` errors the terminal callbacks logged when hitting an unpatched session.

Now that #186 patches those callbacks' `async_session` bindings to the in-memory engine, the stub's only remaining purpose is **isolation** — keeping these session-scoping tests from triggering the callbacks' real side effects (staging deletion under the default `on_success` policy, and per-job cache clearing), which are orthogonal to what the tests assert.

This PR is a **comment-only change**: it expands the `rip_env` docstring to make that distinction explicit, so a future reader doesn't mistake the stub for a leftover bug-workaround and remove it (which would make completing-job tests `rmtree` their own `tmp_path`).

## Why keep the stub (not remove it)

Considered removing the stub to exercise the real callbacks, but the scoping tests are deliberately focused on DB-session lifetime during ripping; firing `delete_staging`/`clear_job_caches` in them adds irrelevant filesystem side effects and coupling. Dedicated coverage of the terminal-callback path lives elsewhere (`test_staging_cleanup.py`, `test_finalization_coordinator.py`).

## Verification

- `uv run pytest tests/unit/test_job_manager.py::TestRunRippingSessionScoping` → **7 passed**
- `uv run ruff check` → clean

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)