### PR TITLE
fix(ui): replace illegible native selects with Radix UI custom dropdowns

### DIFF
--- a/frontend/src/components/ConfigWizard.css
+++ b/frontend/src/components/ConfigWizard.css
@@ -224,8 +224,7 @@
 
 .form-group input[type="text"],
 .form-group input[type="password"],
-.form-group input[type="number"],
-.form-group select {
+.form-group input[type="number"] {
     width: 100%;
     padding: 0.65rem 0.75rem;
     background: rgba(94, 234, 212, 0.04);
@@ -236,8 +235,7 @@
     transition: background 120ms ease-out, border-color 120ms ease-out, box-shadow 120ms ease-out;
 }
 
-.form-group input:focus,
-.form-group select:focus {
+.form-group input:focus {
     outline: none;
     border-color: var(--color-sv-cyan);
     box-shadow: 0 0 12px rgba(94, 234, 212, 0.25);
@@ -248,9 +246,95 @@
     color: var(--color-sv-ink-ghost);
 }
 
-.form-group select option {
-    background: var(--color-sv-bg1);
+/* ─── EngramSelect (Radix UI custom dropdown) ─────────────────────────── */
+.sv-select-trigger {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.65rem 0.75rem;
+    background: rgba(94, 234, 212, 0.04);
+    border: 1px solid var(--color-sv-line-mid);
     color: var(--color-sv-ink);
+    font-size: 0.88rem;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    cursor: pointer;
+    transition: background 120ms ease-out, border-color 120ms ease-out, box-shadow 120ms ease-out;
+}
+
+.sv-select-trigger:hover {
+    background: rgba(94, 234, 212, 0.07);
+    border-color: rgba(94, 234, 212, 0.38);
+}
+
+.sv-select-trigger[data-state="open"],
+.sv-select-trigger:focus-visible {
+    outline: none;
+    border-color: var(--color-sv-cyan);
+    box-shadow: 0 0 12px rgba(94, 234, 212, 0.25);
+    background: rgba(94, 234, 212, 0.08);
+}
+
+.sv-select-trigger[data-disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.sv-select-icon {
+    color: var(--color-sv-cyan);
+    flex-shrink: 0;
+    margin-left: 8px;
+    transition: transform 160ms ease-out;
+    display: flex;
+    align-items: center;
+}
+
+.sv-select-trigger[data-state="open"] .sv-select-icon {
+    transform: rotate(180deg);
+}
+
+.sv-select-content {
+    background: var(--color-sv-bg1);
+    border: 1px solid var(--color-sv-line-hi);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.65), inset 0 1px 0 rgba(94, 234, 212, 0.08);
+    padding: 4px 0;
+    z-index: 9999;
+    min-width: var(--radix-select-trigger-width);
+    max-height: var(--radix-select-content-available-height);
+}
+
+.sv-select-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 7px 28px 7px 10px;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 0.84rem;
+    color: var(--color-sv-ink);
+    cursor: pointer;
+    border-left: 2px solid transparent;
+    outline: none;
+    user-select: none;
+    transition: background 80ms ease-out, border-color 80ms ease-out, color 80ms ease-out;
+}
+
+.sv-select-item[data-highlighted] {
+    background: rgba(94, 234, 212, 0.09);
+    border-left-color: var(--color-sv-cyan);
+    color: var(--color-sv-cyan-hi);
+}
+
+.sv-select-item[data-state="checked"] {
+    color: var(--color-sv-cyan);
+    border-left-color: var(--color-sv-cyan);
+}
+
+.sv-select-indicator {
+    position: absolute;
+    right: 10px;
+    color: var(--color-sv-cyan);
+    font-size: 10px;
+    line-height: 1;
 }
 
 .form-hint {

--- a/frontend/src/components/ConfigWizard.css
+++ b/frontend/src/components/ConfigWizard.css
@@ -337,6 +337,19 @@
     line-height: 1;
 }
 
+.sv-select-scroll-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    color: var(--color-sv-cyan);
+    font-size: 10px;
+    cursor: default;
+    background: var(--color-sv-bg1);
+    border-top: 1px solid var(--color-sv-line);
+    border-bottom: 1px solid var(--color-sv-line);
+}
+
 .form-hint {
     display: block;
     margin-top: 0.45rem;

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -789,7 +789,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                             <EngramSelect
                                                 id="discdbContributionTier"
                                                 value={String(config.discdbContributionTier)}
-                                                onValueChange={(v) => handleInputChange('discdbContributionTier', parseInt(v))}
+                                                onValueChange={(v) => handleInputChange('discdbContributionTier', parseInt(v, 10))}
                                                 options={[
                                                     { value: '2', label: 'Automatic — share auto-collected data' },
                                                     { value: '3', label: 'Full — prompt for UPC and images' },

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
 import { QRCodeSVG } from 'qrcode.react';
 import { FEATURES } from '../config/constants';
+import { EngramSelect } from './ui/EngramSelect';
 import './ConfigWizard.css';
 
 interface ConfigWizardProps {
@@ -718,16 +719,17 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             <>
                                 <div className="form-group">
                                     <label htmlFor="aiProvider">AI Provider</label>
-                                    <select
+                                    <EngramSelect
                                         id="aiProvider"
                                         value={config.aiProvider}
-                                        onChange={(e) => handleInputChange('aiProvider', e.target.value)}
-                                    >
-                                        <option value="anthropic">Anthropic (Claude)</option>
-                                        <option value="openai">OpenAI</option>
-                                        <option value="openrouter">OpenRouter</option>
-                                        <option value="gemini">Google Gemini</option>
-                                    </select>
+                                        onValueChange={(v) => handleInputChange('aiProvider', v)}
+                                        options={[
+                                            { value: 'anthropic', label: 'Anthropic (Claude)' },
+                                            { value: 'openai', label: 'OpenAI' },
+                                            { value: 'openrouter', label: 'OpenRouter' },
+                                            { value: 'gemini', label: 'Google Gemini' },
+                                        ]}
+                                    />
                                 </div>
                                 <div className="form-group">
                                     <label htmlFor="aiApiKey">
@@ -784,14 +786,15 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                     <>
                                         <div className="form-group">
                                             <label htmlFor="discdbContributionTier">Contribution Level</label>
-                                            <select
+                                            <EngramSelect
                                                 id="discdbContributionTier"
-                                                value={config.discdbContributionTier}
-                                                onChange={(e) => handleInputChange('discdbContributionTier', parseInt(e.target.value))}
-                                            >
-                                                <option value={2}>Automatic — share auto-collected data</option>
-                                                <option value={3}>Full — prompt for UPC and images</option>
-                                            </select>
+                                                value={String(config.discdbContributionTier)}
+                                                onValueChange={(v) => handleInputChange('discdbContributionTier', parseInt(v))}
+                                                options={[
+                                                    { value: '2', label: 'Automatic — share auto-collected data' },
+                                                    { value: '3', label: 'Full — prompt for UPC and images' },
+                                                ]}
+                                            />
                                         </div>
 
                                         <div className="form-group">
@@ -839,16 +842,17 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group">
                             <label htmlFor="conflictResolution">Default Conflict Resolution</label>
-                            <select
+                            <EngramSelect
                                 id="conflictResolution"
                                 value={config.conflictResolutionDefault}
-                                onChange={(e) => handleInputChange('conflictResolutionDefault', e.target.value)}
-                            >
-                                <option value="ask">Always ask me</option>
-                                <option value="rename">Automatically rename (keep both)</option>
-                                <option value="overwrite">Automatically overwrite</option>
-                                <option value="skip">Automatically skip</option>
-                            </select>
+                                onValueChange={(v) => handleInputChange('conflictResolutionDefault', v)}
+                                options={[
+                                    { value: 'ask', label: 'Always ask me' },
+                                    { value: 'rename', label: 'Automatically rename (keep both)' },
+                                    { value: 'overwrite', label: 'Automatically overwrite' },
+                                    { value: 'skip', label: 'Automatically skip' },
+                                ]}
+                            />
                             <span className="form-hint">
                                 What should Engram do when a file already exists in your library?
                             </span>
@@ -856,16 +860,17 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group">
                             <label htmlFor="stagingCleanup">Staging Cleanup Policy</label>
-                            <select
+                            <EngramSelect
                                 id="stagingCleanup"
                                 value={config.stagingCleanupPolicy}
-                                onChange={(e) => handleInputChange('stagingCleanupPolicy', e.target.value)}
-                            >
-                                <option value="on_success">Clean on success (delete after organization)</option>
-                                <option value="on_completion">Clean on completion (delete after success or failure)</option>
-                                <option value="after_days">Clean after N days</option>
-                                <option value="manual">Manual only (never auto-delete)</option>
-                            </select>
+                                onValueChange={(v) => handleInputChange('stagingCleanupPolicy', v)}
+                                options={[
+                                    { value: 'on_success', label: 'Clean on success (delete after organization)' },
+                                    { value: 'on_completion', label: 'Clean on completion (delete after success or failure)' },
+                                    { value: 'after_days', label: 'Clean after N days' },
+                                    { value: 'manual', label: 'Manual only (never auto-delete)' },
+                                ]}
+                            />
                             <span className="form-hint">
                                 When should staging files be automatically deleted? A single Blu-ray rip can be 30-50GB.
                             </span>
@@ -890,14 +895,15 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group">
                             <label htmlFor="watchdogEnabled">Stale-Job Watchdog</label>
-                            <select
+                            <EngramSelect
                                 id="watchdogEnabled"
                                 value={config.watchdogEnabled ? 'on' : 'off'}
-                                onChange={(e) => handleInputChange('watchdogEnabled', e.target.value === 'on')}
-                            >
-                                <option value="on">Enabled (auto-advance stuck jobs)</option>
-                                <option value="off">Disabled</option>
-                            </select>
+                                onValueChange={(v) => handleInputChange('watchdogEnabled', v === 'on')}
+                                options={[
+                                    { value: 'on', label: 'Enabled (auto-advance stuck jobs)' },
+                                    { value: 'off', label: 'Disabled' },
+                                ]}
+                            />
                             <span className="form-hint">
                                 When a job stops making progress for longer than its phase timeout, Engram
                                 resolves the stuck tracks (ripped-but-unmatched → review) and moves the job
@@ -955,15 +961,16 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group">
                             <label htmlFor="extrasPolicy">Extras Handling</label>
-                            <select
+                            <EngramSelect
                                 id="extrasPolicy"
                                 value={config.extrasPolicy}
-                                onChange={(e) => handleInputChange('extrasPolicy', e.target.value)}
-                            >
-                                <option value="keep">Keep all extras (organize to Extras/ folder)</option>
-                                <option value="skip">Skip extras (discard after ripping)</option>
-                                <option value="ask">Ask me (show in Review Queue)</option>
-                            </select>
+                                onValueChange={(v) => handleInputChange('extrasPolicy', v)}
+                                options={[
+                                    { value: 'keep', label: 'Keep all extras (organize to Extras/ folder)' },
+                                    { value: 'skip', label: 'Skip extras (discard after ripping)' },
+                                    { value: 'ask', label: 'Ask me (show in Review Queue)' },
+                                ]}
+                            />
                             <span className="form-hint">
                                 How to handle bonus content that doesn&apos;t match any episode runtime.
                             </span>
@@ -971,7 +978,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group">
                             <label htmlFor="namingConvention">Naming Convention</label>
-                            <select
+                            <EngramSelect
                                 id="namingConvention"
                                 value={
                                     NAMING_PRESETS.find(
@@ -980,19 +987,20 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                             p.episodeFormat === config.namingEpisodeFormat,
                                     )?.id ?? 'custom'
                                 }
-                                onChange={(e) => {
-                                    const preset = NAMING_PRESETS.find((p) => p.id === e.target.value);
+                                onValueChange={(v) => {
+                                    const preset = NAMING_PRESETS.find((p) => p.id === v);
                                     if (preset) {
                                         handleInputChange('namingSeasonFormat', preset.seasonFormat);
                                         handleInputChange('namingEpisodeFormat', preset.episodeFormat);
                                     }
                                 }}
-                            >
-                                <option value="plex">Plex (Season 01 / Show - S01E01)</option>
-                                <option value="kodi">Kodi (Season 1 / Show - S01E01)</option>
-                                <option value="minimal">Minimal (S01 / Show - S01E01)</option>
-                                <option value="custom">Custom</option>
-                            </select>
+                                options={[
+                                    { value: 'plex', label: 'Plex (Season 01 / Show - S01E01)' },
+                                    { value: 'kodi', label: 'Kodi (Season 1 / Show - S01E01)' },
+                                    { value: 'minimal', label: 'Minimal (S01 / Show - S01E01)' },
+                                    { value: 'custom', label: 'Custom' },
+                                ]}
+                            />
                             <span className="form-hint">
                                 Preview: TV/{config.namingSeasonFormat.replace('{season:02d}', '01').replace('{season:d}', '1')}/{config.namingEpisodeFormat.replace('{show}', 'Breaking Bad').replace('{season:02d}', '01').replace('{season:d}', '1').replace('{episode:02d}', '05').replace('{episode:d}', '5')}.mkv
                             </span>

--- a/frontend/src/components/ui/EngramSelect.tsx
+++ b/frontend/src/components/ui/EngramSelect.tsx
@@ -1,0 +1,41 @@
+import * as Select from '@radix-ui/react-select';
+
+interface EngramSelectOption {
+    value: string;
+    label: string;
+}
+
+interface EngramSelectProps {
+    id?: string;
+    value: string;
+    onValueChange: (value: string) => void;
+    options: EngramSelectOption[];
+    disabled?: boolean;
+}
+
+export function EngramSelect({ id, value, onValueChange, options, disabled }: EngramSelectProps) {
+    return (
+        <Select.Root value={value} onValueChange={onValueChange} disabled={disabled}>
+            <Select.Trigger id={id} className="sv-select-trigger">
+                <Select.Value />
+                <Select.Icon className="sv-select-icon">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+                        <path d="M6 9l6 6 6-6" />
+                    </svg>
+                </Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+                <Select.Content className="sv-select-content" position="popper" sideOffset={4}>
+                    <Select.Viewport>
+                        {options.map((opt) => (
+                            <Select.Item key={opt.value} value={opt.value} className="sv-select-item">
+                                <Select.ItemText>{opt.label}</Select.ItemText>
+                                <Select.ItemIndicator className="sv-select-indicator">✓</Select.ItemIndicator>
+                            </Select.Item>
+                        ))}
+                    </Select.Viewport>
+                </Select.Content>
+            </Select.Portal>
+        </Select.Root>
+    );
+}

--- a/frontend/src/components/ui/EngramSelect.tsx
+++ b/frontend/src/components/ui/EngramSelect.tsx
@@ -26,6 +26,7 @@ export function EngramSelect({ id, value, onValueChange, options, disabled }: En
             </Select.Trigger>
             <Select.Portal>
                 <Select.Content className="sv-select-content" position="popper" sideOffset={4}>
+                    <Select.ScrollUpButton className="sv-select-scroll-btn">▴</Select.ScrollUpButton>
                     <Select.Viewport>
                         {options.map((opt) => (
                             <Select.Item key={opt.value} value={opt.value} className="sv-select-item">
@@ -34,6 +35,7 @@ export function EngramSelect({ id, value, onValueChange, options, disabled }: En
                             </Select.Item>
                         ))}
                     </Select.Viewport>
+                    <Select.ScrollDownButton className="sv-select-scroll-btn">▾</Select.ScrollDownButton>
                 </Select.Content>
             </Select.Portal>
         </Select.Root>


### PR DESCRIPTION
## Summary

- Native `<select>` popups on Windows are rendered by the OS and ignore custom CSS — the dark Synapse v2 theme tokens were silently discarded, leaving options with a white/light system background that was completely unreadable
- Replaced all 7 `<select>` elements in `ConfigWizard` with a new `EngramSelect` component built on `@radix-ui/react-select` (already a project dependency at v2.1.6)
- The Radix `Portal` renders the popup as React DOM, giving full CSS control over the dropdown list

## What changed

**New file: `frontend/src/components/ui/EngramSelect.tsx`**
- Thin wrapper around Radix `Select.Root / Trigger / Portal / Content / Item`
- Props: `{ id?, value, onValueChange, options[], disabled? }`
- Uses `position="popper"` so the popup anchors correctly inside the modal

**`frontend/src/components/ConfigWizard.css`**
- Removed `.form-group select` and `.form-group select option` rules (these were the dead CSS the OS was ignoring)
- Added `.sv-select-trigger`, `.sv-select-icon`, `.sv-select-content`, `.sv-select-item`, `.sv-select-indicator` classes using Synapse v2 tokens throughout

**`frontend/src/components/ConfigWizard.tsx`**
- All 7 native `<select>` elements replaced: AI Provider, Contribution Level, Conflict Resolution, Staging Cleanup Policy, Stale-Job Watchdog, Extras Handling, Naming Convention
- `discdbContributionTier` correctly stringifies on the way in and parses back to int on `onValueChange`

## Visual result

| State | Appearance |
|-------|-----------|
| Trigger (idle) | Matches existing `<input>` — `sv-line-mid` border, 4% cyan tint background |
| Trigger (open/focus) | `sv-cyan` border + 12px cyan glow, 8% background — same as input `:focus` |
| Popup | `sv-bg1` (#0a0e18) background, `sv-line-hi` border, elevation shadow |
| Option (hover/focused) | 9% cyan tint background + `sv-cyan` left-border accent |
| Option (selected) | Cyan text + ✓ checkmark at right |
| Chevron | Rotates 180° on open |

## Reviewer notes

- Keyboard navigation (arrow keys, Home/End, Enter, Escape, type-ahead) is handled by Radix with full ARIA compliance — no custom keyboard code needed
- `@radix-ui/react-select` was already in `package.json`; no new dependency added

🤖 Generated with [Claude Code](https://claude.ai/claude-code)