### PR TITLE
fix(ci): wire Docker image publish into release pipeline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:  # manual trigger; dispatch with --ref vX.Y.Z to build and push to GHCR
   pull_request:
     paths:
       - "Dockerfile"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  actions: write  # needed to dispatch release.yml via gh workflow run
+  actions: write  # needed to dispatch release.yml and docker.yml via gh workflow run
 
 # See ci.yml for context on the Node 24 opt-in.
 env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -57,3 +57,5 @@ jobs:
           gh workflow run release.yml \
             --ref "${{ steps.version.outputs.tag }}" \
             --field tag="${{ steps.version.outputs.tag }}"
+          gh workflow run docker.yml \
+            --ref "${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Problem

`tag-release.yml` creates the version tag and dispatches `release.yml` (executables) but never dispatches `docker.yml`. Because `GITHUB_TOKEN`-pushed tags don't fire `push: tags` workflow triggers (GitHub security model), `docker.yml` only ever ran as a PR build — no GHCR push. This means v0.8.0 and v0.8.1 have no Docker image on GHCR.

## Fix

- **`docker.yml`**: add `workflow_dispatch` trigger so the workflow can be invoked manually (`gh workflow run docker.yml --ref vX.Y.Z`) or dispatched by automation. When triggered with a tag ref, `github.ref` is `refs/tags/vX.Y.Z` so the existing `startsWith(github.ref, 'refs/tags/')` push guard works without any other changes.
- **`tag-release.yml`**: dispatch `docker.yml` alongside `release.yml` after pushing the tag.

## Unblocking v0.8.1

After this PR merges, the Docker image for v0.8.1 will be dispatched manually via `gh workflow run docker.yml --ref v0.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)