### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to Engram will be documented in this file.
 
+## [Unreleased]
+
 ## [0.8.0] - 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 All notable changes to Engram will be documented in this file.
 
-## [Unreleased]
+## [0.8.0] - 2026-05-26
 
 ### Added
 - **LLM episode matching (opt-in)** — when audio fingerprint matching can't confidently identify a TV episode, an LLM compares the cleaned transcript against the season's TMDB synopses and suggests an episode through the review queue. Supports Gemini, Anthropic, OpenAI, and OpenRouter providers (Gemini Flash-Lite recommended); shares the existing `ai_provider`/`ai_api_key` settings. Never auto-organizes — always requires user confirmation. (#109)
-- **Google Gemini provider** added to the AI provider list, usable by both AI title resolution and the new episode matcher.
+- **Google Gemini provider** added to the AI provider list, usable by both AI title resolution and the new LLM episode matcher.
+- **Docker / Linux container support** — official Docker image with a single-volume design (`/config` holds the database, logs, caches, and HF models). MakeMKV is compiled from source on first start to avoid redistribution restrictions; the stored MakeMKV license key is automatically seeded into MakeMKV's `settings.conf`. `docker-compose.yml` and full documentation included. (#193)
+- **LAN access toggle** — opt-in setting in Preferences that binds the server to `0.0.0.0` so the dashboard is reachable from other devices on the local network. Settings panel shows the LAN URL, a copy button, and a QR code; a "restart to apply" notice appears until the socket is rebound. The `HOST` environment variable still takes precedence for Docker / headless deployments. (#211)
+
+### Fixed
+- **TV extras tagging after organize failure** — if organizing an extras track failed (e.g. destination already exists), the `is_extra` flag was silently dropped and the UI showed the track as an ordinary completed episode instead of marking it with an EXTRA chip. (#224)
+- **Per-track deep re-match missing from inspector** — the v0.7 inspector redesign removed the per-track "Deep re-match" button for low-confidence titles; only the disc-level conflict re-match was preserved. Restored the per-track action and wired a `deep` flag through `RematchRequest` → `rematch_single_title` → matcher (stricter scan points and vote thresholds). (#224)
+- **Auto-escalation never fired for needs-review titles** — `_maybe_escalate_conflicts` only escalated episode collisions, not titles routed to REVIEW. Added `_maybe_escalate_reviews` on the same 10 → 25 → full-coverage ladder; separate pass counters for conflicts vs. reviews prevent them from clearing each other (which previously pinned the ladder at pass 1). (#224)
+- **Race condition on shared matcher temp files** — concurrent title threads writing `chunk_{start}_{dur}.wav` and `preprocessed_{stem}.wav` without a source-file disambiguator caused PyAV `InvalidDataError` when two threads sampled the same offset. Chunk and preprocessed paths now hash the canonical source path to keep them per-source. (#216)
+- **Stale precomputed-cache manifest entries** — when `manifest.json` claimed coverage for a show/season whose `.npz` was missing, the fallback warning fired once per title and the in-memory manifest was never corrected, causing repeated spurious warnings. Stale entries are now pruned from the manifest on detection. (#216)
+- **TF-IDF matcher reference-set reuse** — `TfidfMatcher` reused across calls with a different reference set (precomputed episode codes vs. scraped SRT paths) caused silent `KeyError` swallows that rejected every chunk. The matcher is rebuilt when its `reference_signature()` changes. (#216)
+- **Config dropdowns unreadable on Windows** — native `<select>` elements render with the OS-controlled light background on Windows, making options invisible against the dark Synapse v2 theme. Replaced all 7 config `<select>` elements with a new `EngramSelect` component built on Radix UI, which renders the popup as React DOM and respects theme tokens.
 
 ## [0.7.3] - 2026-05-25
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.7.3"
+__version__ = "0.8.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.7.3"
+version = "0.8.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.7.3"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.7.3",
+            "version": "0.8.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.7.3",
+    "version": "0.8.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Version bump 0.7.3 → 0.8.0 across all files (`__init__.py`, `pyproject.toml`, `package.json`, `package-lock.json`, `uv.lock`, `CHANGELOG.md`)
- Includes nine changes merged since v0.7.3:
  - **LLM episode matching (opt-in)** (#109/#217) — LLM compares transcripts against TMDB synopses when fingerprint matching is inconclusive; Gemini, Anthropic, OpenAI, OpenRouter support; always routes to review queue
  - **Google Gemini provider** — added to AI provider list for both AI title resolution and the new episode matcher
  - **Docker / Linux container support** (#193) — single-volume image, MakeMKV compiled on first start, `docker-compose.yml` + docs
  - **LAN access toggle** (#211) — bind to `0.0.0.0` with LAN URL panel, QR code, and "restart to apply" notice
  - **Fix: TV extras tagging + per-track re-match + auto-escalation** (#224) — three pipeline regressions: extras lost EXTRA chip after organize failure, per-track deep re-match missing from inspector, auto-escalation never fired for needs-review titles
  - **Fix: matcher race condition + stale manifest + TF-IDF reuse** (#216) — concurrent title threads colliding on shared temp paths; stale precomputed-cache manifest entries; TF-IDF matcher reused with wrong reference set
  - **Fix: config dropdowns unreadable on Windows** — replaced all 7 native `<select>` elements with Radix UI `EngramSelect` component so dark theme tokens apply
  - **CI: drop macOS Intel x64** (#214) — `llvmlite` 0.46 has no macOS x86_64 wheels
  - **CI: fix auto-tag → release chain** (#213) — `workflow_dispatch` fix for tag→release pipeline

## Test plan
- [x] All 6 version files updated to 0.8.0
- [x] CHANGELOG `[Unreleased]` promoted to `[0.8.0] - 2026-05-26`
- [x] `uv lock` ran cleanly (`engram-backend v0.7.3 -> v0.8.0`)
- [x] `package-lock.json` root + `packages[""]` entries patched (no full regen)
- [x] 1203 unit tests pass
- [x] Pre-commit hooks passed (ruff, format, toml checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)