### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Engram will be documented in this file.
 
+## [0.7.1] - 2026-05-23
+
+### Fixed
+- **Frozen-build database upgrades**: the packaged app now drops columns removed from the model on startup, fixing a crash when inserting a disc (`NOT NULL constraint failed: disc_jobs.is_transcoding_enabled`) for users upgrading from a build that still had the removed "Enable transcoding" setting (#190).
+
 ## [0.7.0] - 2026-05-23
 
 ### Added

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.7.0"
+version = "0.7.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.7.0",
+    "version": "0.7.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

Patch release **v0.7.1**. Bumps the version across `backend/pyproject.toml`, `backend/app/__init__.py`, `frontend/package.json`, and the two lock files, and adds the CHANGELOG entry.

The only change since v0.7.0 is the frozen-build database fix:

- **Frozen-build database upgrades** ([#190](https://github.com/Jsakkos/engram/pull/190)): the packaged app now drops columns removed from the model on startup, fixing a crash when inserting a disc (`NOT NULL constraint failed: disc_jobs.is_transcoding_enabled`) for users upgrading from a build that still had the removed "Enable transcoding" setting.

## Release

Merging this, then pushing the `v0.7.1` tag, triggers `release.yml` to build + smoke-test the Windows/Linux/macOS executables and publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)