### PR TITLE
fix(ci): add tag input to docker.yml for manual GHCR publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,12 @@ name: Docker
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:  # manual trigger; dispatch with --ref vX.Y.Z to build and push to GHCR
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build and push to GHCR (e.g. v0.8.1). Leave empty for a smoke-test-only branch build.'
+        required: false
+        default: ''
   pull_request:
     paths:
       - "Dockerfile"
@@ -17,6 +22,8 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   IMAGE: ghcr.io/${{ github.repository }}
+  # True for tag pushes and for manual dispatches that supply an explicit tag.
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') || inputs.tag != '' }}
 
 permissions:
   contents: read
@@ -28,6 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # When dispatched with an explicit tag, check out that tag's code.
+          ref: ${{ inputs.tag || github.sha }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -37,9 +47,9 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref }}
+            type=raw,value=latest,enable=${{ env.IS_RELEASE }}
 
       # Build once and load locally so we can smoke test before publishing.
       - name: Build image (load for smoke test)
@@ -85,7 +95,7 @@ jobs:
           echo "Detected MakeMKV version: $VERSION"
 
       - name: Log in to GHCR
-        if: startsWith(github.ref, 'refs/tags/')
+        if: env.IS_RELEASE == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -94,7 +104,7 @@ jobs:
 
       # Re-runs from the buildx cache, so this is fast.
       - name: Push image
-        if: startsWith(github.ref, 'refs/tags/')
+        if: env.IS_RELEASE == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Problem

`gh workflow run docker.yml --ref vX.Y.Z` requires `workflow_dispatch` to exist in the workflow file **at that ref**. The `v0.8.1` tag was created before PR #231 added the trigger, so dispatching to it always returns HTTP 422.

## Fix

Add a `tag` input to `workflow_dispatch` so the workflow can be triggered from `main` (which has the trigger) while still building and pushing the correct versioned image:

- `actions/checkout` uses `ref: inputs.tag || github.sha` — checks out the tag's code when a tag is supplied
- `docker/metadata-action` uses `value: inputs.tag || github.ref` for semver extraction — produces correct `0.8.1`/`0.8` image tags
- Push guards use `IS_RELEASE` env (`true` when on a tag push **or** when `inputs.tag` is non-empty)

After this merges, v0.8.1 will be published via:
```
gh workflow run docker.yml --repo Jsakkos/engram --field tag=v0.8.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)