### PR TITLE
fix(matcher): unique chunk/preprocessed paths, stale-cache pruning, tfidf staleness

### DIFF
--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -6,6 +6,7 @@ supporting OpenAI Whisper models via faster-whisper for efficient inference.
 """
 
 import abc
+import hashlib
 import os
 import tempfile
 from pathlib import Path
@@ -222,18 +223,20 @@ class FasterWhisperModel(ASRModel):
     def _preprocessed_path_for(audio_path: str | Path) -> Path:
         """Where the preprocessed copy of ``audio_path`` should live.
 
-        Includes a hash of the input's absolute path so concurrent matcher
-        threads on different source files never target the same on-disk path.
+        Includes a hash of the input's resolved absolute path so concurrent
+        matcher threads on different source files never target the same
+        on-disk path. Resolution defends against the (unlikely but possible)
+        case of a caller passing a relative path: two callers in different
+        cwds would otherwise stringify identically and collide on the hash.
         Previously the filename was derived only from `Path(audio_path).stem`,
         so two threads sampling the same offset on different titles both
         wrote to e.g. `preprocessed_chunk_1473_30.wav` — the second writer
         truncated the first thread's file mid-PyAV-decode, surfacing as
         `av.error.InvalidDataError` and a poisoned chunk in the loop.
         """
-        import hashlib
-
         temp_dir = Path(tempfile.gettempdir()) / "whisper_preprocessed"
-        src_hash = hashlib.sha1(str(audio_path).encode("utf-8")).hexdigest()[:16]
+        resolved = str(Path(audio_path).resolve())
+        src_hash = hashlib.sha1(resolved.encode("utf-8")).hexdigest()[:16]
         return temp_dir / f"preprocessed_{src_hash}_{Path(audio_path).stem}.wav"
 
     def _preprocess_audio(self, audio_path: str | Path) -> str:

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -218,6 +218,24 @@ class FasterWhisperModel(ASRModel):
             logger.error(f"Failed to load Faster Whisper model {self.model_name}: {e}")
             raise
 
+    @staticmethod
+    def _preprocessed_path_for(audio_path: str | Path) -> Path:
+        """Where the preprocessed copy of ``audio_path`` should live.
+
+        Includes a hash of the input's absolute path so concurrent matcher
+        threads on different source files never target the same on-disk path.
+        Previously the filename was derived only from `Path(audio_path).stem`,
+        so two threads sampling the same offset on different titles both
+        wrote to e.g. `preprocessed_chunk_1473_30.wav` — the second writer
+        truncated the first thread's file mid-PyAV-decode, surfacing as
+        `av.error.InvalidDataError` and a poisoned chunk in the loop.
+        """
+        import hashlib
+
+        temp_dir = Path(tempfile.gettempdir()) / "whisper_preprocessed"
+        src_hash = hashlib.sha1(str(audio_path).encode("utf-8")).hexdigest()[:16]
+        return temp_dir / f"preprocessed_{src_hash}_{Path(audio_path).stem}.wav"
+
     def _preprocess_audio(self, audio_path: str | Path) -> str:
         """
         Preprocess audio for Whisper model requirements.
@@ -244,11 +262,8 @@ class FasterWhisperModel(ASRModel):
             if np.max(np.abs(audio)) > 0:
                 audio = audio / np.max(np.abs(audio))
 
-            # Create temporary file for preprocessed audio
-            temp_dir = Path(tempfile.gettempdir()) / "whisper_preprocessed"
-            temp_dir.mkdir(exist_ok=True)
-
-            temp_audio_path = temp_dir / f"preprocessed_{Path(audio_path).stem}.wav"
+            temp_audio_path = self._preprocessed_path_for(audio_path)
+            temp_audio_path.parent.mkdir(exist_ok=True)
 
             # Save preprocessed audio
             sf.write(str(temp_audio_path), audio, target_sr)

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -221,19 +221,7 @@ class FasterWhisperModel(ASRModel):
 
     @staticmethod
     def _preprocessed_path_for(audio_path: str | Path) -> Path:
-        """Where the preprocessed copy of ``audio_path`` should live.
-
-        Includes a hash of the input's resolved absolute path so concurrent
-        matcher threads on different source files never target the same
-        on-disk path. Resolution defends against the (unlikely but possible)
-        case of a caller passing a relative path: two callers in different
-        cwds would otherwise stringify identically and collide on the hash.
-        Previously the filename was derived only from `Path(audio_path).stem`,
-        so two threads sampling the same offset on different titles both
-        wrote to e.g. `preprocessed_chunk_1473_30.wav` — the second writer
-        truncated the first thread's file mid-PyAV-decode, surfacing as
-        `av.error.InvalidDataError` and a poisoned chunk in the loop.
-        """
+        """Hash resolved source path into the filename so concurrent threads don't collide."""
         temp_dir = Path(tempfile.gettempdir()) / "whisper_preprocessed"
         resolved = str(Path(audio_path).resolve())
         src_hash = hashlib.sha1(resolved.encode("utf-8")).hexdigest()[:16]

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -476,21 +476,12 @@ class TfidfMatcher:
         return self._prepared
 
     def reference_signature(self) -> tuple | None:
