### PR TITLE
feat(network): LAN access toggle — monitor dashboard from other devices

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -15,7 +15,7 @@ from typing import Literal
 from urllib.parse import quote
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func
@@ -253,6 +253,8 @@ class ConfigResponse(BaseModel):
     opensubtitles_api_key: str  # "***" if set
     opensubtitles_username: str
     opensubtitles_password: str  # "***" if set
+    # Network access
+    allow_lan_access: bool
     # Onboarding
     setup_complete: bool
 
@@ -315,6 +317,8 @@ class ConfigUpdate(BaseModel):
     opensubtitles_api_key: str | None = None
     opensubtitles_username: str | None = None
     opensubtitles_password: str | None = None
+    # Network access
+    allow_lan_access: bool | None = None
     # Onboarding
     setup_complete: bool | None = None
 
@@ -986,8 +990,48 @@ async def get_config() -> ConfigResponse:
         opensubtitles_api_key="***" if config.opensubtitles_api_key else "",  # Redacted
         opensubtitles_username=config.opensubtitles_username,
         opensubtitles_password="***" if config.opensubtitles_password else "",  # Redacted
+        # Network access
+        allow_lan_access=config.allow_lan_access,
         # Onboarding
         setup_complete=config.setup_complete,
+    )
+
+
+class NetworkInfoResponse(BaseModel):
+    """Network reachability info for the dashboard's LAN access panel."""
+
+    lan_access_enabled: bool  # persisted toggle (may differ from the live bind)
+    active_lan_bound: bool  # True if the server actually bound a LAN address this session
+    lan_ip: str | None  # host's primary LAN IP, if detectable
+    port: int
+    lan_url: str | None  # http://<lan_ip>:<port>, if an IP was detected
+
+
+@router.get("/network/info", response_model=NetworkInfoResponse)
+async def get_network_info(request: Request) -> NetworkInfoResponse:
+    """Report whether the dashboard is reachable on the LAN and at what URL.
+
+    ``active_lan_bound`` reflects the address uvicorn actually bound this
+    session; when it disagrees with ``lan_access_enabled`` the UI shows a
+    "restart to apply" notice.
+    """
+    from app.core.network import ALL_INTERFACES, get_lan_ip
+    from app.services.config_service import get_config as get_db_config
+
+    config = await get_db_config()
+    bound_host = getattr(request.app.state, "bound_host", settings.host)
+    port = getattr(request.app.state, "bound_port", settings.port)
+
+    active_lan_bound = bound_host == ALL_INTERFACES
+    lan_ip = get_lan_ip()
+    lan_url = f"http://{lan_ip}:{port}" if lan_ip else None
+
+    return NetworkInfoResponse(
+        lan_access_enabled=config.allow_lan_access,
+        active_lan_bound=active_lan_bound,
+        lan_ip=lan_ip,
+        port=port,
+        lan_url=lan_url,
     )
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1023,7 +1023,7 @@ async def get_network_info(request: Request) -> NetworkInfoResponse:
     port = getattr(request.app.state, "bound_port", settings.port)
 
     active_lan_bound = bound_host == ALL_INTERFACES
