### PR TITLE
feat: downloadable per-job diagnostic bundle for bug reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Each module maps to a stage in the disc processing pipeline:
 5. **Organizer** (`organizer.py`) — File organization. Moves from staging to library with naming conventions: `Movies/Name (Year)/Name (Year).mkv` and `TV/Show/Season XX/Show - SXXEXX.mkv`.
 6. **TMDB Classifier** (`tmdb_classifier.py`) — TMDB-based content type classification. Provides strong signals for TV vs Movie detection beyond the heuristic-based Analyst.
 7. **Errors** (`errors.py`) — Custom exception hierarchy (`EngramError` base, with `MakeMKVError`, `MatchingError`, `ConfigurationError`, `OrganizationError`, `SubtitleError`, `DatabaseError`). Includes `@handle_errors` decorator for standardized error handling.
-8. **Logging** (`logging.py`) — Centralized logging configuration.
+8. **Logging** (`logging.py`) — Centralized logging configuration. Lines carry a `job=<id>` tag (`job=-` when outside a job). Per-job coroutines run inside `logger.contextualize(job_id=...)` via `app/core/log_context.py` (`with_job_log_context` wraps top-level task spawns in `job_manager.py`/`simulation_service.py`; `match_single_file` self-tags); nested `create_task`s inherit the tag. The diagnostics bundle greps the `job=<id>` token. **Caveat:** only jobs that ran *after* this change have tagged lines — older jobs fall back to the global ERROR/CRITICAL tail. Long-lived `provider_scheduler` worker threads log `job=-` (accepted gap).
 
 ### Orchestration (`backend/app/services/`)
 
@@ -126,7 +126,7 @@ Integrated from standalone `mkv-episode-matcher` project. Flattened directory st
 
 ### API (`backend/app/api/`)
 
-- `routes.py` — REST endpoints under `/api` prefix (job CRUD, review actions, config, simulation, staging management, job history with `GET /api/jobs/history`, job detail with `GET /api/jobs/{job_id}/detail`, stats with `GET /api/jobs/stats`, diagnostics with `GET /api/diagnostics/report`)
+- `routes.py` — REST endpoints under `/api` prefix (job CRUD, review actions, config, simulation, staging management, job history with `GET /api/jobs/history`, job detail with `GET /api/jobs/{job_id}/detail`, stats with `GET /api/jobs/stats`, diagnostics with `GET /api/diagnostics/report` and a downloadable per-job diagnostic `.zip` at `GET /api/diagnostics/report/{job_id}/bundle` — report.md + job-detail.json + job-tagged logs + raw MakeMKV scan/rip logs + subtitle cache/coverage, all sanitized via `_sanitize_obj`/`_sanitize_line`. Job-detail assembly is shared via `build_job_detail`; env/markdown via `_collect_environment`/`_build_markdown_summary`)
 - `validation.py` — Tool validation endpoints (`POST /api/validate/makemkv`, `POST /api/validate/ffmpeg`, `GET /api/detect-tools`)
 - `test_routes.py` — Standalone testing endpoints for subtitle download, transcription, matching
 - `websocket.py` — `ConnectionManager` singleton for broadcasting real-time updates to all connected clients

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,11 +1,13 @@
 """REST API routes for Engram."""
 
 import asyncio
+import io
 import json
 import logging
 import platform
 import re
 import sys
+import zipfile
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
@@ -14,14 +16,17 @@ from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from app.config import settings
+from app.core.discdb_exporter import get_makemkv_log_dir
 from app.core.security import is_allowed_image_url
 from app.database import get_session
+from app.matcher.coverage_tracker import get_cache_status
 from app.matcher.tmdb_client import fetch_season_episodes
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle
@@ -598,13 +603,13 @@ async def get_season_roster(
     )
 
 
-@router.get("/jobs/{job_id}/detail", response_model=JobDetailResponse)
-async def get_job_detail(
-    job: DiscJob = Depends(get_job_or_404),
-    session: AsyncSession = Depends(get_session),
-) -> dict:
-    """Get full job detail with titles for history drill-down."""
-    # Fetch associated titles
+async def build_job_detail(job: DiscJob, session: AsyncSession) -> dict:
+    """Assemble the full job-detail dict (job fields + ordered titles).
+
+    Shared by the history drill-down endpoint and the diagnostics bundle so
+    the two never drift. ``titles`` are ORM objects; callers that need a
+    JSON-safe form validate the result through ``JobDetailResponse``.
+    """
     titles_result = await session.execute(
         select(DiscTitle).where(DiscTitle.job_id == job.id).order_by(DiscTitle.title_index)
     )
@@ -649,6 +654,15 @@ async def get_job_detail(
         "final_path": job.final_path,
         "titles": titles,
     }