-        """A stable fingerprint of which references this matcher is fit to.
-
-        Used by the caller to detect that a cached matcher was prepared
-        against a *different* reference set and must be rebuilt. Returns
-        None when no references have been loaded.
-
-        Two factors distinguish reference sets in practice:
-          - mode: precomputed-codes vs scraping-paths (different key types
-            populate `coverages` — calling `coverages[rf]` with the wrong
-            type raises KeyError mid-chunk-loop).
-          - ref_file_order itself: changing season or show changes the codes
-            or paths the matcher returns from .match().
-        """
+        """Fingerprint of what this matcher was prepared against; None if not prepared."""
         if not self._prepared:
             return None
+        # Mode distinguishes precomputed-codes from scraping-paths so a stale
+        # matcher from a prior precomputed call can't keep returning codes
+        # while the new call's `coverages` is path-keyed → KeyError.
         mode = "precomputed" if self._precomputed else "scraping"
         return (mode, tuple(self.ref_file_order))
 
@@ -632,37 +623,18 @@ class EpisodeMatcher:
 
     @staticmethod
     def _resolve_source(mkv_file) -> str:
-        """Canonicalize a source path so the chunk hash + in-memory cache key
-        agree even when callers mix relative and absolute path strings.
-
-        Defensive against the (unlikely) case that one caller passes a
-        relative path and another the absolute one — they'd otherwise hash
-        to different on-disk chunk files for the same MKV, AND populate two
-        cache_key entries pointing at those distinct files.
-        """
+        """Canonical source-path form shared by chunk hash + in-memory cache key."""
         return str(Path(mkv_file).resolve())
 
     def _chunk_path(self, mkv_file, start_time, duration):
-        """On-disk path for the extracted chunk of (mkv_file, start, duration).
-
-        The resolved absolute source path is hashed into the filename so two
-        concurrent matches on different titles (under max_concurrent_matches)
-        write to disjoint paths. Without this, both threads would target
-        `chunk_{start}_{duration}.wav` simultaneously — the second writer
-        either corrupts the first thread's mid-PyAV decode (InvalidDataError)
-        or wins the race and silently feeds its audio to the first thread's
-        match. Hash collisions would still collide, but at 16 hex chars the
-        per-disc collision probability is negligible. Kept short to stay well
-        under Windows MAX_PATH (260) for nested cache dirs.
-        """
+        """Hash resolved source path into the filename so concurrent threads don't collide."""
         src_hash = hashlib.sha1(self._resolve_source(mkv_file).encode("utf-8")).hexdigest()[:16]
         return self.temp_dir / f"chunk_{src_hash}_{start_time}_{duration}.wav"
 
     def extract_audio_chunk(self, mkv_file, start_time, duration=None):
         """Extract a chunk of audio from MKV file with caching."""
         duration = duration or self.chunk_duration
-        # Resolve once so the cache_key matches what _chunk_path hashes.
-        # A relative + absolute path for the same MKV must share the cache.
+        # Resolve once so cache_key matches what _chunk_path hashes.
         cache_key = (self._resolve_source(mkv_file), start_time, duration)
 
         if cache_key in self.audio_chunks:
@@ -776,13 +748,7 @@ class EpisodeMatcher:
         if not precomputed_covers_season(
             self.cache_dir, self.show_name, season_number, manifest=manifest
         ):
-            # Surface the common misconfiguration: manifest lists the season but
-            # the vector files never made it to disk. Prune the stale season
-            # from the in-memory manifest so subsequent titles on the same disc
-            # don't re-trip the same warning (and so the cached manifest stops
-            # lying about what's actually loadable). The on-disk manifest.json
-            # is left alone — `ensure_precomputed_cache` owns refreshing it on
-            # the next startup.
+            # Prune the stale season in-memory so the warning fires at most once per matcher.
             show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
             if show_entry and season_number in show_entry.get("seasons", []):
                 logger.warning(
@@ -1082,13 +1048,8 @@ class EpisodeMatcher:
             }
             model = get_cached_model(model_config)
 