-    lan_ip = get_lan_ip()
+    lan_ip = await asyncio.to_thread(get_lan_ip)
     lan_url = f"http://{lan_ip}:{port}" if lan_ip else None
 
     return NetworkInfoResponse(

--- a/backend/app/core/network.py
+++ b/backend/app/core/network.py
@@ -48,7 +48,7 @@ def resolve_startup_host(default_host: str = LOCALHOST) -> str:
 
         allow_lan = bool(get_config_sync().allow_lan_access)
     except Exception as e:  # noqa: BLE001 — startup must never crash on a config read
-        logger.warning("Could not read LAN access setting, binding localhost: %s", e)
+        logger.warning("Could not read LAN access setting, binding localhost: %s", e, exc_info=True)
         allow_lan = False
     return compute_effective_host(
         allow_lan=allow_lan, env_host=_env_host(), default_host=default_host

--- a/backend/app/core/network.py
+++ b/backend/app/core/network.py
@@ -1,0 +1,69 @@
+"""Network helpers for LAN access.
+
+Determines the address uvicorn should bind to, and detects the host's primary
+LAN IP so the dashboard can show a reachable URL for other devices.
+"""
+
+import logging
+import os
+import socket
+
+logger = logging.getLogger(__name__)
+
+LOCALHOST = "127.0.0.1"
+ALL_INTERFACES = "0.0.0.0"  # noqa: S104 — intentional: opt-in LAN exposure
+
+
+def _env_host() -> str | None:
+    """Return an explicitly set HOST env var, if any (case-tolerant)."""
+    return os.environ.get("HOST") or os.environ.get("host")
+
+
+def compute_effective_host(
+    allow_lan: bool, env_host: str | None, default_host: str = LOCALHOST
+) -> str:
+    """Pick the bind address.
+
+    Precedence: an explicitly set HOST env var wins (docker/.env, power users),
+    then the LAN toggle (bind all interfaces), otherwise localhost only.
+    A blank/whitespace env value does not count as "explicitly set".
+    """
+    if env_host and env_host.strip():
+        return env_host
+    if allow_lan:
+        return ALL_INTERFACES
+    return default_host
+
+
+def resolve_startup_host(default_host: str = LOCALHOST) -> str:
+    """Resolve the bind address at startup, reading the persisted LAN toggle.
+
+    Called before the event loop exists, so it uses the synchronous config
+    reader. Any failure (e.g. DB tables not yet created on first run) falls
+    back to the safe default — the LAN toggle defaults off anyway.
+    """
+    allow_lan = False
+    try:
+        from app.services.config_service import get_config_sync
+
+        allow_lan = bool(get_config_sync().allow_lan_access)
+    except Exception as e:  # noqa: BLE001 — startup must never crash on a config read
+        logger.warning("Could not read LAN access setting, binding localhost: %s", e)
+        allow_lan = False
+    return compute_effective_host(
+        allow_lan=allow_lan, env_host=_env_host(), default_host=default_host
+    )
+
+
+def get_lan_ip() -> str | None:
+    """Return the host's primary outbound interface IP, or None if undetectable.
+
+    Uses a UDP socket "connect" to a public address. No packets are sent — the
+    OS just resolves which local interface would route there, revealing its IP.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -225,9 +225,15 @@ if __name__ == "__main__":
     # in error handling so crashes are always visible.
     import uvicorn
 
+    from app.core.network import resolve_startup_host
+
+    host = resolve_startup_host(settings.host)
+    app.state.bound_host = host
+    app.state.bound_port = settings.port
+
     uvicorn.run(
         app,
-        host=settings.host,
+        host=host,
         port=settings.port,
         reload=settings.debug,
         factory=False,

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -121,5 +121,10 @@ class AppConfig(SQLModel, table=True):
     opensubtitles_username: str = ""
     opensubtitles_password: str = ""
 
+    # Network access
+    # When True, the server binds 0.0.0.0 (reachable on the LAN) instead of localhost.
+    # Read at startup before uvicorn binds; an explicit HOST env var takes precedence.
+    allow_lan_access: bool = Field(default=False, sa_column_kwargs={"server_default": text("0")})
+
     # Onboarding
     setup_complete: bool = False  # Set True after user completes setup wizard

--- a/backend/run.py
+++ b/backend/run.py
@@ -44,22 +44,31 @@ def main() -> None:
 
         import uvicorn
 
+        from app.core.network import ALL_INTERFACES, resolve_startup_host
         from app.main import app, settings
 
         is_frozen = getattr(sys, "frozen", False)
-        port = _find_free_port(settings.host, settings.port) if is_frozen else settings.port
+        host = resolve_startup_host(settings.host)
+        port = _find_free_port(host, settings.port) if is_frozen else settings.port
 
         if port != settings.port:
             print(f"Port {settings.port} in use, using {port} instead")
 
+        # Record what we actually bound so the dashboard can report the LAN URL.
+        app.state.bound_host = host
+        app.state.bound_port = port
+
         if is_frozen:
-            # Open browser after a short delay to let the server bind the port
-            url = f"http://{settings.host}:{port}"
+            # Open browser after a short delay to let the server bind the port.
+            # When bound to all interfaces, open localhost (http://0.0.0.0 is not
+            # a valid client address); LAN clients use the address shown in the UI.
+            browser_host = "localhost" if host == ALL_INTERFACES else host
+            url = f"http://{browser_host}:{port}"
             threading.Timer(1.5, webbrowser.open, args=[url]).start()
 
         uvicorn.run(
             app,
-            host=settings.host,
+            host=host,
             port=port,
             # reload is incompatible with frozen PyInstaller bundles
             reload=False if is_frozen else settings.debug,

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -175,6 +175,18 @@ class TestConfigEndpoints:
         response = await client.get("/api/config")
         assert response.status_code == 200
 
+    async def test_allow_lan_access_defaults_false(self, client):
+        await _seed_config()
+        config = (await client.get("/api/config")).json()
+        assert config["allow_lan_access"] is False
+
+    async def test_allow_lan_access_roundtrips(self, client):
+        await _seed_config()
+        response = await client.put("/api/config", json={"allow_lan_access": True})
+        assert response.status_code == 200
+        config = (await client.get("/api/config")).json()
+        assert config["allow_lan_access"] is True
+
     async def test_update_config(self, client):
         await _seed_config()
         update_data = {
@@ -202,6 +214,46 @@ class TestConfigEndpoints:
         config = verify.json()
         assert config["makemkv_key"] == "***"
         assert config["tmdb_api_key"] == "***"
+
+
+# ---------------------------------------------------------------------------
+# Network info
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkInfoEndpoint:
+    """Test the LAN access network info endpoint."""
+
+    async def test_reports_disabled_by_default(self, client):
+        await _seed_config()
+        info = (await client.get("/api/network/info")).json()
+        assert info["lan_access_enabled"] is False
+        assert info["active_lan_bound"] is False
+        assert isinstance(info["port"], int)
+
+    async def test_reports_enabled_toggle_before_restart(self, client):
+        # Toggle persisted but server still bound to localhost this session:
+        # enabled True, active_lan_bound False → UI shows "restart to apply".
+        await _seed_config(allow_lan_access=True)
+        info = (await client.get("/api/network/info")).json()
+        assert info["lan_access_enabled"] is True
+        assert info["active_lan_bound"] is False
+
+    async def test_active_when_bound_all_interfaces(self, client):
+        await _seed_config(allow_lan_access=True)
+        app.state.bound_host = "0.0.0.0"
+        app.state.bound_port = 8000
+        try:
+            info = (await client.get("/api/network/info")).json()
+        finally:
+            del app.state.bound_host
+            del app.state.bound_port
+        assert info["active_lan_bound"] is True
+        assert info["port"] == 8000
+        # lan_ip may be None in a network-less CI sandbox; when present, the URL
+        # is derived from it.
+        if info["lan_ip"] is not None:
+            assert info["lan_url"] == f"http://{info['lan_ip']}:8000"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_network.py
+++ b/backend/tests/unit/test_network.py
@@ -1,0 +1,42 @@
+"""Unit tests for network helpers (LAN bind address + IP detection)."""
+
+import re
+from unittest.mock import patch
+
+from app.core.network import compute_effective_host, get_lan_ip
+
+_IPV4_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+
+class TestComputeEffectiveHost:
+    """Bind-address precedence: explicit env > LAN toggle > localhost default."""
+
+    def test_default_is_localhost(self):
+        assert compute_effective_host(allow_lan=False, env_host=None) == "127.0.0.1"
+
+    def test_lan_enabled_binds_all_interfaces(self):
+        assert compute_effective_host(allow_lan=True, env_host=None) == "0.0.0.0"
+
+    def test_env_host_takes_precedence_over_toggle(self):
+        # An explicit HOST env var wins even when the LAN toggle is on.
+        assert compute_effective_host(allow_lan=True, env_host="192.168.1.5") == "192.168.1.5"
+
+    def test_env_host_used_even_when_lan_disabled(self):
+        assert compute_effective_host(allow_lan=False, env_host="0.0.0.0") == "0.0.0.0"
+
+    def test_blank_env_host_is_ignored(self):
+        # Empty/whitespace env value should not count as "explicitly set".
+        assert compute_effective_host(allow_lan=True, env_host="") == "0.0.0.0"
+        assert compute_effective_host(allow_lan=False, env_host="   ") == "127.0.0.1"
+
+
+class TestGetLanIp:
+    """Primary outbound interface IP detection."""
+
+    def test_returns_ipv4_or_none(self):
+        result = get_lan_ip()
+        assert result is None or _IPV4_RE.match(result)
+
+    def test_returns_none_on_socket_error(self):
+        with patch("app.core.network.socket.socket", side_effect=OSError("no network")):
+            assert get_lan_ip() is None

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -50,6 +50,38 @@ PORT=8000
 !!! note
     The `.env` file is optional. All fields have sensible defaults. The file is included in `.gitignore` and should never be committed.
 
+## LAN Access (Dashboard on Other Devices)
+
+By default Engram binds to `127.0.0.1` (localhost only), so the dashboard is only reachable on the machine running Engram. To monitor from a phone, tablet, or another computer on the same network:
+
+### Via Settings (Windows desktop)
+
+1. Open the Settings page (gear icon) → **Preferences** step.
+2. Enable **"Allow access from other devices on my network (LAN)"**.
+3. The panel below the toggle shows your LAN address and a QR code once the change is applied.
+4. Click **Save** and **restart Engram** — the bind address is fixed at startup.
+
+!!! warning "No authentication"
+    Engram has no login. Anyone on your network can view job status and control the application.
+    Only enable this on a trusted home network.
+
+After restart, access the dashboard from any device on your LAN at `http://<host-ip>:8000`.
+The QR code makes it easy to open on a phone or tablet.
+
+### Via environment variable (power users / Docker)
+
+Set `HOST=0.0.0.0` in your `backend/.env` file (or pass it as an environment variable in Docker).
+The env var takes precedence over the UI toggle:
+
+```ini
+HOST=0.0.0.0
+PORT=8000
+```
+
+For Docker containers this is typically the right approach — the container has its own network
+namespace, so binding to `127.0.0.1` inside the container would make it unreachable even via
+published ports.
+
 ## Configuration Sources
 
 Configuration is resolved in this priority order:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -645,6 +645,29 @@
             "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
             "license": "MIT"
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
                 "lucide-react": "0.487.0",
                 "motion": "12.23.24",
                 "next-themes": "0.4.6",
+                "qrcode.react": "^4.2.0",
                 "react": "^18.2.0",
                 "react-day-picker": "^9.14.0",
                 "react-dnd": "16.0.1",
@@ -643,29 +644,6 @@
             "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
             "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
             "license": "MIT"
-        },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
         },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
@@ -9763,6 +9741,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qrcode.react": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+            "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
         "lucide-react": "0.487.0",
         "motion": "12.23.24",
         "next-themes": "0.4.6",
+        "qrcode.react": "^4.2.0",
         "react": "^18.2.0",
         "react-day-picker": "^9.14.0",
         "react-dnd": "16.0.1",

--- a/frontend/src/components/ConfigWizard.css
+++ b/frontend/src/components/ConfigWizard.css
@@ -304,6 +304,95 @@
     color: #8893a8;
 }
 
+/* LAN Address Panel */
+.lan-address-panel {
+    margin-top: 0.75rem;
+    padding: 1rem;
+    background: rgba(94, 234, 212, 0.05);
+    border: 1px solid rgba(94, 234, 212, 0.3);
+}
+
+.lan-status-live {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    color: #5eead4;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    margin-bottom: 0.75rem;
+}
+
+.lan-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #5eead4;
+    box-shadow: 0 0 6px #5eead4;
+    flex-shrink: 0;
+}
+
+.lan-restart-notice {
+    font-size: 0.8rem;
+    color: #f59e0b;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    margin-bottom: 0.75rem;
+}
+
+.lan-url-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.lan-url {
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: #e6ecf5;
+    background: rgba(0, 0, 0, 0.4);
+    padding: 0.3rem 0.5rem;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lan-copy-btn {
+    padding: 0.3rem 0.75rem;
+    background: rgba(94, 234, 212, 0.1);
+    border: 1px solid rgba(94, 234, 212, 0.4);
+    color: #5eead4;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+}
+
+.lan-copy-btn:hover {
+    background: rgba(94, 234, 212, 0.2);
+    border-color: rgba(94, 234, 212, 0.7);
+}
+
+.lan-qr {
+    margin-top: 0.75rem;
+    display: flex;
+    justify-content: center;
+    padding: 0.5rem;
+    background: #fff;
+    width: fit-content;
+}
+
+.lan-qr-pending {
+    opacity: 0.5;
+}
+
+.lan-loading {
+    font-size: 0.8rem;
+    color: var(--color-sv-ink-faint, #8893a8);
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
 /* Config Summary */
 .config-summary {
     margin-top: 2rem;

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -158,9 +158,13 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         }
     }, []);
 
-    // Fetch network info once when the LAN toggle is first enabled.
+    // Fetch network info when the LAN toggle is enabled; clear stale data when disabled.
     useEffect(() => {
-        if (config.allowLanAccess) fetchNetworkInfo();
+        if (config.allowLanAccess) {
+            fetchNetworkInfo();
+        } else {
+            setNetworkInfo(null);
+        }
     }, [config.allowLanAccess, fetchNetworkInfo]);
 
     // Load existing config on mount
@@ -1037,7 +1041,13 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                                     <button
                                                         type="button"
                                                         className="lan-copy-btn"
-                                                        onClick={() => navigator.clipboard.writeText(networkInfo.lan_url as string)}
+                                                        onClick={() => {
+                                                            navigator.clipboard?.writeText(networkInfo.lan_url as string).catch(() => {
+                                                                // HTTP context (LAN): clipboard API unavailable; select text for manual copy
+                                                                const el = document.querySelector('.lan-url') as HTMLElement;
+                                                                if (el) window.getSelection()?.selectAllChildren(el);
+                                                            });
+                                                        }}
                                                     >
                                                         Copy
                                                     </button>
@@ -1061,7 +1071,13 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                                     <button
                                                         type="button"
                                                         className="lan-copy-btn"
-                                                        onClick={() => navigator.clipboard.writeText(networkInfo.lan_url as string)}
+                                                        onClick={() => {
+                                                            navigator.clipboard?.writeText(networkInfo.lan_url as string).catch(() => {
+                                                                // HTTP context (LAN): clipboard API unavailable; select text for manual copy
+                                                                const el = document.querySelector('.lan-url') as HTMLElement;
+                                                                if (el) window.getSelection()?.selectAllChildren(el);
+                                                            });
+                                                        }}
                                                     >
                                                         Copy
                                                     </button>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
+import { QRCodeSVG } from 'qrcode.react';
 import { FEATURES } from '../config/constants';
 import './ConfigWizard.css';
 
@@ -75,6 +76,15 @@ interface ConfigData {
     opensubtitlesApiKey: string;
     opensubtitlesUsername: string;
     opensubtitlesPassword: string;
+    allowLanAccess: boolean;
+}
+
+interface NetworkInfo {
+    lan_access_enabled: boolean;
+    active_lan_bound: boolean;
+    lan_ip: string | null;
+    port: number;
+    lan_url: string | null;
 }
 
 interface ToolDetectionResult {
@@ -126,7 +136,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         opensubtitlesApiKey: '',
         opensubtitlesUsername: '',
         opensubtitlesPassword: '',
+        allowLanAccess: false,
     });
+    const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
     const [isSaving, setIsSaving] = useState(false);
     const [toolDetection, setToolDetection] = useState<DetectToolsResponse | null>(null);
     const [isDetecting, setIsDetecting] = useState(false);
@@ -136,6 +148,20 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid', error?: string}>({status: 'idle'});
 
     const totalSteps = 4;
+
+    const fetchNetworkInfo = useCallback(async () => {
+        try {
+            const res = await fetch('/api/network/info');
+            if (res.ok) setNetworkInfo(await res.json());
+        } catch {
+            // non-fatal; address panel renders nothing if unreachable
+        }
+    }, []);
+
+    // Fetch network info once when the LAN toggle is first enabled.
+    useEffect(() => {
+        if (config.allowLanAccess) fetchNetworkInfo();
+    }, [config.allowLanAccess, fetchNetworkInfo]);
 
     // Load existing config on mount
     useEffect(() => {
@@ -187,6 +213,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     opensubtitlesApiKey: data.opensubtitles_api_key === '***' ? '' : (data.opensubtitles_api_key || ''),
                     opensubtitlesUsername: data.opensubtitles_username || '',
                     opensubtitlesPassword: data.opensubtitles_password === '***' ? '' : (data.opensubtitles_password || ''),
+                    allowLanAccess: data.allow_lan_access ?? false,
                 });
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -289,6 +316,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     ...optional('opensubtitles_api_key', config.opensubtitlesApiKey),
                     opensubtitles_username: config.opensubtitlesUsername,
                     ...optional('opensubtitles_password', config.opensubtitlesPassword),
+                    allow_lan_access: config.allowLanAccess,
                     setup_complete: true,
                 }),
             });
@@ -973,6 +1001,79 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                     </span>
                                 </div>
                             </>
+                        )}
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    checked={config.allowLanAccess}
+                                    onChange={(e) => handleInputChange('allowLanAccess', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>Allow access from other devices on my network (LAN)</strong>
+                                    <span className="checkbox-hint">
+                                        ⚠ Engram has no login — anyone on your network can view and control it.
+                                        Use only on a trusted home network. Takes effect after restarting Engram.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
+
+                        {config.allowLanAccess && (
+                            <div className="lan-address-panel">
+                                {!networkInfo ? (
+                                    <div className="lan-loading">Detecting network address…</div>
+                                ) : networkInfo.active_lan_bound ? (
+                                    <>
+                                        <div className="lan-status-live">
+                                            <span className="lan-status-dot" />
+                                            Engram is live on your network
+                                        </div>
+                                        {networkInfo.lan_url && (
+                                            <>
+                                                <div className="lan-url-row">
+                                                    <code className="lan-url">{networkInfo.lan_url}</code>
+                                                    <button
+                                                        type="button"
+                                                        className="lan-copy-btn"
+                                                        onClick={() => navigator.clipboard.writeText(networkInfo.lan_url as string)}
+                                                    >
+                                                        Copy
+                                                    </button>
+                                                </div>
+                                                <div className="lan-qr">
+                                                    <QRCodeSVG value={networkInfo.lan_url} size={120} />
+                                                </div>
+                                            </>
+                                        )}
+                                    </>
+                                ) : (
+                                    <>
+                                        <div className="lan-restart-notice">
+                                            Save settings and restart Engram to apply.
+                                        </div>
+                                        {networkInfo.lan_url && (
+                                            <>
+                                                <span className="form-hint">After restart, access Engram at:</span>
+                                                <div className="lan-url-row">
+                                                    <code className="lan-url">{networkInfo.lan_url}</code>
+                                                    <button
+                                                        type="button"
+                                                        className="lan-copy-btn"
+                                                        onClick={() => navigator.clipboard.writeText(networkInfo.lan_url as string)}
+                                                    >
+                                                        Copy
+                                                    </button>
+                                                </div>
+                                                <div className="lan-qr lan-qr-pending">
+                                                    <QRCodeSVG value={networkInfo.lan_url} size={120} />
+                                                </div>
+                                            </>
+                                        )}
+                                    </>
+                                )}
+                            </div>
                         )}
 
                         <div className="config-summary">


### PR DESCRIPTION
## Summary

- Adds a **LAN access toggle** in ConfigWizard → Preferences so the backend can bind to `0.0.0.0` and the dashboard becomes reachable from any device on the home network.
- In the shipped app (frozen exe / Docker), FastAPI already serves the built SPA on one origin (port 8000) and the WebSocket URL is derived from `window.location.host`, so **no CORS or WebSocket changes** are needed — the only blocker was the bind address.
- The `HOST` env var takes precedence over the DB toggle, so Docker users just set `HOST=0.0.0.0` and ignore the toggle.

## What changed

**Backend**
- `AppConfig.allow_lan_access` (`bool`, default `False`, `server_default=0` — picked up by the `_add_missing_columns` reconciler in existing DBs)
- `backend/app/core/network.py` (new): `get_lan_ip()` (UDP-connect trick, no packets sent), `compute_effective_host()` (pure; env > toggle > localhost), `resolve_startup_host()` (reads DB toggle before uvicorn binds; fails silently to localhost on any error)
- `run.py` / `app/main.py __main__`: call `resolve_startup_host()` before `uvicorn.run()`; record `app.state.bound_host/port`; **fix frozen-build browser-open** to use `localhost` when bound to `0.0.0.0` (opening `http://0.0.0.0:…` is invalid on Windows)
- `GET /api/network/info`: returns `lan_access_enabled`, `active_lan_bound`, `lan_ip`, `port`, `lan_url`. `active_lan_bound` reflects the live socket bind so the UI can show a "restart to apply" notice
- `ConfigResponse` / `ConfigUpdate`: `allow_lan_access` field added

**Frontend**
- ConfigWizard Preferences step: checkbox with an explicit no-auth warning ("Engram has no login — anyone on your network can view and control it") + an address panel (LAN URL, copy button, QR code via `qrcode.react`) when the toggle is on. Panel distinguishes "live now" vs "restart required"

**Docs**
- `docs/getting-started/configuration.md`: new LAN Access section covering the UI toggle and the `HOST` env-var path (for Docker / power users)

## Coordination with PR #193 (Docker)

The env-var precedence in `resolve_startup_host()` means containers just set `HOST=0.0.0.0` in the entrypoint / compose and the UI toggle is irrelevant in-container. No changes to the docker files are needed here; the docs section covers both approaches. Once #193 merges, its compose file should set `HOST=0.0.0.0`.

## Test plan

- [x] 7 new unit tests for `core/network.py` (TDD red-green): `compute_effective_host` precedence (env wins / toggle on → 0.0.0.0 / default → 127.0.0.1), `get_lan_ip` happy path and socket-error path
- [x] 5 new tests in `test_api_routes.py`: config round-trip, `allow_lan_access` defaults false, `GET /api/network/info` before restart (`active_lan_bound=False`), after setting `app.state.bound_host="0.0.0.0"` (`active_lan_bound=True`)
- [x] 1116 unit tests pass (`uv run pytest tests/unit/`)
- [x] `ruff check` clean
- [x] Frontend TypeScript check + Vite build clean (`npm run build`)
- [ ] Manual: toggle on → save → restart → `netstat` shows `0.0.0.0:8000` → access dashboard from another device at displayed LAN URL / QR

🤖 Generated with [Claude Code](https://claude.com/claude-code)