### PR TITLE
feat(docker): add Linux container packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Keep the build context small and free of host-only / secret artifacts.
+
+# Python
+**/.venv
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+
+# The dev database holds API keys/credentials — never bake it into an image.
+backend/engram.db
+backend/engram.db-*
+backend/.engram
+
+# Build outputs (regenerated inside the image)
+frontend/node_modules
+frontend/dist
+backend/dist
+backend/build
+backend/*.spec
+
+# Repo tooling / docs / local junk
+.git
+.github
+.claude
+artifacts/
+docs/
+*.log
+*.png

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts must use LF so they run inside Linux containers — a CRLF in the
+# shebang line breaks execution ("bad interpreter").
+*.sh text eol=lf
+docker/entrypoint.sh text eol=lf
+docker/install-makemkv.sh text eol=lf
+Dockerfile text eol=lf

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,93 @@
+name: Docker
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker/**"
+      - "backend/**"
+      - "frontend/**"
+      - ".github/workflows/docker.yml"
+
+# See ci.yml for context on the Node 24 opt-in.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  IMAGE: ghcr.io/${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      # Build once and load locally so we can smoke test before publishing.
+      - name: Build image (load for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: engram:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: |
+          # MAKEMKV_SKIP_INSTALL avoids the slow first-run MakeMKV compile; we
+          # only need the web server to come up and answer /health.
+          docker run -d --name engram-ci -e MAKEMKV_SKIP_INSTALL=1 -p 8000:8000 engram:ci
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8000/health > /dev/null; then
+              ready=1
+              break
+            fi
+            sleep 2
+          done
+          docker logs engram-ci || true
+          docker rm -f engram-ci > /dev/null 2>&1 || true
+          if [ "$ready" != "1" ]; then
+            echo "container never became healthy"
+            exit 1
+          fi
+          echo "smoke test passed"
+
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Re-runs from the buildx cache, so this is fast.
+      - name: Push image
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1
+
+# Engram — Linux container image.
+#
+# Three stages: build the React frontend, resolve the Python venv, then assemble
+# a Debian runtime. MakeMKV is intentionally NOT baked in — it is compiled into a
+# persistent volume on first start (see docker/install-makemkv.sh) so this image
+# never redistributes MakeMKV binaries.
+
+# ---------------------------------------------------------------------------
+# Stage 1: frontend build (Vite -> static SPA)
+# ---------------------------------------------------------------------------
+FROM node:24-bookworm-slim AS frontend-builder
+WORKDIR /build/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+# Output: /build/frontend/dist
+
+# ---------------------------------------------------------------------------
+# Stage 2: Python dependency resolution (uv -> .venv)
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS backend-builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+WORKDIR /app
+# Resolve deps first (cached unless the lockfile changes). The project itself is
+# not installed (no [build-system]); it runs from source — mirrors CI's
+# `uv sync --no-install-project`.
+COPY backend/pyproject.toml backend/uv.lock ./
+RUN uv sync --frozen --no-install-project --no-dev
+# Output: /app/.venv
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS runtime
+
+# Runtime tools + MakeMKV build toolchain (needed for the first-run compile) +
+# gosu (privilege drop). The toolchain inflates the image but is the cost of
+# keeping MakeMKV out of the published layers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libsndfile1 \
+        util-linux \
+        eject \
+        ca-certificates \
+        curl \
+        gosu \
+        build-essential \
+        pkg-config \
+        libc6-dev \
+        libssl-dev \
+        libexpat1-dev \
+        libavcodec-dev \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Python venv + application source.
+COPY --from=backend-builder /app/.venv /app/.venv
+COPY backend/ /app/
+# Bundled SPA. main.py serves it from "<main.py dir>/static" -> /app/app/static.
+COPY --from=frontend-builder /build/frontend/dist /app/app/static
+
+# Entrypoint + MakeMKV installer.
+COPY docker/entrypoint.sh docker/install-makemkv.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/install-makemkv.sh
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    HOME=/config \
+    HF_HOME=/config/.cache/huggingface \
+    DATABASE_URL="sqlite+aiosqlite:////config/.engram/engram.db" \
+    HOST=0.0.0.0 \
+    PORT=8000 \
+    DEBUG=false \
+    PUID=1000 \
+    PGID=1000 \
+    MAKEMKV_VERSION=latest
+
+EXPOSE 8000
+VOLUME ["/config"]
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /build/frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 COPY frontend/ ./
+# vite.config.ts reads the app version from the backend package (../backend/app/__init__.py).
+COPY backend/app/__init__.py /build/backend/app/__init__.py
 RUN npm run build
 # Output: /build/frontend/dist
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ npm run dev
 
 Open http://localhost:5173 in your browser. See the [installation guide](docs/getting-started/installation.md) for distro-specific prerequisites and verification steps.
 
+### Option C: Docker (Linux)
+
+Run Engram as a container with the optical drive passed through from the host:
+
+```bash
+git clone https://github.com/Jsakkos/engram.git
+cd engram
+# Set MAKEMKV_APP_KEY (and PUID/PGID) in docker-compose.yml, then:
+docker compose up -d
+```
+
+Open http://localhost:8000 and complete the setup wizard. MakeMKV is compiled
+into the `./config` volume on first start (one-time), so the image itself ships
+no MakeMKV binaries. Optical-disc ripping requires a real Linux host with a
+drive — Docker Desktop on Windows/macOS can run the UI but can't pass through
+`/dev/sr0`. See the [Docker deployment guide](docs/deployment/docker.md) for
+volumes, device passthrough, GPU notes, and troubleshooting.
+
 ## Configuration
 
 On first launch the Config Wizard walks you through setup: MakeMKV path, library paths, TMDB token, and more. Settings are stored in the database and editable from the Settings page.

--- a/backend/app/core/makemkv_registration.py
+++ b/backend/app/core/makemkv_registration.py
@@ -45,9 +45,8 @@ def write_makemkv_settings(key: str, settings_path: Path | None = None) -> bool:
     path = settings_path or makemkv_settings_path()
     new_line = f'app_Key = "{key}"'
 
-    existing_lines: list[str] = []
-    if path.exists():
-        existing_lines = path.read_text(encoding="utf-8").splitlines()
+    original_text = path.read_text(encoding="utf-8") if path.exists() else ""
+    existing_lines = original_text.splitlines()
 
     replaced = False
     out_lines: list[str] = []
@@ -64,14 +63,14 @@ def write_makemkv_settings(key: str, settings_path: Path | None = None) -> bool:
         out_lines.append(new_line)
 
     new_contents = "\n".join(out_lines) + "\n"
-    if path.exists() and path.read_text(encoding="utf-8") == new_contents:
+    if original_text == new_contents:
         return False  # Idempotent: nothing to do.
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(new_contents, encoding="utf-8")
     except OSError as e:
-        logger.warning(f"Could not write MakeMKV settings to {path}: {e}")
+        logger.warning(f"Could not write MakeMKV settings to {path}: {e}", exc_info=True)
         return False
 
     logger.info(f"Registered MakeMKV key in {path}")

--- a/backend/app/core/makemkv_registration.py
+++ b/backend/app/core/makemkv_registration.py
@@ -1,0 +1,78 @@
+"""Bridge Engram's stored MakeMKV license key into MakeMKV's own settings file.
+
+``makemkvcon`` reads its registration key from ``settings.conf`` (the ``app_Key``
+line) — a file entirely separate from Engram's config database. The desktop build
+sidesteps this because users register MakeMKV out-of-band via its GUI, but a
+headless/containerized install has no GUI. This module upserts the key into
+``settings.conf`` (merging, never clobbering unrelated settings) so ripping works
+once the user enters their key in the Engram UI or via ``MAKEMKV_APP_KEY``.
+"""
+
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Matches a settings.conf line that assigns app_Key, e.g.  app_Key = "T-..."
+_APP_KEY_LINE = re.compile(r"^\s*app_Key\s*=", re.IGNORECASE)
+
+
+def makemkv_settings_path() -> Path:
+    """Return the per-OS location of MakeMKV's settings.conf."""
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "MakeMKV" / "settings.conf"
+    # Linux and macOS both use ~/.MakeMKV/settings.conf.
+    return Path.home() / ".MakeMKV" / "settings.conf"
+
+
+def write_makemkv_settings(key: str, settings_path: Path | None = None) -> bool:
+    """Upsert ``app_Key`` into MakeMKV's settings.conf.
+
+    Preserves all other lines in the file. Blank keys are ignored (no-op), and a
+    rewrite is skipped when the stored key already matches — both so this is safe
+    to call unconditionally on startup and on every config save.
+
+    Returns True if the file was written, False if nothing changed.
+    """
+    if not key or not key.strip():
+        return False
+
+    key = key.strip()
+    path = settings_path or makemkv_settings_path()
+    new_line = f'app_Key = "{key}"'
+
+    existing_lines: list[str] = []
+    if path.exists():
+        existing_lines = path.read_text(encoding="utf-8").splitlines()
+
+    replaced = False
+    out_lines: list[str] = []
+    for line in existing_lines:
+        if _APP_KEY_LINE.match(line):
+            if replaced:
+                continue  # Drop any duplicate app_Key lines.
+            out_lines.append(new_line)
+            replaced = True
+        else:
+            out_lines.append(line)
+
+    if not replaced:
+        out_lines.append(new_line)
+
+    new_contents = "\n".join(out_lines) + "\n"
+    if path.exists() and path.read_text(encoding="utf-8") == new_contents:
+        return False  # Idempotent: nothing to do.
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(new_contents, encoding="utf-8")
+    except OSError as e:
+        logger.warning(f"Could not write MakeMKV settings to {path}: {e}")
+        return False
+
+    logger.info(f"Registered MakeMKV key in {path}")
+    return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,14 @@ async def lifespan(app: FastAPI):
 
     config = await get_config()
 
+    # Reconcile a stored MakeMKV key into MakeMKV's settings.conf on boot so
+    # makemkvcon is registered even if the key was entered before this bridge
+    # existed (idempotent — skips the write when already in sync).
+    if config.makemkv_key:
+        from app.core.makemkv_registration import write_makemkv_settings
+
+        await asyncio.to_thread(write_makemkv_settings, config.makemkv_key)
+
     # Auto-detect MakeMKV if path is empty
     if not config.makemkv_path:
         makemkv_result = await asyncio.to_thread(detect_makemkv)

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -3,6 +3,7 @@
 Provides functions to get and update configuration stored in SQLite.
 """
 
+import asyncio
 import logging
 import sys
 from pathlib import Path
@@ -143,7 +144,7 @@ async def update_config(**kwargs) -> AppConfig:
         if "makemkv_key" in kwargs and config.makemkv_key:
             from app.core.makemkv_registration import write_makemkv_settings
 
-            write_makemkv_settings(config.makemkv_key)
+            await asyncio.to_thread(write_makemkv_settings, config.makemkv_key)
 
         logger.info(f"Updated configuration: {list(kwargs.keys())}")
         return config

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -137,6 +137,14 @@ async def update_config(**kwargs) -> AppConfig:
 
             clear_caches()
 
+        # Bridge a changed MakeMKV key into MakeMKV's own settings.conf so
+        # makemkvcon picks it up — Engram's config DB and MakeMKV's settings
+        # file are otherwise unconnected. No-op for blank keys.
+        if "makemkv_key" in kwargs and config.makemkv_key:
+            from app.core.makemkv_registration import write_makemkv_settings
+
+            write_makemkv_settings(config.makemkv_key)
+
         logger.info(f"Updated configuration: {list(kwargs.keys())}")
         return config
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -13,6 +13,19 @@ from app.main import app
 from app.models import AppConfig
 
 
+@pytest.fixture(autouse=True)
+def no_real_makemkv_settings(monkeypatch):
+    """Never write the developer's real ~/.MakeMKV/settings.conf during tests.
+
+    A saved makemkv_key flows into write_makemkv_settings; stub it so integration
+    runs can't clobber a real MakeMKV license. config_service imports it lazily,
+    so patching the source attribute is enough.
+    """
+    import app.core.makemkv_registration as _reg
+
+    monkeypatch.setattr(_reg, "write_makemkv_settings", lambda *a, **k: False)
+
+
 @pytest.fixture(autouse=True, scope="session")
 def enable_debug_mode():
     """Enable debug mode for all integration tests.

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -108,6 +108,14 @@ async def isolate_database(monkeypatch):
     monkeypatch.setattr(_config_mod, "_sync_engine", _unit_sync_engine)
     monkeypatch.setattr(_config_mod, "_get_sync_engine", lambda: _unit_sync_engine)
 
+    # Neutralize MakeMKV settings.conf writes so tests that save a makemkv_key
+    # never touch the developer's real ~/.MakeMKV/settings.conf. config_service
+    # imports this lazily, so patching the source attribute is enough. Tests in
+    # test_makemkv_registration.py bind the real function at import and pass
+    # explicit tmp paths, so they're unaffected.
+    _reg_mod = importlib.import_module("app.core.makemkv_registration")
+    monkeypatch.setattr(_reg_mod, "write_makemkv_settings", lambda *a, **k: False)
+
     yield
 
     async with _unit_engine.begin() as conn:

--- a/backend/tests/unit/test_makemkv_registration.py
+++ b/backend/tests/unit/test_makemkv_registration.py
@@ -85,24 +85,22 @@ class TestConfigServiceWiring:
     """update_config must register a changed MakeMKV key with makemkvcon."""
 
     async def test_update_config_registers_makemkv_key(self, monkeypatch):
-        import app.core.makemkv_registration as reg
         from app.services import config_service
 
         # Override the conftest no-op with a recording mock (lazy import in
         # update_config re-reads this attribute at call time).
         mock_write = MagicMock(return_value=True)
-        monkeypatch.setattr(reg, "write_makemkv_settings", mock_write)
+        monkeypatch.setattr("app.core.makemkv_registration.write_makemkv_settings", mock_write)
 
         await config_service.update_config(makemkv_key="T-wired-key")
 
         mock_write.assert_called_once_with("T-wired-key")
 
     async def test_update_config_skips_registration_without_key(self, monkeypatch):
-        import app.core.makemkv_registration as reg
         from app.services import config_service
 
         mock_write = MagicMock(return_value=True)
-        monkeypatch.setattr(reg, "write_makemkv_settings", mock_write)
+        monkeypatch.setattr("app.core.makemkv_registration.write_makemkv_settings", mock_write)
 
         await config_service.update_config(staging_path="/tmp/x")
 

--- a/backend/tests/unit/test_makemkv_registration.py
+++ b/backend/tests/unit/test_makemkv_registration.py
@@ -1,0 +1,109 @@
+"""Unit tests for MakeMKV settings.conf registration.
+
+makemkvcon reads its license from MakeMKV's own settings.conf (separate from
+Engram's config DB). These tests cover the upsert helper that bridges Engram's
+stored ``makemkv_key`` into that file without clobbering unrelated settings.
+"""
+
+from unittest.mock import MagicMock
+
+from app.core.makemkv_registration import makemkv_settings_path, write_makemkv_settings
+
+
+class TestWriteMakemkvSettings:
+    def test_creates_file_and_parent_dir(self, tmp_path):
+        target = tmp_path / "MakeMKV" / "settings.conf"
+
+        written = write_makemkv_settings("T-newkey123", settings_path=target)
+
+        assert written is True
+        assert target.exists()
+        assert 'app_Key = "T-newkey123"' in target.read_text()
+
+    def test_preserves_unrelated_settings(self, tmp_path):
+        target = tmp_path / "settings.conf"
+        target.write_text(
+            'app_DefaultSelectionString = "-sel:all"\n'
+            'app_Key = "T-oldkey"\n'
+            'app_DestinationDir = "/media"\n'
+        )
+
+        write_makemkv_settings("T-rotated", settings_path=target)
+
+        contents = target.read_text()
+        assert 'app_DefaultSelectionString = "-sel:all"' in contents
+        assert 'app_DestinationDir = "/media"' in contents
+        # Old key replaced, exactly one app_Key line remains.
+        assert 'app_Key = "T-rotated"' in contents
+        assert 'app_Key = "T-oldkey"' not in contents
+        assert contents.count("app_Key") == 1
+
+    def test_appends_key_when_absent(self, tmp_path):
+        target = tmp_path / "settings.conf"
+        target.write_text('app_DefaultLanguage = "eng"\n')
+
+        write_makemkv_settings("T-appended", settings_path=target)
+
+        contents = target.read_text()
+        assert 'app_DefaultLanguage = "eng"' in contents
+        assert 'app_Key = "T-appended"' in contents
+
+    def test_blank_key_is_noop(self, tmp_path):
+        target = tmp_path / "settings.conf"
+
+        assert write_makemkv_settings("", settings_path=target) is False
+        assert write_makemkv_settings("   ", settings_path=target) is False
+        assert not target.exists()
+
+    def test_idempotent_when_key_unchanged(self, tmp_path):
+        target = tmp_path / "settings.conf"
+
+        assert write_makemkv_settings("T-same", settings_path=target) is True
+        # Second call with the same key should not rewrite the file.
+        assert write_makemkv_settings("T-same", settings_path=target) is False
+
+
+class TestSettingsPathResolution:
+    def test_unix_path_uses_home_dot_makemkv(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        path = makemkv_settings_path()
+
+        assert path == tmp_path / ".MakeMKV" / "settings.conf"
+
+    def test_windows_path_uses_appdata(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("sys.platform", "win32")
+        monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+
+        path = makemkv_settings_path()
+
+        assert path == tmp_path / "AppData" / "Roaming" / "MakeMKV" / "settings.conf"
+
+
+class TestConfigServiceWiring:
+    """update_config must register a changed MakeMKV key with makemkvcon."""
+
+    async def test_update_config_registers_makemkv_key(self, monkeypatch):
+        import app.core.makemkv_registration as reg
+        from app.services import config_service
+
+        # Override the conftest no-op with a recording mock (lazy import in
+        # update_config re-reads this attribute at call time).
+        mock_write = MagicMock(return_value=True)
+        monkeypatch.setattr(reg, "write_makemkv_settings", mock_write)
+
+        await config_service.update_config(makemkv_key="T-wired-key")
+
+        mock_write.assert_called_once_with("T-wired-key")
+
+    async def test_update_config_skips_registration_without_key(self, monkeypatch):
+        import app.core.makemkv_registration as reg
+        from app.services import config_service
+
+        mock_write = MagicMock(return_value=True)
+        monkeypatch.setattr(reg, "write_makemkv_settings", mock_write)
+
+        await config_service.update_config(staging_path="/tmp/x")
+
+        mock_write.assert_not_called()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+# Engram — Linux deployment.
+#
+# Quick start:
+#   1. Put your MakeMKV license/beta key in MAKEMKV_APP_KEY below (or leave blank
+#      and enter it in the setup wizard).
+#   2. Adjust the optical drive path under `devices` if yours isn't /dev/sr0.
+#   3. `docker compose up -d`, then open http://localhost:8000 and complete setup.
+#      In the wizard, set the library/staging paths to the in-container mount
+#      points: /media/movies, /media/tv, /staging.
+#
+# First start is slow: it compiles MakeMKV into ./config and downloads the
+# speech-recognition model. Both are cached in ./config and reused afterwards.
+
+services:
+  engram:
+    # Pull the published image:
+    image: ghcr.io/jsakkos/engram:latest
+    # ...or build locally instead by commenting out `image:` above and
+    # uncommenting:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    container_name: engram
+    restart: unless-stopped
+
+    ports:
+      - "8000:8000"
+
+    # Pass the optical drive through to the container. `ls -l /dev/sr*` on the
+    # host to confirm the device. Add more lines for multiple drives.
+    devices:
+      - "/dev/sr0:/dev/sr0"
+
+    environment:
+      # Match these to your host user so library files aren't root-owned
+      # (`id -u` / `id -g`).
+      PUID: "1000"
+      PGID: "1000"
+      TZ: "Etc/UTC"
+      # MakeMKV license or current beta key (https://www.makemkv.com/forum/viewtopic.php?t=1053).
+      # The beta key rotates ~monthly; refresh it here or in the setup wizard.
+      MAKEMKV_APP_KEY: ""
+      # "latest" tracks the current MakeMKV release; pin a version (e.g. 1.18.1)
+      # for reproducible builds.
+      MAKEMKV_VERSION: "latest"
+
+    volumes:
+      # Persistent app state: database, caches, logs, the compiled MakeMKV, and
+      # MakeMKV's settings.conf. Back this up.
+      - ./config:/config
+      # Your media library (point the wizard at /media/movies and /media/tv).
+      - ./media/movies:/media/movies
+      - ./media/tv:/media/tv
+      # Working area for in-progress rips (point the wizard at /staging).
+      - ./staging:/staging

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -42,11 +42,16 @@ fi
 # 4. Seed the MakeMKV license from MAKEMKV_APP_KEY (merge, don't clobber).
 if [ -n "${MAKEMKV_APP_KEY:-}" ]; then
     touch "${SETTINGS}"
-    if grep -qE '^[[:space:]]*app_Key[[:space:]]*=' "${SETTINGS}"; then
-        sed -i -E "s|^[[:space:]]*app_Key[[:space:]]*=.*|app_Key = \"${MAKEMKV_APP_KEY}\"|" "${SETTINGS}"
-    else
-        echo "app_Key = \"${MAKEMKV_APP_KEY}\"" >> "${SETTINGS}"
-    fi
+    # Rebuild the file with the new app_Key first, then the other lines. Using
+    # printf '%s' (not sed) keeps the key value out of any regex/replacement
+    # context, so a key with characters special to sed can't corrupt the file.
+    {
+        printf 'app_Key = "%s"\n' "${MAKEMKV_APP_KEY}"
+        grep -vE '^[[:space:]]*app_Key[[:space:]]*=' "${SETTINGS}" || true
+    } > "${SETTINGS}.tmp"
+    mv "${SETTINGS}.tmp" "${SETTINGS}"
+    # The server runs as PUID and (re)writes this file on startup, so it must own it.
+    chown "${PUID}:${PGID}" "${SETTINGS}"
 fi
 
 # 5. Optical-drive access: the host's /dev/sr0 group GID varies, so add the
@@ -62,8 +67,15 @@ if [ -e /dev/sr0 ]; then
     fi
 fi
 
-# 6. Own the persistent state as the runtime user.
-chown -R "${PUID}:${PGID}" /config
+# 6. Own the persistent state as the runtime user. A recursive chown over the
+#    whole volume (whisper models, caches) is slow, so only run it when the
+#    PUID/PGID change — tracked by a stamp file. Files the app creates later are
+#    already owned correctly because it runs as this user.
+OWNERSHIP_STAMP="/config/.ownership-${PUID}-${PGID}"
+if [ ! -f "${OWNERSHIP_STAMP}" ]; then
+    chown -R "${PUID}:${PGID}" /config
+    touch "${OWNERSHIP_STAMP}"
+fi
 
 # 7. Drop privileges (gosu by name applies the user's supplementary groups,
 #    including the optical group joined above) and exec the server.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Engram container entrypoint. Runs as root to set up state, install/register
+# MakeMKV, and grant optical-drive access, then drops to an unprivileged user
+# (PUID/PGID) via gosu before launching the server.
+set -euo pipefail
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+INSTALL_DIR="${MAKEMKV_INSTALL_DIR:-/config/makemkv}"
+SETTINGS="/config/.MakeMKV/settings.conf"
+
+# 1. Persistent state directories (all under /config because HOME=/config).
+mkdir -p /config/.engram /config/.MakeMKV /config/.cache/huggingface "${INSTALL_DIR}"
+
+# 2. Create the runtime user/group at the requested PUID/PGID.
+if ! getent group "${PGID}" >/dev/null 2>&1; then
+    groupadd -g "${PGID}" engram
+fi
+if ! getent passwd "${PUID}" >/dev/null 2>&1; then
+    useradd -u "${PUID}" -g "${PGID}" -d /config -s /usr/sbin/nologin engram
+fi
+USER_NAME="$(getent passwd "${PUID}" | cut -d: -f1)"
+
+# 3. First-run MakeMKV compile (skips if already built for this version).
+#    MAKEMKV_SKIP_INSTALL lets CI / smoke tests boot without the slow compile.
+if [ -z "${MAKEMKV_SKIP_INSTALL:-}" ]; then
+    if [ ! -x "${INSTALL_DIR}/bin/makemkvcon" ]; then
+        if ! /usr/local/bin/install-makemkv.sh; then
+            echo "WARNING: MakeMKV install failed — ripping is unavailable until resolved." >&2
+        fi
+    fi
+fi
+
+# Make makemkvcon discoverable on PATH and its libraries loadable.
+if [ -x "${INSTALL_DIR}/bin/makemkvcon" ]; then
+    ln -sf "${INSTALL_DIR}/bin/makemkvcon" /usr/local/bin/makemkvcon
+    echo "${INSTALL_DIR}/lib" > /etc/ld.so.conf.d/makemkv.conf
+    ldconfig
+fi
+
+# 4. Seed the MakeMKV license from MAKEMKV_APP_KEY (merge, don't clobber).
+if [ -n "${MAKEMKV_APP_KEY:-}" ]; then
+    touch "${SETTINGS}"
+    if grep -qE '^[[:space:]]*app_Key[[:space:]]*=' "${SETTINGS}"; then
+        sed -i -E "s|^[[:space:]]*app_Key[[:space:]]*=.*|app_Key = \"${MAKEMKV_APP_KEY}\"|" "${SETTINGS}"
+    else
+        echo "app_Key = \"${MAKEMKV_APP_KEY}\"" >> "${SETTINGS}"
+    fi
+fi
+
+# 5. Optical-drive access: the host's /dev/sr0 group GID varies, so add the
+#    runtime user to whatever group owns the device node.
+if [ -e /dev/sr0 ]; then
+    SR_GID="$(stat -c '%g' /dev/sr0)"
+    if [ "${SR_GID}" != "0" ]; then
+        if ! getent group "${SR_GID}" >/dev/null 2>&1; then
+            groupadd -g "${SR_GID}" optical
+        fi
+        SR_GROUP="$(getent group "${SR_GID}" | cut -d: -f1)"
+        usermod -aG "${SR_GROUP}" "${USER_NAME}"
+    fi
+fi
+
+# 6. Own the persistent state as the runtime user.
+chown -R "${PUID}:${PGID}" /config
+
+# 7. Drop privileges (gosu by name applies the user's supplementary groups,
+#    including the optical group joined above) and exec the server.
+exec gosu "${USER_NAME}" "$@"

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -44,10 +44,20 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
 cd "${WORK}"
 
+# NOTE: MakeMKV publishes no checksums on its download page, so these tarballs
+# are trusted on the basis of HTTPS to makemkv.com alone. Operators wanting a
+# stronger guarantee can cross-check the SHA256 hashes posted in the MakeMKV
+# forum release thread (https://www.makemkv.com/forum/viewtopic.php?t=1053).
 for part in oss bin; do
     echo "    downloading makemkv-${part}-${VERSION}.tar.gz"
     curl -fSL -o "makemkv-${part}.tar.gz" "${DL_BASE}/makemkv-${part}-${VERSION}.tar.gz"
     tar xzf "makemkv-${part}.tar.gz"
+    # Fail clearly if the archive didn't expand to the expected directory rather
+    # than cd'ing into a missing/unexpected path later.
+    if [ ! -d "makemkv-${part}-${VERSION}" ]; then
+        echo "ERROR: makemkv-${part}-${VERSION}.tar.gz did not extract to the expected directory" >&2
+        exit 1
+    fi
 done
 
 # 1. Open-source part: shared libraries + makemkvcon, GUI disabled.

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# First-run MakeMKV installer.
+#
+# Downloads the official MakeMKV source from makemkv.com and compiles it into a
+# persistent directory (default /config/makemkv) so the published image never
+# redistributes MakeMKV binaries. Idempotent: skips work when the requested
+# version is already built. Technique adapted from jlesage/docker-makemkv.
+#
+# Build is CLI-only (./configure --disable-gui) so Qt is not required.
+set -euo pipefail
+
+INSTALL_DIR="${MAKEMKV_INSTALL_DIR:-/config/makemkv}"
+VERSION="${MAKEMKV_VERSION:-latest}"
+DL_BASE="https://www.makemkv.com/download"
+MARKER="${INSTALL_DIR}/.installed-version"
+
+resolve_latest_version() {
+    # The download page lists the current tarball, e.g. makemkv-bin-1.18.1.tar.gz
+    curl -fsSL "${DL_BASE}/" \
+        | grep -oE 'makemkv-bin-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' \
+        | head -n1 \
+        | sed -E 's/makemkv-bin-([0-9.]+)\.tar\.gz/\1/'
+}
+
+if [ "${VERSION}" = "latest" ]; then
+    VERSION="$(resolve_latest_version || true)"
+    if [ -z "${VERSION}" ]; then
+        echo "ERROR: could not resolve the latest MakeMKV version from ${DL_BASE}/" >&2
+        echo "       Set MAKEMKV_VERSION to a specific release (e.g. 1.18.1)." >&2
+        exit 1
+    fi
+fi
+
+if [ -x "${INSTALL_DIR}/bin/makemkvcon" ] && [ "$(cat "${MARKER}" 2>/dev/null || true)" = "${VERSION}" ]; then
+    echo "MakeMKV ${VERSION} already installed at ${INSTALL_DIR}; skipping."
+    exit 0
+fi
+
+echo "==> Installing MakeMKV ${VERSION} into ${INSTALL_DIR} (one-time compile, this can take a few minutes)..."
+mkdir -p "${INSTALL_DIR}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+cd "${WORK}"
+
+for part in oss bin; do
+    echo "    downloading makemkv-${part}-${VERSION}.tar.gz"
+    curl -fSL -o "makemkv-${part}.tar.gz" "${DL_BASE}/makemkv-${part}-${VERSION}.tar.gz"
+    tar xzf "makemkv-${part}.tar.gz"
+done
+
+# 1. Open-source part: shared libraries + makemkvcon, GUI disabled.
+echo "    building makemkv-oss"
+cd "${WORK}/makemkv-oss-${VERSION}"
+./configure --prefix="${INSTALL_DIR}" --disable-gui
+make -j"$(nproc)"
+make install
+
+# 2. Binary part: precompiled blobs + data. The Makefile prompts to accept the
+#    EULA on first build; pre-creating tmp/eula_accepted answers it non-interactively.
+echo "    installing makemkv-bin"
+cd "${WORK}/makemkv-bin-${VERSION}"
+mkdir -p tmp
+echo "accepted" > tmp/eula_accepted
+make install PREFIX="${INSTALL_DIR}"
+
+echo "${VERSION}" > "${MARKER}"
+echo "==> MakeMKV ${VERSION} installed at ${INSTALL_DIR}."

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,114 @@
+# Docker deployment (Linux)
+
+Run Engram as a container on a Linux host with an optical drive. The image
+serves the API and dashboard from a single process on port `8000`.
+
+> **MakeMKV is not bundled.** It is proprietary and license-keyed, so the image
+> compiles the official MakeMKV source into a persistent volume the first time
+> the container starts. You supply your own license (or the free beta key).
+
+## Requirements
+
+- A Linux host with Docker and an optical drive (e.g. `/dev/sr0`).
+- A MakeMKV license, or the current free beta key from the
+  [MakeMKV forum](https://www.makemkv.com/forum/viewtopic.php?t=1053).
+- A TMDB Read Access Token (entered later in the setup wizard).
+
+> Docker Desktop on Windows/macOS (WSL2) **cannot** pass an optical drive into a
+> container. You can run the dashboard there to try the UI, but ripping requires
+> a native Linux host.
+
+## Quick start
+
+```bash
+git clone https://github.com/Jsakkos/engram.git
+cd engram
+# Edit docker-compose.yml: set MAKEMKV_APP_KEY, PUID/PGID, TZ, and the drive path.
+docker compose up -d
+```
+
+Open <http://localhost:8000> and complete the setup wizard. In the wizard set the
+library and staging paths to the in-container mount points:
+
+- Movies library → `/media/movies`
+- TV library → `/media/tv`
+- Staging → `/staging`
+
+> **First start is slow.** The container compiles MakeMKV (a few minutes) and the
+> first episode match downloads the speech-recognition model (~465 MB). Both are
+> cached in the `config` volume and reused on every subsequent start.
+
+## Using the published image
+
+Instead of building locally, pull the prebuilt image:
+
+```yaml
+services:
+  engram:
+    image: ghcr.io/jsakkos/engram:latest
+```
+
+Tags: `latest`, `MAJOR.MINOR`, and exact versions (e.g. `0.7.1`) are published to
+GHCR on each release.
+
+## Configuration
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PUID` / `PGID` | `1000` | User/group the server runs as. Match your host user (`id -u` / `id -g`) so library files aren't root-owned. |
+| `TZ` | `Etc/UTC` | Container timezone. |
+| `MAKEMKV_APP_KEY` | _(empty)_ | MakeMKV license / beta key. Written to MakeMKV's `settings.conf` on start. Can also be set later in the wizard. |
+| `MAKEMKV_VERSION` | `latest` | MakeMKV version to compile. Pin a number (e.g. `1.18.1`) for reproducibility. |
+| `MAKEMKV_SKIP_INSTALL` | _(unset)_ | Set to `1` to skip the MakeMKV compile (used for CI/smoke tests; ripping is unavailable). |
+
+The server also honors `DATABASE_URL`, `HOST`, `PORT`, and `DEBUG` — these are
+preset in the image and rarely need changing.
+
+### Volumes
+
+| Mount | Holds |
+|-------|-------|
+| `/config` | Database, caches, logs, the compiled MakeMKV, and MakeMKV's `settings.conf`. **Back this up.** |
+| `/media/movies`, `/media/tv` | Organized library output. |
+| `/staging` | Work area for in-progress rips and the staging auto-import workflow. |
+
+### Optical drive passthrough
+
+Pass each drive through with `devices:`. Find yours with `ls -l /dev/sr*`:
+
+```yaml
+    devices:
+      - "/dev/sr0:/dev/sr0"
+```
+
+The entrypoint detects the group that owns the device on the host and adds the
+runtime user to it, so ripping works without `--privileged`. If your host has
+unusual device permissions, you can fall back to `privileged: true`.
+
+## MakeMKV licensing
+
+- The **free beta key** rotates roughly monthly. When ripping starts failing with
+  a registration error, grab the new key from the forum and update
+  `MAKEMKV_APP_KEY` (then `docker compose up -d`) or paste it into the wizard.
+- A **purchased license** is stable and does not need refreshing.
+- The key is stored in `/config/.MakeMKV/settings.conf`. You may bind-mount your
+  own `settings.conf` there instead of using the env var.
+
+## GPU acceleration
+
+The image is CPU-only. Episode matching runs whisper with int8 quantization,
+which is slower but needs no GPU. A CUDA image variant may be offered later.
+
+## Troubleshooting
+
+- **MakeMKV compile failed on first start** — check `docker compose logs`. The
+  most common cause is a `MAKEMKV_VERSION` whose tarball is no longer on
+  makemkv.com; pin a current version. You can also mount a host-installed
+  `makemkvcon` and symlink it onto the container `PATH` as a fallback.
+- **Ripping can't access the drive** — confirm the `devices:` path matches a real
+  `/dev/sr*` and that the host can read the disc (`blkid /dev/sr0`).
+- **Library files are root-owned** — set `PUID`/`PGID` to your host user.
+- **The dashboard loads but nothing rips on Windows/macOS** — expected; optical
+  passthrough is Linux-only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
     - Review Queue: guide/review-queue.md
     - Job History: guide/history.md
     - LLM Episode Matcher: guide/llm-episode-matcher.md
+  - Deployment:
+    - Docker (Linux): deployment/docker.md
   - Architecture:
     - Overview: architecture/overview.md
     - State Machine: architecture/state-machine.md


### PR DESCRIPTION
## Summary

Adds a Docker image so Engram can run on Linux as a container (user request). The container serves the API and the built SPA from a single `uvicorn` process — FastAPI already mounts the frontend from `app/static/`, so this sidesteps the PyInstaller frozen-build machinery entirely.

**MakeMKV is deliberately not baked into the image** (proprietary, redistribution-restricted). The entrypoint compiles the official MakeMKV source into a persistent `/config` volume on first start (the jlesage technique, on a Debian base since Alpine's musl breaks the ML wheels). Pointing `HOME` at `/config` consolidates the DB, logs, caches, HF models, and MakeMKV's own config into one backed-up volume.

It also bridges a gap surfaced by containerization: Engram stored `makemkv_key` in its DB but never wrote MakeMKV's own `settings.conf` (desktop users register MakeMKV out-of-band via its GUI). A small cross-platform helper now upserts the key into `settings.conf` on config save and at startup, plus a `MAKEMKV_APP_KEY` env seed in the entrypoint.

## What changed

**Packaging (new):**
- `Dockerfile` — 3-stage (frontend build → uv venv → Debian runtime), CPU-only.
- `docker/entrypoint.sh` + `docker/install-makemkv.sh` — first-run MakeMKV compile, license seeding, PUID/PGID, dynamic `/dev/sr0` group join, `gosu` privilege drop.
- `docker-compose.yml`, `.dockerignore`, `.gitattributes` (forces LF on scripts so shebangs survive a Windows checkout).
- `.github/workflows/docker.yml` — PR build + `/health` smoke test; tag → publish to `ghcr.io/jsakkos/engram` (`linux/amd64`).
- `docs/deployment/docker.md`, README "Option C: Docker (Linux)", mkdocs nav.

**App code (cross-platform):**
- `backend/app/core/makemkv_registration.py` — per-OS `settings.conf` upsert (merge, idempotent, blank = no-op).
- Wired into `config_service.update_config` (mirrors the existing TMDB cache-clear side-effect) and the startup reconcile in `main.py`.
- Both test conftests stub the writer so the suite can never touch a real `~/.MakeMKV/settings.conf`.

## Design decisions

- **CPU-only** first release (int8 whisper); GPU variant deferred.
- **Both** local build (Dockerfile + compose) and CI GHCR publishing.
- Whisper models keep their lazy download, cached into the `/config` volume.

## Testing

- [x] Backend unit suite: **1101 passed**; new `test_makemkv_registration.py` covers the upsert (new file, preserve-other-keys, rotation, blank no-op, idempotency, path resolution) and the `update_config` wiring.
- [x] `ruff check` + `ruff format --check` clean on all changed files; pre-commit hooks passed.
- [x] `bash -n` syntax check on both shell scripts (LF confirmed); YAML parse of compose/workflow/mkdocs.

## Not verified locally (needs a Linux host)

> Docker is **not installed** on the dev machine, so the image was **not built or run** here. The Dockerfile, entrypoint, and MakeMKV compile recipe follow the canonical Linux build but are unproven until `docker compose build` runs on Linux. The MakeMKV compile step (`install-makemkv.sh`) is the most likely thing to need a tweak (version availability, the bin Makefile's `PREFIX` handling). Disc ripping requires a native Linux host with an optical drive — Docker Desktop on Windows/macOS cannot pass through `/dev/sr0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)