### PR TITLE
ci: drop macOS Intel x64 build (llvmlite 0.46 has no macOS x86_64 wheels)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14 # Apple Silicon arm64 (also runs on Intel via Rosetta 2)
+          - runner: macos-15 # Apple Silicon arm64 (also runs on Intel via Rosetta 2)
             arch: arm64
             file_arch: arm64
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-15-intel # Intel x64
-            arch: x64
-            file_arch: x86_64
-          - runner: macos-14 # Apple Silicon arm64
+          - runner: macos-14 # Apple Silicon arm64 (also runs on Intel via Rosetta 2)
             arch: arm64
             file_arch: arm64
     steps:
@@ -295,9 +292,6 @@ jobs:
           name: engram-linux-x64
       - uses: actions/download-artifact@v8
         with:
-          name: engram-macos-x64
-      - uses: actions/download-artifact@v8
-        with:
           name: engram-macos-arm64
       - uses: softprops/action-gh-release@v3
         with:
@@ -307,5 +301,4 @@ jobs:
           files: |
             engram-windows-x64.zip
             engram-linux-x64.tar.gz
-            engram-macos-x64.tar.gz
             engram-macos-arm64.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Engram will be documented in this file.
 - **Redundant disc re-scans during ripping**: each title previously triggered its own `makemkvcon` invocation, re-opening and re-scanning the whole disc every time. Ripping now issues one `makemkvcon … all` pass for the full disc selection, falling back to individual re-rips only for any titles missing from that pass (#209).
 
 ### Changed
-- **CI macOS Intel runner**: the `macos-13` GitHub Actions runner used to build the x64 release binary was retired and is no longer available; replaced with `macos-15-intel` so macOS x64 release builds succeed again (#210).
+- **macOS Intel build dropped**: `llvmlite` 0.46.0 (December 2025) no longer ships macOS x86_64 wheels; building from source fails on Python 3.13. The `engram-macos-x64` release artifact is removed. Intel Mac users should use `engram-macos-arm64.tar.gz`, which runs transparently on Intel Macs via Rosetta 2.
 - **Subtitle cache build speed**: seasons already covered on disk are skipped on each daily run — no TMDB, OpenSubtitles, or scraper calls — until a configurable freshness window (default 30 days) expires or `--refresh` forces a full re-harvest. Previously every season was re-attempted on each run regardless of prior coverage (#204).
 
 ## [0.7.2] - 2026-05-25

--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ No Python or Node.js required — the Config Wizard opens in your browser on fir
 |----------|----------|-----|
 | Windows | `engram-windows-x64.zip` | `engram.exe` |
 | Linux (x64) | `engram-linux-x64.tar.gz` | `./engram/engram` |
-| macOS (Apple Silicon) | `engram-macos-arm64.tar.gz` | `./engram/engram` |
-| macOS (Intel) | `engram-macos-x64.tar.gz` | `./engram/engram` |
+| macOS | `engram-macos-arm64.tar.gz` | `./engram/engram` |
 
-On macOS, pick the build that matches your chip: **Apple Silicon** (M1/M2/M3/M4) → `arm64`, **Intel** → `x64`. Run `uname -m` if unsure (`arm64` vs `x86_64`). macOS has no automatic optical-drive detection — use the staging-folder workflow (see [Linux / macOS setup](docs/guide/linux-setup.md)).
+On macOS, download `engram-macos-arm64.tar.gz`. It runs natively on Apple Silicon (M1/M2/M3/M4) and transparently on Intel Macs via Rosetta 2. macOS has no automatic optical-drive detection — use the staging-folder workflow (see [Linux / macOS setup](docs/guide/linux-setup.md)).
 
 ### Option B: From source (all platforms)
 


### PR DESCRIPTION
## Root cause

`llvmlite` 0.46.0 (Dec 2025) and `numba` 0.63.1 ship **zero macOS x86_64 wheels** — only arm64, Linux, and Windows. This is confirmed from `backend/uv.lock`:

```
llvmlite wheels (macOS):
  cp311-cp311-macosx_11_0_arm64.whl  ← only arm64
  cp312-cp312-macosx_11_0_arm64.whl
  cp313-cp313-macosx_12_0_arm64.whl
  (no macosx_*_x86_64 entries)
```

On the `macos-15-intel` runner, `uv sync` reads `.python-version: 3.13`, finds no pre-built llvmlite wheel, and falls back to source compilation. The source build fails:

```
TypeError: spawn() got an unexpected keyword argument 'dry_run'
```

llvmlite's `setup.py` calls a `distutils.spawn()` API that Python 3.13 removed. The arm64 build passes because llvmlite ships arm64 wheels — no source build is ever attempted.

## Why previous fixes didn't work

- PR #206: correctly split x64/arm64 into a matrix but left `macos-13` which was already retired
- PR #210: replaced `macos-13` with `macos-15-intel` — runner works fine, but the *library* (llvmlite) has no x64 macOS wheels regardless of which runner is used

## This fix

Drop the x64 matrix entry entirely. The numba ecosystem's direction is clear (macOS 15 doesn't run on Intel hardware). Intel Mac users run the arm64 binary via Rosetta 2 transparently — no configuration needed.

## Changes

- **`.github/workflows/release.yml`**: Remove `macos-15-intel` matrix row; remove `engram-macos-x64` artifact download and upload
- **`README.md`**: Single macOS row pointing at `arm64`, Rosetta 2 note for Intel users
- **`CHANGELOG.md`**: Replace misleading "CI runner" entry with accurate explanation

## Verification

After merge, trigger the release workflow from main or tag `v0.7.4` — the build should produce 3 artifacts: `engram-windows-x64.zip`, `engram-linux-x64.tar.gz`, `engram-macos-arm64.tar.gz`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)