### PR TITLE
ci: fix auto-tag → release chain via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,7 @@ jobs:
         with:
           draft: false
           generate_release_notes: true
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             engram-windows-x64.zip
             engram-linux-x64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.7.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -44,3 +44,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Dispatch release workflow
+        # GITHUB_TOKEN-pushed tags don't fire push:tags workflows; dispatch explicitly.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --ref "${{ steps.version.outputs.tag }}" \
+            --field tag="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -47,9 +47,12 @@ jobs:
 
       - name: Dispatch release workflow
         # GITHUB_TOKEN-pushed tags don't fire push:tags workflows; dispatch explicitly.
+        # Guard matches the push step so we don't re-trigger builds on an existing tag.
+        if: steps.tag_check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sleep 5
           gh workflow run release.yml \
             --ref "${{ steps.version.outputs.tag }}" \
             --field tag="${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Problem

The `tag-release.yml` workflow (added in #212) creates and pushes `v*` tags after a release PR merges, but the downstream `release.yml` never fired. Root cause: **GitHub suppresses `push` events triggered by GITHUB_TOKEN** — including tag pushes — to prevent recursive workflow loops. Even though a tag push can't recurse, the suppression is unconditional.

This was discovered after merging #212: the `v0.7.3` tag was created correctly but the release builds didn't start. The immediate fix for v0.7.3 was a manual delete + re-push of the tag using local credentials (which ARE subject to the push:tags trigger).

## Fix

Add a `workflow_dispatch` trigger to `release.yml` (with a `tag` input for labeling). `workflow_dispatch` is explicitly permitted even when called with `GITHUB_TOKEN`, so it's not subject to the suppression.

Update `tag-release.yml` to call `gh workflow run release.yml --ref <tag>` after pushing the tag, instead of relying on the tag push to chain through.

The existing `push: tags: ["v*"]` trigger is kept as a fallback for manual tag pushes.

## Test plan
- [x] YAML passes `check-yaml` pre-commit hook
- [x] `release.yml` still triggers on `git push origin vX.Y.Z` (fallback path unchanged)
- [ ] Next release PR merge → `tag-release.yml` should push tag + dispatch release workflow → builds fire without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)