### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to Engram will be documented in this file.
 
+## [0.7.0] - 2026-05-23
+
+### Added
+- **Pre-built subtitle cache**: ships a precomputed subtitle-vector cache so episode matching can run without scraping subtitle sites on every disc, falling back to live scraping only when a season isn't covered (#140). Cache builds are now resumable and log API status (#149), and the builder accepts a `--show-list` to target specific shows.
+- **Smarter episode matcher**: persistent on-disk caches plus a threaded provider scheduler and reworked subtitle providers (#155), a per-provider circuit breaker so a failing source no longer stalls a run, interpretable 0–1 confidence scores (#169), and automatic deep re-matching when episodes conflict (#171). Match results now surface which subtitle provider contributed (#158).
+- **Redesigned TV disc review**: an inspector-style layout with disc-level conflict detection, making it clearer which episodes clash before you commit (#165).
+- **Diagnostics improvements**: bug reports can be previewed before sending and now report real installed tool versions (#174).
+- **Resilient frontend**: API and WebSocket errors are handled gracefully with reconnection instead of breaking the dashboard (#180).
+- **Brand refresh**: the canonical Synapse v2 brand system (#156), plus an ambient ripping animation and a bottom-anchored status bar (#137).
+
+### Fixed
+- **Ripping reliability**: the long-held database session in `_run_ripping` is now tightly scoped to avoid blocking other work (#185), and MakeMKV subprocesses are drained on shutdown alongside matching-lifecycle fixes (#181).
+- **Movies**: long bonus tracks are no longer incorrectly flagged as needing review (#175).
+- **Review flow**: the Process action returns to the dashboard instead of erroring (#173), and re-running a match re-matches all titles with live progress (#164).
+- **MakeMKV validation**: the real installed version is detected from the robot-mode banner (#177).
+- **Subtitle matching**: subtitle download is skipped when the precomputed cache already covers a season (#163); tvsubtitles episode resolution and candidate parsing were corrected (#159); UTF-16-encoded SRTs are now accepted; OpenSubtitles quota is reported accurately and skipped when exhausted.
+- **Logging**: corrected log-source attribution and now surfaces disc-event errors that were previously silent (#168).
+- **Security**: hardened SSRF and path-traversal sinks flagged by CodeQL (#147).
+
+### Changed
+- **Subtitle cache format v2**: ~85% smaller on disk via a compact `uint16` encoding (#154).
+- **Documentation**: README reworked to be end-user-first with supporting docs consolidated (#162).
+- Codebase-wide simplification sweep for maintainability (#143).
+
+### Removed
+- The unimplemented "Enable transcoding" setting (#138).
+- The obsolete skyline-silhouette atmosphere layer (#139).
+
 ## [0.6.0] - 2026-05-02
 
 ### Added

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -215,7 +215,7 @@ else:
         """Root endpoint - API status (dev mode only, no bundled frontend)."""
         return {
             "name": "Engram",
-            "version": "0.1.0",
+            "version": __version__,
             "status": "running",
         }
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.6.0"
+version = "0.7.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.6.0"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.6.0",
+    "version": "0.7.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

Release prep for **v0.7.0** (the next version after v0.6.0). No code behavior changes beyond a dev-only endpoint fix — this is a version bump + changelog.

- Bump `0.6.0 → 0.7.0` in all version sources: `backend/app/__init__.py`, `backend/pyproject.toml`, `frontend/package.json`, and both lock files (lock files edited surgically to avoid unrelated dependency churn).
- Add the `[0.7.0]` section to `CHANGELOG.md` summarizing user-facing changes since v0.6.0 (matcher overhaul, pre-built subtitle cache, redesigned TV review, brand refresh, ripping/review fixes, security hardening).
- Fix the dev-mode root endpoint in `main.py` to report `__version__` instead of a stale hard-coded `"0.1.0"`.

## Verification

- Backend unit suite green (1078 passed), including the `test_diagnostics` guard that enforces `pyproject.toml` version == `app.__version__`.
- Backend lint + format clean; frontend lint clean.
- Production build succeeds and bakes `0.7.0` into the bundle via the `vite.config.ts` → `__init__.py` version wiring.

## Cutting the release (after merge)

This PR intentionally stops before tagging. Once merged to `main`, push the tag to trigger `.github/workflows/release.yml` (builds + smoke-tests + publishes the Windows/Linux/macOS bundles):

```
git tag v0.7.0 && git push origin v0.7.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)