### PR TITLE
ci: replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13 # Intel x64
+          - runner: macos-15-intel # Intel x64
             arch: x64
             file_arch: x86_64
           - runner: macos-14 # Apple Silicon arm64


### PR DESCRIPTION
## Summary

- The `Build macOS Executable (x64)` job in the release workflow has been stuck for 2+ hours on run [#26415043415](https://github.com/Jsakkos/engram/actions/runs/26415043415/job/77757583029) because `macos-13` (Intel) has been retired by GitHub and is no longer available as a hosted runner
- Replaced `macos-13` with `macos-15-intel`, which is the current standard Intel/x64 macOS runner label
- No other changes needed — `file_arch: x86_64` and the binary architecture check remain valid for Intel runners

## Test plan

- [ ] Merge and re-tag `v0.7.2` (or patch bump) to trigger a new release run
- [ ] Verify `Build macOS Executable (x64)` picks up a runner and completes within ~5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)