### PR TITLE
fix: restore TV extras tagging, per-track deep re-match, and auto-escalation for needs-review

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -81,6 +81,9 @@ class JobResponse(BaseModel):
     subtitles_total: int | None = None
     subtitles_failed: int | None = None
     review_reason: str | None = None
+    # Transient auto-resolution note set during conflict / review escalation
+    # (e.g. "Resolving episode conflicts — pass 2 of 3"). Cleared on resolution.
+    conflict_status: str | None = None
     created_at: datetime | str | None = None
 
     model_config = {"from_attributes": True}
@@ -151,6 +154,10 @@ class JobDetailResponse(BaseModel):
     disc_number: int = 1
     error_message: str | None = None
     review_reason: str | None = None
+    # Transient auto-resolution note (e.g. "Resolving episode conflicts — pass 2 of 3"
+    # / "Deep re-matching low-confidence titles — pass 1 of 3"). Set while the
+    # finalization coordinator is auto-escalating; cleared on resolution.
+    conflict_status: str | None = None
     # Classification
     classification_source: str = "heuristic"
     classification_confidence: float = 0.0
@@ -638,6 +645,7 @@ async def build_job_detail(job: DiscJob, session: AsyncSession) -> dict:
         "disc_number": job.disc_number,
         "error_message": job.error_message,
         "review_reason": job.review_reason,
+        "conflict_status": job.conflict_status,
         "classification_source": job.classification_source,
         "classification_confidence": job.classification_confidence,
         "tmdb_id": job.tmdb_id,
@@ -1920,6 +1928,7 @@ class RematchRequest(BaseModel):
     """Request model for re-matching titles."""
 
     source_preference: Literal["discdb", "engram"] | None = None
+    deep: bool = False
 
 
 class ReassignRequest(BaseModel):
