### PR TITLE
feat(jobs): self-heal stuck jobs with watchdog + force-progress

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -215,6 +215,13 @@ class ConfigResponse(BaseModel):
     ripping_file_ready_timeout: float
     # Sentinel monitoring
     sentinel_poll_interval: float
+    # Stale-job watchdog
+    watchdog_enabled: bool
+    watchdog_poll_seconds: int
+    timeout_identifying_seconds: int
+    timeout_ripping_seconds: int
+    timeout_matching_seconds: int
+    timeout_organizing_seconds: int
     # Staging cleanup
     staging_cleanup_policy: str
     staging_cleanup_days: int
@@ -270,6 +277,13 @@ class ConfigUpdate(BaseModel):
     ripping_file_ready_timeout: float | None = None
     # Sentinel monitoring
     sentinel_poll_interval: float | None = None
+    # Stale-job watchdog
+    watchdog_enabled: bool | None = None
+    watchdog_poll_seconds: int | None = None
+    timeout_identifying_seconds: int | None = None
+    timeout_ripping_seconds: int | None = None
+    timeout_matching_seconds: int | None = None
+    timeout_organizing_seconds: int | None = None
     # Staging cleanup
     staging_cleanup_policy: str | None = None
     staging_cleanup_days: int | None = None
@@ -659,6 +673,58 @@ async def cancel_job(job: DiscJob = Depends(get_job_or_404)) -> dict:
     return {"status": "cancelled", "job_id": job.id}
 
 