+
+
+@router.get("/jobs/{job_id}/detail", response_model=JobDetailResponse)
+async def get_job_detail(
+    job: DiscJob = Depends(get_job_or_404),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Get full job detail with titles for history drill-down."""
+    return await build_job_detail(job, session)
 
 
 @router.post("/jobs/{job_id}/start")
@@ -1447,6 +1461,210 @@ def _sanitize_line(line: str) -> str:
     return _SENSITIVE_RE.sub("***REDACTED***", line)
 
 
+async def _collect_environment() -> dict:
+    """Gather app/OS/tool versions and a redacted config snapshot.
+
+    Shared by the diagnostics report and the diagnostics bundle. Tool
+    detection spawns subprocesses (up to a 10 s timeout each), so the two
+    probes run concurrently off the event loop.
+    """
+    from app import __version__
+    from app.api.validation import detect_ffmpeg, detect_makemkv
+    from app.services.config_service import get_config
+
+    config = await get_config()
+    mk, ff = await asyncio.gather(
+        asyncio.to_thread(detect_makemkv),
+        asyncio.to_thread(detect_ffmpeg),
+    )
+    return {
+        "app_version": __version__,
+        "python_version": sys.version.split()[0],
+        "os": f"{platform.system()} {platform.release()}",
+        "makemkv_version": mk.version if mk.found else (mk.error or "not found"),
+        "ffmpeg_version": ff.version if ff.found else (ff.error or "not found"),
+        "config": {
+            "staging_path": _redact_home(config.staging_path),
+            "library_movies_path": _redact_home(config.library_movies_path),
+            "library_tv_path": _redact_home(config.library_tv_path),
+            "max_concurrent_matches": config.max_concurrent_matches,
+            "conflict_resolution_default": config.conflict_resolution_default,
+            "extras_policy": config.extras_policy,
+            "discdb_enabled": config.discdb_enabled,
+        },
+    }
+
+
+def _build_markdown_summary(env: dict, job_summary: dict | None, recent_errors: list[str]) -> str:
+    """Render the factual core of a bug report (env + job context + errors).
+
+    Used verbatim by the GitHub issue body and as the opening of the
+    downloadable bundle's ``report.md`` so the two never diverge.
+    """
+    parts = [
+        "## Bug Report",
+        "",
+        f"**Engram version**: {env['app_version']}",
+        f"**OS**: {env['os']}",
+        f"**Python**: {env['python_version']}",
+        f"**MakeMKV**: {env['makemkv_version']}",
+        f"**FFmpeg**: {env['ffmpeg_version']}",
+        "",
+    ]
+    if job_summary:
+        parts += [
+            "### Job Context",
+            f"- **ID**: {job_summary['id']}",
+            f"- **Label**: {job_summary['volume_label']}",
+            f"- **Type**: {job_summary['content_type']}",
+            f"- **State**: {job_summary['state']}",
+        ]
+        if job_summary["error"]:
+            parts.append(f"- **Error**: {job_summary['error']}")
+        parts.append("")
+    if recent_errors:
+        parts += ["### Recent Errors", "```"]
+        parts += recent_errors[-10:]
+        parts += ["```", ""]
+    return "\n".join(parts)
+
+
+def _read_recent_error_lines(limit: int = 20, log_path: Path | None = None) -> list[str]:
+    """Return the last ``limit`` sanitized ERROR/CRITICAL lines from the log.
+
+    The global fallback when a job has no job-tagged lines (e.g. it ran
+    before job-tagged logging existed).
+    """
+    log_path = log_path or (Path.home() / ".engram" / "engram.log")
+    if not log_path.exists():
+        return []
+    try:
+        raw = log_path.read_text(encoding="utf-8", errors="replace")
+        error_lines = [ln for ln in raw.splitlines() if "ERROR" in ln or "CRITICAL" in ln]
+        return [_sanitize_line(line) for line in error_lines[-limit:]]
+    except Exception:
+        logger.warning(f"Failed to read log file for bug report: {log_path}", exc_info=True)
+        return ["(could not read log file)"]
+
+
+def _sanitize_obj(obj: object) -> object:
+    """Recursively redact every string in a nested dict/list structure.
+
+    Reuses ``_sanitize_line`` (home path + secret patterns) so paths, volume
+    labels, detected titles, and the ``match_details``/``discdb_match_details``
+    JSON blobs are all scrubbed before leaving the machine.
+    """
+    if isinstance(obj, str):
+        return _sanitize_line(obj)
+    if isinstance(obj, dict):
+        return {k: _sanitize_obj(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_obj(v) for v in obj]
+    return obj
+
+
+def _read_job_tagged_logs(
+    job_id: int, limit: int = 2000, log_path: Path | None = None
+) -> tuple[list[str], bool]:
+    """Return ``(lines, is_fallback)`` for a job's log lines.
+
+    Filters the global log to lines carrying this job's ``| job=<id> |`` tag.
+    Jobs that ran before job-tagged logging existed have no tagged lines — in
+    that case fall back to the recent global ERROR/CRITICAL tail and flag it.
+    """
+    log_path = log_path or (Path.home() / ".engram" / "engram.log")
+    if not log_path.exists():
+        return ([], False)
+    try:
+        raw = log_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        logger.warning(f"Failed to read log file for bundle: {log_path}", exc_info=True)
+        return (["(could not read log file)"], False)
+    token = f"| job={job_id} |"
+    matched = [ln for ln in raw.splitlines() if token in ln]
+    if matched:
+        return ([_sanitize_line(ln) for ln in matched[-limit:]], False)
+    return (_read_recent_error_lines(log_path=log_path), True)
+
+
+def _cap_text(text: str, max_chars: int = 200_000) -> str:
+    """Keep the tail of an oversized log so the bundle stays small."""
+    if len(text) <= max_chars:
+        return text
+    return f"... (truncated; showing last {max_chars} chars)\n" + text[-max_chars:]
+
+
+def _build_track_table(detail: dict) -> str:
+    titles = detail.get("titles") or []
+    if not titles:
+        return "### Tracks\n\n_No tracks recorded._"
+    rows = [
+        "### Tracks",
+        "",
+        "| # | Duration (s) | Chapters | Resolution | State | Episode | Conf | Source |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for t in titles:
+        rows.append(
+            f"| {t.get('title_index')} | {t.get('duration_seconds')} "
+            f"| {t.get('chapter_count')} | {t.get('video_resolution') or '-'} "
+            f"| {t.get('state')} | {t.get('matched_episode') or '-'} "
+            f"| {t.get('match_confidence')} | {t.get('match_source') or '-'} |"
+        )
+    return "\n".join(rows)
+
+
+def _build_cache_table(cache_status: dict) -> str:
+    rows = [
+        "### Subtitle Cache / Coverage",
+        "",
+        f"- **TMDB show metadata cached**: {cache_status['tmdb_show_cached']}",
+        f"- **TMDB season metadata cached**: {cache_status['tmdb_season_cached']}",
+        "",
+    ]
+    coverage = cache_status.get("coverage") or []
+    if not coverage:
+        rows.append("_No subtitle-coverage records for this show._")
+        return "\n".join(rows)
+    rows += ["| Season | Covered | Total | Ratio |", "|---|---|---|---|"]
+    for row in coverage:
+        ratio = row.get("coverage_ratio")
+        ratio_str = f"{ratio:.2f}" if isinstance(ratio, (int, float)) else str(ratio)
+        rows.append(
+            f"| {row.get('season')} | {row.get('covered_episodes')} "
+            f"| {row.get('total_episodes')} | {ratio_str} |"
+        )
+    return "\n".join(rows)
+
+
+def _build_bundle_markdown(
+    env: dict,
+    job_summary: dict,
+    detail: dict,
+    cache_status: dict,
+    log_is_fallback: bool,
+) -> str:
+    parts = [
+        _build_markdown_summary(env, job_summary, []),
+        "### Configuration",
+        *[f"- **{k}**: {v}" for k, v in env["config"].items()],
+        "",
+        _build_track_table(detail),
+        "",
+        _build_cache_table(cache_status),
+        "",
+        "### Attached Files",
+        "- `job-detail.json` — full job + per-track detail",
+        (
+            "- `job-logs.txt` — recent global errors (this job predates job-tagged logging)"
+            if log_is_fallback
+            else "- `job-logs.txt` — log lines for this job"
+        ),
+        "- `scan.log` / `rip.log` — raw MakeMKV output (when present)",
+    ]
+    return "\n".join(parts)
+
+
 @router.get("/diagnostics/logs")
 async def get_recent_logs(
     lines: int = Query(default=50, ge=1, le=200),
@@ -1475,21 +1693,7 @@ async def generate_bug_report(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     """Generate a sanitized bug report with optional job context."""
-    from app import __version__
-    from app.api.validation import detect_ffmpeg, detect_makemkv
-    from app.services.config_service import get_config
-
-    config = await get_config()
-
-    # --- External tool versions (detection runs subprocesses; keep off the loop) ---
-    # Run concurrently — each spawns a subprocess with up to a 10 s timeout, so
-    # serial detection would double the worst-case latency before the modal opens.
-    mk, ff = await asyncio.gather(
-        asyncio.to_thread(detect_makemkv),
-        asyncio.to_thread(detect_ffmpeg),
-    )
-    makemkv_version = mk.version if mk.found else (mk.error or "not found")
-    ffmpeg_version = ff.version if ff.found else (ff.error or "not found")
+    env = await _collect_environment()
 
     # --- Job summary (optional) ---
     job_summary = None
@@ -1506,71 +1710,22 @@ async def generate_bug_report(
                 "completed_at": str(job.completed_at) if job.completed_at else None,
             }
 
-    # --- Recent error lines from log ---
-    log_path = Path.home() / ".engram" / "engram.log"
-    recent_errors: list[str] = []
-    if log_path.exists():
-        try:
-            raw = log_path.read_text(encoding="utf-8", errors="replace")
-            all_lines = raw.splitlines()
-            error_lines = [ln for ln in all_lines if "ERROR" in ln or "CRITICAL" in ln]
-            recent_errors = [_sanitize_line(line) for line in error_lines[-20:]]
-        except Exception:
-            logger.warning(f"Failed to read log file for bug report: {log_path}", exc_info=True)
-            recent_errors = ["(could not read log file)"]
+    recent_errors = _read_recent_error_lines()
 
-    # --- Redacted config ---
-    redacted_config = {
-        "staging_path": _redact_home(config.staging_path),
-        "library_movies_path": _redact_home(config.library_movies_path),
-        "library_tv_path": _redact_home(config.library_tv_path),
-        "max_concurrent_matches": config.max_concurrent_matches,
-        "conflict_resolution_default": config.conflict_resolution_default,
-        "extras_policy": config.extras_policy,
-        "discdb_enabled": config.discdb_enabled,
-    }
-
-    # --- Build report ---
     report = {
-        "app_version": __version__,
-        "python_version": sys.version.split()[0],
-        "os": f"{platform.system()} {platform.release()}",
-        "makemkv_version": makemkv_version,
-        "ffmpeg_version": ffmpeg_version,
+        "app_version": env["app_version"],
+        "python_version": env["python_version"],
+        "os": env["os"],
+        "makemkv_version": env["makemkv_version"],
+        "ffmpeg_version": env["ffmpeg_version"],
         "job": job_summary,
         "recent_errors": recent_errors,
-        "config": redacted_config,
+        "config": env["config"],
     }
 
-    # --- Build GitHub issue body ---
+    # --- GitHub issue body (kept small; full detail lives in the bundle) ---
     body_parts = [
-        "## Bug Report",
-        "",
-        f"**Engram version**: {__version__}",
-        f"**OS**: {report['os']}",
-        f"**Python**: {report['python_version']}",
-        f"**MakeMKV**: {makemkv_version}",
-        f"**FFmpeg**: {ffmpeg_version}",
-        "",
-    ]
-    if job_summary:
-        body_parts += [
-            "### Job Context",
-            f"- **ID**: {job_summary['id']}",
-            f"- **Label**: {job_summary['volume_label']}",
-            f"- **Type**: {job_summary['content_type']}",
-            f"- **State**: {job_summary['state']}",
-        ]
-        if job_summary["error"]:
-            body_parts.append(f"- **Error**: {job_summary['error']}")
-        body_parts.append("")
-
-    if recent_errors:
-        body_parts += ["### Recent Errors", "```"]
-        body_parts += recent_errors[-10:]
-        body_parts += ["```", ""]
-
-    body_parts += [
+        _build_markdown_summary(env, job_summary, recent_errors),
         "### Steps to Reproduce",
         "1. ",
         "",
@@ -1580,7 +1735,6 @@ async def generate_bug_report(
         "### Actual Behavior",
         "",
     ]
-
     issue_body = "\n".join(body_parts)
     title = "[Bug] " + (
         f"Job {job_id} failed in {job_summary['state']}" if job_summary else "Describe the issue"
@@ -1592,7 +1746,79 @@ async def generate_bug_report(
 
     report["github_url"] = github_url
     report["markdown"] = issue_body
+
+    # Bundle-preview hints so the modal can describe the downloadable bundle
+    # without fetching it. Only meaningful for an existing job.
+    if job_summary is not None:
+        cache_status = await asyncio.to_thread(get_cache_status, job.tmdb_id, job.detected_season)
+        report["bundle_available"] = True
+        report["has_scan_log"] = (get_makemkv_log_dir(job_id) / "scan.log").exists()
+        report["coverage_seasons"] = len(cache_status["coverage"])
+        report["tmdb_cached"] = cache_status["tmdb_show_cached"]
+    else:
+        report["bundle_available"] = False
+
     return report
+
+
+@router.get("/diagnostics/report/{job_id}/bundle")
+async def download_bug_report_bundle(
+    job_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> StreamingResponse:
+    """Download a sanitized diagnostic bundle (.zip) for a single job.
+
+    Bundles the full job + per-track detail, the job's tagged log lines, the
+    subtitle cache/coverage status for the series, and the raw MakeMKV scan
+    logs — everything run through the same sanitization as the inline report.
+    """
+    job = await session.get(DiscJob, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    detail = await build_job_detail(job, session)
+    detail_json = JobDetailResponse.model_validate(detail).model_dump(mode="json")
+    safe_detail = _sanitize_obj(detail_json)
+
+    env = await _collect_environment()
+    cache_status = await asyncio.to_thread(get_cache_status, job.tmdb_id, job.detected_season)
+    log_lines, log_is_fallback = await asyncio.to_thread(_read_job_tagged_logs, job_id)
+
+    job_summary = {
+        "id": job.id,
+        "volume_label": _sanitize_line(job.volume_label or ""),
+        "content_type": job.content_type.value if job.content_type else "unknown",
+        "state": job.state.value if job.state else "unknown",
+        "error": job.error_message,
+    }
+    report_md = _build_bundle_markdown(env, job_summary, safe_detail, cache_status, log_is_fallback)
+
+    def _build_zip() -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("report.md", report_md)
+            zf.writestr("job-detail.json", json.dumps(safe_detail, indent=2))
+            zf.writestr("job-logs.txt", "\n".join(log_lines) if log_lines else "(no logs)")
+            log_dir = get_makemkv_log_dir(job_id)
+            for name in ("scan.log", "rip.log"):
+                p = log_dir / name
+                if not p.exists():
+                    continue
+                try:
+                    raw = p.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    continue
+                sanitized = "\n".join(_sanitize_line(ln) for ln in raw.splitlines())
+                zf.writestr(name, _cap_text(sanitized))
+        return buf.getvalue()
+
+    data = await asyncio.to_thread(_build_zip)
+    filename = f"engram-bug-report-job-{job_id}.zip"
+    return StreamingResponse(
+        io.BytesIO(data),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 # ── TheDiscDB Contribution Endpoints ─────────────────────────────────────

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1573,13 +1573,15 @@ def _read_job_tagged_logs(
     that case fall back to the recent global ERROR/CRITICAL tail and flag it.
     """
     log_path = log_path or (Path.home() / ".engram" / "engram.log")
+    # No file / unreadable → mark as fallback (not job-specific) so the bundle
+    # never labels empty/placeholder content as "log lines for this job".
     if not log_path.exists():
-        return ([], False)
+        return ([], True)
     try:
         raw = log_path.read_text(encoding="utf-8", errors="replace")
     except Exception:
         logger.warning(f"Failed to read log file for bundle: {log_path}", exc_info=True)
-        return (["(could not read log file)"], False)
+        return (["(could not read log file)"], True)
     token = f"| job={job_id} |"
     matched = [ln for ln in raw.splitlines() if token in ln]
     if matched:
@@ -1702,10 +1704,11 @@ async def generate_bug_report(
         if job:
             job_summary = {
                 "id": job.id,
-                "volume_label": job.volume_label,
+                # Sanitized: these flow into the GitHub issue title/body.
+                "volume_label": _sanitize_line(job.volume_label or ""),
                 "content_type": job.content_type.value if job.content_type else "unknown",
                 "state": job.state.value if job.state else "unknown",
-                "error": job.error_message,
+                "error": _sanitize_line(job.error_message) if job.error_message else None,
                 "created_at": str(job.created_at) if job.created_at else None,
                 "completed_at": str(job.completed_at) if job.completed_at else None,
             }
@@ -1789,7 +1792,7 @@ async def download_bug_report_bundle(
         "volume_label": _sanitize_line(job.volume_label or ""),
         "content_type": job.content_type.value if job.content_type else "unknown",
         "state": job.state.value if job.state else "unknown",
-        "error": job.error_message,
+        "error": _sanitize_line(job.error_message) if job.error_message else None,
     }
     report_md = _build_bundle_markdown(env, job_summary, safe_detail, cache_status, log_is_fallback)
 

--- a/backend/app/core/log_context.py
+++ b/backend/app/core/log_context.py
@@ -1,0 +1,40 @@
+"""Bind a job id into the logging context for the life of a coroutine.
+
+Engram's logs are a single global stream (``~/.engram/engram.log``). To let
+the diagnostics bundle extract exactly one job's lines, every per-job
+coroutine is run inside ``logger.contextualize(job_id=...)`` so each emitted
+line carries a ``job=<id>`` tag.
+
+The tag flows through both logging paths:
+- loguru-native calls in ``app/matcher`` (they read the contextvar directly), and
+- stdlib ``logging`` calls in the services/coordinators, which reach loguru via
+  the ``InterceptHandler`` in ``app/core/logging.py`` — and that handler emits
+  through ``logger.opt(...).log(...)``, which also reads the contextvar.
+
+Tasks spawned *within* the wrapped coroutine inherit the binding automatically,
+because ``asyncio.create_task`` copies the current context at creation time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Coroutine
+from typing import Any
+
+from loguru import logger
+
+
+async def with_job_log_context(job_id: int, coro: Coroutine[Any, Any, Any]) -> Any:
+    """Await ``coro`` with ``job_id`` bound into the loguru logging context."""
+    with logger.contextualize(job_id=job_id):
+        return await coro
+
+
+def job_log_context(job_id: int):
+    """Return a context manager binding ``job_id`` into the logging context.
+
+    For coroutines that may be entered directly (not only via
+    ``asyncio.create_task``) — e.g. matching invoked straight from an API
+    handler — wrap the body in ``with job_log_context(job_id):`` so the lines
+    are tagged regardless of how the coroutine was reached.
+    """
+    return logger.contextualize(job_id=job_id)

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -14,6 +14,20 @@ from loguru import logger
 
 from app.config import settings
 
+# Job-tagged formats. ``{extra[job_id]}`` is always present because
+# ``setup_logging`` configures a default of ``"-"`` (overridden per job via
+# ``logger.contextualize(job_id=...)``). The ``job=<id>`` token is what the
+# diagnostics bundle greps to extract a single job's lines.
+_FILE_LOG_FORMAT = (
+    "{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | job={extra[job_id]} | "
+    "{name}:{function}:{line} - {message}"
+)
+_CONSOLE_LOG_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | "
+    "<magenta>job={extra[job_id]}</magenta> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
+)
+
 
 class InterceptHandler(logging.Handler):
     """
@@ -56,11 +70,15 @@ def setup_logging() -> None:
     # configure loguru
     logger.remove()  # Remove default handler
 
+    # Default `extra` so the `{extra[job_id]}` placeholder is always present;
+    # per-job code overrides it via `logger.contextualize(job_id=...)`.
+    logger.configure(extra={"job_id": "-"})
+
     # 1. Console handler (stderr)
     logger.add(
         sys.stderr,
         level="DEBUG" if settings.debug else "INFO",
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+        format=_CONSOLE_LOG_FORMAT,
     )
 
     # 2. File handler
@@ -73,7 +91,7 @@ def setup_logging() -> None:
         retention="1 week",  # Keep logs for 1 week
         compression="zip",  # Compress rotated logs
         level="DEBUG",  # Always log debug to file for troubleshooting
-        format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {name}:{function}:{line} - {message}",
+        format=_FILE_LOG_FORMAT,
         enqueue=True,  # Thread-safe for async
         backtrace=True,
         diagnose=True,

--- a/backend/app/matcher/coverage_tracker.py
+++ b/backend/app/matcher/coverage_tracker.py
@@ -95,6 +95,54 @@ def is_done(
     return True, row
 
 
+def get_show_coverage(tmdb_id: int) -> list[dict[str, Any]]:
+    """Return every recorded coverage row for a show, oldest season first.
+
+    Read-only; returns ``[]`` when the cache DB doesn't exist. Used by the
+    diagnostics bundle to surface why subtitle matching may have come up
+    short for a series (e.g. a season recorded at 10% coverage that the
+    skip window subsequently suppressed).
+    """
+    if not tmdb_persistent_cache.CACHE_DB_PATH.exists():
+        return []
+    conn = tmdb_persistent_cache.get_conn()
+    rows = conn.execute(
+        "SELECT season, attempted_at, total_episodes, covered_episodes, coverage_ratio "
+        "FROM subtitle_coverage WHERE tmdb_id = ? ORDER BY season",
+        (tmdb_id,),
+    ).fetchall()
+    return [
+        {
+            "season": season,
+            "attempted_at": attempted_at,
+            "total_episodes": total,
+            "covered_episodes": covered,
+            "coverage_ratio": ratio,
+        }
+        for season, attempted_at, total, covered, ratio in rows
+    ]
+
+
+def get_cache_status(tmdb_id: int | None, season: int | None = None) -> dict[str, Any]:
+    """Summarise cache state for a job's series, for the diagnostics bundle.
+
+    Returns subtitle-coverage rows for the show plus whether TMDB show and
+    season metadata are currently cached. Empty/False when ``tmdb_id`` is
+    unknown (movies, unidentified discs). All reads are read-only.
+    """
+    if tmdb_id is None:
+        return {"coverage": [], "tmdb_show_cached": False, "tmdb_season_cached": False}
+    return {
+        "coverage": get_show_coverage(tmdb_id),
+        "tmdb_show_cached": tmdb_persistent_cache.is_cached(f"show_details:{tmdb_id}"),
+        "tmdb_season_cached": (
+            tmdb_persistent_cache.is_cached(f"season:{tmdb_id}:{season}")
+            if season is not None
+            else False
+        ),
+    }
+
+
 def record(tmdb_id: int, season: int, total: int, covered: int) -> None:
     """Insert or replace the coverage row for ``(tmdb_id, season)``.
 

--- a/backend/app/matcher/tmdb_persistent_cache.py
+++ b/backend/app/matcher/tmdb_persistent_cache.py
@@ -155,6 +155,27 @@ def get(cache_key: str) -> Any | None:
         return None
 
 
+def is_cached(cache_key: str) -> bool:
+    """Return True iff a fresh (unexpired) entry exists for ``cache_key``.
+
+    Read-only companion to :func:`get` for diagnostics. Unlike ``get`` it
+    never creates the cache file and never deletes expired rows, so it is
+    safe to call while assembling a bug report. Returns False when the DB
+    doesn't exist yet.
+    """
+    if not CACHE_DB_PATH.exists():
+        return False
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT fetched_at, ttl_seconds FROM tmdb_cache WHERE cache_key = ?",
+        (cache_key,),
+    ).fetchone()
+    if row is None:
+        return False
+    fetched_at, ttl_seconds = row
+    return (time.time() - fetched_at) < ttl_seconds
+
+
 def put(cache_key: str, payload: Any, ttl_seconds: int) -> None:
     """Insert or replace a cache entry. ``payload`` must be JSON-serializable."""
     serialized = json.dumps(payload, default=str)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -485,11 +485,9 @@ class JobManager:
                         if not file_path.exists():
                             file_path = staging / file_path.name
                         if file_path.exists():
+                            # match_single_file self-tags the job log context.
                             match_task = asyncio.create_task(
-                                with_job_log_context(
-                                    job_id,
-                                    self._matching.match_single_file(job_id, title.id, file_path),
-                                )
+                                self._matching.match_single_file(job_id, title.id, file_path)
                             )
                             match_task.add_done_callback(
                                 lambda t, jid=job_id, tid=title.id: (
@@ -660,10 +658,9 @@ class JobManager:
                 if applied:
                     await self._finalization.check_job_completion(session, job_id)
             if not applied:
+                # match_single_file self-tags the job log context.
                 task = asyncio.create_task(
-                    with_job_log_context(
-                        job_id, self._matching.match_single_file(job_id, title_id, file_path)
-                    )
+                    self._matching.match_single_file(job_id, title_id, file_path)
                 )
                 task.add_done_callback(
                     lambda t, jid=job_id, tid=title_id: self._matching.on_match_task_done(
@@ -1709,10 +1706,9 @@ class JobManager:
                 if discdb_applied:
                     await self._finalization.check_job_completion(session, job_id)
                 else:
+                    # match_single_file self-tags the job log context.
                     task = asyncio.create_task(
-                        with_job_log_context(
-                            job_id, self._matching.match_single_file(job_id, title.id, path)
-                        )
+                        self._matching.match_single_file(job_id, title.id, path)
                     )
                     task.add_done_callback(
                         lambda t, jid=job_id, tid=title.id: self._matching.on_match_task_done(

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -20,6 +20,7 @@ from sqlmodel import select
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
 from app.core.extractor import STALL_FAILURE_REASON, MakeMKVExtractor
+from app.core.log_context import with_job_log_context
 from app.core.organizer import movie_organizer
 from app.core.security import sanitize_log_value
 from app.core.sentinel import DriveMonitor
@@ -339,7 +340,9 @@ class JobManager:
 
                 logger.info(f"Created job {job.id} for disc in {drive_letter}")
 
-                task = asyncio.create_task(self._identification.identify_disc(job.id))
+                task = asyncio.create_task(
+                    with_job_log_context(job.id, self._identification.identify_disc(job.id))
+                )
                 task.add_done_callback(lambda t, jid=job.id: self._on_task_done(t, jid))
                 self._active_jobs[job.id] = task
                 # Stamp the cooldown only after the task is scheduled, so a failure
@@ -386,7 +389,9 @@ class JobManager:
 
         await event_broadcaster.broadcast_drive_inserted("staging", volume_label)
 
-        task = asyncio.create_task(self._identification.identify_from_staging(job_id))
+        task = asyncio.create_task(
+            with_job_log_context(job_id, self._identification.identify_from_staging(job_id))
+        )
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
 
@@ -404,7 +409,7 @@ class JobManager:
         """Set a user-provided name for an unlabeled disc and resume ripping."""
         await self._identification.set_name_and_resume(job_id, name, content_type_str, season)
 
-        task = asyncio.create_task(self._run_ripping(job_id))
+        task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
 
@@ -423,10 +428,10 @@ class JobManager:
 
         if result["has_ripped"]:
             # Post-rip: re-run matching for existing files
-            task = asyncio.create_task(self._rerun_matching(job_id))
+            task = asyncio.create_task(with_job_log_context(job_id, self._rerun_matching(job_id)))
         else:
             # Pre-rip: start ripping with corrected metadata
-            task = asyncio.create_task(self._run_ripping(job_id))
+            task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
 
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
@@ -481,7 +486,10 @@ class JobManager:
                             file_path = staging / file_path.name
                         if file_path.exists():
                             match_task = asyncio.create_task(
-                                self._matching.match_single_file(job_id, title.id, file_path)
+                                with_job_log_context(
+                                    job_id,
+                                    self._matching.match_single_file(job_id, title.id, file_path),
+                                )
                             )
                             match_task.add_done_callback(
                                 lambda t, jid=job_id, tid=title.id: (
@@ -507,7 +515,7 @@ class JobManager:
             job.updated_at = datetime.now(UTC)
             await session.commit()
 
-            task = asyncio.create_task(self._run_ripping(job_id))
+            task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
             task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
             self._active_jobs[job_id] = task
 
@@ -653,7 +661,9 @@ class JobManager:
                     await self._finalization.check_job_completion(session, job_id)
             if not applied:
                 task = asyncio.create_task(
-                    self._matching.match_single_file(job_id, title_id, file_path)
+                    with_job_log_context(
+                        job_id, self._matching.match_single_file(job_id, title_id, file_path)
+                    )
                 )
                 task.add_done_callback(
                     lambda t, jid=job_id, tid=title_id: self._matching.on_match_task_done(
@@ -1700,7 +1710,9 @@ class JobManager:
                     await self._finalization.check_job_completion(session, job_id)
                 else:
                     task = asyncio.create_task(
-                        self._matching.match_single_file(job_id, title.id, path)
+                        with_job_log_context(
+                            job_id, self._matching.match_single_file(job_id, title.id, path)
+                        )
                     )
                     task.add_done_callback(
                         lambda t, jid=job_id, tid=title.id: self._matching.on_match_task_done(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -14,6 +14,7 @@ from sqlmodel import select
 from app.api.websocket import manager as ws_manager
 from app.core.curator import curator as episode_curator
 from app.core.errors import MatchingError
+from app.core.log_context import job_log_context
 from app.database import async_session
 from app.models import DiscJob
 from app.models.disc_job import DiscTitle, TitleState
@@ -321,6 +322,26 @@ class MatchingCoordinator:
         )
 
     async def match_single_file(
+        self,
+        job_id: int,
+        title_id: int,
+        file_path: Path,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+    ) -> None:
+        """Run matching for a single ripped file, tagging logs with the job id.
+
+        Self-tags so every matching log line carries ``job=<id>`` regardless of
+        how this is reached — task spawn, direct ``await`` from an API handler
+        (deep re-match / conflict resolution), or via the injected callback used
+        by the identification/finalization coordinators.
+        """
+        with job_log_context(job_id):
+            await self._run_match_single_file(
+                job_id, title_id, file_path, num_points, min_vote_count
+            )
+
+    async def _run_match_single_file(
         self,
         job_id: int,
         title_id: int,

--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.websocket import manager as ws_manager
+from app.core.log_context import with_job_log_context
 from app.database import async_session
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
@@ -163,7 +164,10 @@ class SimulationService:
             if content_type == ContentType.TV and detected_title and detected_season:
                 self._subtitle_ready[job.id] = asyncio.Event()
                 self._subtitle_tasks[job.id] = asyncio.create_task(
-                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
+                    with_job_log_context(
+                        job.id,
+                        self._simulate_subtitle_download(job.id, len(title_params), detected_title),
+                    )
                 )
                 logger.info(
                     f"Job {job.id}: starting simulated subtitle download for "
@@ -197,7 +201,10 @@ class SimulationService:
                 )
             elif simulate_ripping:
                 task = asyncio.create_task(
-                    self._simulate_ripping(job.id, titles, rip_speed_multiplier, content_type)
+                    with_job_log_context(
+                        job.id,
+                        self._simulate_ripping(job.id, titles, rip_speed_multiplier, content_type),
+                    )
                 )
                 task.add_done_callback(lambda t, jid=job.id: self._on_task_done(t, jid))
                 self._active_jobs[job.id] = task
@@ -297,7 +304,10 @@ class SimulationService:
             if content_type == ContentType.TV and detected_title and detected_season:
                 self._subtitle_ready[job.id] = asyncio.Event()
                 self._subtitle_tasks[job.id] = asyncio.create_task(
-                    self._simulate_subtitle_download(job.id, len(title_params), detected_title)
+                    with_job_log_context(
+                        job.id,
+                        self._simulate_subtitle_download(job.id, len(title_params), detected_title),
+                    )
                 )
                 logger.info(
                     f"Job {job.id}: starting simulated subtitle download for "
@@ -305,7 +315,12 @@ class SimulationService:
                 )
 
             task = asyncio.create_task(
-                self._simulate_realistic_ripping(job.id, titles, content_type, rip_speed_multiplier)
+                with_job_log_context(
+                    job.id,
+                    self._simulate_realistic_ripping(
+                        job.id, titles, content_type, rip_speed_multiplier
+                    ),
+                )
             )
             self._active_jobs[job.id] = task
 

--- a/backend/tests/unit/test_coverage_tracker.py
+++ b/backend/tests/unit/test_coverage_tracker.py
@@ -102,6 +102,59 @@ class TestIsDone:
 
 
 @pytest.mark.unit
+class TestGetShowCoverage:
+    def test_returns_all_seasons_ordered(self):
+        coverage_tracker.record(1396, 2, total=13, covered=4)
+        coverage_tracker.record(1396, 1, total=7, covered=7)
+        rows = coverage_tracker.get_show_coverage(1396)
+        assert [r["season"] for r in rows] == [1, 2]
+        assert rows[0]["covered_episodes"] == 7
+        assert rows[1]["coverage_ratio"] == pytest.approx(4 / 13)
+
+    def test_unknown_show_returns_empty(self):
+        assert coverage_tracker.get_show_coverage(42424242) == []
+
+    def test_returns_empty_when_db_absent(self, monkeypatch, tmp_path):
+        from app.matcher import tmdb_persistent_cache
+
+        tmdb_persistent_cache.close()
+        monkeypatch.setattr(
+            tmdb_persistent_cache, "CACHE_DB_PATH", tmp_path / "never_created.sqlite"
+        )
+        assert coverage_tracker.get_show_coverage(1396) == []
+
+
+@pytest.mark.unit
+class TestGetCacheStatus:
+    def test_none_tmdb_id_is_empty(self):
+        status = coverage_tracker.get_cache_status(None)
+        assert status == {
+            "coverage": [],
+            "tmdb_show_cached": False,
+            "tmdb_season_cached": False,
+        }
+
+    def test_reports_coverage_and_tmdb_presence(self):
+        from app.matcher import tmdb_persistent_cache
+
+        coverage_tracker.record(1396, 1, total=7, covered=1)
+        tmdb_persistent_cache.put("show_details:1396", {"name": "Breaking Bad"}, ttl_seconds=3600)
+        tmdb_persistent_cache.put("season:1396:1", 7, ttl_seconds=3600)
+
+        status = coverage_tracker.get_cache_status(1396, season=1)
+        assert status["tmdb_show_cached"] is True
+        assert status["tmdb_season_cached"] is True
+        assert [r["season"] for r in status["coverage"]] == [1]
+
+    def test_uncached_tmdb_reports_false(self):
+        coverage_tracker.record(2, 1, total=10, covered=2)
+        status = coverage_tracker.get_cache_status(2, season=1)
+        assert status["tmdb_show_cached"] is False
+        assert status["tmdb_season_cached"] is False
+        assert len(status["coverage"]) == 1
+
+
+@pytest.mark.unit
 class TestClear:
     def test_clear_all(self):
         coverage_tracker.record(10, 1, 5, 0)

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -5,7 +5,9 @@ versions, job context) rather than placeholders, and that the version source of
 truth cannot silently drift between app/__init__.py and pyproject.toml.
 """
 
+import io
 import tomllib
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,7 @@ import app as app_pkg
 from app.api.validation import ToolDetectionResult
 from app.database import get_session
 from app.main import app
+from app.models.disc_job import DiscTitle, TitleState
 from tests.unit.conftest import _unit_session_factory
 from tests.unit.test_api_routes import _seed_job
 
@@ -111,6 +114,114 @@ class TestBugReport:
         data = resp.json()
         assert data["makemkv_version"] == "MakeMKV not found"
         assert data["ffmpeg_version"] == "FFmpeg not found"
+
+
+class TestBundle:
+    async def test_bundle_returns_zip_with_expected_members(self, client, fake_tools, monkeypatch):
+        monkeypatch.setattr(
+            "app.api.routes._read_job_tagged_logs",
+            lambda *a, **k: (["2026-01-01 00:00:00 | INFO | job=1 | x:y:1 - hello"], False),
+        )
+        job = await _seed_job(volume_label="THE_OFFICE_S1")
+
+        resp = await client.get(f"/api/diagnostics/report/{job.id}/bundle")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert f"engram-bug-report-job-{job.id}.zip" in resp.headers["content-disposition"]
+
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        names = set(zf.namelist())
+        assert {"report.md", "job-detail.json", "job-logs.txt"} <= names
+        assert "## Bug Report" in zf.read("report.md").decode()
+
+    async def test_bundle_includes_scan_log(self, client, fake_tools, monkeypatch, tmp_path):
+        log_dir = tmp_path / "makemkv"
+        log_dir.mkdir()
+        (log_dir / "scan.log").write_text("MSG: scan output line\n", encoding="utf-8")
+        monkeypatch.setattr("app.api.routes.get_makemkv_log_dir", lambda jid: log_dir)
+        monkeypatch.setattr("app.api.routes._read_job_tagged_logs", lambda *a, **k: ([], False))
+        job = await _seed_job()
+
+        resp = await client.get(f"/api/diagnostics/report/{job.id}/bundle")
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        assert "scan.log" in zf.namelist()
+        assert "scan output line" in zf.read("scan.log").decode()
+
+    async def test_bundle_redacts_secrets(self, client, fake_tools, monkeypatch):
+        secret = "eyJhbGciOiJIUzITESTsupersecretpayloadvalue1234567890"
+        monkeypatch.setattr("app.api.routes._read_job_tagged_logs", lambda *a, **k: ([], False))
+        job = await _seed_job(volume_label="SECRET_DISC")
+        async with _unit_session_factory() as session:
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=0,
+                    duration_seconds=1200,
+                    file_size_bytes=1,
+                    match_details=f"token={secret}",
+                    state=TitleState.MATCHED,
+                )
+            )
+            await session.commit()
+
+        resp = await client.get(f"/api/diagnostics/report/{job.id}/bundle")
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        combined = b"\n".join(zf.read(n) for n in zf.namelist())
+        assert secret.encode() not in combined
+        assert b"***REDACTED***" in combined
+
+    async def test_bundle_404_for_missing_job(self, client, fake_tools):
+        resp = await client.get("/api/diagnostics/report/999999/bundle")
+        assert resp.status_code == 404
+
+
+class TestJobTaggedLogReader:
+    def test_filters_to_matching_job(self, tmp_path):
+        from app.api.routes import _read_job_tagged_logs
+
+        log = tmp_path / "engram.log"
+        log.write_text(
+            "t | INFO | job=42 | a:b:1 - keep me\n"
+            "t | INFO | job=99 | a:b:1 - drop me\n"
+            "t | INFO | job=- | a:b:1 - untagged drop\n"
+            "t | INFO | job=42 | a:b:2 - keep me too\n",
+            encoding="utf-8",
+        )
+        lines, is_fallback = _read_job_tagged_logs(42, log_path=log)
+        assert is_fallback is False
+        assert len(lines) == 2
+        assert all("job=42 |" in ln for ln in lines)
+        assert not any("drop" in ln for ln in lines)
+
+    def test_falls_back_to_global_errors_when_untagged(self, tmp_path):
+        from app.api.routes import _read_job_tagged_logs
+
+        log = tmp_path / "engram.log"
+        log.write_text(
+            "t | ERROR | job=- | a:b:1 - something broke\n"
+            "t | INFO | job=7 | a:b:1 - unrelated job\n",
+            encoding="utf-8",
+        )
+        # Job 1234 has no tagged lines → fallback to global ERROR tail.
+        lines, is_fallback = _read_job_tagged_logs(1234, log_path=log)
+        assert is_fallback is True
+        assert any("something broke" in ln for ln in lines)
+
+
+def test_sanitize_obj_redacts_home_and_secrets():
+    from app.api.routes import _sanitize_obj
+
+    home = str(Path.home())
+    data = {
+        "staging_path": f"{home}/.engram/staging/X",
+        "match_details": "token=eyJsecrettokenvaluethatislong1234567890",
+        "nested": [{"final_path": f"{home}/media"}],
+    }
+    out = _sanitize_obj(data)
+    assert home not in out["staging_path"]
+    assert out["staging_path"].startswith("~")
+    assert "***REDACTED***" in out["match_details"]
+    assert home not in out["nested"][0]["final_path"]
 
 
 def test_version_source_of_truth_is_consistent():

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -149,8 +149,13 @@ class TestBundle:
 
     async def test_bundle_redacts_secrets(self, client, fake_tools, monkeypatch):
         secret = "eyJhbGciOiJIUzITESTsupersecretpayloadvalue1234567890"
+        # error_message lands in report.md (not just job-detail.json) — it must
+        # be sanitized too.
+        err_secret = "eyJERRORtokensecretvaluethatislongenough1234567890"
         monkeypatch.setattr("app.api.routes._read_job_tagged_logs", lambda *a, **k: ([], False))
-        job = await _seed_job(volume_label="SECRET_DISC")
+        job = await _seed_job(
+            volume_label="SECRET_DISC", error_message=f"rip failed: token={err_secret}"
+        )
         async with _unit_session_factory() as session:
             session.add(
                 DiscTitle(
@@ -168,6 +173,9 @@ class TestBundle:
         zf = zipfile.ZipFile(io.BytesIO(resp.content))
         combined = b"\n".join(zf.read(n) for n in zf.namelist())
         assert secret.encode() not in combined
+        # report.md error field is sanitized, not just job-detail.json.
+        report_md = zf.read("report.md")
+        assert err_secret.encode() not in report_md
         assert b"***REDACTED***" in combined
 
     async def test_bundle_404_for_missing_job(self, client, fake_tools):
@@ -206,6 +214,15 @@ class TestJobTaggedLogReader:
         lines, is_fallback = _read_job_tagged_logs(1234, log_path=log)
         assert is_fallback is True
         assert any("something broke" in ln for ln in lines)
+
+    def test_absent_log_marks_fallback(self, tmp_path):
+        from app.api.routes import _read_job_tagged_logs
+
+        # Missing log file: empty, but flagged as fallback so the bundle never
+        # mislabels "(no logs)" as job-specific.
+        lines, is_fallback = _read_job_tagged_logs(1, log_path=tmp_path / "nope.log")
+        assert lines == []
+        assert is_fallback is True
 
 
 def test_sanitize_obj_redacts_home_and_secrets():

--- a/backend/tests/unit/test_log_context.py
+++ b/backend/tests/unit/test_log_context.py
@@ -1,0 +1,110 @@
+"""Tests for job-id-tagged logging.
+
+The diagnostics bundle extracts one job's logs by grepping a ``job=<id>``
+token. That only works if ``logger.contextualize(job_id=...)`` tags BOTH
+loguru-native calls (used in ``app/matcher``) AND stdlib ``logging`` calls
+(used in the services/coordinators) which reach loguru via ``InterceptHandler``.
+These tests prove that contract against the real log format.
+"""
+
+import io
+import logging as stdlogging
+
+import pytest
+from loguru import logger
+
+from app.core.log_context import job_log_context, with_job_log_context
+from app.core.logging import _FILE_LOG_FORMAT, InterceptHandler
+
+
+@pytest.mark.unit
+class TestJobLogContext:
+    def test_tags_both_loguru_and_stdlib_lines(self):
+        sink = io.StringIO()
+        logger.configure(extra={"job_id": "-"})
+        sink_id = logger.add(sink, format=_FILE_LOG_FORMAT, level="DEBUG")
+
+        std_logger = stdlogging.getLogger("test_job_ctx")
+        std_logger.handlers = [InterceptHandler()]
+        std_logger.setLevel(stdlogging.DEBUG)
+        std_logger.propagate = False
+        try:
+            with job_log_context(7):
+                logger.info("native tagged")
+                std_logger.info("stdlib tagged")  # routed through InterceptHandler
+            logger.info("native untagged")
+        finally:
+            logger.remove(sink_id)
+            logger.configure(extra={})
+            std_logger.handlers = []
+
+        out = sink.getvalue()
+        # Both the loguru-native and the stdlib-routed line carry the tag.
+        assert out.count("job=7 |") == 2
+        assert "native tagged" in out
+        assert "stdlib tagged" in out
+        # Outside the context the default tag applies.
+        assert "job=- |" in out
+        assert "native untagged" in out
+
+    async def test_nested_create_task_inherits_context(self):
+        """The real flow wraps a top-level task; nested match/progress tasks
+        spawned inside it must inherit the tag (create_task copies the context),
+        including stdlib lines routed through InterceptHandler."""
+        import asyncio
+
+        sink = io.StringIO()
+        logger.configure(extra={"job_id": "-"})
+        sink_id = logger.add(sink, format=_FILE_LOG_FORMAT, level="DEBUG")
+
+        std_logger = stdlogging.getLogger("test_nested_ctx")
+        std_logger.handlers = [InterceptHandler()]
+        std_logger.setLevel(stdlogging.DEBUG)
+        std_logger.propagate = False
+
+        async def nested():
+            std_logger.info("nested stdlib line")
+
+        async def parent():
+            await asyncio.create_task(nested())
+
+        try:
+            await with_job_log_context(123, parent())
+        finally:
+            logger.remove(sink_id)
+            logger.configure(extra={})
+            std_logger.handlers = []
+
+        out = sink.getvalue()
+        assert "job=123 |" in out
+        assert "nested stdlib line" in out
+
+    async def test_async_wrapper_tags_coroutine(self):
+        sink = io.StringIO()
+        logger.configure(extra={"job_id": "-"})
+        sink_id = logger.add(sink, format=_FILE_LOG_FORMAT, level="DEBUG")
+
+        async def work():
+            logger.info("inside async job")
+
+        try:
+            await with_job_log_context(42, work())
+        finally:
+            logger.remove(sink_id)
+            logger.configure(extra={})
+
+        out = sink.getvalue()
+        assert "job=42 |" in out
+        assert "inside async job" in out
+
+    def test_format_defaults_to_dash_without_context(self):
+        sink = io.StringIO()
+        logger.configure(extra={"job_id": "-"})
+        sink_id = logger.add(sink, format=_FILE_LOG_FORMAT, level="DEBUG")
+        try:
+            logger.info("no job here")
+        finally:
+            logger.remove(sink_id)
+            logger.configure(extra={})
+
+        assert "job=- |" in sink.getvalue()

--- a/backend/tests/unit/test_tmdb_persistent_cache.py
+++ b/backend/tests/unit/test_tmdb_persistent_cache.py
@@ -75,6 +75,37 @@ class TestClear:
 
 
 @pytest.mark.unit
+class TestIsCached:
+    def test_true_after_put(self):
+        tmdb_persistent_cache.put("show_details:1396", {"name": "BB"}, ttl_seconds=3600)
+        assert tmdb_persistent_cache.is_cached("show_details:1396") is True
+
+    def test_false_for_missing_key(self):
+        tmdb_persistent_cache.put("show_details:1", {"a": 1}, ttl_seconds=3600)
+        assert tmdb_persistent_cache.is_cached("show_details:999") is False
+
+    def test_false_for_expired_entry_without_deleting(self, monkeypatch):
+        fake_time = {"value": 0.0}
+        monkeypatch.setattr(tmdb_persistent_cache.time, "time", lambda: fake_time["value"])
+        tmdb_persistent_cache.put("season:1:1", 7, ttl_seconds=10)
+        fake_time["value"] = 11.0
+        assert tmdb_persistent_cache.is_cached("season:1:1") is False
+        # Read-only: the expired row is NOT deleted (unlike get()).
+        conn = tmdb_persistent_cache._get_conn()
+        row = conn.execute(
+            "SELECT 1 FROM tmdb_cache WHERE cache_key = ?", ("season:1:1",)
+        ).fetchone()
+        assert row is not None
+
+    def test_false_when_db_absent_without_creating_it(self, monkeypatch, tmp_path):
+        tmdb_persistent_cache.close()
+        missing = tmp_path / "never_created.sqlite"
+        monkeypatch.setattr(tmdb_persistent_cache, "CACHE_DB_PATH", missing)
+        assert tmdb_persistent_cache.is_cached("show_details:1") is False
+        assert not missing.exists()
+
+
+@pytest.mark.unit
 class TestConcurrentReads:
     def test_many_threads_read_simultaneously(self):
         """The W4 scheduler runs one worker per provider; each reads TMDB

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -51,3 +51,12 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
 export async function apiFetchVoid(input: RequestInfo | URL, init?: RequestInit): Promise<void> {
   await request(input, init);
 }
+
+/**
+ * Fetch a binary response as a Blob (e.g. a downloadable .zip bundle).
+ * Throws {@link ApiError} when the response is not ok.
+ */
+export async function apiFetchBlob(input: RequestInfo | URL, init?: RequestInit): Promise<Blob> {
+  const res = await request(input, init);
+  return await res.blob();
+}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -10,6 +10,7 @@ import ReviewQueue from "../components/ReviewQueue";
 import ConfigWizard from "../components/ConfigWizard";
 import NamePromptModal from "../components/NamePromptModal";
 import ReIdentifyModal from "../components/ReIdentifyModal";
+import BugReportModal from "../components/BugReportModal";
 import HistoryPage from "../components/HistoryPage";
 import ContributePage from "../components/ContributePage";
 import LibraryPage from "../components/LibraryPage";
@@ -113,6 +114,7 @@ function MainDashboard() {
   // Job management with WebSocket
   const { jobs, titlesMap, isConnected, cancelJob, advanceJob, skipTrack, clearCompleted, setJobName, reIdentifyJob } = useJobManagement(DEV_MODE);
   const [reIdentifyTarget, setReIdentifyTarget] = useState<Job | null>(null);
+  const [bugReportJobId, setBugReportJobId] = useState<number | null>(null);
 
   // Show the full-screen Splash with a "RECONNECTING…" label when the
   // WebSocket has been down for >2.5s. The grace period absorbs momentary
@@ -509,6 +511,7 @@ function MainDashboard() {
                     const job = jobs.find(j => String(j.id) === disc.id);
                     if (job) setReIdentifyTarget(job);
                   } : undefined}
+                  onReportBug={() => setBugReportJobId(Number(disc.id))}
                 />
               ))}
             </AnimatePresence>
@@ -552,6 +555,13 @@ function MainDashboard() {
           />
         )}
       </AnimatePresence>
+
+      {/* Bug Report Modal — appears when user reports a bug for an active job */}
+      <BugReportModal
+        open={bugReportJobId != null}
+        jobId={bugReportJobId ?? undefined}
+        onClose={() => setBugReportJobId(null)}
+      />
 
       {/* Onboarding Wizard (first run) */}
       {showOnboarding && (

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -80,6 +80,7 @@ interface DiscCardProps {
   onReIdentify?: () => void;
   onAdvance?: () => void;
   onSkipTrack?: (trackId: string) => void;
+  onReportBug?: () => void;
 }
 
 /**
@@ -173,7 +174,7 @@ function CoverOverlay({ children }: { children: React.ReactNode }) {
 }
 
 const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
-  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onSkipTrack }, ref) => {
+  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onSkipTrack, onReportBug }, ref) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const posterUrl = usePosterImage(disc.id, disc.title);
     const isActive = !['completed', 'error', 'idle'].includes(disc.state);
@@ -345,6 +346,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                     onReview={onReview}
                     onReIdentify={onReIdentify}
                     onAdvance={onAdvance}
+                    onReportBug={onReportBug}
                   />
                 </div>
               </div>

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -14,6 +14,7 @@
 
 import { useState, type CSSProperties, type ReactNode, type MouseEvent } from "react";
 import { motion } from "motion/react";
+import { Bug } from "lucide-react";
 import { IcoCancel, IcoError, IcoRetry, IcoPlay } from "../icons";
 import type { DiscState } from "../DiscCard";
 import { sv } from "../synapse";
@@ -25,6 +26,7 @@ interface ActionButtonsProps {
     onReview?: () => void;
     onReIdentify?: () => void;
     onAdvance?: () => void;
+    onReportBug?: () => void;
 }
 
 // States where Force-advance makes sense (job is actively processing).
@@ -102,9 +104,10 @@ interface ToneButtonProps {
     children: ReactNode;
     /** Horizontal padding in px. 0 means render as a square icon-only button. */
     paddingX?: number;
+    testId?: string;
 }
 
-function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0 }: ToneButtonProps) {
+function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0, testId }: ToneButtonProps) {
     const [hovered, setHovered] = useState(false);
     const isSquare = paddingX === 0;
     return (
@@ -120,6 +123,7 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0 }:
             onBlur={() => setHovered(false)}
             title={title}
             aria-label={ariaLabel}
+            data-testid={testId}
             style={{
                 ...baseStyle(tone, hovered),
                 paddingLeft: paddingX,
@@ -133,10 +137,11 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0 }:
     );
 }
 
-export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance }: ActionButtonsProps) {
+export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance, onReportBug }: ActionButtonsProps) {
     const showCancel = !!onCancel && (isHovered || CANCELABLE_STATES.includes(state));
     const showReview = !!onReview && state === "review_needed";
     const showAdvance = !!onAdvance && ACTIVE_STATES.includes(state);
+    const showReportBug = !!onReportBug && isHovered;
 
     const handleAdvance = (e: MouseEvent) => {
         e.stopPropagation();
@@ -199,6 +204,19 @@ export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdenti
                 >
                     <IcoError size={14} />
                     <span style={{ fontSize: 11 }}>Review needed</span>
+                </ToneButton>
+            )}
+
+            {showReportBug && (
+                <ToneButton
+                    tone={RED}
+                    onClick={(e) => { e.stopPropagation(); onReportBug!(); }}
+                    title="Report a bug for this job"
+                    ariaLabel="Report a bug for this job"
+                    paddingX={0}
+                    testId="disc-card-report-bug"
+                >
+                    <Bug size={14} />
                 </ToneButton>
             )}
         </div>

--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Bug, X, Copy, Check, ArrowRight, Loader2 } from "lucide-react";
+import { Bug, X, Copy, Check, ArrowRight, Loader2, Download } from "lucide-react";
 import { SvPanel, SvLabel, SvNotice, sv } from "../app/components/synapse";
+import { apiFetch, apiFetchBlob } from "../api/client";
 
 interface BugReport {
   app_version: string;
@@ -23,6 +24,11 @@ interface BugReport {
   config: Record<string, string | number | boolean>;
   github_url: string;
   markdown: string;
+  // Bundle-preview hints (present when a job_id was supplied).
+  bundle_available?: boolean;
+  has_scan_log?: boolean;
+  coverage_seasons?: number;
+  tmdb_cached?: boolean;
 }
 
 interface BugReportModalProps {
@@ -81,6 +87,7 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
   const [error, setError] = useState<string | null>(null);
   const [report, setReport] = useState<BugReport | null>(null);
   const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
 
   useEffect(() => {
     if (!open) {
@@ -88,6 +95,7 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
       setReport(null);
       setError(null);
       setCopied(false);
+      setDownloading(false);
       return;
     }
 
@@ -100,11 +108,7 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
         ? `/api/diagnostics/report?job_id=${jobId}`
         : "/api/diagnostics/report";
 
-    fetch(url)
-      .then(async (resp) => {
-        if (!resp.ok) throw new Error(`Request failed (${resp.status})`);
-        return (await resp.json()) as BugReport;
-      })
+    apiFetch<BugReport>(url)
       .then((data) => {
         if (!cancelled) setReport(data);
       })
@@ -130,6 +134,27 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
       setError("Could not copy to clipboard.");
     }
   }, [report]);
+
+  const handleDownloadBundle = useCallback(async () => {
+    if (jobId == null) return;
+    setDownloading(true);
+    setError(null);
+    try {
+      const blob = await apiFetchBlob(`/api/diagnostics/report/${jobId}/bundle`);
+      const objectUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = objectUrl;
+      a.download = `engram-bug-report-job-${jobId}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to download bundle.");
+    } finally {
+      setDownloading(false);
+    }
+  }, [jobId]);
 
   useEffect(() => {
     if (!open) return;
@@ -300,6 +325,23 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
                       </Section>
                     )}
 
+                    {report.bundle_available && (
+                      <Section title="Bundle Contents">
+                        <KvRow label="Job logs" value="Scoped to this job" />
+                        <KvRow label="Disc & tracks" value="Full per-track detail" />
+                        <KvRow
+                          label="Cache"
+                          value={`${report.coverage_seasons ?? 0} season(s) recorded · TMDB ${
+                            report.tmdb_cached ? "cached" : "not cached"
+                          }`}
+                        />
+                        <KvRow
+                          label="Scan log"
+                          value={report.has_scan_log ? "Included" : "Not present"}
+                        />
+                      </Section>
+                    )}
+
                     <Section title="Config">
                       {Object.entries(report.config).map(([k, v]) => (
                         <KvRow key={k} label={k} value={String(v)} />
@@ -350,6 +392,31 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
                   borderTop: `1px solid ${sv.line}`,
                 }}
               >
+                {jobId != null && (
+                  <button
+                    onClick={handleDownloadBundle}
+                    disabled={!report || downloading}
+                    data-testid="bug-report-download"
+                    style={{
+                      ...buttonBase,
+                      marginRight: "auto",
+                      color: sv.cyanHi,
+                      border: `1px solid ${sv.cyan}`,
+                      background: `${sv.cyan}1f`,
+                      boxShadow: `0 0 14px ${sv.cyan}4d`,
+                      opacity: report && !downloading ? 1 : 0.5,
+                      cursor: report && !downloading ? "pointer" : "not-allowed",
+                    }}
+                  >
+                    {downloading ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Download size={14} />
+                    )}
+                    {downloading ? "Bundling…" : "Download Bundle"}
+                  </button>
+                )}
+
                 <button
                   onClick={handleCopy}
                   disabled={!report}

--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -148,7 +148,9 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(objectUrl);
+      // Defer revocation: Safari/some Firefox start the download asynchronously
+      // and revoking synchronously cancels it, yielding a 0-byte file.
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 100);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to download bundle.");
     } finally {


### PR DESCRIPTION
## Summary

Reworks the bug-report feature so a user can pick a job and download a **complete, sanitized diagnostic bundle** for it, instead of the previous thin report (id/label/state + last-20 *global* error lines) that was capped by GitHub's prefilled-URL size limit.

- **New endpoint** `GET /api/diagnostics/report/{job_id}/bundle` → a `.zip` containing:
  - `report.md` — env/tool versions, job context, config, per-track table, subtitle cache/coverage table
  - `job-detail.json` — full job + per-track detail
  - `job-logs.txt` — log lines scoped to this job
  - `scan.log` / `rip.log` — raw MakeMKV output (when present)
- **Job-scoped logs**: every log line now carries a `job=<id>` token (`job=-` outside a job) via loguru `contextualize`. A new `app/core/log_context.py` wraps per-job task spawns in `job_manager.py`/`simulation_service.py`, and `match_single_file` self-tags so every match path is covered regardless of caller. Nested `create_task`s inherit the tag.
- **Cache/coverage status** for the series is surfaced via new read-only helpers (`get_show_coverage`, `get_cache_status`, `is_cached`).
- **Frontend**: `BugReportModal` gains a "Download Bundle" button + a "Bundle Contents" preview; active job cards get a per-job "report bug" entry point; new `apiFetchBlob` helper.

## Why

The old report rarely had enough context to act on a bug, and anything richer overflowed GitHub's ~8 KB prefilled-issue URL. A downloadable bundle removes the size limit and gathers the logs/disc-info/cache state that actually explain failures — all run through the existing sanitizers (`_sanitize_obj`/`_sanitize_line`/`_redact_home`) so home paths and secrets are redacted.

## Reviewer notes

- The existing `/api/diagnostics/report` response shape is unchanged (extended additively with bundle-preview hints). Shared assembly was refactored into `build_job_detail`, `_collect_environment`, `_build_markdown_summary` to avoid duplication.
- **Caveat**: only jobs that run *after* this change have tagged log lines; older jobs fall back to the global ERROR/CRITICAL tail (the bundle flags this). Long-lived `provider_scheduler` worker threads log `job=-` (accepted gap, documented in CLAUDE.md).
- The riskiest assumption — that `contextualize` tags both stdlib (via `InterceptHandler`) and loguru-native logs, and that nested `create_task`s inherit it — is locked down by unit tests in `test_log_context.py`.

## Test plan

- [x] Backend unit suite: 1125 passing; ruff clean
- [x] New tests: sanitization (secrets/home redacted), job-tag filtering + historical fallback, contextualize tagging across stdlib+loguru + nested-task inheritance, cache/coverage helpers
- [x] Frontend `tsc` + `vite build` pass; ESLint clean
- [x] Manual: downloaded a real bundle from an isolated backend — valid `.zip` with all members, correct `report.md`, home-path redaction confirmed
- [ ] Integration/pipeline suites + Playwright e2e (deferred — were not run because a real rip was in progress on the dev port; run before merge)