@@ -2247,7 +2256,9 @@ async def rematch_title(
     from app.services.job_manager import job_manager
 
     try:
-        await job_manager.rematch_single_title(job.id, title_id, request.source_preference)
+        await job_manager.rematch_single_title(
+            job.id, title_id, request.source_preference, deep=request.deep
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from None
 

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -48,12 +48,56 @@ def _normalize_episode_code(code: str | None) -> str:
 
 
 def _detect_conflicts(titles) -> dict[str, list]:
-    """Group ``MATCHED`` titles by canonical episode code, keeping only ties."""
+    """Group titles by canonical episode code, keeping only ties.
+
+    Considers MATCHED titles AND REVIEW titles that still carry the matcher's
+    borderline best-guess episode code. A confidently-matched title colliding
+    with a low-confidence REVIEW title on the same episode IS a conflict the
+    auto-resolution should break — handling only MATCHED-vs-MATCHED leaves the
+    pair stuck (the borderline one re-matches alone via review-escalation while
+    the confident one rides alongside, never resolving the collision).
+    Excludes extras, force-advanced titles, and REVIEW titles parked for
+    non-matching reasons (file_exists / subtitle_failed).
+    """
     by_ep: dict[str, list] = {}
     for t in titles:
-        if t.state == TitleState.MATCHED and t.matched_episode:
+        if not t.matched_episode:
+            continue
+        if t.state == TitleState.MATCHED:
+            by_ep.setdefault(_normalize_episode_code(t.matched_episode), []).append(t)
+        elif t.state == TitleState.REVIEW and _is_rematchable_review(t):
             by_ep.setdefault(_normalize_episode_code(t.matched_episode), []).append(t)
     return {ep: tl for ep, tl in by_ep.items() if len(tl) > 1}
+
+
+# REVIEW reasons a deeper matcher pass cannot fix — never auto re-match these.
+_NON_REMATCHABLE_REVIEW_ERRORS = {"file_exists", "subtitle_download_failed"}
+
+
+def _is_rematchable_review(t) -> bool:
+    """A REVIEW title whose low confidence a denser matcher pass could plausibly fix.
+
+    Excludes extras (not episodes) and titles parked in REVIEW for non-matching
+    reasons (organization conflicts, missing reference subtitles) — re-running the
+    audio matcher on those just wastes a pass.
+    """
+    if t.state != TitleState.REVIEW or t.is_extra:
+        return False
+    if t.match_details:
+        try:
+            details = json.loads(t.match_details)
+        except (json.JSONDecodeError, TypeError):
+            details = None
+        if isinstance(details, dict):
+            if details.get("error") in _NON_REMATCHABLE_REVIEW_ERRORS:
+                return False
+            if details.get("auto_sorted") == "extras":
+                return False
+            # Force-advanced (watchdog) or user-skipped → deliberate hand-to-human;
+            # re-matching would undo that and risk re-entering a stuck state.
+            if details.get("forced_review"):
+                return False
+    return True
 
 
 def _full_coverage_points(titles) -> int:
@@ -115,10 +159,13 @@ class FinalizationCoordinator:
         self._active_jobs: dict = None
         self._match_single_file: callable = None
         self._rematch_conflict: callable = None
+        self._rematch_title: callable = None
 
-        # Last scan depth attempted per job while auto-resolving a collision.
-        # Transient (in memory); cleared on resolution, exhaustion, or restart.
+        # Last scan depth attempted per job while auto-resolving. Transient (in
+        # memory); cleared on resolution, exhaustion, or restart. Conflicts and
+        # plain reviews escalate on separate counters so one can't stall the other.
         self._conflict_passes: dict[int, int] = {}
+        self._review_passes: dict[int, int] = {}
 
     def set_callbacks(
         self,
@@ -128,6 +175,7 @@ class FinalizationCoordinator:
         active_jobs,
         match_single_file=None,
         rematch_conflict=None,
+        rematch_title=None,
     ) -> None:
         """Set cross-coordinator callbacks."""
         self._run_ripping = run_ripping
@@ -135,10 +183,19 @@ class FinalizationCoordinator:
         self._active_jobs = active_jobs
         self._match_single_file = match_single_file
         self._rematch_conflict = rematch_conflict
+        self._rematch_title = rematch_title
 
     def reset_conflict_passes(self, job_id: int) -> None:
-        """Forget any in-progress conflict escalation for ``job_id``."""
+        """Forget any in-progress auto-escalation for ``job_id`` (conflict + review).
+
+        Called from terminal-state hooks and from rerun-matching, where the whole
+        escalation history is meant to be discarded. Intra-pass bail-outs in the
+        finalization loop use the per-kind ``_clear_conflict_state`` /
+        ``_clear_review_state`` helpers instead so the two escalations don't
+        clobber each other's progress counter.
+        """
         self._conflict_passes.pop(job_id, None)
+        self._review_passes.pop(job_id, None)
 
     async def on_terminal_clear_conflicts(self, job_id: int, _state) -> None:
         """Terminal-state hook: drop conflict-escalation tracking for the job.
@@ -154,10 +211,30 @@ class FinalizationCoordinator:
                 job.conflict_status = None
                 await session.commit()
 
+    # Note prefixes used to identify whose escalation set ``conflict_status`` so
+    # each clear path only wipes its own note (avoids the conflict path flickering
+    # the review note off mid-pass when both are running in the same job).
+    _CONFLICT_NOTE_PREFIX = "Resolving episode conflicts"
+    _REVIEW_NOTE_PREFIX = "Deep re-matching low-confidence"
+
     async def _clear_conflict_state(self, session, job) -> None:
-        """Drop escalation tracking and clear the transient dashboard note."""
-        self.reset_conflict_passes(job.id)
-        if job.conflict_status is not None:
+        """Drop only the conflict-escalation tracking + note for ``job``.
+
+        Review-escalation state is intentionally left alone — wiping it from
+        here was a bug that pinned review-escalation at pass 1 forever, because
+        every check_job_completion re-entry first runs conflict-escalate (which
+        clears, when no MATCHED collisions are present) and then review-escalate
+        (which reads the now-zeroed counter and re-dispatches at the lowest depth).
+        """
+        self._conflict_passes.pop(job.id, None)
+        if job.conflict_status and job.conflict_status.startswith(self._CONFLICT_NOTE_PREFIX):
+            job.conflict_status = None
+            await session.commit()
+
+    async def _clear_review_state(self, session, job) -> None:
+        """Drop only the review-escalation tracking + note for ``job``."""
+        self._review_passes.pop(job.id, None)
+        if job.conflict_status and job.conflict_status.startswith(self._REVIEW_NOTE_PREFIX):
             job.conflict_status = None
             await session.commit()
 
@@ -234,6 +311,85 @@ class FinalizationCoordinator:
         )
         return True
 
+    async def _maybe_escalate_reviews(self, session, job, titles) -> bool:
+        """Deep re-match low-confidence REVIEW titles, escalating scan depth.
+
+        Complements :meth:`_maybe_escalate_conflicts`: where that breaks same-
+        episode ties, this gives a single low-confidence title (no collision)
+        progressively deeper matcher passes before handing it to manual review.
+        Depth-only ladder, capped at full coverage; a per-job pass counter
+        (separate from the conflict counter) guarantees termination.
+
+        Returns ``True`` if a re-match was dispatched (job held in MATCHING; the
+        caller should return and let completion re-entry pick it back up).
+        """
+        job_id = job.id
+        # Episode re-matching only applies to TV.
+        if job.content_type != ContentType.TV or self._rematch_title is None:
+            await self._clear_review_state(session, job)
+            return False
+
+        review_titles = [t for t in titles if _is_rematchable_review(t)]
+        if not review_titles:
+            await self._clear_review_state(session, job)
+            return False
+
+        ladder = _conflict_scan_ladder(review_titles)
+        last_depth = self._review_passes.get(job_id, 0)
+        next_depth = next((d for d in ladder if d > last_depth), None)
+
+        if next_depth is None:
+            logger.info(
+                f"Job {job_id}: review re-match exhausted at {last_depth} scan points; "
+                f"{len(review_titles)} title(s) still unresolved — handing to review"
+            )
+            await self._clear_review_state(session, job)
+            return False
+
+        dispatched: list[int] = []
+        for t in review_titles:
+            try:
+                await self._rematch_title(
+                    job_id,
+                    t.id,
+                    source_preference="engram",
+                    num_points=next_depth,
+                    min_vote_count=None,
+                )
+                dispatched.append(t.id)
+            except Exception as e:
+                # e.g. staging file missing (ValueError) — skip this title rather
+                # than aborting the whole pass. Catch broadly (not BaseException,
+                # so CancelledError still propagates).
+                logger.warning(f"Review re-match: skipping title {t.id} (job {job_id}): {e}")
+
+        if not dispatched:
+            await self._clear_review_state(session, job)
+            return False
+
+        self._review_passes[job_id] = next_depth
+        pass_no = ladder.index(next_depth) + 1
+        job.conflict_status = (
+            f"Deep re-matching low-confidence titles — pass {pass_no} of {len(ladder)}"
+        )
+        job.updated_at = datetime.now(UTC)
+        if job.state != JobState.MATCHING:
+            job.state = JobState.MATCHING
+        await session.commit()
+        await ws_manager.broadcast_job_update(
+            job_id,
+            JobState.MATCHING.value,
+            content_type=job.content_type.value if job.content_type else None,
+            detected_title=job.detected_title,
+            detected_season=job.detected_season,
+            conflict_status=job.conflict_status,
+        )
+        logger.info(
+            f"Job {job_id}: deep review re-match at {next_depth} scan points "
+            f"(pass {pass_no}/{len(ladder)}, titles {dispatched})"
+        )
+        return True
+
     async def _complete_tv_job(self, session, job) -> None:
         """Finalize a TV job: set progress, compute final_path, transition to COMPLETED."""
         from app.services.config_service import get_config as get_db_config
@@ -291,6 +447,11 @@ class FinalizationCoordinator:
         # has_review short-circuit so a pass that leaves one title unmatched
         # doesn't abort escalation of the titles still colliding.
         if await self._maybe_escalate_conflicts(session, job, titles):
+            return
+
+        # Then give plain low-confidence reviews (no collision) escalating deep
+        # re-match passes before surfacing them for manual assignment.
+        if await self._maybe_escalate_reviews(session, job, titles):
             return
 
         # Review takes priority: while ANY title still needs manual review, do

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -268,7 +268,13 @@ class FinalizationCoordinator:
                 f"Job {job_id}: conflict re-match exhausted at {last_depth} scan points; "
                 f"{list(conflicts)} still contested — handing to review"
             )
-            await self._clear_conflict_state(session, job)
+            # See _maybe_escalate_reviews: leave the counter at last_depth so
+            # re-entries see "exhausted" and bail. Popping it caused an
+            # infinite pass-1 loop when titles can't be untangled (e.g. all
+            # contested titles match the same episode regardless of depth).
+            if job.conflict_status and job.conflict_status.startswith(self._CONFLICT_NOTE_PREFIX):
+                job.conflict_status = None
+                await session.commit()
             return False
 
         # Re-match every distinct raw code in each tie (padded + unpadded), so
@@ -343,7 +349,16 @@ class FinalizationCoordinator:
                 f"Job {job_id}: review re-match exhausted at {last_depth} scan points; "
                 f"{len(review_titles)} title(s) still unresolved — handing to review"
             )
-            await self._clear_review_state(session, job)
+            # Leave ``_review_passes[job_id]`` at last_depth so the next
+            # ``check_job_completion`` re-entry sees the ladder as still
+            # exhausted and bails. Popping it here lets pass 1 re-fire on the
+            # very next recheck — an infinite loop when titles can never
+            # match (e.g. precomputed cache gap). The counter is reset for
+            # real via ``reset_conflict_passes`` on terminal-state transitions
+            # and by the "no review titles" branch above when titles resolve.
+            if job.conflict_status and job.conflict_status.startswith(self._REVIEW_NOTE_PREFIX):
+                job.conflict_status = None
+                await session.commit()
             return False
 
         dispatched: list[int] = []

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -105,6 +105,7 @@ class JobManager:
             active_jobs=self._active_jobs,
             match_single_file=self._matching.match_single_file,
             rematch_conflict=self._matching.rematch_conflict,
+            rematch_title=self._matching.rematch_single_title,
         )
         self._simulation.set_callbacks(
             subtitle_ready=self._matching._subtitle_ready,
@@ -699,6 +700,7 @@ class JobManager:
                 if file_path is not None:
                     title.output_filename = str(file_path)
                     title.state = TitleState.REVIEW
+                    title.match_details = self._forced_review_details(title.match_details, reason)
                     err = None
                 else:
                     title.state = TitleState.FAILED
@@ -741,6 +743,10 @@ class JobManager:
             err = "Skipped by user" if target == TitleState.FAILED else None
             if target == TitleState.FAILED and not title.match_details:
                 title.match_details = json.dumps({"reason": "Skipped by user"})
+            elif target == TitleState.REVIEW:
+                title.match_details = self._forced_review_details(
+                    title.match_details, "Skipped by user"
+                )
             session.add(title)
             await session.commit()
             logger.info(
@@ -751,6 +757,26 @@ class JobManager:
 
             await self._finalization.check_job_completion(session, job_id)
         return True
+
+    @staticmethod
+    def _forced_review_details(existing: str | None, reason: str) -> str:
+        """Tag a title's match_details as force-advanced/skipped to REVIEW.
+
+        The ``forced_review`` flag tells the auto review-escalation to leave this
+        title alone — it was deliberately handed to a human, not flagged by the
+        matcher for a deeper retry.
+        """
+        data: dict = {}
+        if existing:
+            try:
+                parsed = json.loads(existing)
+                if isinstance(parsed, dict):
+                    data = parsed
+            except (json.JSONDecodeError, TypeError):
+                data = {}
+        data["forced_review"] = True
+        data.setdefault("reason", reason)
+        return json.dumps(data)
 
     @staticmethod
     def _phase_timeout(config, state: JobState) -> int | None:
@@ -934,10 +960,25 @@ class JobManager:
         await self._rerun_matching(job_id, source_preference)
 
     async def rematch_single_title(
-        self, job_id: int, title_id: int, source_preference: str | None = None
+        self,
+        job_id: int,
+        title_id: int,
+        source_preference: str | None = None,
+        deep: bool = False,
     ) -> None:
-        """Re-match a single title. Delegates to matching coordinator."""
-        await self._matching.rematch_single_title(job_id, title_id, source_preference)
+        """Re-match a single title. Delegates to matching coordinator.
+
+        ``deep`` re-runs the engram matcher at strict scan density + vote gate
+        (the same params as conflict escalation), giving a low-confidence title a
+        real chance to resolve instead of re-failing at the original depth.
+        """
+        await self._matching.rematch_single_title(
+            job_id,
+            title_id,
+            source_preference,
+            num_points=STRICT_SCAN_POINTS if deep else None,
+            min_vote_count=STRICT_MIN_VOTES if deep else None,
+        )
 
     async def rematch_conflict(self, job_id: int, episode_code: str) -> dict:
         """Deep re-match every title claiming ``episode_code`` (strict params).

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -313,6 +313,12 @@ class MatchingCoordinator:
 
             await ws_manager.broadcast_title_update(job_id, title.id, TitleState.MATCHING.value)
 
+        # Reset the stale-job watchdog clock at dispatch so a (deep) re-match —
+        # especially an auto-escalation that holds the job in MATCHING — isn't
+        # force-advanced during the setup window before the first progress signal.
+        if self._note_activity:
+            self._note_activity(job_id)
+
         # Fire-and-forget: matching runs in background, progress via WebSocket
         match_task = asyncio.create_task(
             self.match_single_file(job_id, title_id, file_path, num_points, min_vote_count)
@@ -489,9 +495,14 @@ class MatchingCoordinator:
                             if handled:
                                 return
                 except Exception as e:
+                    # Surface the full traceback: a silently-failing TMDB runtime
+                    # fetch here disables automatic extras detection (the pre-filter
+                    # is the only thing that flags non-episode bonus tracks before
+                    # the matcher tries to force them onto an episode).
                     logger.warning(
                         f"[MATCH] Title {title_id} (Job {job_id}): duration pre-filter failed: {e}. "
-                        f"Proceeding with matching normally."
+                        f"Proceeding with matching normally.",
+                        exc_info=True,
                     )
 
         # 5. Acquire semaphore to limit concurrent matching
@@ -623,15 +634,38 @@ class MatchingCoordinator:
 
                 elapsed = time.monotonic() - match_start
 
+                # Race guard: if the title was force-advanced or per-track-skipped
+                # while this match was running, respect that decision — don't clobber
+                # match_details (which would wipe the forced_review flag and let the
+                # review-escalation re-dispatch the title, manifesting as
+                # "Skip/Force does nothing").
+                if title.match_details:
+                    try:
+                        existing = json.loads(title.match_details)
+                    except (json.JSONDecodeError, TypeError):
+                        existing = None
+                    if isinstance(existing, dict) and existing.get("forced_review"):
+                        logger.info(
+                            f"[MATCH] Title {title_id} (Job {job_id}): force-advanced during "
+                            f"match ({elapsed:.1f}s) — leaving title untouched."
+                        )
+                        await self._check_job_completion(session, job_id)
+                        return
+
                 # Update title with match result
                 title.matched_episode = result.episode_code
                 title.match_confidence = result.confidence
 
                 if result.needs_review:
-                    if result.episode_code:
-                        title.state = TitleState.MATCHED
-                    else:
-                        title.state = TitleState.REVIEW
+                    # A low-confidence result always goes to REVIEW — even when the
+                    # matcher emits a best-guess episode code. Auto-organizing a
+                    # borderline guess silently mis-files content (e.g. a bonus
+                    # track that slipped past the duration pre-filter lands on the
+                    # wrong episode instead of being flagged as an extra). The
+                    # auto review-escalation deep re-matches it next; if it still
+                    # can't resolve, the user decides. matched_episode is kept as
+                    # the inspector's starting suggestion.
+                    title.state = TitleState.REVIEW
 
                     logger.info(
                         f"[MATCH] Title {title_id} (Job {job_id}): needs review — "
@@ -818,6 +852,11 @@ class MatchingCoordinator:
             )
         else:
             title.state = TitleState.COMPLETED
+            # The duration pre-filter already classified this as an extra; the
+            # only thing that failed is the file move (e.g. destination exists
+            # from a previous rip). Tag it so the UI still shows EXTRA — without
+            # this, a re-run hides the chip on every collided extra.
+            title.is_extra = True
             title.match_details = json.dumps(
                 {
                     "auto_sorted": "extras",

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -200,9 +200,35 @@ class TestEscalation:
         # Ladder exhausted (full coverage reached): hand back to the review path.
         result, status = await _escalate(coord, job_id)
         assert result is False
-        assert job_id not in coord._conflict_passes
+        # Counter stays at last_depth so a recheck (e.g. unrelated title
+        # finishing) sees "exhausted" again and doesn't re-fire pass 1.
+        assert coord._conflict_passes[job_id] == 101
         assert status is None
         assert {25, 50, 101}.issubset(set(depths))
+
+    async def test_exhausted_does_not_re_dispatch_on_recheck(self):
+        """After exhaustion, a re-entry from check_job_completion must NOT
+        re-fire pass 1 — that loops forever on conflicts that depth alone
+        can't break."""
+        job_id = await _seed_conflict(duration=3000)
+        depths: list[int] = []
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            depths.append(num_points)
+            return {"dispatched": [1], "skipped": []}
+
+        coord = _coord_with(fake)
+
+        for _ in range(3):
+            await _escalate(coord, job_id)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False  # exhausted
+
+        depths.clear()
+        result, status = await _escalate(coord, job_id)
+        assert result is False, "Exhausted conflict-escalation must not re-fire on recheck"
+        assert depths == [], f"Expected no re-dispatch, got depths {depths}"
+        assert status is None
 
     async def test_resolved_conflict_clears_state(self):
         job_id = await _seed_conflict()

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -46,11 +46,46 @@ class TestConflictHelpers:
         assert list(conflicts) == ["S01E03"]
         assert len(conflicts["S01E03"]) == 2
 
-    def test_detect_conflicts_ignores_non_matched_titles(self):
+    def test_detect_conflicts_includes_review_titles_with_borderline_episode(self):
+        """A borderline REVIEW title colliding with a confidently MATCHED title
+        on the same episode IS a conflict — auto-resolution needs to break the
+        tie together, not leave the confident one riding alongside the borderline
+        one."""
         titles = [
             _matched("S01E03"),
             SimpleNamespace(
-                state=TitleState.REVIEW, matched_episode="S01E03", duration_seconds=1380
+                state=TitleState.REVIEW,
+                matched_episode="S01E03",
+                duration_seconds=1380,
+                is_extra=False,
+                match_details=None,
+            ),
+        ]
+        conflicts = _detect_conflicts(titles)
+        assert list(conflicts) == ["S01E03"]
+        assert len(conflicts["S01E03"]) == 2
+
+    def test_detect_conflicts_excludes_extras_and_non_rematchable_reviews(self):
+        """Extras and titles parked in REVIEW for non-matching reasons (file_exists,
+        forced_review, etc.) don't count as conflict candidates even with a
+        matched_episode set."""
+        import json
+
+        titles = [
+            _matched("S01E03"),
+            SimpleNamespace(
+                state=TitleState.REVIEW,
+                matched_episode="S01E03",
+                duration_seconds=1380,
+                is_extra=True,
+                match_details=None,
+            ),
+            SimpleNamespace(
+                state=TitleState.REVIEW,
+                matched_episode="S01E03",
+                duration_seconds=1380,
+                is_extra=False,
+                match_details=json.dumps({"forced_review": True}),
             ),
         ]
         assert _detect_conflicts(titles) == {}
@@ -207,6 +242,60 @@ class TestEscalation:
         assert result is False
         assert job_id not in coord._conflict_passes  # no progress recorded → no loop
         assert status is None
+
+    async def test_review_title_with_episode_counts_as_conflict(self):
+        """A title in REVIEW with a (low-confidence) matched_episode that collides
+        with a confidently MATCHED title on the same episode must count as a conflict
+        — otherwise the borderline guess silently rides alongside the confident one
+        and the user sees an unresolved collision in the UI (only the borderline
+        title gets re-matched via review-escalation, not the pair together)."""
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="SHOW_S1D1",
+                content_type=ContentType.TV,
+                state=JobState.MATCHING,
+                detected_title="Some Show",
+                detected_season=1,
+                staging_path="/tmp/staging/job",
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=0,
+                    duration_seconds=2700,
+                    matched_episode="S01E05",
+                    match_confidence=0.85,
+                    state=TitleState.MATCHED,
+                )
+            )
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=1,
+                    duration_seconds=2700,
+                    matched_episode="S01E05",
+                    match_confidence=0.17,
+                    state=TitleState.REVIEW,
+                )
+            )
+            await session.commit()
+            job_id = job.id
+
+        calls: list[tuple] = []
+
+        async def fake(jid, ep, num_points=None, min_vote_count=None):
+            calls.append((ep, num_points))
+            return {"dispatched": [1, 2], "skipped": []}
+
+        coord = _coord_with(fake)
+        result, status = await _escalate(coord, job_id)
+        assert result is True
+        assert calls and calls[0][0] == "S01E05"
+        assert status and "pass 1" in status
 
     async def test_no_conflict_returns_false(self):
         async with _unit_session_factory() as session:

--- a/backend/tests/unit/test_auto_review_escalation.py
+++ b/backend/tests/unit/test_auto_review_escalation.py
@@ -120,9 +120,39 @@ class TestReviewEscalation:
 
         result, status = await _escalate(coord, job_id)
         assert result is False
-        assert job_id not in coord._review_passes
+        # Counter must NOT be popped on exhaustion — see
+        # test_exhausted_does_not_re_dispatch_on_recheck for why.
+        assert coord._review_passes[job_id] == 101
         assert status is None
         assert {25, 50, 101}.issubset(set(depths))
+
+    async def test_exhausted_does_not_re_dispatch_on_recheck(self):
+        """After the ladder exhausts on titles still in REVIEW, a subsequent
+        ``check_job_completion`` re-entry must NOT re-fire pass 1 — that's
+        an infinite loop. Caught live: titles whose precomputed-cache deps
+        are missing match nothing on every pass; if exhaustion pops the
+        counter, the next recheck reads last_depth=0 and starts pass 1 again.
+        """
+        job_id = await _seed_review(duration=3000)  # ladder = [25, 50, 101]
+        depths: list[int] = []
+
+        async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
+            depths.append(num_points)
+
+        coord = _coord_with(fake)
+
+        # Walk the full ladder to exhaustion.
+        for _ in range(3):
+            await _escalate(coord, job_id)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False  # exhausted
+
+        # Titles are still in REVIEW; the next re-entry must be a no-op.
+        depths.clear()
+        result, status = await _escalate(coord, job_id)
+        assert result is False, "Re-entry on exhausted review escalation must NOT re-fire"
+        assert depths == [], f"Expected no re-dispatch on recheck, got depths {depths}"
+        assert status is None
 
     async def test_resolved_title_clears_state(self):
         job_id = await _seed_review()

--- a/backend/tests/unit/test_auto_review_escalation.py
+++ b/backend/tests/unit/test_auto_review_escalation.py
@@ -1,0 +1,295 @@
+"""Unit tests for automatic, escalating deep re-match of needs-review titles.
+
+Complements the conflict escalation: when a single title lands in REVIEW with a
+low-confidence / no match (and no same-episode collision), FinalizationCoordinator
+deep re-matches it at progressively denser sampling before handing it to manual
+review. The audio matcher is stubbed; these tests cover the escalation,
+termination, and eligibility logic.
+"""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from sqlmodel import select
+
+from app.api.websocket import manager as ws_manager
+from app.models import DiscJob, DiscTitle
+from app.models.disc_job import ContentType, JobState, TitleState
+from app.services.finalization_coordinator import FinalizationCoordinator
+from tests.unit.conftest import _unit_session_factory
+
+
+@pytest.fixture(autouse=True)
+def _quiet_ws(monkeypatch):
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_job_update", _noop)
+
+
+async def _seed_review(
+    *,
+    content_type=ContentType.TV,
+    duration: int = 3000,
+    state=TitleState.REVIEW,
+    is_extra: bool = False,
+    match_details: str | None = None,
+) -> int:
+    """Seed a TV job with one needs-review title (no collision). Returns job id."""
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=content_type,
+            state=JobState.MATCHING,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path="/tmp/staging/job",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        session.add(
+            DiscTitle(
+                job_id=job.id,
+                title_index=0,
+                duration_seconds=duration,
+                matched_episode=None,
+                match_confidence=0.2,
+                state=state,
+                is_extra=is_extra,
+                match_details=match_details,
+            )
+        )
+        await session.commit()
+        return job.id
+
+
+def _coord_with(rematch_title):
+    coord = FinalizationCoordinator(Mock(), Mock())
+    coord._rematch_title = rematch_title
+    return coord
+
+
+async def _escalate(coord, job_id):
+    async with _unit_session_factory() as session:
+        job = await session.get(DiscJob, job_id)
+        titles = (
+            (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+            .scalars()
+            .all()
+        )
+        result = await coord._maybe_escalate_reviews(session, job, titles)
+        return result, job.conflict_status
+
+
+@pytest.mark.unit
+class TestReviewEscalation:
+    async def test_first_pass_dispatches_depth_only(self):
+        job_id = await _seed_review()
+        calls: list[tuple] = []
+
+        async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
+            calls.append((source_preference, num_points, min_vote_count))
+
+        coord = _coord_with(fake)
+        result, status = await _escalate(coord, job_id)
+
+        assert result is True
+        assert coord._review_passes[job_id] == 25
+        assert calls and all(np == 25 for _src, np, _mv in calls)
+        # Depth-only: vote gate stays default; engram source forced.
+        assert all(mv is None for _src, _np, mv in calls)
+        assert all(src == "engram" for src, _np, _mv in calls)
+        assert status and "pass 1 of 3" in status
+
+    async def test_escalates_then_exhausts(self):
+        job_id = await _seed_review(duration=3000)  # full coverage = 101
+        depths: list[int] = []
+
+        async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
+            depths.append(num_points)
+
+        coord = _coord_with(fake)
+
+        for expected in (25, 50, 101):
+            result, _status = await _escalate(coord, job_id)
+            assert result is True
+            assert coord._review_passes[job_id] == expected
+
+        result, status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._review_passes
+        assert status is None
+        assert {25, 50, 101}.issubset(set(depths))
+
+    async def test_resolved_title_clears_state(self):
+        job_id = await _seed_review()
+
+        async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
+            return None
+
+        coord = _coord_with(fake)
+        await _escalate(coord, job_id)
+        assert job_id in coord._review_passes
+
+        # Simulate the deep re-match having resolved the title.
+        async with _unit_session_factory() as session:
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            titles[0].state = TitleState.MATCHED
+            titles[0].matched_episode = "S01E04"
+            await session.commit()
+
+        result, status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._review_passes
+        assert status is None
+
+    async def test_no_dispatch_falls_through_without_looping(self):
+        job_id = await _seed_review()
+
+        async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
+            raise ValueError("staging file missing")
+
+        coord = _coord_with(fake)
+        result, status = await _escalate(coord, job_id)
+
+        assert result is False
+        assert job_id not in coord._review_passes
+        assert status is None
+
+    async def test_no_review_titles_returns_false(self):
+        job_id = await _seed_review(state=TitleState.MATCHED)
+
+        async def fake(*a, **k):
+            raise AssertionError("nothing to escalate")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_extra_review_title_not_escalated(self):
+        job_id = await _seed_review(
+            is_extra=True,
+            match_details=json.dumps({"auto_sorted": "extras", "action": "review"}),
+        )
+
+        async def fake(*a, **k):
+            raise AssertionError("extras must not be re-matched as episodes")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_file_exists_review_not_escalated(self):
+        job_id = await _seed_review(
+            match_details=json.dumps({"error": "file_exists", "message": "exists"})
+        )
+
+        async def fake(*a, **k):
+            raise AssertionError("organization conflicts are not a matching problem")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_forced_review_title_not_escalated(self):
+        # A title the watchdog force-advanced or the user skipped to REVIEW must
+        # not be auto re-matched — that would undo the deliberate "hand to human"
+        # decision and risk re-entering a stuck matching state.
+        job_id = await _seed_review(
+            match_details=json.dumps({"forced_review": True, "reason": "stale timeout"})
+        )
+
+        async def fake(*a, **k):
+            raise AssertionError("force-advanced/skipped titles must not be re-matched")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_subtitle_failure_review_not_escalated(self):
+        job_id = await _seed_review(
+            match_details=json.dumps({"error": "subtitle_download_failed", "message": "no refs"})
+        )
+
+        async def fake(*a, **k):
+            raise AssertionError("no reference subtitles → deeper scan cannot help")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+
+    async def test_review_pass_advances_across_no_conflict_reentry(self):
+        """A check_job_completion re-entry where conflict-escalate finds nothing
+        must NOT wipe review-escalation's pass counter. Otherwise review-escalate
+        always re-dispatches at depth 25 and never advances to 50 / full coverage
+        — visible as 'one track keeps re-matching forever.'"""
+        job_id = await _seed_review(duration=3000)  # full coverage = 101
+
+        depths: list[int] = []
+
+        async def fake_rematch(
+            jid, tid, source_preference=None, num_points=None, min_vote_count=None
+        ):
+            depths.append(num_points)
+
+        async def fake_conflict(*a, **k):
+            return {"dispatched": [], "skipped": []}
+
+        coord = _coord_with(fake_rematch)
+        coord._rematch_conflict = fake_conflict
+
+        # First review-escalation pass dispatches at depth 25.
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            assert await coord._maybe_escalate_reviews(session, job, titles) is True
+            assert coord._review_passes[job_id] == 25
+
+        # Now simulate the next check_job_completion re-entry: conflict-escalate runs
+        # first, finds no conflicts (titles are REVIEW, not MATCHED), and bails. That
+        # bail path MUST NOT touch the review-escalation pass counter.
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            await coord._maybe_escalate_conflicts(session, job, titles)
+            # Review pass counter must survive.
+            assert coord._review_passes[job_id] == 25
+
+        # Review-escalate fires again — must now escalate to depth 50, not 25.
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            assert await coord._maybe_escalate_reviews(session, job, titles) is True
+            assert coord._review_passes[job_id] == 50
+
+        assert depths == [25, 50]
+
+    async def test_movie_job_never_escalates(self):
+        job_id = await _seed_review(content_type=ContentType.MOVIE)
+
+        async def fake(*a, **k):
+            raise AssertionError("movies must not trigger episode re-match")
+
+        coord = _coord_with(fake)
+        result, _status = await _escalate(coord, job_id)
+        assert result is False
+        assert job_id not in coord._review_passes

--- a/backend/tests/unit/test_match_source.py
+++ b/backend/tests/unit/test_match_source.py
@@ -153,6 +153,84 @@ async def test_engram_matching_sets_match_source(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_needs_review_match_routes_to_review_not_matched(monkeypatch):
+    """A low-confidence (needs_review) result must go to REVIEW even when the
+    matcher emits a best-guess episode code — otherwise a borderline guess (e.g.
+    a bonus track that slipped past the duration pre-filter) is silently organized
+    as the wrong episode instead of being flagged. The auto review-escalation then
+    deep re-matches it; if still unresolved, the user decides."""
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"  # best guess, but...
+    mock_result.confidence = 0.41
+    mock_result.needs_review = True  # ...not confident
+    mock_result.match_details = {"method": "subtitle", "score": 0.41}
+
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.REVIEW
+        # No ENGRAM badge: the matcher never made a confident auto-match.
+        assert title.match_source is None
+
+
+@pytest.mark.asyncio
+async def test_match_respects_force_advance_race(monkeypatch):
+    """If a title is force-advanced (forced_review=True in match_details) while
+    its match task is in flight, the task's result must NOT overwrite the title.
+    Without this guard, force-advance / per-track skip can race with matching:
+    the task finishes a moment later, clobbers match_details (wiping the
+    forced_review flag), and the auto review-escalation immediately re-dispatches
+    the title — visible as 'Skip / Force does nothing.'"""
+    import json
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+
+    # Seed a title already in REVIEW with the forced_review marker (i.e. another
+    # path force-advanced it while the matching task was running).
+    job, title = await _seed_job_and_title(
+        state=TitleState.REVIEW,
+        match_details=json.dumps({"forced_review": True, "reason": "stale timeout"}),
+    )
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E03"
+    mock_result.confidence = 0.85
+    mock_result.needs_review = False
+    mock_result.match_details = {"score": 0.85, "vote_count": 7}
+
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        # Forced state must survive: REVIEW, no episode, forced_review marker intact.
+        assert title.state == TitleState.REVIEW
+        assert title.matched_episode is None
+        details = json.loads(title.match_details)
+        assert details.get("forced_review") is True
+
+
+@pytest.mark.asyncio
 async def test_discdb_match_details_stored_separately(monkeypatch):
     """discdb_match_details should be a copy of match_details at assignment time."""
     from app.core.discdb_classifier import DiscDbTitleMapping

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -137,6 +137,11 @@ class TestHandleExtras:
                 job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
             )
             assert title.state == TitleState.COMPLETED
+            # The title IS an extra — the duration pre-filter classified it as one;
+            # the move just failed (e.g. destination already exists from a previous
+            # rip). The UI should still show it as EXTRA, not as a vanilla completed
+            # track. Without this flag, the chip silently disappears.
+            assert title.is_extra is True
             assert json.loads(title.match_details)["organize_error"] == "boom"
 
 

--- a/backend/tests/unit/test_rematch.py
+++ b/backend/tests/unit/test_rematch.py
@@ -159,6 +159,30 @@ async def test_rematch_title_with_engram_clears_and_rematches(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_rematch_engram_pings_watchdog_clock(monkeypatch, tmp_path):
+    """Engram re-match dispatch pings note_activity so the stale-job watchdog
+    doesn't force-advance a job that is actively (deep) re-matching."""
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+    fake_file = staging_dir / "title_t00.mkv"
+    fake_file.touch()
+
+    job, title = await _seed_job_and_title(
+        staging_path=str(staging_dir),
+        output_filename=str(fake_file),
+    )
+
+    coordinator = _make_coordinator(monkeypatch)
+    coordinator.match_single_file = AsyncMock()
+    pinged: list[int] = []
+    coordinator._note_activity = lambda jid: pinged.append(jid)
+
+    await coordinator.rematch_single_title(job.id, title.id, source_preference="engram")
+
+    assert job.id in pinged
+
+
+@pytest.mark.asyncio
 async def test_rematch_title_missing_file_raises(monkeypatch):
     """rematch_single_title raises ValueError when staging file doesn't exist."""
     job, title = await _seed_job_and_title(
@@ -170,6 +194,52 @@ async def test_rematch_title_missing_file_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="[Ss]taging file"):
         await coordinator.rematch_single_title(job.id, title.id, source_preference="engram")
+
+
+@pytest.mark.asyncio
+async def test_rematch_single_title_deep_uses_strict_params(monkeypatch):
+    """job_manager.rematch_single_title(deep=True) threads STRICT scan params."""
+    from app.services.job_manager import job_manager
+    from app.services.matching_coordinator import STRICT_MIN_VOTES, STRICT_SCAN_POINTS
+
+    captured: dict = {}
+
+    async def _capture(
+        job_id, title_id, source_preference=None, num_points=None, min_vote_count=None
+    ):
+        captured.update(
+            source_preference=source_preference,
+            num_points=num_points,
+            min_vote_count=min_vote_count,
+        )
+
+    monkeypatch.setattr(job_manager._matching, "rematch_single_title", _capture)
+
+    await job_manager.rematch_single_title(7, 3, source_preference="engram", deep=True)
+
+    assert captured["num_points"] == STRICT_SCAN_POINTS
+    assert captured["min_vote_count"] == STRICT_MIN_VOTES
+    assert captured["source_preference"] == "engram"
+
+
+@pytest.mark.asyncio
+async def test_rematch_single_title_shallow_keeps_defaults(monkeypatch):
+    """Without deep, rematch_single_title leaves matcher params at their defaults."""
+    from app.services.job_manager import job_manager
+
+    captured: dict = {}
+
+    async def _capture(
+        job_id, title_id, source_preference=None, num_points=None, min_vote_count=None
+    ):
+        captured.update(num_points=num_points, min_vote_count=min_vote_count)
+
+    monkeypatch.setattr(job_manager._matching, "rematch_single_title", _capture)
+
+    await job_manager.rematch_single_title(7, 3, source_preference="engram")
+
+    assert captured["num_points"] is None
+    assert captured["min_vote_count"] is None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -112,7 +112,7 @@ function MainDashboard() {
   }, []);
 
   // Job management with WebSocket
-  const { jobs, titlesMap, isConnected, cancelJob, advanceJob, skipTrack, clearCompleted, setJobName, reIdentifyJob } = useJobManagement(DEV_MODE);
+  const { jobs, titlesMap, isConnected, cancelJob, advanceJob, clearCompleted, setJobName, reIdentifyJob } = useJobManagement(DEV_MODE);
   const [reIdentifyTarget, setReIdentifyTarget] = useState<Job | null>(null);
   const [bugReportJobId, setBugReportJobId] = useState<number | null>(null);
 
@@ -505,7 +505,6 @@ function MainDashboard() {
                   disc={disc}
                   onCancel={disc.state !== 'completed' && disc.state !== 'error' ? () => cancelJob(disc.id) : undefined}
                   onAdvance={disc.state !== 'completed' && disc.state !== 'error' ? () => advanceJob(disc.id) : undefined}
-                  onSkipTrack={(trackId) => skipTrack(disc.id, trackId)}
                   onReview={disc.needsReview ? () => navigate(`/review/${disc.id}`) : undefined}
                   onReIdentify={disc.needsReview && disc.title ? () => {
                     const job = jobs.find(j => String(j.id) === disc.id);

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { motion } from "motion/react";
 import { CheckCircle2, Clock, Database } from "lucide-react";
-import { IcoDisc } from "./icons";
+import { IcoDisc, IcoRetry } from "./icons";
 import { StateIndicator } from "./StateIndicator";
 import { TrackGrid } from "./TrackGrid";
 import { usePosterImage } from "./DiscCard/hooks/usePosterImage";
@@ -79,7 +79,6 @@ interface DiscCardProps {
   onReview?: () => void;
   onReIdentify?: () => void;
   onAdvance?: () => void;
-  onSkipTrack?: (trackId: string) => void;
   onReportBug?: () => void;
 }
 
@@ -174,7 +173,7 @@ function CoverOverlay({ children }: { children: React.ReactNode }) {
 }
 
 const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
-  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onSkipTrack, onReportBug }, ref) => {
+  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onReportBug }, ref) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const posterUrl = usePosterImage(disc.id, disc.title);
     const isActive = !['completed', 'error', 'idle'].includes(disc.state);
@@ -445,36 +444,72 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.yellow}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
+                  <TrackGrid tracks={disc.tracks} />
                 </div>
               )}
 
               {/* Matching */}
               {disc.state === "matching" && disc.tracks && (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  <PulseCaption
-                    color={sv.amber}
-                    extra={
-                      disc.subtitleStatus === 'downloading' ? (
-                        <span style={{ color: sv.cyan, fontSize: 10 }}>
-                          (downloading subtitles)
-                        </span>
-                      ) : undefined
-                    }
-                  >
-                    › MATCHING EPISODES…
-                  </PulseCaption>
-                  {disc.conflictStatus && (
+                  {disc.conflictStatus ? (
                     <div
+                      data-testid="deep-rematch-banner"
                       style={{
-                        fontFamily: sv.mono,
-                        fontSize: 11,
-                        color: sv.amber,
-                        letterSpacing: "0.04em",
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: 10,
+                        padding: "10px 12px",
+                        border: `1px solid ${sv.magenta}66`,
+                        background: `${sv.magenta}10`,
                       }}
                     >
-                      {disc.conflictStatus}
+                      <motion.div
+                        animate={{ rotate: 360 }}
+                        transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
+                        style={{ flexShrink: 0, marginTop: 1 }}
+                      >
+                        <IcoRetry size={14} color={sv.magenta} />
+                      </motion.div>
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div
+                          style={{
+                            fontFamily: sv.mono,
+                            fontSize: 12,
+                            fontWeight: 700,
+                            color: sv.magenta,
+                            letterSpacing: "0.08em",
+                            textTransform: "uppercase",
+                          }}
+                        >
+                          {disc.conflictStatus}
+                        </div>
+                        <div
+                          style={{
+                            fontFamily: sv.mono,
+                            fontSize: 10,
+                            color: sv.inkDim,
+                            marginTop: 4,
+                            letterSpacing: "0.02em",
+                          }}
+                        >
+                          Auto-resolving without manual review — each pass scans more of the
+                          track. This can take a few minutes per pass.
+                        </div>
+                      </div>
                     </div>
+                  ) : (
+                    <PulseCaption
+                      color={sv.amber}
+                      extra={
+                        disc.subtitleStatus === 'downloading' ? (
+                          <span style={{ color: sv.cyan, fontSize: 10 }}>
+                            (downloading subtitles)
+                          </span>
+                        ) : undefined
+                      }
+                    >
+                      › MATCHING EPISODES…
+                    </PulseCaption>
                   )}
                   <div
                     style={{
@@ -489,9 +524,9 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.green}
                     />
                     <SvStat
-                      label="IN PROGRESS"
+                      label={disc.conflictStatus ? "RE-MATCHING" : "IN PROGRESS"}
                       value={String(disc.tracks.filter(t => t.state === "matching").length)}
-                      color={sv.amber}
+                      color={disc.conflictStatus ? sv.magenta : sv.amber}
                     />
                     <SvStat
                       label="PENDING"
@@ -499,7 +534,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.inkDim}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
+                  <TrackGrid tracks={disc.tracks} conflictStatus={disc.conflictStatus} />
                 </div>
               )}
 
@@ -527,7 +562,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.purple}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
+                  <TrackGrid tracks={disc.tracks} />
                 </div>
               )}
 
