### PR TITLE
fix: stop stall watchdog killing small tracks + loud no-subtitles warning

### DIFF
--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 # Matches a robot-mode MSG line announcing a created .mkv file, e.g. ... "Show_t00.mkv" ...
 _CREATED_MKV_PATTERN = re.compile(r'["\']([^"\']+\.mkv)["\']')
 
+# Single source of truth for the user-facing stall reason, shared by the watchdog
+# callback and the job_manager fallback so the live update and History agree.
+STALL_FAILURE_REASON = "Ripping stalled — no progress; the disc may be dirty or damaged."
+
 
 def _to_drive_spec(drive: str) -> str:
     """Normalize a drive identifier into a MakeMKV drive spec.
@@ -557,13 +561,13 @@ class MakeMKVExtractor:
                             _safe_callback(
                                 title_error_callback,
                                 current_title_idx,
-                                f"Ripping stalled — no progress for {timeout:.0f}s, "
-                                "title skipped. The disc may be dirty or damaged.",
+                                STALL_FAILURE_REASON,
                                 label="title_error_callback",
                             )
                         try:
                             proc.terminate()
                         except (ProcessLookupError, PermissionError):
+                            # Process already gone (raced its own exit) — nothing to kill.
                             pass
                         return
 

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -36,6 +36,16 @@ def _to_drive_spec(drive: str) -> str:
     return drive
 
 
+def _is_stalled(now: float, last_progress: float, timeout: float) -> bool:
+    """Whether a rip is stalled: no progress for `timeout` seconds.
+
+    "Progress" is any liveness signal — output-file growth OR MakeMKV stdout
+    activity — recorded in ``last_progress``. A tiny track that has finished
+    writing but is still emitting progress lines is therefore NOT stalled.
+    """
+    return (now - last_progress) >= timeout
+
+
 def _extract_created_mkv(line: str, output_dir: Path) -> Path | None:
     """Extract the created .mkv path from a MakeMKV output line, if present."""
     if ".mkv" not in line or "created" not in line:
@@ -495,17 +505,23 @@ class MakeMKVExtractor:
             prgc_current_title: int = 1
             # Tracks which commands were terminated due to stall detection
             stalled_commands: set[int] = set()
+            # Liveness timestamp shared with the stdout reader. It is bumped both on
+            # MakeMKV progress lines (see PRGC/PRGV parsing below) and on output-file
+            # growth, so a small/fast track that has finished writing but is still
+            # being finalized — while MakeMKV keeps emitting progress — is not flagged
+            # as stalled. Single-element list write/read is atomic under the GIL.
+            last_progress = [time.monotonic()]
 
             def _stall_watchdog(proc, watch_dir, timeout, poll_interval=5.0):
-                """Kill MakeMKV if no file growth for timeout seconds.
+                """Terminate MakeMKV if it shows no liveness for `timeout` seconds.
 
-                Runs in a daemon thread alongside each MakeMKV subprocess.
-                Monitors .mkv file sizes in the output directory. If no file
-                grows for `timeout` seconds, terminates the process so the
-                command loop can skip to the next title.
+                Runs in a daemon thread alongside each MakeMKV subprocess. Liveness
+                is output-file growth OR MakeMKV stdout activity (recorded in
+                ``last_progress`` by the reader loop). Using stdout — not file growth
+                alone — avoids false positives on tiny tracks that finish writing in
+                one burst while MakeMKV is still emitting progress.
                 """
                 prev_sizes: dict[str, int] = {}
-                stall_start = None
 
                 while proc.poll() is None:
                     time.sleep(poll_interval)
@@ -522,39 +538,34 @@ class MakeMKVExtractor:
                     except OSError:
                         continue
 
-                    # Check if any file grew since last poll
-                    any_growth = False
+                    # File growth counts as liveness.
                     for name, size in current_sizes.items():
                         if size > prev_sizes.get(name, 0):
-                            any_growth = True
+                            last_progress[0] = time.monotonic()
                             break
 