+@router.post("/jobs/{job_id}/advance")
+async def advance_job(job: DiscJob = Depends(get_job_or_404)) -> dict:
+    """Force a stuck job forward to its next resting state.
+
+    Reconciles tracks still ripping/matching (ripped-but-unmatched → review,
+    no-file → failed), then organizes whatever matched and lands the job in
+    completed or review_needed. The manual counterpart to the stale-job watchdog.
+    """
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    from app.services.job_manager import job_manager
+
+    advanced = await job_manager.reconcile_and_advance(job.id, reason="manual advance")
+    if not advanced:
+        raise HTTPException(status_code=400, detail="Job could not be advanced")
+    return {"status": "advanced", "job_id": job.id}
+
+
+class SkipTitleRequest(BaseModel):
+    """Request model for skipping a single stuck title."""
+
+    target: str = "review"  # "review" | "fail"
+
+
+@router.post("/jobs/{job_id}/titles/{title_id}/skip")
+async def skip_title(
+    title_id: int,
+    req: SkipTitleRequest | None = None,
+    job: DiscJob = Depends(get_job_or_404),
+) -> dict:
+    """Skip a single track stuck in ripping/matching, without forcing the whole job."""
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    target = (req.target if req else "review").lower()
+    if target not in ("review", "fail"):
+        raise HTTPException(status_code=400, detail="target must be 'review' or 'fail'")
+
+    from app.models.disc_job import TitleState
+    from app.services.job_manager import job_manager
+
+    target_state = TitleState.FAILED if target == "fail" else TitleState.REVIEW
+    skipped = await job_manager.skip_title(job.id, title_id, target=target_state)
+    if not skipped:
+        raise HTTPException(
+            status_code=400,
+            detail="Title not found, not part of this job, or already resolved",
+        )
+    return {"status": "skipped", "job_id": job.id, "title_id": title_id, "target": target}
+
+
 @router.post("/jobs/{job_id}/review")
 async def submit_review(
     review: ReviewRequest,
@@ -875,6 +941,13 @@ async def get_config() -> ConfigResponse:
         ripping_file_ready_timeout=config.ripping_file_ready_timeout,
         # Sentinel monitoring
         sentinel_poll_interval=config.sentinel_poll_interval,
+        # Stale-job watchdog
+        watchdog_enabled=config.watchdog_enabled,
+        watchdog_poll_seconds=config.watchdog_poll_seconds,
+        timeout_identifying_seconds=config.timeout_identifying_seconds,
+        timeout_ripping_seconds=config.timeout_ripping_seconds,
+        timeout_matching_seconds=config.timeout_matching_seconds,
+        timeout_organizing_seconds=config.timeout_organizing_seconds,
         # Staging cleanup
         staging_cleanup_policy=config.staging_cleanup_policy,
         staging_cleanup_days=config.staging_cleanup_days,

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -695,7 +695,7 @@ async def advance_job(job: DiscJob = Depends(get_job_or_404)) -> dict:
 class SkipTitleRequest(BaseModel):
     """Request model for skipping a single stuck title."""
 
-    target: str = "review"  # "review" | "fail"
+    target: Literal["review", "fail"] = "review"
 
 
 @router.post("/jobs/{job_id}/titles/{title_id}/skip")
@@ -708,9 +708,7 @@ async def skip_title(
     if job.state in (JobState.COMPLETED, JobState.FAILED):
         raise HTTPException(status_code=400, detail="Job has already finished")
 
-    target = (req.target if req else "review").lower()
-    if target not in ("review", "fail"):
-        raise HTTPException(status_code=400, detail="target must be 'review' or 'fail'")
+    target = req.target if req else "review"
 
     from app.models.disc_job import TitleState
     from app.services.job_manager import job_manager

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -66,6 +66,25 @@ class AppConfig(SQLModel, table=True):
     # Sentinel Drive Monitoring
     sentinel_poll_interval: float = 2.0  # Seconds between drive polls
 
+    # Stale-job watchdog — auto-advances jobs that stop making progress.
+    # Per-phase "no activity" ceilings (seconds). server_default carries the same
+    # value so pre-existing databases get a sane timeout, not the _add_missing_columns
+    # int fallback of 0 (which would fire the watchdog instantly).
+    watchdog_enabled: bool = Field(default=True, sa_column_kwargs={"server_default": text("1")})
+    watchdog_poll_seconds: int = Field(default=60, sa_column_kwargs={"server_default": text("60")})
+    timeout_identifying_seconds: int = Field(
+        default=600, sa_column_kwargs={"server_default": text("600")}
+    )
+    timeout_ripping_seconds: int = Field(
+        default=1200, sa_column_kwargs={"server_default": text("1200")}
+    )
+    timeout_matching_seconds: int = Field(
+        default=1800, sa_column_kwargs={"server_default": text("1800")}
+    )
+    timeout_organizing_seconds: int = Field(
+        default=600, sa_column_kwargs={"server_default": text("600")}
+    )
+
     # Staging Cleanup
     staging_cleanup_policy: str = (
         "on_success"  # "on_success" | "on_completion" | "manual" | "after_days"

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -220,6 +220,7 @@ class JobManager:
             try:
                 await self._watchdog_task
             except asyncio.CancelledError:
+                # Expected: we just cancelled the watchdog loop above.
                 pass
             self._watchdog_task = None
 
@@ -587,7 +588,8 @@ class JobManager:
                         )
                     session.add(title)
                     logger.warning(
-                        f"Job {job_id}: title {title.title_index} stuck with no file → FAILED"
+                        f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
+                        "stuck with no file → FAILED"
                     )
                     await ws_manager.broadcast_title_update(
                         job_id,
@@ -601,8 +603,9 @@ class JobManager:
                 title.state = TitleState.MATCHING if is_tv else TitleState.MATCHED
                 session.add(title)
                 logger.info(
-                    f"Job {job_id}: recovered orphaned title {title.title_index} "
-                    f"({file_path.name}) → {title.state.value}"
+                    f"Job {job_id}: recovered orphaned title "
+                    f"{sanitize_log_value(title.title_index)} "
+                    f"({sanitize_log_value(file_path.name)}) → {title.state.value}"
                 )
                 await ws_manager.broadcast_title_update(
                     job_id,
@@ -672,7 +675,7 @@ class JobManager:
                 session.add(title)
                 logger.info(
                     f"Job {job_id}: force-advance ({reason}) — title "
-                    f"{title.title_index} → {title.state.value}"
+                    f"{sanitize_log_value(title.title_index)} → {title.state.value}"
                 )
                 await ws_manager.broadcast_title_update(
                     job_id,
@@ -707,7 +710,10 @@ class JobManager:
                 title.match_details = json.dumps({"reason": "Skipped by user"})
             session.add(title)
             await session.commit()
-            logger.info(f"Job {job_id}: title {title.title_index} skipped → {target.value}")
+            logger.info(
+                f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
+                f"skipped → {target.value}"
+            )
             await ws_manager.broadcast_title_update(job_id, title.id, target.value, error=err)
 
             await self._finalization.check_job_completion(session, job_id)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -588,8 +588,8 @@ class JobManager:
                         )
                     session.add(title)
                     logger.warning(
-                        f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
-                        "stuck with no file → FAILED"
+                        f"Job {sanitize_log_value(job_id)}: title "
+                        f"{sanitize_log_value(title.title_index)} stuck with no file → FAILED"
                     )
                     await ws_manager.broadcast_title_update(
                         job_id,
@@ -603,7 +603,7 @@ class JobManager:
                 title.state = TitleState.MATCHING if is_tv else TitleState.MATCHED
                 session.add(title)
                 logger.info(
-                    f"Job {job_id}: recovered orphaned title "
+                    f"Job {sanitize_log_value(job_id)}: recovered orphaned title "
                     f"{sanitize_log_value(title.title_index)} "
                     f"({sanitize_log_value(file_path.name)}) → {title.state.value}"
                 )
@@ -625,8 +625,8 @@ class JobManager:
                 title = await session.get(DiscTitle, title_id)
                 if title is None:
                     logger.warning(
-                        f"Job {job_id}: recovered title {sanitize_log_value(title_id)} "
-                        "vanished before re-queue"
+                        f"Job {sanitize_log_value(job_id)}: recovered title "
+                        f"{sanitize_log_value(title_id)} vanished before re-queue"
                     )
                     continue
                 applied = await self._matching.try_discdb_assignment(job_id, title, session)
@@ -681,7 +681,7 @@ class JobManager:
                         title.match_details = json.dumps({"reason": err})
                 session.add(title)
                 logger.info(
-                    f"Job {job_id}: force-advance ({reason}) — title "
+                    f"Job {sanitize_log_value(job_id)}: force-advance ({reason}) — title "
                     f"{sanitize_log_value(title.title_index)} → {title.state.value}"
                 )
                 await ws_manager.broadcast_title_update(
@@ -718,8 +718,8 @@ class JobManager:
             session.add(title)
             await session.commit()
             logger.info(
-                f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
-                f"skipped → {target.value}"
+                f"Job {sanitize_log_value(job_id)}: title "
+                f"{sanitize_log_value(title.title_index)} skipped → {target.value}"
             )
             await ws_manager.broadcast_title_update(job_id, title.id, target.value, error=err)
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -620,8 +620,15 @@ class JobManager:
         # Queue matching for recovered TV titles (mirrors _on_title_ripped), each
         # outside the session above so match tasks own their own sessions.
         for title_id, file_path in recovered:
+            applied = False
             async with async_session() as session:
                 title = await session.get(DiscTitle, title_id)
+                if title is None:
+                    logger.warning(
+                        f"Job {job_id}: recovered title {sanitize_log_value(title_id)} "
+                        "vanished before re-queue"
+                    )
+                    continue
                 applied = await self._matching.try_discdb_assignment(job_id, title, session)
                 if applied:
                     await self._finalization.check_job_completion(session, job_id)
@@ -745,7 +752,7 @@ class JobManager:
                 try:
                     config = await get_config()
                 except Exception as e:
-                    logger.warning(f"Watchdog: could not load config: {e}")
+                    logger.warning(f"Watchdog: could not load config: {e}", exc_info=True)
                 poll = (config.watchdog_poll_seconds if config else 60) or 60
                 await asyncio.sleep(poll)
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -68,6 +68,9 @@ class JobManager:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._timed_cleanup_task: asyncio.Task | None = None
         self._staging_watcher: StagingWatcher | None = None
+        # Stale-job watchdog: monotonic timestamp of the last progress signal per job.
+        self._last_activity: dict[int, float] = {}
+        self._watchdog_task: asyncio.Task | None = None
 
         # Create coordinators
         self._cleanup = CleanupService()
@@ -81,6 +84,7 @@ class JobManager:
         # Wire cross-coordinator callbacks
         self._matching.set_callbacks(
             check_job_completion=self._finalization.check_job_completion,
+            note_activity=self._note_activity,
         )
         self._identification.set_callbacks(
             get_discdb_mappings=self._matching.get_discdb_mappings,
@@ -112,6 +116,9 @@ class JobManager:
         state_machine.on_terminal_state(self._cleanup.on_job_terminal)
         state_machine.on_terminal_state(self._matching.clear_job_caches)
         state_machine.on_terminal_state(self._finalization.on_terminal_clear_conflicts)
+
+        # Reset the watchdog activity clock whenever a job changes phase.
+        state_machine.on_transition(self._note_activity_on_transition)
 
     async def start(self) -> None:
         """Start the job manager and begin monitoring drives."""
@@ -151,6 +158,10 @@ class JobManager:
             self._staging_watcher = StagingWatcher(config.staging_path, config=config)
             self._staging_watcher.set_async_callback(self._on_staging_event, self._loop)
             self._staging_watcher.start()
+
+        # Start the stale-job watchdog
+        if config.watchdog_enabled:
+            self._watchdog_task = asyncio.create_task(self._watchdog_loop())
 
         logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
 
@@ -203,6 +214,14 @@ class JobManager:
         self._drive_monitor.stop()
         if self._staging_watcher:
             self._staging_watcher.stop()
+
+        if self._watchdog_task:
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except asyncio.CancelledError:
+                pass
+            self._watchdog_task = None
 
         for job_id, task in self._active_jobs.items():
             task.cancel()
@@ -505,6 +524,268 @@ class JobManager:
                 await state_machine.transition_to_failed(
                     job, session, error_message="Cancelled by user"
                 )
+
+    # --- Stale-job watchdog + force-progress engine ---
+
+    def _note_activity(self, job_id: int) -> None:
+        """Record that a job made progress just now (watchdog activity clock)."""
+        self._last_activity[job_id] = time.monotonic()
+
+    def _note_activity_on_transition(self, job_id: int, state: JobState) -> None:
+        """on_transition observer: reset the clock on phase change, drop it on terminal."""
+        if state in (JobState.COMPLETED, JobState.FAILED):
+            self._last_activity.pop(job_id, None)
+        else:
+            self._last_activity[job_id] = time.monotonic()
+
+    @staticmethod
+    def _find_title_file(title: DiscTitle, staging: Path | None) -> Path | None:
+        """Locate a title's ripped .mkv: its recorded output, else a staging glob."""
+        if title.output_filename:
+            p = Path(title.output_filename)
+            if p.exists():
+                return p
+        if staging:
+            matches = list(staging.glob(f"*_t{title.title_index:02d}.mkv"))
+            if matches:
+                return matches[0]
+        return None
+
+    async def reconcile_stuck_titles(self, job_id: int) -> None:
+        """Resolve selected titles orphaned in PENDING/RIPPING after a rip finishes.
+
+        A title whose staging file exists is routed into the normal completion path
+        (TV → DiscDB assignment or matching; movie → MATCHED); one with no file is
+        marked FAILED. Guarantees no selected title is stranded in RIPPING once the
+        MakeMKV subprocess has exited (the orphaned-last-title bug). Recovers work
+        rather than discarding it.
+        """
+        recovered: list[tuple[int, Path]] = []
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+            result = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id))
+            stuck = [
+                t
+                for t in result.scalars().all()
+                if t.is_selected and t.state in (TitleState.PENDING, TitleState.RIPPING)
+            ]
+            if not stuck:
+                return
+
+            staging = Path(job.staging_path) if job.staging_path else None
+            is_tv = job.content_type == ContentType.TV
+
+            for title in stuck:
+                file_path = self._find_title_file(title, staging)
+                if file_path is None:
+                    title.state = TitleState.FAILED
+                    if not title.match_details:
+                        title.match_details = json.dumps(
+                            {"reason": "Ripping ended with no output file"}
+                        )
+                    session.add(title)
+                    logger.warning(
+                        f"Job {job_id}: title {title.title_index} stuck with no file → FAILED"
+                    )
+                    await ws_manager.broadcast_title_update(
+                        job_id,
+                        title.id,
+                        TitleState.FAILED.value,
+                        error="Ripping ended with no output file",
+                    )
+                    continue
+
+                title.output_filename = str(file_path)
+                title.state = TitleState.MATCHING if is_tv else TitleState.MATCHED
+                session.add(title)
+                logger.info(
+                    f"Job {job_id}: recovered orphaned title {title.title_index} "
+                    f"({file_path.name}) → {title.state.value}"
+                )
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title.id,
+                    title.state.value,
+                    output_filename=str(file_path),
+                )
+                if is_tv:
+                    recovered.append((title.id, file_path))
+            await session.commit()
+
+        # Queue matching for recovered TV titles (mirrors _on_title_ripped), each
+        # outside the session above so match tasks own their own sessions.
+        for title_id, file_path in recovered:
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                applied = await self._matching.try_discdb_assignment(job_id, title, session)
+                if applied:
+                    await self._finalization.check_job_completion(session, job_id)
+            if not applied:
+                task = asyncio.create_task(
+                    self._matching.match_single_file(job_id, title_id, file_path)
+                )
+                task.add_done_callback(
+                    lambda t, jid=job_id, tid=title_id: self._matching.on_match_task_done(
+                        t, jid, tid
+                    )
+                )
+
+    async def reconcile_and_advance(self, job_id: int, *, reason: str = "forced") -> bool:
+        """Force a stuck job to its next resting state (watchdog + manual advance).
+
+        Cancels any in-flight rip, resolves every still-active title (PENDING/RIPPING/
+        MATCHING) — to REVIEW if its ripped file exists (so the user can assign it),
+        else FAILED — then runs the normal completion check, which organizes whatever
+        matched and lands the job in COMPLETED or REVIEW_NEEDED. Returns True if the
+        job was non-terminal and processed.
+        """
+        # Stop any in-flight rip/processing task so it can't race the reconcile.
+        if job_id in self._active_jobs:
+            self._active_jobs[job_id].cancel()
+            del self._active_jobs[job_id]
+        self._extractor.cancel(job_id)
+
+        active = (TitleState.PENDING, TitleState.RIPPING, TitleState.MATCHING)
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job or job.state in (JobState.COMPLETED, JobState.FAILED):
+                return False
+
+            result = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id))
+            staging = Path(job.staging_path) if job.staging_path else None
+
+            for title in result.scalars().all():
+                if not title.is_selected or title.state not in active:
+                    continue
+                file_path = self._find_title_file(title, staging)
+                if file_path is not None:
+                    title.output_filename = str(file_path)
+                    title.state = TitleState.REVIEW
+                    err = None
+                else:
+                    title.state = TitleState.FAILED
+                    err = "Force-advanced with no output file"
+                    if not title.match_details:
+                        title.match_details = json.dumps({"reason": err})
+                session.add(title)
+                logger.info(
+                    f"Job {job_id}: force-advance ({reason}) — title "
+                    f"{title.title_index} → {title.state.value}"
+                )
+                await ws_manager.broadcast_title_update(
+                    job_id,
+                    title.id,
+                    title.state.value,
+                    error=err,
+                    output_filename=title.output_filename,
+                )
+            await session.commit()
+
+            await self._finalization.check_job_completion(session, job_id)
+        return True
+
+    async def skip_title(
+        self, job_id: int, title_id: int, *, target: TitleState = TitleState.REVIEW
+    ) -> bool:
+        """Skip one stuck title: mark it REVIEW (default) or FAILED, then re-check completion.
+
+        Only acts on titles still in an active state (PENDING/RIPPING/MATCHING). Lets the
+        user unblock a single track without forcing the whole job forward.
+        """
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                return False
+            if title.state not in (TitleState.PENDING, TitleState.RIPPING, TitleState.MATCHING):
+                return False
+
+            title.state = target
+            err = "Skipped by user" if target == TitleState.FAILED else None
+            if target == TitleState.FAILED and not title.match_details:
+                title.match_details = json.dumps({"reason": "Skipped by user"})
+            session.add(title)
+            await session.commit()
+            logger.info(f"Job {job_id}: title {title.title_index} skipped → {target.value}")
+            await ws_manager.broadcast_title_update(job_id, title.id, target.value, error=err)
+
+            await self._finalization.check_job_completion(session, job_id)
+        return True
+
+    @staticmethod
+    def _phase_timeout(config, state: JobState) -> int | None:
+        """Per-phase no-activity ceiling (seconds), or None for resting/untimed states."""
+        return {
+            JobState.IDENTIFYING: config.timeout_identifying_seconds,
+            JobState.RIPPING: config.timeout_ripping_seconds,
+            JobState.MATCHING: config.timeout_matching_seconds,
+            JobState.ORGANIZING: config.timeout_organizing_seconds,
+        }.get(state)
+
+    async def _watchdog_loop(self) -> None:
+        """Periodically auto-advance jobs that have stopped making progress."""
+        from app.services.config_service import get_config
+
+        watched = (
+            JobState.IDENTIFYING,
+            JobState.RIPPING,
+            JobState.MATCHING,
+            JobState.ORGANIZING,
+        )
+        try:
+            while True:
+                config = None
+                try:
+                    config = await get_config()
+                except Exception as e:
+                    logger.warning(f"Watchdog: could not load config: {e}")
+                poll = (config.watchdog_poll_seconds if config else 60) or 60
+                await asyncio.sleep(poll)
+
+                if config is None or not config.watchdog_enabled:
+                    continue
+
+                try:
+                    async with async_session() as session:
+                        result = await session.execute(
+                            select(DiscJob).where(DiscJob.state.in_(watched))
+                        )
+                        jobs = result.scalars().all()
+
+                    now = time.monotonic()
+                    for job in jobs:
+                        timeout = self._phase_timeout(config, job.state)
+                        if not timeout or timeout <= 0:
+                            continue
+                        last = self._last_activity.get(job.id)
+                        if last is None:
+                            # First sighting — seed the clock so we time from now, not
+                            # from an unknown past (avoids an instant false trip).
+                            self._last_activity[job.id] = now
+                            continue
+                        idle = now - last
+                        if idle >= timeout:
+                            logger.warning(
+                                f"Watchdog: job {job.id} idle {idle:.0f}s in "
+                                f"{job.state.value} (timeout {timeout}s) → auto-advancing"
+                            )
+                            try:
+                                await self.reconcile_and_advance(
+                                    job.id, reason=f"stale timeout in {job.state.value}"
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    f"Watchdog: auto-advance of job {job.id} failed: {e}",
+                                    exc_info=True,
+                                )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.error(f"Watchdog loop iteration failed: {e}", exc_info=True)
+        except asyncio.CancelledError:
+            logger.info("Watchdog loop cancelled")
+            raise
 
     async def apply_review(
         self,
@@ -926,6 +1207,7 @@ class JobManager:
                 rip_indices = None
 
             def _fire_progress(p):
+                self._note_activity(job_id)
                 t = asyncio.create_task(progress_callback(p))
                 _background_tasks.add(t)
                 t.add_done_callback(_background_tasks.discard)
@@ -1120,6 +1402,10 @@ class JobManager:
             if content_type == ContentType.TV:
                 await self._backfill_unmatched_titles(job_id, output_dir, sorted_titles)
 
+                # Recover any title the rip left stranded in PENDING/RIPPING (e.g. the
+                # final title whose completion callback never fired) before advancing.
+                await self.reconcile_stuck_titles(job_id)
+
                 async with async_session() as session:
                     job = await session.get(DiscJob, job_id)
                     if not job:
@@ -1144,6 +1430,11 @@ class JobManager:
 
             else:
                 # Movie post-ripping flow
+
+                # Recover any title stranded in PENDING/RIPPING (movie titles move to
+                # MATCHED) so the main-feature selection below sees every ripped file.
+                await self.reconcile_stuck_titles(job_id)
+
                 async with async_session() as session:
                     job = await session.get(DiscJob, job_id)
                     if not job:

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -57,6 +57,7 @@ class JobStateMachine:
     def __init__(self, event_broadcaster: EventBroadcaster):
         self._broadcaster = event_broadcaster
         self._on_terminal_callbacks: list = []
+        self._on_transition_callbacks: list = []
 
     def on_terminal_state(self, callback) -> None:
         """Register a callback invoked when a job reaches a terminal state (COMPLETED/FAILED).
@@ -64,6 +65,15 @@ class JobStateMachine:
         Callback signature: async def callback(job_id: int, state: JobState) -> None
         """
         self._on_terminal_callbacks.append(callback)
+
+    def on_transition(self, callback) -> None:
+        """Register a callback invoked after every successful state transition.
+
+        Used by the stale-job watchdog to reset a job's activity clock whenever it
+        enters a new phase. Callback signature: callback(job_id: int, state: JobState).
+        Synchronous and best-effort — exceptions are logged, never raised.
+        """
+        self._on_transition_callbacks.append(callback)
 
     def can_transition(self, from_state: JobState, to_state: JobState) -> bool:
         """Validate if state transition is allowed.
@@ -128,6 +138,13 @@ class JobStateMachine:
 
         # Persist to database
         await session.commit()
+
+        # Notify transition observers (e.g. watchdog activity clock). Best-effort.
+        for cb in self._on_transition_callbacks:
+            try:
+                cb(job.id, to_state)
+            except Exception as e:
+                logger.error(f"Job {job.id}: transition callback failed: {e}", exc_info=True)
 
         # Broadcast state change if requested (failure is non-fatal since DB is committed)
         if broadcast:

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -549,6 +549,7 @@ class MatchingCoordinator:
                         try:
                             self._note_activity(job_id)
                         except Exception:
+                            # Best-effort watchdog heartbeat; never let it disrupt matching.
                             pass
                     try:
                         details = None

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -48,12 +48,14 @@ class MatchingCoordinator:
         self._subtitle_tasks: dict[int, asyncio.Task] = {}
         self._match_semaphore: asyncio.Semaphore | None = None
 
-        # Cross-coordinator callback
+        # Cross-coordinator callbacks
         self._check_job_completion: callable = None
+        self._note_activity: callable | None = None
 
-    def set_callbacks(self, *, check_job_completion) -> None:
+    def set_callbacks(self, *, check_job_completion, note_activity=None) -> None:
         """Set cross-coordinator callbacks."""
         self._check_job_completion = check_job_completion
+        self._note_activity = note_activity
 
     def init_semaphore(self, concurrency: int) -> None:
         """Initialize the match semaphore with the given concurrency."""
@@ -543,6 +545,11 @@ class MatchingCoordinator:
                 _json_dumps = json.dumps
 
                 def on_progress(stage: str, percent: float, vote_data: list | None = None):
+                    if self._note_activity:
+                        try:
+                            self._note_activity(job_id)
+                        except Exception:
+                            pass
                     try:
                         details = None
                         if vote_data:
@@ -621,7 +628,12 @@ class MatchingCoordinator:
                     except Exception as e:
                         logger.error(f"Failed to dump match_details: {e}")
 
-                title.match_source = "engram"
+                # Only attribute the match to Engram when an episode match was
+                # actually recorded. A title routed to REVIEW with no episode must
+                # not carry the "ENGRAM" provider badge — that implies a confident
+                # auto-match the matcher never made.
+                if title.state == TitleState.MATCHED:
+                    title.match_source = "engram"
 
                 # Extract match stats for broadcast
                 matches_found = 1

--- a/backend/tests/integration/test_force_progress_api.py
+++ b/backend/tests/integration/test_force_progress_api.py
@@ -95,9 +95,10 @@ class TestForceProgressApi:
         resp = await client.post(f"/api/jobs/{job_id}/titles/888888/skip")
         assert resp.status_code == 400
 
-    async def test_skip_invalid_target_400(self, client, tmp_path):
+    async def test_skip_invalid_target_422(self, client, tmp_path):
+        # Literal["review", "fail"] → Pydantic rejects unknown values before the handler.
         job_id, title_id = await _job_with_stuck_title(tmp_path)
         resp = await client.post(
             f"/api/jobs/{job_id}/titles/{title_id}/skip", json={"target": "nope"}
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 422

--- a/backend/tests/integration/test_force_progress_api.py
+++ b/backend/tests/integration/test_force_progress_api.py
@@ -1,0 +1,103 @@
+"""Integration tests for the force-progress + skip-track HTTP endpoints.
+
+Verifies route wiring and status codes for POST /api/jobs/{id}/advance and
+POST /api/jobs/{id}/titles/{tid}/skip. Scenarios route stuck tracks to REVIEW so
+finalization never organizes into the real library.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _job_with_stuck_title(tmp_path, *, state=JobState.MATCHING):
+    f = tmp_path / "disc_t00.mkv"
+    f.write_bytes(b"x")
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="Z:",
+            volume_label="API_TEST",
+            content_type=ContentType.TV,
+            state=state,
+            staging_path=str(tmp_path),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        title = DiscTitle(
+            job_id=job.id,
+            title_index=0,
+            duration_seconds=2700,
+            state=TitleState.MATCHING,
+            output_filename=str(f),
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+        return job.id, title.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestForceProgressApi:
+    async def test_advance_unknown_job_404(self, client):
+        resp = await client.post("/api/jobs/999999/advance")
+        assert resp.status_code == 404
+
+    async def test_advance_happy_path(self, client, tmp_path):
+        job_id, _ = await _job_with_stuck_title(tmp_path)
+        resp = await client.post(f"/api/jobs/{job_id}/advance")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "advanced"
+
+        # Stuck MATCHING title (file present) routed to REVIEW → job in REVIEW_NEEDED.
+        detail = await client.get(f"/api/jobs/{job_id}")
+        assert detail.json()["state"] == "review_needed"
+
+    async def test_advance_terminal_job_400(self, client, tmp_path):
+        job_id, _ = await _job_with_stuck_title(tmp_path, state=JobState.COMPLETED)
+        resp = await client.post(f"/api/jobs/{job_id}/advance")
+        assert resp.status_code == 400
+
+    async def test_skip_title_happy_path(self, client, tmp_path):
+        job_id, title_id = await _job_with_stuck_title(tmp_path)
+        resp = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/skip")
+        assert resp.status_code == 200
+        assert resp.json()["target"] == "review"
+
+        async with async_session() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+
+    async def test_skip_unknown_title_400(self, client, tmp_path):
+        job_id, _ = await _job_with_stuck_title(tmp_path)
+        resp = await client.post(f"/api/jobs/{job_id}/titles/888888/skip")
+        assert resp.status_code == 400
+
+    async def test_skip_invalid_target_400(self, client, tmp_path):
+        job_id, title_id = await _job_with_stuck_title(tmp_path)
+        resp = await client.post(
+            f"/api/jobs/{job_id}/titles/{title_id}/skip", json={"target": "nope"}
+        )
+        assert resp.status_code == 400

--- a/backend/tests/unit/test_stuck_job_recovery.py
+++ b/backend/tests/unit/test_stuck_job_recovery.py
@@ -1,0 +1,262 @@
+"""Tests for stuck-job recovery, force-advance, per-track skip, and match attribution.
+
+Covers the four fixes:
+- Issue 1: reconcile_stuck_titles recovers titles orphaned in PENDING/RIPPING.
+- Issue 2: a no-match title goes to REVIEW with match_source unset (not "engram").
+- Issue 3/4: reconcile_and_advance / skip_title drive a stuck job to a resting state.
+
+The unit-test conftest (isolate_database) patches ``async_session`` per module to an
+in-memory SQLite DB. To share that DB, these helpers reach ``async_session`` through
+the module object (``db.async_session``) so the monkeypatch is honored at call time.
+Scenarios are built so finalization never organizes into the real library — stuck or
+unmatched titles route to REVIEW, holding the job in REVIEW_NEEDED.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import app.database as db
+from app.models import AppConfig, DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.job_manager import job_manager
+
+
+async def _make_job(
+    staging: Path,
+    *,
+    content_type: ContentType = ContentType.TV,
+    state: JobState = JobState.MATCHING,
+) -> int:
+    async with db.async_session() as session:
+        job = DiscJob(
+            drive_id="Z:",
+            volume_label="TEST_DISC",
+            content_type=content_type,
+            state=state,
+            staging_path=str(staging),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job.id
+
+
+async def _add_title(
+    job_id: int,
+    index: int,
+    state: TitleState,
+    *,
+    output: str | None = None,
+    matched_episode: str | None = None,
+    selected: bool = True,
+) -> int:
+    async with db.async_session() as session:
+        t = DiscTitle(
+            job_id=job_id,
+            title_index=index,
+            duration_seconds=2700,
+            state=state,
+            is_selected=selected,
+            output_filename=output,
+            matched_episode=matched_episode,
+        )
+        session.add(t)
+        await session.commit()
+        await session.refresh(t)
+        return t.id
+
+
+async def _title(title_id: int) -> DiscTitle:
+    async with db.async_session() as session:
+        return await session.get(DiscTitle, title_id)
+
+
+async def _job(job_id: int) -> DiscJob:
+    async with db.async_session() as session:
+        return await session.get(DiscJob, job_id)
+
+
+# --- Issue 1: reconcile_stuck_titles ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_stuck_no_file_fails(tmp_path):
+    job_id = await _make_job(tmp_path, state=JobState.RIPPING)
+    tid = await _add_title(job_id, 0, TitleState.RIPPING)  # no file anywhere
+
+    await job_manager.reconcile_stuck_titles(job_id)
+
+    assert (await _title(tid)).state == TitleState.FAILED
+
+
+@pytest.mark.asyncio
+async def test_reconcile_stuck_movie_with_file_matched(tmp_path):
+    f = tmp_path / "disc_t00.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.MOVIE, state=JobState.RIPPING)
+    tid = await _add_title(job_id, 0, TitleState.RIPPING, output=str(f))
+
+    await job_manager.reconcile_stuck_titles(job_id)
+
+    t = await _title(tid)
+    assert t.state == TitleState.MATCHED
+    assert t.output_filename == str(f)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_stuck_tv_with_file_queues_match(tmp_path, monkeypatch):
+    f = tmp_path / "disc_t03.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.RIPPING)
+    tid = await _add_title(job_id, 3, TitleState.RIPPING, output=str(f))
+
+    called = {}
+
+    async def fake_discdb(jid, title, session):
+        return False
+
+    async def fake_match(jid, title_id, path):
+        called["match"] = (jid, title_id, str(path))
+
+    monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", fake_discdb)
+    monkeypatch.setattr(job_manager._matching, "match_single_file", fake_match)
+    monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
+
+    await job_manager.reconcile_stuck_titles(job_id)
+    await asyncio.sleep(0.05)  # let the queued match task run
+
+    assert (await _title(tid)).state == TitleState.MATCHING
+    assert called.get("match") == (job_id, tid, str(f))
+
+
+# --- Issue 2: match attribution --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_match_leaves_review_without_engram_source(tmp_path, monkeypatch):
+    f = tmp_path / "disc_t05.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.MATCHING)
+    tid = await _add_title(job_id, 5, TitleState.MATCHING, output=str(f))
+
+    async def no_match(*args, **kwargs):
+        return SimpleNamespace(
+            episode_code=None,
+            confidence=0.0,
+            needs_review=True,
+            match_details={"matches_found": 0, "matches_rejected": 10},
+        )
+
+    monkeypatch.setattr(
+        "app.services.matching_coordinator.episode_curator.match_single_file", no_match
+    )
+    # Isolate the gating assertion from finalization.
+    monkeypatch.setattr(
+        job_manager._matching, "_check_job_completion", lambda *a, **k: asyncio.sleep(0)
+    )
+
+    await job_manager._matching._match_single_file_inner(job_id, tid, f)
+
+    t = await _title(tid)
+    assert t.state == TitleState.REVIEW
+    assert t.match_source is None  # NOT "engram"
+
+
+@pytest.mark.asyncio
+async def test_successful_match_sets_engram_source(tmp_path, monkeypatch):
+    f = tmp_path / "disc_t00.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.MATCHING)
+    tid = await _add_title(job_id, 0, TitleState.MATCHING, output=str(f))
+
+    async def good_match(*args, **kwargs):
+        return SimpleNamespace(
+            episode_code="S01E01",
+            confidence=0.92,
+            needs_review=False,
+            match_details={"score": 0.92, "vote_count": 9},
+        )
+
+    monkeypatch.setattr(
+        "app.services.matching_coordinator.episode_curator.match_single_file", good_match
+    )
+    monkeypatch.setattr(
+        job_manager._matching, "_check_job_completion", lambda *a, **k: asyncio.sleep(0)
+    )
+
+    await job_manager._matching._match_single_file_inner(job_id, tid, f)
+
+    t = await _title(tid)
+    assert t.state == TitleState.MATCHED
+    assert t.match_source == "engram"
+
+
+# --- Issue 3/4: force-advance + skip ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advance_sends_stuck_to_review(tmp_path):
+    f = tmp_path / "disc_t05.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.MATCHING)
+    await _add_title(job_id, 0, TitleState.MATCHED, matched_episode="S01E01")
+    stuck = await _add_title(job_id, 5, TitleState.MATCHING, output=str(f))
+
+    assert await job_manager.reconcile_and_advance(job_id, reason="test") is True
+
+    assert (await _title(stuck)).state == TitleState.REVIEW
+    assert (await _job(job_id)).state == JobState.REVIEW_NEEDED
+
+
+@pytest.mark.asyncio
+async def test_advance_no_file_fails_track(tmp_path):
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.RIPPING)
+    stuck = await _add_title(job_id, 0, TitleState.RIPPING)  # no file
+
+    assert await job_manager.reconcile_and_advance(job_id, reason="test") is True
+
+    assert (await _title(stuck)).state == TitleState.FAILED
+
+
+@pytest.mark.asyncio
+async def test_advance_rejects_terminal(tmp_path):
+    job_id = await _make_job(tmp_path, state=JobState.COMPLETED)
+    assert await job_manager.reconcile_and_advance(job_id) is False
+
+
+@pytest.mark.asyncio
+async def test_skip_title_to_review(tmp_path):
+    f = tmp_path / "disc_t02.mkv"
+    f.write_bytes(b"x")
+    job_id = await _make_job(tmp_path, content_type=ContentType.TV, state=JobState.MATCHING)
+    tid = await _add_title(job_id, 2, TitleState.MATCHING, output=str(f))
+
+    assert await job_manager.skip_title(job_id, tid) is True
+
+    assert (await _title(tid)).state == TitleState.REVIEW
+    assert (await _job(job_id)).state == JobState.REVIEW_NEEDED
+
+
+@pytest.mark.asyncio
+async def test_skip_title_already_resolved_returns_false(tmp_path):
+    job_id = await _make_job(tmp_path, state=JobState.MATCHING)
+    tid = await _add_title(job_id, 0, TitleState.MATCHED)
+
+    assert await job_manager.skip_title(job_id, tid) is False
+
+
+# --- watchdog config helper ------------------------------------------------
+
+
+def test_phase_timeout_reads_config():
+    cfg = AppConfig()
+    assert job_manager._phase_timeout(cfg, JobState.IDENTIFYING) == cfg.timeout_identifying_seconds
+    assert job_manager._phase_timeout(cfg, JobState.RIPPING) == cfg.timeout_ripping_seconds
+    assert job_manager._phase_timeout(cfg, JobState.MATCHING) == cfg.timeout_matching_seconds
+    assert job_manager._phase_timeout(cfg, JobState.ORGANIZING) == cfg.timeout_organizing_seconds
+    # Resting / untimed states have no ceiling.
+    assert job_manager._phase_timeout(cfg, JobState.REVIEW_NEEDED) is None
+    assert job_manager._phase_timeout(cfg, JobState.IDLE) is None

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -111,7 +111,7 @@ function MainDashboard() {
   }, []);
 
   // Job management with WebSocket
-  const { jobs, titlesMap, isConnected, cancelJob, clearCompleted, setJobName, reIdentifyJob } = useJobManagement(DEV_MODE);
+  const { jobs, titlesMap, isConnected, cancelJob, advanceJob, skipTrack, clearCompleted, setJobName, reIdentifyJob } = useJobManagement(DEV_MODE);
   const [reIdentifyTarget, setReIdentifyTarget] = useState<Job | null>(null);
 
   // Show the full-screen Splash with a "RECONNECTING…" label when the
@@ -502,6 +502,8 @@ function MainDashboard() {
                   key={disc.id}
                   disc={disc}
                   onCancel={disc.state !== 'completed' && disc.state !== 'error' ? () => cancelJob(disc.id) : undefined}
+                  onAdvance={disc.state !== 'completed' && disc.state !== 'error' ? () => advanceJob(disc.id) : undefined}
+                  onSkipTrack={(trackId) => skipTrack(disc.id, trackId)}
                   onReview={disc.needsReview ? () => navigate(`/review/${disc.id}`) : undefined}
                   onReIdentify={disc.needsReview && disc.title ? () => {
                     const job = jobs.find(j => String(j.id) === disc.id);

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -14,7 +14,7 @@ import { formatEta } from "../../utils/formatting";
 
 export type MediaType = "movie" | "tv" | "unknown";
 export type DiscState = "idle" | "scanning" | "review_needed" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
-export type TrackState = "pending" | "ripping" | "matching" | "matched" | "failed" | "completed";
+export type TrackState = "pending" | "ripping" | "matching" | "matched" | "review" | "failed" | "completed";
 
 export interface MatchCandidate {
   episode: string;
@@ -77,6 +77,8 @@ interface DiscCardProps {
   onCancel?: () => void;
   onReview?: () => void;
   onReIdentify?: () => void;
+  onAdvance?: () => void;
+  onSkipTrack?: (trackId: string) => void;
 }
 
 /**
@@ -170,7 +172,7 @@ function CoverOverlay({ children }: { children: React.ReactNode }) {
 }
 
 const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
-  ({ disc, onCancel, onReview, onReIdentify }, ref) => {
+  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onSkipTrack }, ref) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const posterUrl = usePosterImage(disc.id, disc.title);
     const isActive = !['completed', 'error', 'idle'].includes(disc.state);
@@ -349,6 +351,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                     onCancel={onCancel}
                     onReview={onReview}
                     onReIdentify={onReIdentify}
+                    onAdvance={onAdvance}
                   />
                 </div>
               </div>
@@ -418,7 +421,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.yellow}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
                 </div>
               )}
 
@@ -472,7 +475,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.inkDim}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
                 </div>
               )}
 
@@ -500,7 +503,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.purple}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
                 </div>
               )}
 
@@ -510,7 +513,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   <PulseCaption color={sv.amber}>
                     › PROCESSING…
                   </PulseCaption>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
                 </div>
               )}
 

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -14,7 +14,7 @@
 
 import { useState, type CSSProperties, type ReactNode, type MouseEvent } from "react";
 import { motion } from "motion/react";
-import { IcoCancel, IcoError, IcoRetry } from "../icons";
+import { IcoCancel, IcoError, IcoRetry, IcoPlay } from "../icons";
 import type { DiscState } from "../DiscCard";
 import { sv } from "../synapse";
 
@@ -24,7 +24,11 @@ interface ActionButtonsProps {
     onCancel?: () => void;
     onReview?: () => void;
     onReIdentify?: () => void;
+    onAdvance?: () => void;
 }
+
+// States where a job is actively processing and can be force-advanced/cancelled.
+const ACTIVE_STATES = ["scanning", "ripping", "matching", "organizing", "processing"];
 
 interface Tone {
     fg: string;        // foreground / icon / text
@@ -126,9 +130,21 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0 }:
     );
 }
 
-export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify }: ActionButtonsProps) {
-    const showCancel = !!onCancel && (isHovered || ["scanning", "ripping", "processing"].includes(state));
+export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance }: ActionButtonsProps) {
+    const showCancel = !!onCancel && (isHovered || ACTIVE_STATES.includes(state));
     const showReview = !!onReview && state === "review_needed";
+    const showAdvance = !!onAdvance && ACTIVE_STATES.includes(state);
+
+    const handleAdvance = (e: MouseEvent) => {
+        e.stopPropagation();
+        if (window.confirm(
+            "Force this job to its next step?\n\n" +
+            "Tracks still ripping or matching will be sent to review (or failed if no " +
+            "file was produced), and anything already matched will be organized."
+        )) {
+            onAdvance!();
+        }
+    };
 
     return (
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -141,6 +157,19 @@ export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdenti
                     paddingX={0}
                 >
                     <IcoCancel size={14} />
+                </ToneButton>
+            )}
+
+            {showAdvance && (
+                <ToneButton
+                    tone={CYAN}
+                    onClick={handleAdvance}
+                    title="Force this job to its next step"
+                    ariaLabel="Force job to next step"
+                    paddingX={10}
+                >
+                    <IcoPlay size={12} />
+                    <span style={{ fontSize: 10 }}>Force</span>
                 </ToneButton>
             )}
 

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -27,8 +27,11 @@ interface ActionButtonsProps {
     onAdvance?: () => void;
 }
 
-// States where a job is actively processing and can be force-advanced/cancelled.
+// States where Force-advance makes sense (job is actively processing).
 const ACTIVE_STATES = ["scanning", "ripping", "matching", "organizing", "processing"];
+// Cancel was historically shown only during rip-phase states; keep that scope so it
+// doesn't surface during organizing, where cancelling could leave files partially moved.
+const CANCELABLE_STATES = ["scanning", "ripping", "processing"];
 
 interface Tone {
     fg: string;        // foreground / icon / text
@@ -131,7 +134,7 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0 }:
 }
 
 export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance }: ActionButtonsProps) {
-    const showCancel = !!onCancel && (isHovered || ACTIVE_STATES.includes(state));
+    const showCancel = !!onCancel && (isHovered || CANCELABLE_STATES.includes(state));
     const showReview = !!onReview && state === "review_needed";
     const showAdvance = !!onAdvance && ACTIVE_STATES.includes(state);
 

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -11,7 +11,9 @@ interface TrackGridProps {
   onSkip?: (trackId: string) => void;
 }
 
-// Track states where a per-track "skip" makes sense (still in flight).
+// Track states where a per-track "skip" makes sense (still in flight). PENDING is
+// intentionally excluded — selected titles only briefly sit there before ripping, and
+// the backend skip endpoint still accepts PENDING if ever needed.
 const SKIPPABLE: ReadonlyArray<TrackState> = ["ripping", "matching"];
 
 interface StateConfig {

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -7,7 +7,12 @@ import { formatBytesBinary } from "../../utils/formatting";
 
 interface TrackGridProps {
   tracks: Track[];
+  /** Skip a single stuck track (ripping/matching) → sends it to review. */
+  onSkip?: (trackId: string) => void;
 }
+
+// Track states where a per-track "skip" makes sense (still in flight).
+const SKIPPABLE: ReadonlyArray<TrackState> = ["ripping", "matching"];
 
 interface StateConfig {
   label: string;
@@ -22,6 +27,7 @@ const STATE: Record<TrackState, StateConfig> = {
   ripping:   { label: "RIPPING",  color: sv.magenta, border: `${sv.magenta}66`,    bg: `${sv.magenta}10`, Icon: IcoRipping },
   matching:  { label: "MATCHING", color: sv.amber,   border: `${sv.amber}55`,      bg: `${sv.amber}10`, Icon: IcoMatching },
   matched:   { label: "MATCHED",  color: sv.green,   border: `${sv.green}55`,      bg: `${sv.green}10`, Icon: IcoComplete },
+  review:    { label: "NEEDS REVIEW", color: sv.yellow, border: `${sv.yellow}66`,  bg: `${sv.yellow}10`, Icon: IcoError  },
   failed:    { label: "FAILED",   color: sv.red,     border: `${sv.red}66`,        bg: `${sv.red}10`, Icon: IcoError    },
   completed: { label: "DONE",     color: sv.green,   border: `${sv.green}55`,      bg: `${sv.green}10`, Icon: IcoComplete },
 };
@@ -38,7 +44,7 @@ const matchSourceLabel = (source?: string): string => {
   return "ENGRAM";
 };
 
-export const TrackGrid = React.memo(function TrackGrid({ tracks }: TrackGridProps) {
+export const TrackGrid = React.memo(function TrackGrid({ tracks, onSkip }: TrackGridProps) {
   return (
     <div data-testid="sv-track-grid" style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 10 }}>
       <SvLabel>TRACK STATUS</SvLabel>
@@ -140,18 +146,47 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks }: TrackGridProp
                   )}
                 </div>
 
-                {Icon && (
-                  <motion.div
-                    animate={
-                      track.state === "ripping" || track.state === "matching"
-                        ? { rotate: 360 }
-                        : {}
-                    }
-                    transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
-                  >
-                    <Icon size={14} color={config.color} />
-                  </motion.div>
-                )}
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                  {onSkip && SKIPPABLE.includes(track.state) && (
+                    <button
+                      type="button"
+                      data-testid={`track-skip-${track.id}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (window.confirm("Skip this track and send it to review?")) {
+                          onSkip(track.id);
+                        }
+                      }}
+                      title="Skip this track — send to review"
+                      aria-label="Skip this track"
+                      style={{
+                        fontFamily: sv.mono,
+                        fontSize: 9,
+                        fontWeight: 700,
+                        letterSpacing: "0.18em",
+                        color: sv.yellow,
+                        background: "transparent",
+                        border: `1px solid ${sv.yellow}66`,
+                        padding: "2px 6px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      SKIP
+                    </button>
+                  )}
+                  {Icon && (
+                    <motion.div
+                      animate={
+                        track.state === "ripping" || track.state === "matching"
+                          ? { rotate: 360 }
+                          : {}
+                      }
+                      transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
+                    >
+                      <Icon size={14} color={config.color} />
+                    </motion.div>
+                  )}
+                </div>
               </div>
 
               {/* Failed: error message */}
@@ -177,6 +212,18 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks }: TrackGridProp
                 <div style={{ marginTop: 4 }}>
                   <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, letterSpacing: "0.18em" }}>
                     QUEUED
+                  </span>
+                </div>
+              )}
+
+              {/* Review: no confident match — needs manual episode assignment */}
+              {track.state === "review" && (
+                <div style={{ marginTop: 4 }}>
+                  <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.yellow, letterSpacing: "0.18em", fontWeight: 700 }}>
+                    NEEDS REVIEW
+                  </span>
+                  <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8 }}>
+                    no confident match — assign in review queue
                   </span>
                 </div>
               )}

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -163,6 +163,31 @@ export function useJobManagement(devMode: boolean = false) {
         }
     }
 
+    async function advanceJob(jobId: string) {
+        try {
+            await apiFetchVoid(`/api/jobs/${jobId}/advance`, { method: 'POST' });
+            toast.success('Forcing the job to its next step.');
+            // Job will update via WebSocket
+        } catch (error) {
+            console.error('Failed to advance job:', error);
+            toast.error('Failed to advance the job. Please try again.');
+        }
+    }
+
+    async function skipTrack(jobId: string, titleId: string, target: 'review' | 'fail' = 'review') {
+        try {
+            await apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/skip`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ target }),
+            });
+            // Title + job will update via WebSocket
+        } catch (error) {
+            console.error('Failed to skip track:', error);
+            toast.error('Failed to skip the track. Please try again.');
+        }
+    }
+
     async function clearCompleted() {
         try {
             const completedJobs = jobs.filter(j => j.state === 'completed');
@@ -355,6 +380,8 @@ export function useJobManagement(devMode: boolean = false) {
         titlesMap,
         isConnected,
         cancelJob,
+        advanceJob,
+        skipTrack,
         clearCompleted,
         setJobName,
         reIdentifyJob,

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -52,6 +52,11 @@ interface ConfigData {
     maxConcurrentMatches: number;
     ffmpegPath: string;
     conflictResolutionDefault: string;
+    watchdogEnabled: boolean;
+    timeoutIdentifyingSeconds: number;
+    timeoutRippingSeconds: number;
+    timeoutMatchingSeconds: number;
+    timeoutOrganizingSeconds: number;
     stagingCleanupPolicy: string;
     stagingCleanupDays: number;
     extrasPolicy: string;
@@ -98,6 +103,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         maxConcurrentMatches: 2,
         ffmpegPath: '',
         conflictResolutionDefault: 'ask',
+        watchdogEnabled: true,
+        timeoutIdentifyingSeconds: 600,
+        timeoutRippingSeconds: 1200,
+        timeoutMatchingSeconds: 1800,
+        timeoutOrganizingSeconds: 600,
         stagingCleanupPolicy: 'on_success',
         stagingCleanupDays: 7,
         extrasPolicy: 'keep',
@@ -154,6 +164,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     maxConcurrentMatches: data.max_concurrent_matches ?? 2,
                     ffmpegPath: data.ffmpeg_path || '',
                     conflictResolutionDefault: data.conflict_resolution_default || 'ask',
+                    watchdogEnabled: data.watchdog_enabled ?? true,
+                    timeoutIdentifyingSeconds: data.timeout_identifying_seconds ?? 600,
+                    timeoutRippingSeconds: data.timeout_ripping_seconds ?? 1200,
+                    timeoutMatchingSeconds: data.timeout_matching_seconds ?? 1800,
+                    timeoutOrganizingSeconds: data.timeout_organizing_seconds ?? 600,
                     stagingCleanupPolicy: data.staging_cleanup_policy || 'on_success',
                     stagingCleanupDays: data.staging_cleanup_days ?? 7,
                     extrasPolicy: data.extras_policy || 'keep',
@@ -251,6 +266,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     max_concurrent_matches: config.maxConcurrentMatches,
                     ffmpeg_path: config.ffmpegPath,
                     conflict_resolution_default: config.conflictResolutionDefault,
+                    watchdog_enabled: config.watchdogEnabled,
+                    timeout_identifying_seconds: config.timeoutIdentifyingSeconds,
+                    timeout_ripping_seconds: config.timeoutRippingSeconds,
+                    timeout_matching_seconds: config.timeoutMatchingSeconds,
+                    timeout_organizing_seconds: config.timeoutOrganizingSeconds,
                     staging_cleanup_policy: config.stagingCleanupPolicy,
                     staging_cleanup_days: config.stagingCleanupDays,
                     extras_policy: config.extrasPolicy,
@@ -810,6 +830,71 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 />
                                 <span className="form-hint">
                                     Delete staging files older than this many days.
+                                </span>
+                            </div>
+                        )}
+
+                        <div className="form-group">
+                            <label htmlFor="watchdogEnabled">Stale-Job Watchdog</label>
+                            <select
+                                id="watchdogEnabled"
+                                value={config.watchdogEnabled ? 'on' : 'off'}
+                                onChange={(e) => handleInputChange('watchdogEnabled', e.target.value === 'on')}
+                            >
+                                <option value="on">Enabled (auto-advance stuck jobs)</option>
+                                <option value="off">Disabled</option>
+                            </select>
+                            <span className="form-hint">
+                                When a job stops making progress for longer than its phase timeout, Engram
+                                resolves the stuck tracks (ripped-but-unmatched → review) and moves the job
+                                forward instead of leaving it stuck. You can also force this manually per job.
+                            </span>
+                        </div>
+
+                        {config.watchdogEnabled && (
+                            <div className="form-group">
+                                <label>Phase Timeouts (seconds of no progress)</label>
+                                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12 }}>
+                                    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                                        Identifying
+                                        <input
+                                            type="number"
+                                            min={30}
+                                            value={config.timeoutIdentifyingSeconds}
+                                            onChange={(e) => handleInputChange('timeoutIdentifyingSeconds', Math.max(30, parseInt(e.target.value) || 600))}
+                                        />
+                                    </label>
+                                    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                                        Ripping
+                                        <input
+                                            type="number"
+                                            min={60}
+                                            value={config.timeoutRippingSeconds}
+                                            onChange={(e) => handleInputChange('timeoutRippingSeconds', Math.max(60, parseInt(e.target.value) || 1200))}
+                                        />
+                                    </label>
+                                    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                                        Matching
+                                        <input
+                                            type="number"
+                                            min={60}
+                                            value={config.timeoutMatchingSeconds}
+                                            onChange={(e) => handleInputChange('timeoutMatchingSeconds', Math.max(60, parseInt(e.target.value) || 1800))}
+                                        />
+                                    </label>
+                                    <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
+                                        Organizing
+                                        <input
+                                            type="number"
+                                            min={30}
+                                            value={config.timeoutOrganizingSeconds}
+                                            onChange={(e) => handleInputChange('timeoutOrganizingSeconds', Math.max(30, parseInt(e.target.value) || 600))}
+                                        />
+                                    </label>
+                                </div>
+                                <span className="form-hint">
+                                    Ripping leans on MakeMKV&apos;s own no-growth stall watchdog; this is an
+                                    additional ceiling on total silence per phase.
                                 </span>
                             </div>
                         )}

--- a/frontend/src/types/__tests__/adapters.test.ts
+++ b/frontend/src/types/__tests__/adapters.test.ts
@@ -37,7 +37,7 @@ describe("mapTitleStateToTrackState", () => {
     ["ripping", "ripping"],
     ["matching", "matching"],
     ["matched", "matched"],
-    ["review", "matched"],
+    ["review", "review"],
     ["completed", "completed"],
     ["failed", "failed"],
   ];

--- a/frontend/src/types/__tests__/discstate-mapping.test.ts
+++ b/frontend/src/types/__tests__/discstate-mapping.test.ts
@@ -55,8 +55,8 @@ describe('Issue #16: Processing state visibility', () => {
       expect(mapTitleStateToTrackState('completed')).toBe('completed');
     });
 
-    it('should map "review" to "matched"', () => {
-      expect(mapTitleStateToTrackState('review')).toBe('matched');
+    it('should map "review" to "review"', () => {
+      expect(mapTitleStateToTrackState('review')).toBe('review');
     });
   });
 });

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -29,7 +29,7 @@ export function mapTitleStateToTrackState(
     'ripping': 'ripping',
     'matching': 'matching',
     'matched': 'matched',
-    'review': 'matched',
+    'review': 'review',
     'completed': 'completed',
     'failed': 'failed'
   };


### PR DESCRIPTION
## Summary

Fixes four issues found while reviewing a live job stuck mid-pipeline, and makes stuck jobs self-healing.

1. **Last track stuck in `ripping`.** The final title could be orphaned in `RIPPING` when its completion callback never fired and no "next title" event arrived. Added `reconcile_stuck_titles`, called post-rip, which recovers any selected title still in `PENDING`/`RIPPING` (route the ripped file into matching, or fail it if no file exists).
2. **Unmatched title mislabeled "ENGRAM".** `match_source` was set to `"engram"` unconditionally, so a title that routed to review still showed the ENGRAM provider badge. It's now set **only** when an episode match is actually recorded; unmatched titles surface as **NEEDS REVIEW** in the UI (new distinct `review` track state) with no false attribution.
3. **No stale-job watchdog.** Added a per-phase, **configurable** watchdog that auto-advances jobs idle past their timeout to their natural resting state (`COMPLETED` or `REVIEW_NEEDED`), preserving already-ripped/matched work.
4. **Cancel was the only option.** Added manual force-progress: a whole-job **Force** button and a per-track **SKIP** control.

## Design

The watchdog and the Force button share one `reconcile_and_advance` engine that reuses the existing `FinalizationCoordinator.check_job_completion` logic ("organize what matched, route the rest to review, complete only if all resolved"). Because unmatched rips land in the non-terminal `REVIEW_NEEDED` state, the terminal-state staging cleanup never fires, so ripped files are never auto-deleted on a force-advance.

## Changes

- **Backend**
  - `reconcile_stuck_titles`, `reconcile_and_advance`, `skip_title`, in-memory activity tracking, and `_watchdog_loop` in `job_manager.py`.
  - `on_transition` hook on `JobStateMachine` (resets the watchdog clock per phase).
  - Gated `match_source="engram"` in `matching_coordinator.py`.
  - New `AppConfig` fields (`watchdog_enabled`, `watchdog_poll_seconds`, `timeout_*_seconds`) with `server_default`s so existing/frozen DBs converge via the `database.py` reconcilers; surfaced through `/api/config`.
  - New endpoints `POST /api/jobs/{id}/advance` and `POST /api/jobs/{id}/titles/{tid}/skip`.
- **Frontend**
  - New `review` `TrackState` → **NEEDS REVIEW** badge (replaces the misleading ENGRAM badge on unmatched tracks).
  - **Force** button (`ActionButtons`) + per-track **SKIP** (`TrackGrid`), wired via `advanceJob`/`skipTrack` in `useJobManagement`.
  - Stale-job watchdog + per-phase timeout settings in `ConfigWizard`.

## Reviewer notes

- New config columns rely on `server_default` (not the `_add_missing_columns` int fallback of `0`) so a migrated DB doesn't fire the watchdog instantly.
- The watchdog seeds a job's activity clock on first sighting to avoid false trips for jobs that predate startup.

## Test plan

- [x] Backend: 1092 unit + 92 pipeline + 93 integration pass, incl. 11 new recovery/attribution unit tests (`test_stuck_job_recovery.py`) and 6 new endpoint tests (`test_force_progress_api.py`).
- [x] `ruff check` / `ruff format` clean (enforced by pre-commit).
- [x] Frontend: `npm run build` (TS exhaustiveness on the new track state), `npm run lint`, 79 unit tests pass.
- [x] Manual: drove the dashboard against a seeded job — verified NEEDS REVIEW (no ENGRAM badge), the Force button, per-track SKIP, and the watchdog timeout settings render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)