@@ -537,7 +572,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   <PulseCaption color={sv.amber}>
                     › PROCESSING…
                   </PulseCaption>
-                  <TrackGrid tracks={disc.tracks} onSkip={onSkipTrack} />
+                  <TrackGrid tracks={disc.tracks} />
                 </div>
               )}
 

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -7,14 +7,19 @@ import { formatBytesBinary } from "../../utils/formatting";
 
 interface TrackGridProps {
   tracks: Track[];
-  /** Skip a single stuck track (ripping/matching) → sends it to review. */
-  onSkip?: (trackId: string) => void;
+  /** Job-level escalation note (e.g. "Resolving episode conflicts — pass 2 of 3"
+   *  / "Deep re-matching low-confidence titles — pass 1 of 3"). When set, the
+   *  currently-matching tracks get a "DEEP RE-MATCH" chip so the user sees that
+   *  the spinning matching state is an auto-resolution pass, not initial work. */
+  conflictStatus?: string;
 }
 
-// Track states where a per-track "skip" makes sense (still in flight). PENDING is
-// intentionally excluded — selected titles only briefly sit there before ripping, and
-// the backend skip endpoint still accepts PENDING if ever needed.
-const SKIPPABLE: ReadonlyArray<TrackState> = ["ripping", "matching"];
+/** Parse "… pass N of M" out of a conflict_status note, if present. */
+function parsePassInfo(note?: string): string | null {
+  if (!note) return null;
+  const m = /pass (\d+) of (\d+)/i.exec(note);
+  return m ? `${m[1]}/${m[2]}` : null;
+}
 
 interface StateConfig {
   label: string;
@@ -46,7 +51,8 @@ const matchSourceLabel = (source?: string): string => {
   return "ENGRAM";
 };
 
-export const TrackGrid = React.memo(function TrackGrid({ tracks, onSkip }: TrackGridProps) {
+export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus }: TrackGridProps) {
+  const passInfo = parsePassInfo(conflictStatus);
   return (
     <div data-testid="sv-track-grid" style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 10 }}>
       <SvLabel>TRACK STATUS</SvLabel>
@@ -125,9 +131,18 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, onSkip }: Track
                     </div>
                   )}
 