-                    if current_sizes and not any_growth:
-                        if stall_start is None:
-                            stall_start = time.monotonic()
-                        elif time.monotonic() - stall_start >= timeout:
-                            logger.warning(
-                                f"Ripping stall detected: no file growth for "
-                                f"{timeout}s. Terminating MakeMKV process "
-                                f"(command {current_title_idx}/{len(commands)})"
+                    if _is_stalled(time.monotonic(), last_progress[0], timeout):
+                        logger.warning(
+                            f"Ripping stall detected: no progress for "
+                            f"{timeout:.0f}s. Terminating MakeMKV process "
+                            f"(command {current_title_idx}/{len(commands)})"
+                        )
+                        stalled_commands.add(current_title_idx)
+                        # Fire error callback immediately so the UI
+                        # shows the title as FAILED right away
+                        if title_error_callback:
+                            _safe_callback(
+                                title_error_callback,
+                                current_title_idx,
+                                f"Ripping stalled — no progress for {timeout:.0f}s, "
+                                "title skipped. The disc may be dirty or damaged.",
+                                label="title_error_callback",
                             )
-                            stalled_commands.add(current_title_idx)
-                            # Fire error callback immediately so the UI
-                            # shows the title as FAILED right away
-                            if title_error_callback:
-                                _safe_callback(
-                                    title_error_callback,
-                                    current_title_idx,
-                                    "Ripping stalled — possible disc damage",
-                                    label="title_error_callback",
-                                )
-                            try:
-                                proc.terminate()
-                            except (ProcessLookupError, PermissionError):
-                                pass
-                            return
-                    else:
-                        stall_start = None
+                        try:
+                            proc.terminate()
+                        except (ProcessLookupError, PermissionError):
+                            pass
+                        return
 
                     prev_sizes = current_sizes
 
@@ -583,6 +594,8 @@ class MakeMKVExtractor:
                     # Start stall watchdog thread if timeout is configured
                     watchdog_thread = None
                     if stall_timeout and stall_timeout > 0:
+                        # Fresh liveness baseline for this title's watchdog.
+                        last_progress[0] = time.monotonic()
                         watchdog_thread = threading.Thread(
                             target=_stall_watchdog,
                             args=(process, output_dir, stall_timeout),
@@ -601,6 +614,11 @@ class MakeMKVExtractor:
                             continue
 
                         output_lines.append(line)
+
+                        # MakeMKV progress codes are liveness — feed the stall
+                        # watchdog so a tiny track being finalized isn't killed.
+                        if line.startswith(("PRGV:", "PRGC:", "PRGT:")):
+                            last_progress[0] = time.monotonic()
 
                         # Parse progress messages
                         if line.startswith("PRGC:"):

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -79,6 +79,9 @@ class DiscJob(SQLModel, table=True):
 
     # Subtitle tracking
     subtitle_status: str | None = None  # "downloading", "completed", "partial", "failed", None
+    # Subtitle-specific failure detail, kept separate from the catch-all
+    # error_message so the two can't clobber each other or leak across banners.
+    subtitle_error_message: str | None = None
     subtitles_downloaded: int = 0
     subtitles_total: int = 0
     subtitles_failed: int = 0

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -19,7 +19,7 @@ from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
-from app.core.extractor import MakeMKVExtractor, RipProgress
+from app.core.extractor import STALL_FAILURE_REASON, MakeMKVExtractor, RipProgress
 from app.core.organizer import movie_organizer
 from app.core.security import sanitize_log_value
 from app.core.sentinel import DriveMonitor
@@ -1390,10 +1390,7 @@ class JobManager:
                             ):
                                 db_title.state = TitleState.FAILED
                                 db_title.match_details = json.dumps(
-                                    {
-                                        "reason": "Ripping stalled — no progress, "
-                                        "title skipped. The disc may be dirty or damaged."
-                                    }
+                                    {"reason": STALL_FAILURE_REASON}
                                 )
                                 logger.warning(
                                     f"Job {safe_job}: title {db_title.title_index} "
@@ -1403,7 +1400,7 @@ class JobManager:
                                     job_id,
                                     db_title.id,
                                     TitleState.FAILED.value,
-                                    error="Ripping stalled — possible disc damage",
+                                    error=STALL_FAILURE_REASON,
                                 )
                     await stall_session.commit()
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1390,7 +1390,10 @@ class JobManager:
                             ):
                                 db_title.state = TitleState.FAILED
                                 db_title.match_details = json.dumps(
-                                    {"reason": "Ripping stalled — possible disc damage"}
+                                    {
+                                        "reason": "Ripping stalled — no progress, "
+                                        "title skipped. The disc may be dirty or damaged."
+                                    }
                                 )
                                 logger.warning(
                                     f"Job {safe_job}: title {db_title.title_index} "

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1036,7 +1036,12 @@ class MatchingCoordinator:
 
             error_msg = None
             if status == "failed":
-                error_msg = "Subtitle download failed: No subtitles found"
+                error_msg = (
+                    f"No reference subtitles found for '{show_name}'. Episode matching "
+                    "can't run without them — add an OpenSubtitles API key in Settings, "
+                    "drop .srt files into the show's cache folder, or assign episodes "
+                    "manually in Review."
+                )
 
             if using_precomputed:
                 logger.info(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -112,8 +112,10 @@ class MatchingCoordinator:
             job = await session.get(DiscJob, job_id)
             if job is None:
                 return
-            update_values: dict = {"subtitle_status": None}
-            # Only wipe error_message if it came from the subtitle pipeline.
+            update_values: dict = {"subtitle_status": None, "subtitle_error_message": None}
+            # Only wipe the catch-all error_message if it came from the subtitle
+            # pipeline's exception path (the actionable "no subtitles" detail lives
+            # on subtitle_error_message, cleared unconditionally above).
             if job.error_message and (
                 job.error_message.startswith("Subtitle download")
                 or job.error_message.startswith("Download error")
@@ -1055,14 +1057,14 @@ class MatchingCoordinator:
                 )
 
             async with async_session() as session:
-                update_values = {"subtitle_status": status}
+                # Always assign subtitle_error_message: the actionable string on
+                # failure, None on success/partial so a stale banner from a prior
+                # attempt is cleared. Kept off the catch-all error_message.
+                update_values = {"subtitle_status": status, "subtitle_error_message": error_msg}
 
                 if result.get("show_name") and result["show_name"] != show_name:
                     logger.info(f"Updating job {job_id} title to canonical: {result['show_name']}")
                     update_values["detected_title"] = result["show_name"]
-
-                if error_msg:
-                    update_values["error_message"] = error_msg
 
                 await session.execute(
                     update(DiscJob).where(DiscJob.id == job_id).values(**update_values)

--- a/backend/tests/unit/test_extractor.py
+++ b/backend/tests/unit/test_extractor.py
@@ -19,6 +19,7 @@ from app.core.extractor import (
     MakeMKVExtractor,
     _extract_created_mkv,
     _find_linux_mount_point,
+    _is_stalled,
     _safe_callback,
     _save_makemkv_log,
     _to_drive_spec,
@@ -100,6 +101,25 @@ class TestFindLinuxMountPoint:
     def test_returns_none_on_read_error(self):
         with patch("builtins.open", side_effect=OSError("nope")):
             assert _find_linux_mount_point("/dev/sr0") is None
+
+
+@pytest.mark.unit
+class TestIsStalled:
+    """The stall decision is liveness-based: a rip is stalled only when there has
+    been no progress (file growth OR MakeMKV stdout) for `timeout` seconds. A small
+    track that finished writing but is still emitting progress must NOT be stalled.
+    """
+
+    def test_recent_progress_is_not_stalled(self):
+        # Last progress 10s ago, 120s timeout -> healthy.
+        assert _is_stalled(now=1000.0, last_progress=990.0, timeout=120.0) is False
+
+    def test_no_progress_past_timeout_is_stalled(self):
+        # 150s since last progress, 120s timeout -> stalled.
+        assert _is_stalled(now=1000.0, last_progress=850.0, timeout=120.0) is True
+
+    def test_exactly_at_timeout_is_stalled(self):
+        assert _is_stalled(now=1000.0, last_progress=880.0, timeout=120.0) is True
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -229,3 +229,41 @@ class TestRematchSingleTitle:
         coord = _make_coord()
         with pytest.raises(ValueError):
             await coord.rematch_single_title(9999, 9999, source_preference="discdb")
+
+
+@pytest.mark.unit
+class TestDownloadSubtitlesMessaging:
+    """When a show has no reference subtitles anywhere, the job's error_message
+    must be loud and actionable — naming the show and the ways to recover —
+    instead of the old generic 'No subtitles found'.
+    """
+
+    async def test_no_subtitles_sets_actionable_show_specific_message(self, monkeypatch):
+        coord = _make_coord()
+
+        async def _noop(*a, **k):
+            return None
+
+        monkeypatch.setattr(ws_manager, "broadcast_subtitle_event", _noop)
+
+        # Every episode comes back not_found -> status "failed".
+        monkeypatch.setattr(
+            "app.matcher.testing_service.download_subtitles",
+            lambda show, season: {
+                "episodes": [{"status": "not_found"}, {"status": "not_found"}],
+                "show_name": "The Osbournes",
+            },
+        )
+
+        async with _unit_session_factory() as session:
+            job, _title = await _seed(session)
+            job_id = job.id
+
+        await coord.download_subtitles(job_id, "The Osbournes", 1)
+
+        async with _unit_session_factory() as session:
+            refreshed = await session.get(DiscJob, job_id)
+            assert refreshed.subtitle_status == "failed"
+            msg = refreshed.error_message or ""
+            assert "The Osbournes" in msg
+            assert "manually" in msg.lower()

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -233,27 +233,24 @@ class TestRematchSingleTitle:
 
 @pytest.mark.unit
 class TestDownloadSubtitlesMessaging:
-    """When a show has no reference subtitles anywhere, the job's error_message
-    must be loud and actionable — naming the show and the ways to recover —
-    instead of the old generic 'No subtitles found'.
+    """When a show has no reference subtitles anywhere, the actionable detail
+    lives on the dedicated subtitle_error_message field (not the catch-all
+    error_message, which other failure paths also write to).
     """
 
-    async def test_no_subtitles_sets_actionable_show_specific_message(self, monkeypatch):
-        coord = _make_coord()
-
+    def _mock(self, monkeypatch, episodes):
         async def _noop(*a, **k):
             return None
 
         monkeypatch.setattr(ws_manager, "broadcast_subtitle_event", _noop)
-
-        # Every episode comes back not_found -> status "failed".
         monkeypatch.setattr(
             "app.matcher.testing_service.download_subtitles",
-            lambda show, season: {
-                "episodes": [{"status": "not_found"}, {"status": "not_found"}],
-                "show_name": "The Osbournes",
-            },
+            lambda show, season: {"episodes": episodes, "show_name": show},
         )
+
+    async def test_no_subtitles_sets_actionable_show_specific_message(self, monkeypatch):
+        coord = _make_coord()
+        self._mock(monkeypatch, [{"status": "not_found"}, {"status": "not_found"}])
 
         async with _unit_session_factory() as session:
             job, _title = await _seed(session)
@@ -264,6 +261,26 @@ class TestDownloadSubtitlesMessaging:
         async with _unit_session_factory() as session:
             refreshed = await session.get(DiscJob, job_id)
             assert refreshed.subtitle_status == "failed"
-            msg = refreshed.error_message or ""
+            msg = refreshed.subtitle_error_message or ""
             assert "The Osbournes" in msg
             assert "manually" in msg.lower()
+            # The catch-all field must stay clean so it can't leak into other banners.
+            assert refreshed.error_message is None
+
+    async def test_partial_download_clears_stale_subtitle_error(self, monkeypatch):
+        coord = _make_coord()
+        self._mock(monkeypatch, [{"status": "downloaded"}, {"status": "not_found"}])
+
+        async with _unit_session_factory() as session:
+            job, _title = await _seed(session)
+            job.subtitle_error_message = "stale message from a prior attempt"
+            session.add(job)
+            await session.commit()
+            job_id = job.id
+
+        await coord.download_subtitles(job_id, "The Osbournes", 1)
+
+        async with _unit_session_factory() as session:
+            refreshed = await session.get(DiscJob, job_id)
+            assert refreshed.subtitle_status == "partial"
+            assert refreshed.subtitle_error_message is None

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -67,6 +67,7 @@ export interface DiscData {
   currentSpeed?: string;
   etaSeconds?: number;
   subtitleStatus?: string;
+  subtitleError?: string;
   startedAt?: string;
   needsReview?: boolean;
   conflictStatus?: string;
@@ -320,14 +321,6 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       {failedTrackCount} FAILED
                     </span>
                   )}
-                  {disc.subtitleStatus === 'failed' && (
-                    <span
-                      title="Subtitle download failed"
-                      style={{ fontSize: 16, color: sv.yellow }}
-                    >
-                      ⚠
-                    </span>
-                  )}
                   {elapsed && (
                     <div
                       title="Elapsed time"
@@ -355,6 +348,34 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   />
                 </div>
               </div>
+
+              {/* No reference subtitles — loud, actionable, shown in every state */}
+              {disc.subtitleStatus === 'failed' && (
+                <div
+                  role="alert"
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    marginBottom: 16,
+                    padding: "10px 12px",
+                    border: `1px solid ${sv.red}`,
+                    borderLeft: `3px solid ${sv.red}`,
+                    background: "rgba(255, 77, 79, 0.08)",
+                    fontFamily: sv.mono,
+                    fontSize: 12,
+                    lineHeight: 1.45,
+                    letterSpacing: "0.02em",
+                    color: sv.red,
+                  }}
+                >
+                  <span aria-hidden style={{ flexShrink: 0 }}>⚠</span>
+                  <span>
+                    {disc.subtitleError ||
+                      "No subtitles found — episode matching can't run. Open to assign episodes manually."}
+                  </span>
+                </div>
+              )}
 
               {/* Scanning / identifying — full disc-insert visualization */}
               {disc.state === "scanning" && (() => {

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -349,8 +349,9 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                 </div>
               </div>
 
-              {/* No reference subtitles — loud, actionable, shown in every state */}
-              {disc.subtitleStatus === 'failed' && (
+              {/* No reference subtitles — loud + actionable while the job is still
+                  actionable. Hidden once completed (e.g. user assigned manually). */}
+              {disc.subtitleStatus === 'failed' && disc.state !== 'completed' && (
                 <div
                   role="alert"
                   style={{

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -723,15 +723,19 @@ function ReviewQueue() {
             {/* Content */}
             <div className="max-w-[1280px] mx-auto px-6 py-8 relative z-0 pb-24">
                 {error && <SvNotice tone="error">› ERROR: {error}</SvNotice>}
-                {job.error_message && <SvNotice tone="warn">› {job.error_message}</SvNotice>}
+                {/* The no-subtitles case owns a single loud notice; otherwise show the
+                    generic error_message banner so the two don't double up. */}
+                {job.subtitle_status === 'failed' ? (
+                    <SvNotice tone="error">
+                        › {job.error_message ||
+                            "NO REFERENCE SUBTITLES FOUND — EPISODE MATCHING CAN'T RUN. ASSIGN EPISODES MANUALLY BELOW."}
+                    </SvNotice>
+                ) : (
+                    job.error_message && <SvNotice tone="warn">› {job.error_message}</SvNotice>
+                )}
                 {hasConflicts && (
                     <SvNotice tone="warn">
                         › {collisions.size} EPISODE CONFLICT{collisions.size > 1 ? 'S' : ''} — TWO TITLES SHARE AN EPISODE. RESOLVE BEFORE SAVING.
-                    </SvNotice>
-                )}
-                {job.subtitle_status === 'failed' && !job.error_message?.includes('Subtitle') && (
-                    <SvNotice tone="warn">
-                        › SUBTITLE DOWNLOAD FAILED. MANUAL FETCH MAY BE REQUIRED.
                     </SvNotice>
                 )}
                 {rosterError && (

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -723,16 +723,15 @@ function ReviewQueue() {
             {/* Content */}
             <div className="max-w-[1280px] mx-auto px-6 py-8 relative z-0 pb-24">
                 {error && <SvNotice tone="error">› ERROR: {error}</SvNotice>}
-                {/* The no-subtitles case owns a single loud notice; otherwise show the
-                    generic error_message banner so the two don't double up. */}
-                {job.subtitle_status === 'failed' ? (
+                {/* Subtitle failure and any other job error are independent now that
+                    subtitle detail lives on its own field — both can surface. */}
+                {job.subtitle_status === 'failed' && (
                     <SvNotice tone="error">
-                        › {job.error_message ||
+                        › {job.subtitle_error_message ||
                             "NO REFERENCE SUBTITLES FOUND — EPISODE MATCHING CAN'T RUN. ASSIGN EPISODES MANUALLY BELOW."}
                     </SvNotice>
-                ) : (
-                    job.error_message && <SvNotice tone="warn">› {job.error_message}</SvNotice>
                 )}
+                {job.error_message && <SvNotice tone="warn">› {job.error_message}</SvNotice>}
                 {hasConflicts && (
                     <SvNotice tone="warn">
                         › {collisions.size} EPISODE CONFLICT{collisions.size > 1 ? 'S' : ''} — TWO TITLES SHARE AN EPISODE. RESOLVE BEFORE SAVING.

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -62,7 +62,7 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     currentSpeed: job.current_speed,
     etaSeconds: job.eta_seconds,
     subtitleStatus: job.subtitle_status || undefined,
-    subtitleError: job.subtitle_status === 'failed' ? job.error_message || undefined : undefined,
+    subtitleError: job.subtitle_error_message || undefined,
     conflictStatus: job.conflict_status || undefined,
     startedAt: job.created_at
       ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -62,6 +62,7 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     currentSpeed: job.current_speed,
     etaSeconds: job.eta_seconds,
     subtitleStatus: job.subtitle_status || undefined,
+    subtitleError: job.subtitle_status === 'failed' ? job.error_message || undefined : undefined,
     conflictStatus: job.conflict_status || undefined,
     startedAt: job.created_at
       ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,7 @@ export interface Job {
     detected_title?: string;
     detected_season?: number;
     subtitle_status?: SubtitleStatus;
+    subtitle_error_message?: string | null;
     subtitles_downloaded?: number;
     subtitles_total?: number;
     subtitles_failed?: number;


### PR DESCRIPTION
## Summary

Addresses two independent defects surfaced by issue #197 (and the r/MakeMKV
"Osbournes" report) that made a healthy disc look broken when a show has no
reference subtitles.

- **fix(ripping): stall detection based on MakeMKV stdout, not file growth.**
  The watchdog only watched output-file size, so discs with many small/fast
  extras were terminated mid-finalize and mislabeled "possible disc damage"
  even while MakeMKV was still reporting progress. Liveness is now a single
  `last_progress` timestamp bumped by both file growth and MakeMKV progress
  codes (`PRGC`/`PRGV`/`PRGT`), reset per title. The decision is extracted into
  a pure `_is_stalled()` helper, and the user-facing wording is softened.
- **feat(ui): loud, actionable no-subtitles warning.** Replaces the generic
  "No subtitles found" with a show-specific message (add an OpenSubtitles key,
  drop in `.srt` files, or assign episodes manually), shown as a prominent card
  banner and an `error`-tone review notice.

## Why

From the [r/MakeMKV thread](https://www.reddit.com/r/makemkv/comments/1tm32kz/),
The Osbournes S1D2 (~80 extras, 60 of them <=50 MB) repeatedly tripped the
120s no-file-growth timer because tiny tracks write in one burst then finalize
without the file growing — the UI even showed 100% before "stalled". The user
also had no idea the real blocker was that the free scrapers carry no subtitles
for the show. These two fixes target exactly those failure modes.

## Update (review round)

Addressed all six bot review threads:
- Subtitle failure detail now lives on a dedicated `DiscJob.subtitle_error_message`
  field (set/cleared with `subtitle_status`), decoupled from the shared
  `error_message` — fixes the stale-banner-after-retry regression and the
  cross-error leakage in both `DiscCard` and `ReviewQueue`.
- Single `STALL_FAILURE_REASON` constant shared by the watchdog callback, the
  fallback `match_details`, and the WebSocket broadcast (live toast and History
  now agree).
- Card banner gated on `state !== 'completed'`; empty `except` documented.

## Reviewer notes

- The watchdog only runs against real `makemkvcon`, which the simulation path
  bypasses, so the threaded watchdog itself isn't covered by automated tests.
  The **decision logic** is unit-tested via `_is_stalled`; a true end-to-end
  check needs a real extras-heavy disc.
- Default `ripping_stall_timeout` stays 120s — this changes the *mechanism*,
  not the value.

## Test plan

- [x] Backend: `uv run ruff check` + `format --check` clean; `uv run pytest tests/unit/` — 1097 passing (incl. `_is_stalled` and subtitle-field tests, written test-first)
- [x] Frontend: `npm run build` (tsc) + `npm run lint` clean; `npm run test:unit` — 79 passing
- [x] Browser: loud banner + review notice rendered via Playwright against the real `DiscCard`/`SvNotice` components at 2560×1440 (banner-with-message, fallback copy, and `error`-tone review notice all confirmed)
- [ ] Manual: rip a real extras-heavy disc, confirm small tracks aren't killed and no false "disc damage" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)