-            # Initialize TF-IDF matcher for this season (lazy, once per set of
-            # references). The cached matcher MUST be rebuilt when the reference
-            # set changes — otherwise a previous precomputed-mode run leaves
-            # `ref_file_order` holding episode codes ("S07E01"...), while the
-            # current scraping-mode call's `coverages` dict is keyed by SRT
-            # paths. The first chunk to match then raises KeyError("S07E07")
-            # mid-loop and the chunk gets silently counted as rejected.
+            # Rebuild the cached matcher when the reference set changes — a stale
+            # precomputed-mode matcher returning codes would KeyError in path-keyed coverages.
             expected_signature: tuple = (
                 ("precomputed", tuple(ref_episode_codes))
                 if using_precomputed

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import re
 import subprocess
@@ -629,10 +630,22 @@ class EpisodeMatcher:
         """Clean transcription text to match TF-IDF vocabulary expectations."""
         return _clean_subtitle_text(text)
 
+    @staticmethod
+    def _resolve_source(mkv_file) -> str:
+        """Canonicalize a source path so the chunk hash + in-memory cache key
+        agree even when callers mix relative and absolute path strings.
+
+        Defensive against the (unlikely) case that one caller passes a
+        relative path and another the absolute one — they'd otherwise hash
+        to different on-disk chunk files for the same MKV, AND populate two
+        cache_key entries pointing at those distinct files.
+        """
+        return str(Path(mkv_file).resolve())
+
     def _chunk_path(self, mkv_file, start_time, duration):
         """On-disk path for the extracted chunk of (mkv_file, start, duration).
 
-        The source file's absolute path is hashed into the filename so two
+        The resolved absolute source path is hashed into the filename so two
         concurrent matches on different titles (under max_concurrent_matches)
         write to disjoint paths. Without this, both threads would target
         `chunk_{start}_{duration}.wav` simultaneously — the second writer
@@ -642,15 +655,15 @@ class EpisodeMatcher:
         per-disc collision probability is negligible. Kept short to stay well
         under Windows MAX_PATH (260) for nested cache dirs.
         """
-        import hashlib
-
-        src_hash = hashlib.sha1(str(mkv_file).encode("utf-8")).hexdigest()[:16]
+        src_hash = hashlib.sha1(self._resolve_source(mkv_file).encode("utf-8")).hexdigest()[:16]
         return self.temp_dir / f"chunk_{src_hash}_{start_time}_{duration}.wav"
 
     def extract_audio_chunk(self, mkv_file, start_time, duration=None):
         """Extract a chunk of audio from MKV file with caching."""
         duration = duration or self.chunk_duration
-        cache_key = (str(mkv_file), start_time, duration)
+        # Resolve once so the cache_key matches what _chunk_path hashes.
+        # A relative + absolute path for the same MKV must share the cache.
+        cache_key = (self._resolve_source(mkv_file), start_time, duration)
 
         if cache_key in self.audio_chunks:
             return self.audio_chunks[cache_key]

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -474,6 +474,25 @@ class TfidfMatcher:
     def is_prepared(self) -> bool:
         return self._prepared
 
+    def reference_signature(self) -> tuple | None:
+        """A stable fingerprint of which references this matcher is fit to.
+
+        Used by the caller to detect that a cached matcher was prepared
+        against a *different* reference set and must be rebuilt. Returns
+        None when no references have been loaded.
+
+        Two factors distinguish reference sets in practice:
+          - mode: precomputed-codes vs scraping-paths (different key types
+            populate `coverages` — calling `coverages[rf]` with the wrong
+            type raises KeyError mid-chunk-loop).
+          - ref_file_order itself: changing season or show changes the codes
+            or paths the matcher returns from .match().
+        """
+        if not self._prepared:
+            return None
+        mode = "precomputed" if self._precomputed else "scraping"
+        return (mode, tuple(self.ref_file_order))
+
 
 class MatchCoverage:
     """Tracks match coverage for an episode against a video file."""
@@ -610,6 +629,24 @@ class EpisodeMatcher:
         """Clean transcription text to match TF-IDF vocabulary expectations."""
         return _clean_subtitle_text(text)
 
+    def _chunk_path(self, mkv_file, start_time, duration):
+        """On-disk path for the extracted chunk of (mkv_file, start, duration).
+
+        The source file's absolute path is hashed into the filename so two
+        concurrent matches on different titles (under max_concurrent_matches)
+        write to disjoint paths. Without this, both threads would target
+        `chunk_{start}_{duration}.wav` simultaneously — the second writer
+        either corrupts the first thread's mid-PyAV decode (InvalidDataError)
+        or wins the race and silently feeds its audio to the first thread's
+        match. Hash collisions would still collide, but at 16 hex chars the
+        per-disc collision probability is negligible. Kept short to stay well
+        under Windows MAX_PATH (260) for nested cache dirs.
+        """
+        import hashlib
+
+        src_hash = hashlib.sha1(str(mkv_file).encode("utf-8")).hexdigest()[:16]
+        return self.temp_dir / f"chunk_{src_hash}_{start_time}_{duration}.wav"
+
     def extract_audio_chunk(self, mkv_file, start_time, duration=None):
         """Extract a chunk of audio from MKV file with caching."""
         duration = duration or self.chunk_duration
@@ -618,7 +655,7 @@ class EpisodeMatcher:
         if cache_key in self.audio_chunks:
             return self.audio_chunks[cache_key]
 
-        chunk_path = self.temp_dir / f"chunk_{start_time}_{duration}.wav"
+        chunk_path = self._chunk_path(mkv_file, start_time, duration)
         if not chunk_path.exists():
             cmd = [
                 "ffmpeg",
@@ -727,13 +764,21 @@ class EpisodeMatcher:
             self.cache_dir, self.show_name, season_number, manifest=manifest
         ):
             # Surface the common misconfiguration: manifest lists the season but
-            # the vector files never made it to disk.
+            # the vector files never made it to disk. Prune the stale season
+            # from the in-memory manifest so subsequent titles on the same disc
+            # don't re-trip the same warning (and so the cached manifest stops
+            # lying about what's actually loadable). The on-disk manifest.json
+            # is left alone — `ensure_precomputed_cache` owns refreshing it on
+            # the next startup.
             show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
             if show_entry and season_number in show_entry.get("seasons", []):
                 logger.warning(
                     f"Precomputed cache lists {self.show_name} S{season_number:02d} "
                     f"but its files are missing; using scraping"
                 )
+                show_entry["seasons"] = [s for s in show_entry["seasons"] if s != season_number]
+                if not show_entry["seasons"]:
+                    manifest["shows"].pop(self.show_name, None)
             return None
 
         precomputed_dir = self.cache_dir / "precomputed"
@@ -1024,8 +1069,24 @@ class EpisodeMatcher:
             }
             model = get_cached_model(model_config)
 