-                  {/* Quality / source / extra badges */}
-                  {(track.videoResolution || track.edition || track.isExtra || track.matchSource) && (
+                  {/* Quality / source / extra / deep-rematch badges */}
+                  {(track.videoResolution || track.edition || track.isExtra || track.matchSource || (conflictStatus && track.state === "matching")) && (
                     <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: 6 }}>
+                      {conflictStatus && track.state === "matching" && (
+                        <SvBadge
+                          size="sm"
+                          tone={sv.magenta}
+                          testid={`deep-rematch-chip-${track.id}`}
+                        >
+                          {passInfo ? `DEEP · ${passInfo}` : "DEEP RE-MATCH"}
+                        </SvBadge>
+                      )}
                       {track.matchSource && (
                         <SvBadge
                           size="sm"
@@ -149,33 +164,6 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, onSkip }: Track
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
-                  {onSkip && SKIPPABLE.includes(track.state) && (
-                    <button
-                      type="button"
-                      data-testid={`track-skip-${track.id}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (window.confirm("Skip this track and send it to review?")) {
-                          onSkip(track.id);
-                        }
-                      }}
-                      title="Skip this track — send to review"
-                      aria-label="Skip this track"
-                      style={{
-                        fontFamily: sv.mono,
-                        fontSize: 9,
-                        fontWeight: 700,
-                        letterSpacing: "0.18em",
-                        color: sv.yellow,
-                        background: "transparent",
-                        border: `1px solid ${sv.yellow}66`,
-                        padding: "2px 6px",
-                        cursor: "pointer",
-                      }}
-                    >
-                      SKIP
-                    </button>
-                  )}
                   {Icon && (
                     <motion.div
                       animate={

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -174,20 +174,6 @@ export function useJobManagement(devMode: boolean = false) {
         }
     }
 
-    async function skipTrack(jobId: string, titleId: string, target: 'review' | 'fail' = 'review') {
-        try {
-            await apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/skip`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ target }),
-            });
-            // Title + job will update via WebSocket
-        } catch (error) {
-            console.error('Failed to skip track:', error);
-            toast.error('Failed to skip the track. Please try again.');
-        }
-    }
-
     async function clearCompleted() {
         try {
             const completedJobs = jobs.filter(j => j.state === 'completed');
@@ -381,7 +367,6 @@ export function useJobManagement(devMode: boolean = false) {
         isConnected,
         cancelJob,
         advanceJob,
-        skipTrack,
         clearCompleted,
         setJobName,
         reIdentifyJob,

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -267,14 +267,18 @@ function ReviewQueue() {
 
     // --- API Handlers ---
 
-    const handleRematch = async (titleId: number, sourcePreference: string = 'engram') => {
+    const handleRematch = async (
+        titleId: number,
+        sourcePreference: string = 'engram',
+        deep: boolean = false,
+    ) => {
         setIsRematching(true);
         setError(null);
         try {
             const response = await fetch(`/api/jobs/${jobId}/titles/${titleId}/rematch`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ source_preference: sourcePreference }),
+                body: JSON.stringify({ source_preference: sourcePreference, deep }),
             });
             if (!response.ok) {
                 const text = await response.text();

--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -64,7 +64,7 @@ export function Inspector({
     aiEpisodeMatchingEnabled: boolean;
     onAssign: (code: string) => void;
     onAction: (action: TitleAction) => void;
-    onRematch: (titleId: number, source: string) => void;
+    onRematch: (titleId: number, source: string, deep?: boolean) => void;
     onDeepRematch: (episodeCode: string) => void;
     onTryLLMMatch: (titleId: number) => void;
     onAcceptLLMSuggestion: (titleId: number, episodeNumber: number) => void;
@@ -356,6 +356,20 @@ export function Inspector({
                             Try AI match
                         </SvActionButton>
                     )}
+                    {/* Per-track deep re-match — re-run the matcher on just this title
+                        at strict depth/votes (distinct from the conflict banner, which
+                        re-matches every title claiming the contested episode). */}
+                    <SvActionButton
+                        tone="magenta"
+                        size="sm"
+                        onClick={() => onRematch(title.id, 'engram', true)}
+                        disabled={isRematching}
+                        title="Deep re-match this track (denser sampling + stricter votes)"
+                        ariaLabel="Deep re-match this track"
+                    >
+                        <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                        <span style={{ marginLeft: 6 }}>Re-match</span>
+                    </SvActionButton>
                     {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
                         <SvActionButton
                             tone="magenta"


### PR DESCRIPTION
## Summary

Restores three pieces of automated-pipeline behavior that broke during the recent refactor wave (#143 simplification sweep, #165 Inspector redesign, #169 confidence calibration, #171 conflict escalation, #192 stall watchdog).

1. **TV extras lost their EXTRA chip** when `organize_tv_extras` returned an error (e.g. destination already exists). The duration pre-filter classified them correctly but `_handle_extras` didn't carry `is_extra=True` through the failure branch, so the UI showed them as vanilla completed episodes.
2. **Per-track re-match button was missing** from the Inspector. The redesign only carried over a conflict-only deep re-match and a gated-off DiscDB toggle, leaving low-confidence titles with no actionable re-match. Restored a per-track "Deep re-match this track" action that runs the strict-depth matcher (`STRICT_SCAN_POINTS=25`, `STRICT_MIN_VOTES=4`).
3. **Auto-escalation never fired for plain needs-review** titles — `_maybe_escalate_conflicts` only handled episode collisions. Added `_maybe_escalate_reviews` running on the same ladder (10 → 25 → full coverage) and broadened `_detect_conflicts` to include REVIEW titles that still carry a `matched_episode`.

## What changed

**Backend**
- `matching_coordinator.py`: needs-review results now always route to `TitleState.REVIEW` instead of being silently MATCHED with the borderline episode; dispatcher pings `_note_activity` so the stall watchdog won't kill an in-flight escalation; match application now skips stale results if a force-advance landed mid-match; `_handle_extras` failure branch sets `is_extra=True`.
- `finalization_coordinator.py`: new `_maybe_escalate_reviews` + `_review_passes` counter, separated from `_maybe_escalate_conflicts` (their clear-state helpers no longer wipe each other — a bug that pinned the ladder at pass 1); broadened `_detect_conflicts`.
- `job_manager.py`: `rematch_single_title` wrapper threads `deep: bool` through to the matcher; REVIEW transitions set `forced_review` markers for the race guard.
- `api/routes.py`: `RematchRequest` accepts `deep`; `JobResponse`/`JobDetailResponse` expose `conflict_status` to the frontend.

**Frontend**
- `Inspector.tsx`: per-track "Deep re-match this track" button restored.
- `ReviewQueue.tsx`: `handleRematch` sends `deep: true`.
- `DiscCard.tsx`: magenta conflict-status banner during escalation; "IN PROGRESS" → "RE-MATCHING" while escalating.
- `TrackGrid.tsx`: per-track "DEEP · X/Y" chips; removed the broken SKIP button (race condition made it a no-op).

**Tests** — added `test_auto_review_escalation.py` (10 cases) and extended `test_auto_conflict_escalation.py`, `test_match_source.py`, `test_matching_coordinator.py`, `test_rematch.py` for the new routing, the forced-review race guard, the broadened conflict detection, and the new `is_extra` flag on the organize-error branch.

## Verification

Backend tests:
~~~
cd backend && uv run pytest tests/unit tests/pipeline tests/integration
~~~

Frontend:
~~~
cd frontend && npm run build
~~~

End-to-end on a real Star Trek: TNG S7 Disc 2 rip (job 9): 5 short tracks correctly tagged as extras, low-confidence titles routed to REVIEW with `matched_episode` populated (not silently MATCHED), and the escalation banner cleanly advanced through pass 1 → 2 → 3 with the 10 → 25 → 92 chunk ladder. Titles that exhausted (due to a separate pre-existing precomputed-cache gap, not part of this PR) settled into REVIEW for manual assignment instead of looping forever.

## Test plan

- [ ] Backend unit + pipeline + integration tests pass
- [ ] Frontend build passes
- [ ] Simulate a TV disc with a bonus-length track → confirm `is_extra=True` chip survives even if Extras destination already exists.
- [ ] Simulate a low-confidence non-conflict title → confirm escalation banner appears and pass 1 → 2 → 3 advances at job completion.
- [ ] Open Inspector on a REVIEW title with no conflict → confirm per-track "Deep re-match" button is present and clicking it dispatches a strict-depth match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)