### PR TITLE
fix(docker): fix MakeMKV version detection + add CI coverage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,18 @@ jobs:
           fi
           echo "smoke test passed"
 
+      - name: Verify MakeMKV version detection
+        run: |
+          VERSION=$(docker run --rm \
+            --entrypoint /usr/local/bin/install-makemkv.sh \
+            -e MAKEMKV_DETECT_ONLY=1 \
+            engram:ci)
+          if [ -z "$VERSION" ]; then
+            echo "::error::MakeMKV version detection returned empty — check if download page format changed"
+            exit 1
+          fi
+          echo "Detected MakeMKV version: $VERSION"
+
       - name: Log in to GHCR
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
           VERSION=$(docker run --rm \
             --entrypoint /usr/local/bin/install-makemkv.sh \
             -e MAKEMKV_DETECT_ONLY=1 \
-            engram:ci)
+            engram:ci || true)
           if [ -z "$VERSION" ]; then
             echo "::error::MakeMKV version detection returned empty — check if download page format changed"
             exit 1

--- a/.github/workflows/makemkv-install.yml
+++ b/.github/workflows/makemkv-install.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           MAKEMKV_VERSION: ${{ matrix.version }}
           MAKEMKV_INSTALL_DIR: /tmp/makemkv-test
-        run: bash docker/install-makemkv.sh
+        run: sudo -E bash docker/install-makemkv.sh
 
       - name: Verify makemkvcon binary
         run: |

--- a/.github/workflows/makemkv-install.yml
+++ b/.github/workflows/makemkv-install.yml
@@ -41,9 +41,13 @@ jobs:
         run: sudo -E bash docker/install-makemkv.sh
 
       - name: Verify makemkvcon binary
+        env:
+          LD_LIBRARY_PATH: /tmp/makemkv-test/lib
         run: |
           test -x /tmp/makemkv-test/bin/makemkvcon
           # makemkvcon exits non-zero without real args; capture stderr for version check.
+          # LD_LIBRARY_PATH is needed because /tmp/makemkv-test/lib isn't a system path;
+          # in the Docker container entrypoint.sh registers it via /etc/ld.so.conf.d/.
           MKVER=$(/tmp/makemkv-test/bin/makemkvcon --version 2>&1 || true)
           echo "makemkvcon output: $MKVER"
           echo "$MKVER" | grep -qE 'v[0-9]+\.[0-9]+\.[0-9]+' || {

--- a/.github/workflows/makemkv-install.yml
+++ b/.github/workflows/makemkv-install.yml
@@ -1,0 +1,53 @@
+name: MakeMKV install check
+
+on:
+  schedule:
+    - cron: "0 3 * * *"  # 3 AM UTC nightly
+  workflow_dispatch:       # manual trigger
+  push:
+    paths:
+      - "docker/install-makemkv.sh"
+
+# See ci.yml for context on the Node 24 opt-in.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  install-check:
+    name: Full MakeMKV install (${{ matrix.version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - latest    # tests version detection + real compile
+          - "1.18.3"  # pinned baseline; update when a new version releases
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install MakeMKV build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libc6-dev \
+            libssl-dev libexpat1-dev libavcodec-dev zlib1g-dev curl
+
+      - name: Run install-makemkv.sh (version=${{ matrix.version }})
+        env:
+          MAKEMKV_VERSION: ${{ matrix.version }}
+          MAKEMKV_INSTALL_DIR: /tmp/makemkv-test
+        run: bash docker/install-makemkv.sh
+
+      - name: Verify makemkvcon binary
+        run: |
+          test -x /tmp/makemkv-test/bin/makemkvcon
+          # makemkvcon exits non-zero without real args; capture stderr for version check.
+          MKVER=$(/tmp/makemkv-test/bin/makemkvcon --version 2>&1 || true)
+          echo "makemkvcon output: $MKVER"
+          echo "$MKVER" | grep -qE 'v[0-9]+\.[0-9]+\.[0-9]+' || {
+            echo "::error::makemkvcon did not print a version string"
+            exit 1
+          }
+          echo "makemkvcon installed and responsive ✓"

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -8,6 +8,7 @@
 # version is already built. Technique adapted from jlesage/docker-makemkv.
 #
 # Build is CLI-only (./configure --disable-gui) so Qt is not required.
+# CI runs this script with `sudo -E` so ldconfig can write /etc/ld.so.cache.
 set -euo pipefail
 
 INSTALL_DIR="${MAKEMKV_INSTALL_DIR:-/config/makemkv}"

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -16,12 +16,26 @@ DL_BASE="https://www.makemkv.com/download"
 MARKER="${INSTALL_DIR}/.installed-version"
 
 resolve_latest_version() {
-    # The download page lists the current tarball, e.g. makemkv-bin-1.18.1.tar.gz
+    # The download page no longer lists Linux tarballs directly; scrape the
+    # hash file link instead (e.g. makemkv-sha-1.18.3.txt) — same version
+    # format, present on every release.
     curl -fsSL "${DL_BASE}/" \
-        | grep -oE 'makemkv-bin-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' \
+        | grep -oE 'makemkv-sha-[0-9]+\.[0-9]+\.[0-9]+\.txt' \
         | head -n1 \
-        | sed -E 's/makemkv-bin-([0-9.]+)\.tar\.gz/\1/'
+        | sed -E 's/makemkv-sha-([0-9.]+)\.txt/\1/'
 }
+
+# Detect-only mode: resolve latest version, print it, and exit. Used by CI to
+# verify the download page is still parseable without running the full compile.
+if [ "${MAKEMKV_DETECT_ONLY:-}" = "1" ]; then
+    DETECTED="$(resolve_latest_version || true)"
+    if [ -z "${DETECTED}" ]; then
+        echo "ERROR: could not resolve latest MakeMKV version — download page format may have changed" >&2
+        exit 1
+    fi
+    echo "${DETECTED}"
+    exit 0
+fi
 
 if [ "${VERSION}" = "latest" ]; then
     VERSION="$(resolve_latest_version || true)"


### PR DESCRIPTION
## Summary

- **Fix broken version detection**: `resolve_latest_version()` was grepping for `makemkv-bin-*.tar.gz` which is no longer listed on the MakeMKV download page. Now scrapes the hash file link (`makemkv-sha-X.Y.Z.txt`) which is stable and present on every release.
- **Add `MAKEMKV_DETECT_ONLY=1` mode** to `install-makemkv.sh` so CI can test version detection in seconds without running the full compile.
- **New `docker.yml` step**: runs the detect-only mode inside the built image on every PR touching the Docker setup, verifying the page is still parseable and the script is correctly packaged.
- **New `makemkv-install.yml` workflow**: nightly full compile check (matrix: `latest` + pinned `1.18.3`) — catches download page format changes and build failures before users hit them.

## Root Cause

The MakeMKV download page stopped listing Linux tarball links directly. The regex `makemkv-bin-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz` matched nothing, so every container start logged `ERROR: could not resolve the latest MakeMKV version` and ripping was unavailable.

Verified fix on the server: the hash file pattern resolves to `1.18.3` correctly.

## Test Plan

- [ ] Docker CI (`docker.yml`) passes — "Verify MakeMKV version detection" step prints detected version
- [ ] Manually trigger `makemkv-install.yml` via Actions → Run workflow and confirm both matrix legs pass
- [ ] On the server: `docker compose pull && docker compose up -d` — container should compile MakeMKV on first boot and log `==> MakeMKV 1.18.3 installed at /config/makemkv.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)