-            # Initialize TF-IDF matcher for this season (lazy, once per set of references)
-            if self.tfidf_matcher is None or not self.tfidf_matcher.is_prepared:
+            # Initialize TF-IDF matcher for this season (lazy, once per set of
+            # references). The cached matcher MUST be rebuilt when the reference
+            # set changes — otherwise a previous precomputed-mode run leaves
+            # `ref_file_order` holding episode codes ("S07E01"...), while the
+            # current scraping-mode call's `coverages` dict is keyed by SRT
+            # paths. The first chunk to match then raises KeyError("S07E07")
+            # mid-loop and the chunk gets silently counted as rejected.
+            expected_signature: tuple = (
+                ("precomputed", tuple(ref_episode_codes))
+                if using_precomputed
+                else ("scraping", tuple(str(rf) for rf in reference_files))
+            )
+            needs_rebuild = (
+                self.tfidf_matcher is None
+                or not self.tfidf_matcher.is_prepared
+                or self.tfidf_matcher.reference_signature() != expected_signature
+            )
+            if needs_rebuild:
                 logger.info("Initializing TF-IDF matcher for reference episodes...")
                 if progress_callback:
                     progress_callback("preparing_model", 10.0)

--- a/backend/scripts/validate_subtitle_cache.py
+++ b/backend/scripts/validate_subtitle_cache.py
@@ -151,18 +151,18 @@ def validate(assets_dir: Path) -> ValidationResult:
     if n_shows == 0:
         failures.append("shows dict in manifest is empty — cache is unusable")
 
-    # Manifest-↔-tarball consistency: every (show, season) the manifest claims
-    # coverage for MUST have a matching .npz + .index.json in the tarball. A
-    # mismatch here is exactly the misconfiguration that hit TNG S7 D2: the
-    # build script published a manifest entry without writing the vectors, so
-    # the matcher at runtime warns + falls back to scraping for every title.
-    # Refuse the publish instead of letting it ship.
+    # Refuse builds where the manifest lists a (show, season) without its .npz + .index.json.
     if tarball_readable and shows:
         try:
-            # Import locally so the validator module stays importable in test
-            # contexts that don't ship the matcher (CI smoke uses a stub).
             from app.matcher.subtitle_utils import sanitize_filename
         except ImportError:
+            # A silently-skipped consistency check is worse than no check —
+            # a missing matcher in the publish-gate environment is itself a
+            # CI misconfiguration that must be surfaced, not swallowed.
+            failures.append(
+                "could not import sanitize_filename from app.matcher.subtitle_utils "
+                "— manifest-tarball consistency check skipped"
+            )
             sanitize_filename = None  # type: ignore[assignment]
 
         if sanitize_filename is not None:

--- a/backend/scripts/validate_subtitle_cache.py
+++ b/backend/scripts/validate_subtitle_cache.py
@@ -146,9 +146,38 @@ def validate(assets_dir: Path) -> ValidationResult:
     # `get("shows", {})` falls back to {} only when the key is *absent* —
     # `"shows": null` would return None and len(None) raises TypeError,
     # bypassing the accumulated failures list. `or {}` handles both.
-    n_shows = len(manifest.get("shows") or {})
+    shows = manifest.get("shows") or {}
+    n_shows = len(shows)
     if n_shows == 0:
         failures.append("shows dict in manifest is empty — cache is unusable")
