### PR TITLE
docs(readme): add Downloads section with per-release chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@
   </tr>
 </table>
 
+## Downloads
+
+<p align="center">
+  <img src="docs/downloads-chart.svg" alt="Downloads per release" />
+</p>
+
 ## Features
 
 - **Automatic disc detection** — monitors optical drives and starts processing on insertion


### PR DESCRIPTION
## Summary

The `download-stats` workflow has long generated `docs/downloads-chart.svg` (a per-release downloads bar chart) and committed it to `main`, but it was referenced **nowhere user-facing**. This adds the `## Downloads` section to the README (between Screenshots and Features) that the original spec called for (`docs/superpowers/specs/2026-05-03-download-stats-design.md`, lines 76-82).

```html
## Downloads

<p align="center">
  <img src="docs/downloads-chart.svg" alt="Downloads per release" />
</p>
```

## Why a relative path (not a `raw.githubusercontent.com` URL)

The chart is embedded via the **relative** path `docs/downloads-chart.svg`, matching how the README already embeds its SVG logo at line 2. This is deliberate:

- GitHub routes only **external/absolute** image URLs through its **camo** proxy, which is unreliable with externally-hosted SVGs. **Relative** same-repo paths are served directly from `github.com/.../raw/main/...`, bypassing camo.
- The SVG already lives on `main` at `docs/downloads-chart.svg` (the workflow commits it there), so a relative reference resolves correctly.

## Verification

- `raw/main/docs/downloads-chart.svg` → **200, `image/svg+xml`, 4029 B** — identical serving to the existing, known-rendering `docs/engram.svg` logo.
- GitHub's markdown render API produces byte-identical markup for the chart `<img>` and the logo `<img>`.
- The SVG is a real populated chart (10 releases, Windows/Linux bars + legend).

## Reviewer note

The Download Stats workflow has **failed its last 5 runs**, so the committed chart is stale (stops at v0.6.0; latest release is v0.7.1). That's a separate pre-existing bug, not addressed here — it should be fixed so the embedded chart updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)