### PR TITLE
chore: release v0.7.3

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,46 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+# See ci.yml for context on the Node 24 opt-in.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  tag:
+    name: Tag release commit
+    runs-on: ubuntu-latest
+    # Squash-merge of a release PR produces "chore: release v0.x.y (#NNN)"
+    if: "contains(github.event.head_commit.message, 'chore: release v')"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' backend/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tagging: v$VERSION"
+
+      - name: Check if tag already exists
+        id: tag_check
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Engram will be documented in this file.
 
+## [0.7.3] - 2026-05-25
+
+### Fixed
+- **Ripping progress detection**: MakeMKV robot-mode output (`PRGC`/`PRGV`) was misread — the leading field is a message code (not a title index) and progress is `value/65536` (not `current/total`) — producing phantom "title 5018 is ripping" states and >100% per-title progress bars. The filesystem monitor (output-file sizes) is now the single source of per-title and overall progress; the stall-watchdog heartbeat is also fed from it (#209).
+- **Redundant disc re-scans during ripping**: each title previously triggered its own `makemkvcon` invocation, re-opening and re-scanning the whole disc every time. Ripping now issues one `makemkvcon … all` pass for the full disc selection, falling back to individual re-rips only for any titles missing from that pass (#209).
+
+### Changed
+- **CI macOS Intel runner**: the `macos-13` GitHub Actions runner used to build the x64 release binary was retired and is no longer available; replaced with `macos-15-intel` so macOS x64 release builds succeed again (#210).
+- **Subtitle cache build speed**: seasons already covered on disk are skipped on each daily run — no TMDB, OpenSubtitles, or scraper calls — until a configurable freshness window (default 30 days) expires or `--refresh` forces a full re-harvest. Previously every season was re-attempted on each run regardless of prior coverage (#204).
+
 ## [0.7.2] - 2026-05-25
 
 ### Fixed

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.7.2"
+version = "0.7.3"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.7.2"
+version = "0.7.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.7.2",
+    "version": "0.7.3",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Version bump 0.7.2 → 0.7.3 across all files (`__init__.py`, `pyproject.toml`, `package.json`, `package-lock.json`, `uv.lock`, `CHANGELOG.md`)
- **New: auto-tag workflow** — after this PR merges, the `tag-release.yml` workflow automatically pushes the `v0.7.3` tag, which chains into the existing `release.yml` to build the binaries. No more manual `git tag && git push` step.
- Includes three changes merged since v0.7.2:
  - **Fix: rip progress + one-pass ripping** (#209) — PRGC/PRGV misread caused phantom title states and >100% bars; filesystem monitor is now the sole source of truth; one `makemkvcon all` invocation per disc instead of per-title
  - **CI: macOS x64 runner** (#210) — retired `macos-13` replaced with `macos-15-intel`; this is the primary motivation for the patch release
  - **Perf: subtitle cache build** (#204) — already-covered seasons skipped on daily runs

## How the automation works

`tag-release.yml` fires on every push to `main`. It only runs its job when the commit message contains `chore: release v` (which is the squash-merge format: `chore: release v0.7.3 (#212)`). It then:

1. Reads the version from `backend/pyproject.toml`
2. Checks if the tag already exists (idempotency guard)
3. Pushes `v0.7.3` — which triggers `release.yml` to build and publish the binaries

For future releases, the workflow is already live on `main` and no manual action is needed after merging a release PR.

## Test plan
- [x] All 6 version files updated to 0.7.3
- [x] CHANGELOG entry added with correct date (2026-05-25)
- [x] `uv lock` ran cleanly (`engram-backend v0.7.2 -> v0.7.3`)
- [x] `package-lock.json` patched (root + packages[""] entries only — no full regen to avoid @emnapi drop on Windows)
- [x] Pre-commit hooks passed (ruff, format, yaml, toml checks)
- [x] `tag-release.yml` YAML passes `check-yaml` pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)