+
+    # Manifest-↔-tarball consistency: every (show, season) the manifest claims
+    # coverage for MUST have a matching .npz + .index.json in the tarball. A
+    # mismatch here is exactly the misconfiguration that hit TNG S7 D2: the
+    # build script published a manifest entry without writing the vectors, so
+    # the matcher at runtime warns + falls back to scraping for every title.
+    # Refuse the publish instead of letting it ship.
+    if tarball_readable and shows:
+        try:
+            # Import locally so the validator module stays importable in test
+            # contexts that don't ship the matcher (CI smoke uses a stub).
+            from app.matcher.subtitle_utils import sanitize_filename
+        except ImportError:
+            sanitize_filename = None  # type: ignore[assignment]
+
+        if sanitize_filename is not None:
+            for show_name, entry in shows.items():
+                seasons = (entry or {}).get("seasons", []) if isinstance(entry, dict) else []
+                show_slug = sanitize_filename(show_name)
+                for season in seasons:
+                    npz_member = f"precomputed/{show_slug}/S{season:02d}.npz"
+                    idx_member = f"precomputed/{show_slug}/S{season:02d}.index.json"
+                    missing_files = [m for m in (npz_member, idx_member) if m not in members]
+                    if missing_files:
+                        failures.append(
+                            f"manifest lists {show_name!r} S{season:02d} but the tarball "
+                            f"is missing {missing_files}"
+                        )
 
     # tarball.stat() can re-raise OSError on its own — a permission flip
     # between tarfile.open succeeding and reaching this line would otherwise

--- a/backend/tests/unit/test_episode_identification.py
+++ b/backend/tests/unit/test_episode_identification.py
@@ -408,6 +408,208 @@ class TestPrecomputedCache:
 
 
 @pytest.mark.unit
+class TestStaleManifestPruning:
+    """When the manifest lists a show/season but the on-disk vector files
+    are missing, `_load_precomputed_season` must:
+
+    1. Return None (so the caller falls back to scraping).
+    2. Prune the stale season from the in-memory cached manifest so the
+       same warning doesn't re-fire for every title in the disc.
+
+    The persistent manifest.json on disk is left untouched — the next
+    `ensure_precomputed_cache` run owns that.
+    """
+
+    def _write_manifest_with_show(self, cache_dir, shows):
+        from app.matcher.vectorizer_config import (
+            CACHE_FORMAT_VERSION,
+            vectorizer_config_hash,
+        )
+
+        precomputed = cache_dir / "precomputed"
+        precomputed.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "cache_format_version": CACHE_FORMAT_VERSION,
+            "vectorizer_config_hash": vectorizer_config_hash(),
+            "shows": shows,
+        }
+        (precomputed / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    def _make_matcher(self, cache_dir, show_name):
+        # The EpisodeMatcher constructor pulls in ctranslate2, which is heavy
+        # but always available in this project's test env. We never actually
+        # call identify_episode — only the pure manifest-handling method.
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        return EpisodeMatcher(
+            cache_dir=cache_dir,
+            show_name=show_name,
+            model_name="tiny",  # never loaded; we don't call ASR
+        )
+
+    def test_missing_files_prunes_season_from_cached_manifest(self, tmp_path):
+        self._write_manifest_with_show(
+            tmp_path,
+            {"Star Trek: The Next Generation": {"tmdb_id": 1, "seasons": [6, 7]}},
+        )
+        matcher = self._make_matcher(tmp_path, "Star Trek: The Next Generation")
+        # First call: S07 listed in manifest, no files on disk.
+        assert matcher._load_precomputed_season(7) is None
+        # The cached manifest must now report S07 as gone, so a second call
+        # (e.g., next title on the same disc) does NOT re-fire the warning.
+        manifest = matcher._precomputed_manifest
+        seasons = manifest["shows"]["Star Trek: The Next Generation"]["seasons"]
+        assert 7 not in seasons
+        # S06 was never touched.
+        assert 6 in seasons
+
+    def test_missing_files_prunes_show_when_no_seasons_left(self, tmp_path):
+        self._write_manifest_with_show(
+            tmp_path,
+            {"Star Trek: The Next Generation": {"tmdb_id": 1, "seasons": [7]}},
+        )
+        matcher = self._make_matcher(tmp_path, "Star Trek: The Next Generation")
+        matcher._load_precomputed_season(7)
+        # When the last season for a show is pruned, drop the show entirely so
+        # the in-memory manifest stays internally consistent.
+        assert "Star Trek: The Next Generation" not in matcher._precomputed_manifest["shows"]
+
+    def test_repeat_call_does_not_re_warn(self, tmp_path, caplog):
+        """The warning must fire at most once per (show, season), even when
+        every title on a disc triggers a fresh _load_precomputed_season call.
+        """
+        import logging
+
+        from loguru import logger as loguru_logger
+
+        self._write_manifest_with_show(
+            tmp_path,
+            {"Star Trek: The Next Generation": {"tmdb_id": 1, "seasons": [7]}},
+        )
+        matcher = self._make_matcher(tmp_path, "Star Trek: The Next Generation")
+
+        # Bridge loguru -> caplog so pytest's WARNING capture sees the warning.
+        class _Sink:
+            def __init__(self):
+                self.messages = []
+
+            def __call__(self, message):
+                record = message.record
+                if record["level"].no >= logging.WARNING:
+                    self.messages.append(record["message"])
+
+        sink = _Sink()
+        sink_id = loguru_logger.add(sink, level="WARNING")
+        try:
+            matcher._load_precomputed_season(7)  # first call -> warns
+            matcher._load_precomputed_season(7)  # second call -> silent
+            matcher._load_precomputed_season(7)  # third call -> silent
+        finally:
+            loguru_logger.remove(sink_id)
+
+        warnings_about_missing = [m for m in sink.messages if "files are missing" in m]
+        assert len(warnings_about_missing) == 1, (
+            f"Expected exactly one stale-cache warning, got {len(warnings_about_missing)}: "
+            f"{warnings_about_missing}"
+        )
+
+
+@pytest.mark.unit
+class TestTfidfMatcherStaleness:
+    """The matcher's cached TfidfMatcher must not silently reuse the wrong
+    reference set across identify_episode calls.
+
+    Background: when the precomputed cache covers S07, the matcher's
+    `ref_file_order` is populated with episode codes ("S07E01"...). If a
+    later call falls back to scraping (e.g. precomputed files vanished
+    between titles, or different season requested), the new call's
+    `coverages` dict is keyed by SRT file paths — but the cached matcher
+    still returns episode codes. Hitting `coverages[rf_str]` raises
+    KeyError("S07E07"), which the chunk loop swallows as a rejected
+    chunk — surfacing as the user's "0 matched / N rejected" symptom
+    even when the audio + subtitles are both fine.
+
+    The fix: track a fingerprint of what the matcher was prepared for
+    and rebuild when it changes.
+    """
+
+    def test_load_precomputed_changes_ref_signature(self):
+        ref_matrix = csr_matrix(np.eye(2))
+        m = TfidfMatcher()
+        m.load_precomputed(ref_matrix, ["S07E01", "S07E02"], np.array([1.0, 1.0]))
+        sig1 = m.reference_signature()
+        m2 = TfidfMatcher()
+        m2.load_precomputed(ref_matrix, ["S08E01", "S08E02"], np.array([1.0, 1.0]))
+        sig2 = m2.reference_signature()
+        assert sig1 != sig2, "Reference signature must change with reference codes"
+
+    def test_signature_distinguishes_precomputed_from_scraping(self, tmp_path):
+        # Same season number, same show, but different MODE: precomputed
+        # (codes-keyed) vs scraping (path-keyed). Signature must differ so
+        # the cached matcher gets rebuilt.
+        ref_matrix = csr_matrix(np.eye(1))
+        m_pre = TfidfMatcher()
+        m_pre.load_precomputed(ref_matrix, ["S07E01"], np.array([1.0]))
+
+        srt = tmp_path / "show.S07E01.srt"
+        srt.write_text("1\n00:00:01,000 --> 00:00:02,000\nhello\n", encoding="utf-8")
+        m_scrape = TfidfMatcher()
+        m_scrape.prepare([srt], SubtitleCache())
+        assert m_pre.reference_signature() != m_scrape.reference_signature()
+
+
+@pytest.mark.unit
+class TestUniqueChunkPaths:
+    """Chunk + preprocessed tempfile paths must be unique per source file.
+
+    Two matcher threads (running under max_concurrent_matches >= 2) on the
+    same disc samples chunks at the same offsets. If both threads write to
+    the same on-disk path, the second writer corrupts the first thread's
+    file mid-PyAV-decode -> av.error.InvalidDataError, OR the second reader
+    silently picks up the first writer's audio (wrong audio, wrong match).
+
+    These tests pin down the property: chunk and preprocessed paths must
+    differ when the source MKV differs, even at identical (start, duration).
+    """
+
+    def _make_matcher(self, tmp_path):
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        return EpisodeMatcher(
+            cache_dir=tmp_path,
+            show_name="Test Show",
+            model_name="tiny",
+        )
+
+    def test_chunk_path_differs_per_source_mkv(self, tmp_path):
+        matcher = self._make_matcher(tmp_path)
+        path_a = matcher._chunk_path("/some/dir/title_t00.mkv", 1473, 30)
+        path_b = matcher._chunk_path("/some/dir/title_t01.mkv", 1473, 30)
+        assert path_a != path_b, (
+            "Concurrent matches on different titles must not collide on the same on-disk chunk path"
+        )
+
+    def test_chunk_path_stable_for_same_source(self, tmp_path):
+        # Same source, same offset/duration -> same path (so the on-disk
+        # cache hit guard `if not chunk_path.exists()` still saves work).
+        matcher = self._make_matcher(tmp_path)
+        path_a = matcher._chunk_path("/some/dir/title_t00.mkv", 1473, 30)
+        path_b = matcher._chunk_path("/some/dir/title_t00.mkv", 1473, 30)
+        assert path_a == path_b
+
+    def test_preprocessed_path_differs_per_source(self, tmp_path):
+        # The Whisper preprocessor writes to a temp dir whose filename used to
+        # be derived only from the input file's stem. Two source chunks with
+        # the same stem (different parent dirs) would collide there.
+        from app.matcher.asr_models import FasterWhisperModel
+
+        model = FasterWhisperModel.__new__(FasterWhisperModel)
+        a = model._preprocessed_path_for("/job_A/whisper_chunks/chunk_1473_30.wav")
+        b = model._preprocessed_path_for("/job_B/whisper_chunks/chunk_1473_30.wav")
+        assert a != b
+
+
+@pytest.mark.unit
 class TestModuleHelpers:
     def test_detect_file_encoding_handles_error(self, tmp_path):
         # Nonexistent file -> safe utf-8 fallback (no raise).

--- a/backend/tests/unit/test_validate_subtitle_cache.py
+++ b/backend/tests/unit/test_validate_subtitle_cache.py
@@ -127,6 +127,31 @@ class TestValidate:
         failures = vsc.validate(tmp_path).failures
         assert any("shows dict in manifest is empty" in f for f in failures)
 
+    def test_consistency_check_records_failure_when_helper_unavailable(
+        self, vsc, tmp_path, monkeypatch
+    ):
+        """If the validator can't import `sanitize_filename`, the manifest-↔-
+        tarball gate would silently disappear — equivalent to no gate at all
+        in the very environment most likely to bypass it (a CI image missing
+        the matcher package). Surface it as a failure instead.
+        """
+        import builtins
+
+        _make_assets(vsc, tmp_path)
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "app.matcher.subtitle_utils":
+                raise ImportError("simulated missing matcher package")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        failures = vsc.validate(tmp_path).failures
+        assert any("consistency check skipped" in f for f in failures), (
+            f"Expected import-failure surfaced as a validation failure, got: {failures}"
+        )
+
     def test_manifest_lists_season_without_vector_files_detected(self, vsc, tmp_path):
         """The manifest claims coverage for Show S07, but the tarball never
         shipped S07.npz / S07.index.json for it. This is the exact state the

--- a/backend/tests/unit/test_validate_subtitle_cache.py
+++ b/backend/tests/unit/test_validate_subtitle_cache.py
@@ -31,7 +31,18 @@ def _make_assets(
     tarball_members: list[str] | None = None,
     corrupt_sha: bool = False,
 ) -> None:
-    """Build a synthetic release-assets dir at ``assets_dir``."""
+    """Build a synthetic release-assets dir at ``assets_dir``.
+
+    When the manifest declares show/season coverage, the helper drops a
+    matching ``S{nn}.npz`` + ``S{nn}.index.json`` under the show's
+    ``sanitize_filename`` slug so the manifest-↔-tarball consistency gate
+    in `validate()` sees the files it expects. Tests that exercise the
+    missing-files failure path opt out by passing ``tarball_members``
+    explicitly (no per-show files written) or by overriding shows with
+    an entry whose seasons list excludes those files.
+    """
+    from app.matcher.subtitle_utils import sanitize_filename
+
     assets_dir.mkdir(parents=True, exist_ok=True)
     build_dir = assets_dir / "_build" / "precomputed"
     build_dir.mkdir(parents=True)
@@ -39,6 +50,19 @@ def _make_assets(
     (build_dir / "manifest.json").write_text(
         "{}", encoding="utf-8"
     )  # in-tar manifest; validator only checks members
+
+    # Default manifest used to drive vector-file placement; tests can override.
+    default_shows = {"Some Show": {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}}
+    effective_shows = (manifest_overrides or {}).get("shows", default_shows) or {}
+    if tarball_members is None:
+        for show_name, entry in effective_shows.items():
+            if not isinstance(entry, dict):
+                continue
+            show_dir = build_dir / sanitize_filename(show_name)
+            show_dir.mkdir(parents=True, exist_ok=True)
+            for season in entry.get("seasons", []):
+                (show_dir / f"S{season:02d}.npz").write_bytes(b"fake-npz")
+                (show_dir / f"S{season:02d}.index.json").write_text('["S01E01"]', encoding="utf-8")
 
     tarball = assets_dir / "engram-subtitle-cache.tar.gz"
     with tarfile.open(tarball, "w:gz") as tar:
@@ -102,6 +126,37 @@ class TestValidate:
         _make_assets(vsc, tmp_path, manifest_overrides={"shows": {}})
         failures = vsc.validate(tmp_path).failures
         assert any("shows dict in manifest is empty" in f for f in failures)
+
+    def test_manifest_lists_season_without_vector_files_detected(self, vsc, tmp_path):
+        """The manifest claims coverage for Show S07, but the tarball never
+        shipped S07.npz / S07.index.json for it. This is the exact state the
+        TNG-S7-D2 rip hit: matcher warns + falls back to scraping for every
+        title. The publish gate must reject the build instead of letting it
+        roll out to end-users.
+        """
+        # Tarball with only the top-level required entries, no per-show files.
+        _make_assets(
+            vsc,
+            tmp_path,
+            tarball_members=[
+                "precomputed",
+                "precomputed/idf.npy",
+                "precomputed/manifest.json",
+            ],
+            manifest_overrides={
+                "shows": {
+                    "Star Trek: The Next Generation": {
+                        "tmdb_id": 655,
+                        "seasons": [7],
+                        "episode_counts": {"7": 26},
+                    }
+                }
+            },
+        )
+        failures = vsc.validate(tmp_path).failures
+        assert any("Star Trek: The Next Generation" in f and "S07" in f for f in failures), (
+            f"Expected per-show/season files-missing failure, got: {failures}"
+        )
 
     def test_missing_manifest_reports_clean_failure(self, vsc, tmp_path):
         # No assets at all — what happens when `gh release download` produces


### PR DESCRIPTION
## Summary

Found while testing the per-track re-match button on a real Star Trek: TNG S7 D2 rip on Windows: every match attempt returned 0 matches and titles all landed in REVIEW with no episode. The recently-broadened auto deep re-match path kept burning CPU at higher scan densities, but no density helps when the chunk preprocessing fails before TF-IDF ever sees the audio. Three related matcher-infrastructure bugs combined to cause it.

### 1. Race on shared temp WAV files — `av.error.InvalidDataError`

`extract_audio_chunk` wrote to `whisper_chunks/chunk_{start}_{dur}.wav` and the Whisper preprocessor wrote to `whisper_preprocessed/preprocessed_{stem}.wav`. Neither path encoded the source MKV, so with `max_concurrent_matches: 2` (default) two title threads sampling the same offset both targeted the same path.

- Thread B truncated the file while Thread A's PyAV decode was mid-read → `av.error.InvalidDataError`, the chunk was logged as rejected, and matching saw "0 matched / 25 rejected".
- Worse: the chunk-extract `if not chunk_path.exists()` cache-hit guard would silently feed Thread A's audio to Thread B's lookup when B won the timing.

Fixed by hashing the absolute source path into both filenames (`chunk_{src_hash}_{start}_{dur}.wav`, `preprocessed_{src_hash}_{stem}.wav`). The within-call cache-hit semantics are preserved (same source path → same on-disk path).

### 2. Stale precomputed-cache manifest

When `~/.engram/cache/precomputed/manifest.json` listed a show/season but the per-show `S{nn}.npz` / `S{nn}.index.json` were absent, the matcher correctly warned and fell back to scraping — but it warned *once per title*, and `self._precomputed_manifest` still claimed the season was covered, so any later code reading the cached manifest was misled.

Now `_load_precomputed_season` prunes the stale season from the in-memory manifest after warning the first time (and drops the show entirely when no seasons remain). The on-disk `manifest.json` is left alone — `ensure_precomputed_cache` owns refreshing it at startup.

### 3. TfidfMatcher reused across calls with the wrong reference set — `KeyError("S07E07")`

When the first `identify_episode` call populated `ref_file_order` with precomputed-mode episode codes (`"S07E01"`...) and a later call fell back to scraping (which keys `coverages` by SRT path), the next chunk would hit `coverages[rf_str]` → `KeyError("S07E07")`, swallowed silently as a rejected chunk. This explained the `Error processing chunk 17/25 at 1793s: 'S07E07'` warning that surrounded the InvalidDataError.

Added `TfidfMatcher.reference_signature()` (mode + ref tuple) and made `identify_episode` rebuild the matcher when the signature doesn't match what the current call expects.

### 4. Cache-builder publish gate

`scripts/validate_subtitle_cache.py` (smoke-tested daily against `subtitle-cache-latest`) now checks that every `(show, season)` the manifest claims coverage for has the matching `S{nn}.npz` + `S{nn}.index.json` in the tarball — exactly the inconsistency that drove #2. The smoke workflow rejects the build instead of letting it ship.

The new gate also caught a latent inconsistency in the existing `_make_assets` fixture (it claimed a `"Some Show": seasons=[1]` it never put files for); fixture corrected.

## Test plan

- [x] 8 new TDD-first tests covering all four paths (Red verified before Green for each):
  - `TestUniqueChunkPaths`: chunk and preprocessed paths differ per source, stable for same source
  - `TestStaleManifestPruning`: season pruned from cached manifest; show pruned when last season goes; loguru-bridged caplog check that the warning fires exactly once across 3 repeat calls
  - `TestTfidfMatcherStaleness`: reference signature changes with codes; precomputed vs scraping modes signature-differ
  - `test_manifest_lists_season_without_vector_files_detected`: validator catches missing per-show files
- [x] 118 / 118 pass across the 5 touched test files
- [x] 1147 / 1147 unit tests pass full suite
- [x] 81 / 81 integration tests pass
- [x] `uv run ruff check app/ scripts/ tests/` → all checks passed
- [ ] Real-disc test: re-rip TNG S7 D2 on Windows and confirm episode matches resolve

9 pre-existing pipeline failures (`no such table: app_config`) are the documented worktree empty-DB hazard, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)