### PR TITLE
feat: Import Watch Folder — ingest pre-ripped MKV files from ARM or any external folder

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -84,6 +84,7 @@ class JobResponse(BaseModel):
     # Transient auto-resolution note set during conflict / review escalation
     # (e.g. "Resolving episode conflicts — pass 2 of 3"). Cleared on resolution.
     conflict_status: str | None = None
+    destination_mode: str = "library"
     created_at: datetime | str | None = None
 
     model_config = {"from_attributes": True}
@@ -260,6 +261,9 @@ class ConfigResponse(BaseModel):
     opensubtitles_api_key: str  # "***" if set
     opensubtitles_username: str
     opensubtitles_password: str  # "***" if set
+    # Import watch folder
+    import_watch_path: str | None = None
+    import_destination_mode: str = "library"
     # Network access
     allow_lan_access: bool
     # Onboarding
@@ -324,6 +328,9 @@ class ConfigUpdate(BaseModel):
     opensubtitles_api_key: str | None = None
     opensubtitles_username: str | None = None
     opensubtitles_password: str | None = None
+    # Import watch folder
+    import_watch_path: str | None = None
+    import_destination_mode: str | None = None
     # Network access
     allow_lan_access: bool | None = None
     # Onboarding
@@ -998,6 +1005,9 @@ async def get_config() -> ConfigResponse:
         opensubtitles_api_key="***" if config.opensubtitles_api_key else "",  # Redacted
         opensubtitles_username=config.opensubtitles_username,
         opensubtitles_password="***" if config.opensubtitles_password else "",  # Redacted
+        # Import watch folder
+        import_watch_path=config.import_watch_path,
+        import_destination_mode=config.import_destination_mode,
         # Network access
         allow_lan_access=config.allow_lan_access,
         # Onboarding
@@ -1049,7 +1059,11 @@ async def update_config(config: ConfigUpdate) -> dict:
     from app.services.config_service import update_config as update_db_config
 
     # Build kwargs from non-None fields
-    update_data = {k: v for k, v in config.model_dump().items() if v is not None}
+    # Allow None through for import_watch_path so users can clear the field
+    _nullable_fields = {"import_watch_path"}
+    update_data = {
+        k: v for k, v in config.model_dump().items() if v is not None or k in _nullable_fields
+    }
 
     # Validate naming format strings before persisting
     from app.core.organizer import (
@@ -1079,6 +1093,18 @@ async def update_config(config: ConfigUpdate) -> dict:
 
     if update_data:
         await update_db_config(**update_data)
+
+    # Reload the staging watcher if watch-related settings changed
+    _watch_fields = {
+        "staging_watch_enabled",
+        "staging_path",
+        "import_watch_path",
+        "import_destination_mode",
+    }
+    if update_data.keys() & _watch_fields:
+        from app.services.job_manager import job_manager
+
+        await job_manager.reload_staging_watcher()
 
     return {"status": "updated", "persisted": True}
 

--- a/backend/app/core/staging_watcher.py
+++ b/backend/app/core/staging_watcher.py
@@ -10,6 +10,7 @@ Follows the same polling/callback pattern as DriveMonitor in sentinel.py.
 import asyncio
 import logging
 import os
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,9 @@ logger = logging.getLogger(__name__)
 # Number of consecutive polls with stable file sizes before triggering import
 STABILITY_THRESHOLD = 2
 
+# Matches "Season 1", "season 01", "Season 12", etc.
+_SEASON_RE = re.compile(r"^[Ss]eason\s*0*(\d+)$")
+
 
 class StagingWatcher:
     """Watches a staging directory for new subdirectories with MKV files.
@@ -27,12 +31,22 @@ class StagingWatcher:
     matching the DriveMonitor approach.
     """
 
-    def __init__(self, staging_path: str, config=None) -> None:
-        self._staging_path = Path(staging_path).expanduser()
+    def __init__(
+        self,
+        staging_path: str,
+        import_watch_path: str | None = None,
+        import_destination_mode: str = "library",
+        config=None,
+    ) -> None:
+        self._staging_path = Path(staging_path).expanduser() if staging_path else None
+        self._import_watch_path = (
+            Path(import_watch_path).expanduser() if import_watch_path else None
+        )
+        self._import_destination_mode = import_destination_mode
         self._running = False
         self._task: asyncio.Task | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._async_callback: Callable[[str, str, str], Any] | None = None
+        self._async_callback: Callable[[str, str, str, dict | None], Any] | None = None
         self._config = config
         self._poll_interval: float = 2.0
 
@@ -168,6 +182,111 @@ class StagingWatcher:
         stale_keys = [k for k in self._known_dirs if k not in seen_dirs]
         for key in stale_keys:
             del self._known_dirs[key]
+
+    def _scan_import_dir(self, root: Path) -> list[tuple[Path, int, int, dict]]:
+        """Detect ARM output structure under root and return import units.
+
+        Returns list of (dir_path, mkv_count, total_size, metadata) tuples.
+        """
+        units = []
+        try:
+            for entry in os.scandir(root):
+                if entry.is_file() and entry.name.lower().endswith(".mkv"):
+                    # Pattern C: MKVs directly in root — treat whole root as one unit
+                    mkv_count, total_size = self._count_mkvs(root)
+                    units.append(
+                        (
+                            root,
+                            mkv_count,
+                            total_size,
+                            {
+                                "structure": "flat",
+                                "show_name": None,
+                                "season": None,
+                                "destination_mode": self._import_destination_mode,
+                                "source": "import",
+                            },
+                        )
+                    )
+                    return units  # Whole root is one unit; stop scanning
+
+                if not entry.is_dir():
+                    continue
+
+                subdir = Path(entry.path)
+                # Check for Pattern B: subdir contains Season subdirs with MKVs
+                season_units = self._try_pattern_b(subdir)
+                if season_units:
+                    units.extend(season_units)
+                    continue
+
+                # Pattern A: subdir directly contains MKVs
+                mkv_count, total_size = self._count_mkvs(subdir)
+                if mkv_count > 0:
+                    units.append(
+                        (
+                            subdir,
+                            mkv_count,
+                            total_size,
+                            {
+                                "structure": "disc_folder",
+                                "show_name": None,
+                                "season": None,
+                                "destination_mode": self._import_destination_mode,
+                                "source": "import",
+                            },
+                        )
+                    )
+        except OSError as e:
+            logger.debug(f"Could not scan import directory {root}: {e}")
+        return units
+
+    def _try_pattern_b(self, show_dir: Path) -> list[tuple[Path, int, int, dict]]:
+        """Return season units if show_dir looks like a show-organised ARM folder."""
+        units = []
+        try:
+            for entry in os.scandir(show_dir):
+                if not entry.is_dir():
+                    continue
+                m = _SEASON_RE.match(entry.name)
+                if not m:
+                    continue
+                season_num = int(m.group(1))
+                season_dir = Path(entry.path)
+                mkv_count, total_size = self._count_mkvs(season_dir)
+                if mkv_count > 0:
+                    units.append(
+                        (
+                            season_dir,
+                            mkv_count,
+                            total_size,
+                            {
+                                "structure": "show_organised",
+                                "show_name": show_dir.name,
+                                "season": season_num,
+                                "destination_mode": self._import_destination_mode,
+                                "source": "import",
+                            },
+                        )
+                    )
+        except OSError:
+            pass
+        return units
+
+    def _count_mkvs(self, directory: Path) -> tuple[int, int]:
+        """Return (mkv_count, total_size_bytes) for MKVs directly inside directory."""
+        count, size = 0, 0
+        try:
+            for f in directory.iterdir():
+                if f.is_file() and f.suffix.lower() == ".mkv":
+                    count += 1
+                    try:
+                        size += f.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        return count, size
 
     def _scan_staging_dir(self) -> list[tuple[Path, int, int]]:
         """Scan staging directory for subdirectories with MKV files.

--- a/backend/app/core/staging_watcher.py
+++ b/backend/app/core/staging_watcher.py
@@ -304,8 +304,8 @@ class StagingWatcher:
                             },
                         )
                     )
-        except OSError:
-            pass
+        except OSError as e:
+            logger.debug("Could not scan show directory %s: %s", show_dir, e)
         return units
 
     def _count_mkvs(self, directory: Path) -> tuple[int, int]:
@@ -318,9 +318,9 @@ class StagingWatcher:
                     try:
                         size += f.stat().st_size
                     except OSError:
-                        pass
-        except OSError:
-            pass
+                        pass  # File removed between iterdir and stat; skip size contribution
+        except OSError as e:
+            logger.debug("Could not scan directory %s: %s", directory, e)
         return count, size
 
     def _scan_staging_dir(self) -> list[tuple[Path, int, int]]:

--- a/backend/app/core/staging_watcher.py
+++ b/backend/app/core/staging_watcher.py
@@ -110,78 +110,113 @@ class StagingWatcher:
                 logger.error(f"Error in staging watcher poll: {e}")
                 await asyncio.sleep(self._poll_interval)
 
+    async def _update_stability(
+        self,
+        dir_str: str,
+        dir_path: Path,
+        mkv_count: int,
+        total_size: int,
+        metadata: dict | None,
+    ) -> None:
+        """Shared stability tracking for staging and import entries."""
+        prev = self._known_dirs.get(dir_str)
+        if prev is None:
+            self._known_dirs[dir_str] = {
+                "mkv_count": mkv_count,
+                "total_size": total_size,
+                "stable_polls": 0,
+                "metadata": metadata,
+            }
+            logger.debug(
+                f"Watcher: new directory {dir_path.name} "
+                f"({mkv_count} MKV files, {total_size} bytes)"
+            )
+        elif prev["mkv_count"] != mkv_count or prev["total_size"] != total_size:
+            self._known_dirs[dir_str] = {
+                "mkv_count": mkv_count,
+                "total_size": total_size,
+                "stable_polls": 0,
+                "metadata": metadata,
+            }
+            logger.debug(f"Watcher: {dir_path.name} changed — stability reset")
+        else:
+            prev["stable_polls"] += 1
+            if prev["stable_polls"] >= STABILITY_THRESHOLD:
+                label = dir_path.name.upper().replace(" ", "_")
+                source = metadata["source"] if metadata else "staging"
+                logger.info(
+                    f"Watcher: {dir_path.name} is stable ({mkv_count} MKV files) — "
+                    f"triggering import (source={source})"
+                )
+                self._processed_dirs.add(dir_str)
+                del self._known_dirs[dir_str]
+                await self._notify("staging_ready", dir_str, label, metadata)
+
     async def _check_staging(self) -> None:
-        """Scan staging directory for new subdirectories with MKV files."""
-        if not self._staging_path.exists():
-            return
+        """Scan both staging and import paths for new MKV directories."""
+        # --- Existing staging scan ---
+        if self._staging_path and self._staging_path.exists():
+            try:
+                entries = await asyncio.to_thread(self._scan_staging_dir)
+            except OSError as e:
+                logger.debug(f"Could not scan staging directory: {e}")
+                entries = []
 
-        # List subdirectories (run in thread to avoid blocking)
-        try:
-            entries = await asyncio.to_thread(self._scan_staging_dir)
-        except OSError as e:
-            logger.debug(f"Could not scan staging directory: {e}")
-            return
-
-        # Track which dirs we saw this poll (for cleanup of stale entries)
-        seen_dirs: set[str] = set()
-
-        for dir_path, mkv_count, total_size in entries:
-            dir_str = str(dir_path)
-            seen_dirs.add(dir_str)
-
-            # Skip already-processed directories
-            if dir_str in self._processed_dirs:
-                continue
-
-            # Skip directories with no MKV files
-            if mkv_count == 0:
-                continue
-
-            prev = self._known_dirs.get(dir_str)
-
-            if prev is None:
-                # New directory — start tracking
-                self._known_dirs[dir_str] = {
-                    "mkv_count": mkv_count,
-                    "total_size": total_size,
-                    "stable_polls": 0,
-                }
-                logger.debug(
-                    f"Staging watcher: new directory {dir_path.name} "
-                    f"({mkv_count} MKV files, {total_size} bytes)"
+            seen_staging: set[str] = set()
+            for dir_path, mkv_count, total_size in entries:
+                dir_str = str(dir_path)
+                seen_staging.add(dir_str)
+                if dir_str in self._processed_dirs:
+                    continue
+                if mkv_count == 0:
+                    continue
+                await self._update_stability(
+                    dir_str, dir_path, mkv_count, total_size, metadata=None
                 )
-            elif prev["mkv_count"] != mkv_count or prev["total_size"] != total_size:
-                # Files changed — reset stability counter
-                self._known_dirs[dir_str] = {
-                    "mkv_count": mkv_count,
-                    "total_size": total_size,
-                    "stable_polls": 0,
-                }
-                logger.debug(
-                    f"Staging watcher: {dir_path.name} changed "
-                    f"(files: {prev['mkv_count']}→{mkv_count}, "
-                    f"size: {prev['total_size']}→{total_size})"
+
+            # Clean up tracking for staging dirs that disappeared
+            stale = [
+                k
+                for k in self._known_dirs
+                if k not in seen_staging
+                and not (
+                    self._import_watch_path and str(k).startswith(str(self._import_watch_path))
                 )
-            else:
-                # Same state — increment stability
-                prev["stable_polls"] += 1
+            ]
+            for key in stale:
+                del self._known_dirs[key]
 
-                if prev["stable_polls"] >= STABILITY_THRESHOLD:
-                    # Directory is stable — fire callback
-                    label = dir_path.name.upper().replace(" ", "_")
-                    logger.info(
-                        f"Staging watcher: {dir_path.name} is stable "
-                        f"({mkv_count} MKV files, {total_size} bytes) — "
-                        f"triggering import"
-                    )
-                    self._processed_dirs.add(dir_str)
-                    del self._known_dirs[dir_str]
-                    await self._notify("staging_ready", dir_str, label)
+        # --- Import path scan ---
+        if self._import_watch_path and self._import_watch_path.exists():
+            try:
+                import_entries = await asyncio.to_thread(
+                    self._scan_import_dir, self._import_watch_path
+                )
+            except OSError as e:
+                logger.debug(f"Could not scan import directory: {e}")
+                import_entries = []
 
-        # Clean up tracking for directories that disappeared
-        stale_keys = [k for k in self._known_dirs if k not in seen_dirs]
-        for key in stale_keys:
-            del self._known_dirs[key]
+            seen_import: set[str] = set()
+            for dir_path, mkv_count, total_size, meta in import_entries:
+                dir_str = str(dir_path)
+                seen_import.add(dir_str)
+                if dir_str in self._processed_dirs:
+                    continue
+                if mkv_count == 0:
+                    continue
+                await self._update_stability(
+                    dir_str, dir_path, mkv_count, total_size, metadata=meta
+                )
+
+            # Clean up tracking for import dirs that disappeared
+            if self._import_watch_path:
+                stale_import = [
+                    k
+                    for k in self._known_dirs
+                    if k not in seen_import and str(k).startswith(str(self._import_watch_path))
+                ]
+                for key in stale_import:
+                    del self._known_dirs[key]
 
     def _scan_import_dir(self, root: Path) -> list[tuple[Path, int, int, dict]]:
         """Detect ARM output structure under root and return import units.
@@ -317,10 +352,12 @@ class StagingWatcher:
             pass
         return results
 
-    async def _notify(self, event: str, staging_dir: str, label: str) -> None:
+    async def _notify(
+        self, event: str, staging_dir: str, label: str, metadata: dict | None = None
+    ) -> None:
         """Fire the async callback."""
         if self._async_callback:
             try:
-                await self._async_callback(event, staging_dir, label)
+                await self._async_callback(event, staging_dir, label, metadata)
             except Exception as e:
-                logger.error(f"Staging watcher callback error: {e}", exc_info=True)
+                logger.error(f"Watcher callback error: {e}", exc_info=True)

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -109,6 +109,12 @@ class AppConfig(SQLModel, table=True):
     # Staging auto-import watcher
     staging_watch_enabled: bool = False  # Auto-import MKV folders from staging directory
 
+    # Import watch folder (for ARM / external ripper ingestion)
+    import_watch_path: str | None = Field(default=None)
+    import_destination_mode: str = Field(
+        default="library", sa_column_kwargs={"server_default": text("'library'")}
+    )
+
     # TheDiscDB
     discdb_enabled: bool = True  # Enable TheDiscDB lookups for disc identification
 

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 from enum import StrEnum
 
+from sqlalchemy import text
 from sqlmodel import Field, SQLModel
 
 
@@ -92,6 +93,9 @@ class DiscJob(SQLModel, table=True):
     completed_at: datetime | None = Field(default=None)  # When job reached terminal state
     cleared_at: datetime | None = Field(default=None)  # Soft-delete: hidden from dashboard
     error_message: str | None = None
+    destination_mode: str = Field(
+        default="library", sa_column_kwargs={"server_default": text("'library'")}
+    )
     review_reason: str | None = None  # Human-readable reason why review is needed
     conflict_status: str | None = None  # Transient note while auto-resolving episode conflicts
 

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -111,10 +111,11 @@ async def update_config(**kwargs) -> AppConfig:
         # Special handling for sensitive fields: don't overwrite with empty strings
         sensitive_fields = {"makemkv_key", "tmdb_api_key"}
 
+        _nullable_fields = {"import_watch_path"}
         for key, value in kwargs.items():
             if not hasattr(config, key):
                 continue
-            if value is None:
+            if value is None and key not in _nullable_fields:
                 continue
             # Skip empty strings for sensitive fields (keep existing value)
             if key in sensitive_fields and isinstance(value, str) and not value.strip():

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -22,6 +22,19 @@ from app.services.job_state_machine import JobStateMachine
 
 logger = logging.getLogger(__name__)
 
+
+def _library_path_for_job(job, content_type: str) -> "Path | None":
+    """Return a library_path override for in_place jobs, or None for library mode."""
+    if job.destination_mode != "in_place":
+        return None
+    from app.services.config_service import get_config_sync
+
+    cfg = get_config_sync()
+    if not cfg.import_watch_path:
+        return None
+    return Path(cfg.import_watch_path) / ("Movies" if content_type == "movie" else "TV")
+
+
 # --- Automatic conflict escalation ---------------------------------------
 # When two titles match the same episode, we re-run the audio matcher on the
 # contested titles at progressively denser sampling before falling back to
@@ -690,12 +703,24 @@ class FinalizationCoordinator:
 
                 logger.info(f"Organizing Title {t.id} ({source_file.name}) -> {t.matched_episode}")
 
-                org_result = await asyncio.to_thread(
-                    tv_organizer.organize,
-                    source_file,
-                    job.detected_title,
-                    t.matched_episode,
-                )
+                _lib_path = _library_path_for_job(job, "tv")
+                if _lib_path:
+                    from app.core.organizer import organize_tv_episode
+
+                    org_result = await asyncio.to_thread(
+                        organize_tv_episode,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        t.matched_episode,
+                        _lib_path,
+                    )
+                else:
+                    org_result = await asyncio.to_thread(
+                        tv_organizer.organize,
+                        source_file,
+                        job.detected_title,
+                        t.matched_episode,
+                    )
 
                 if org_result["success"]:
                     t.state = TitleState.COMPLETED
@@ -860,12 +885,24 @@ class FinalizationCoordinator:
                         if edition and edition.lower() not in final_title.lower():
                             final_title = f"{final_title} {{edition-{edition}}}"
 
-                        org_result = await asyncio.to_thread(
-                            movie_organizer.organize,
-                            source_file,
-                            job.volume_label,
-                            final_title,
-                        )
+                        _lib_path = _library_path_for_job(job, "movie")
+                        if _lib_path:
+                            from app.core.organizer import organize_movie
+
+                            org_result = await asyncio.to_thread(
+                                organize_movie,
+                                source_file,
+                                final_title,
+                                None,  # year
+                                _lib_path,
+                            )
+                        else:
+                            org_result = await asyncio.to_thread(
+                                movie_organizer.organize,
+                                source_file,
+                                job.volume_label,
+                                final_title,
+                            )
 
                         if org_result["success"]:
                             title.state = TitleState.COMPLETED
@@ -942,23 +979,37 @@ class FinalizationCoordinator:
                         source_file = Path(disc_title.output_filename)
                         if source_file.exists():
                             if disc_title.matched_episode == "extra":
+                                _lib_path = _library_path_for_job(job, "tv")
                                 org_result = await asyncio.to_thread(
                                     organize_tv_extras,
                                     source_file,
                                     job.detected_title or job.volume_label,
                                     job.detected_season or 1,
+                                    library_path=_lib_path,
                                     disc_number=job.disc_number or 1,
                                     extra_index=extra_index,
                                     title_index=disc_title.title_index,
                                 )
                                 extra_index += 1
                             else:
-                                org_result = await asyncio.to_thread(
-                                    tv_organizer.organize,
-                                    source_file,
-                                    job.detected_title or job.volume_label,
-                                    disc_title.matched_episode,
-                                )
+                                _lib_path = _library_path_for_job(job, "tv")
+                                if _lib_path:
+                                    from app.core.organizer import organize_tv_episode
+
+                                    org_result = await asyncio.to_thread(
+                                        organize_tv_episode,
+                                        source_file,
+                                        job.detected_title or job.volume_label,
+                                        disc_title.matched_episode,
+                                        _lib_path,
+                                    )
+                                else:
+                                    org_result = await asyncio.to_thread(
+                                        tv_organizer.organize,
+                                        source_file,
+                                        job.detected_title or job.volume_label,
+                                        disc_title.matched_episode,
+                                    )
                             if org_result["success"]:
                                 success_count += 1
                                 disc_title.organized_from = source_file.name
@@ -1053,23 +1104,37 @@ class FinalizationCoordinator:
                     continue
 
                 if disc_title.matched_episode == "extra":
+                    _lib_path = _library_path_for_job(job, "tv")
                     org_result = await asyncio.to_thread(
                         organize_tv_extras,
                         source_file,
                         job.detected_title or job.volume_label,
                         job.detected_season or 1,
+                        library_path=_lib_path,
                         disc_number=job.disc_number or 1,
                         extra_index=extra_index,
                         title_index=disc_title.title_index,
                     )
                     extra_index += 1
                 else:
-                    org_result = await asyncio.to_thread(
-                        tv_organizer.organize,
-                        source_file,
-                        job.detected_title or job.volume_label,
-                        disc_title.matched_episode,
-                    )
+                    _lib_path = _library_path_for_job(job, "tv")
+                    if _lib_path:
+                        from app.core.organizer import organize_tv_episode
+
+                        org_result = await asyncio.to_thread(
+                            organize_tv_episode,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                            _lib_path,
+                        )
+                    else:
+                        org_result = await asyncio.to_thread(
+                            tv_organizer.organize,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                        )
 
                 if org_result["success"]:
                     success_count += 1

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -511,7 +511,7 @@ class FinalizationCoordinator:
 
     async def finalize_disc_job(self, job_id: int):
         """Run conflict resolution with cascading reassignment and organize matches."""
-        from app.core.organizer import tv_organizer
+        from app.core.organizer import organize_tv_episode, tv_organizer
 
         logger.info(f"Running conflict resolution for Job {job_id}")
 
@@ -705,8 +705,6 @@ class FinalizationCoordinator:
 
                 _lib_path = _library_path_for_job(job, "tv")
                 if _lib_path:
-                    from app.core.organizer import organize_tv_episode
-
                     org_result = await asyncio.to_thread(
                         organize_tv_episode,
                         source_file,
@@ -784,7 +782,13 @@ class FinalizationCoordinator:
         """Apply a user's review decision for a title."""
         from datetime import UTC, datetime
 
-        from app.core.organizer import movie_organizer, organize_tv_extras, tv_organizer
+        from app.core.organizer import (
+            movie_organizer,
+            organize_movie,
+            organize_tv_episode,
+            organize_tv_extras,
+            tv_organizer,
+        )
 
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
@@ -887,8 +891,6 @@ class FinalizationCoordinator:
 
                         _lib_path = _library_path_for_job(job, "movie")
                         if _lib_path:
-                            from app.core.organizer import organize_movie
-
                             org_result = await asyncio.to_thread(
                                 organize_movie,
                                 source_file,
@@ -978,8 +980,8 @@ class FinalizationCoordinator:
 
                         source_file = Path(disc_title.output_filename)
                         if source_file.exists():
+                            _lib_path = _library_path_for_job(job, "tv")
                             if disc_title.matched_episode == "extra":
-                                _lib_path = _library_path_for_job(job, "tv")
                                 org_result = await asyncio.to_thread(
                                     organize_tv_extras,
                                     source_file,
@@ -992,10 +994,7 @@ class FinalizationCoordinator:
                                 )
                                 extra_index += 1
                             else:
-                                _lib_path = _library_path_for_job(job, "tv")
                                 if _lib_path:
-                                    from app.core.organizer import organize_tv_episode
-
                                     org_result = await asyncio.to_thread(
                                         organize_tv_episode,
                                         source_file,
@@ -1073,7 +1072,7 @@ class FinalizationCoordinator:
 
     async def process_matched_titles(self, job_id: int) -> dict:
         """Process all matched titles for a job without waiting for unresolved ones."""
-        from app.core.organizer import organize_tv_extras, tv_organizer
+        from app.core.organizer import organize_tv_episode, organize_tv_extras, tv_organizer
 
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
@@ -1103,8 +1102,8 @@ class FinalizationCoordinator:
                     logger.warning(f"Source file not found: {source_file}")
                     continue
 
+                _lib_path = _library_path_for_job(job, "tv")
                 if disc_title.matched_episode == "extra":
-                    _lib_path = _library_path_for_job(job, "tv")
                     org_result = await asyncio.to_thread(
                         organize_tv_extras,
                         source_file,
@@ -1117,10 +1116,7 @@ class FinalizationCoordinator:
                     )
                     extra_index += 1
                 else:
-                    _lib_path = _library_path_for_job(job, "tv")
                     if _lib_path:
-                        from app.core.organizer import organize_tv_episode
-
                         org_result = await asyncio.to_thread(
                             organize_tv_episode,
                             source_file,

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -425,8 +425,10 @@ class FinalizationCoordinator:
         job.progress_percent = 100.0
         job.error_message = None
         db_config = await get_db_config()
+        _lib_path = _library_path_for_job(job, "tv")
         job.final_path = str(
-            Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
+            (_lib_path if _lib_path else Path(db_config.library_tv_path))
+            / (job.detected_title or job.volume_label)
         )
         await self._state_machine.transition_to_completed(job, session)
 
@@ -764,8 +766,10 @@ class FinalizationCoordinator:
                 from app.services.config_service import get_config as get_db_config
 
                 db_config = await get_db_config()
+                _lib_path = _library_path_for_job(job, "tv")
                 job.final_path = str(
-                    Path(db_config.library_tv_path) / (job.detected_title or job.volume_label)
+                    (_lib_path if _lib_path else Path(db_config.library_tv_path))
+                    / (job.detected_title or job.volume_label)
                 )
                 await self._state_machine.transition_to_completed(job, session)
             else:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -155,9 +155,17 @@ class JobManager:
                 self._cleanup.run_timed_cleanup(config.staging_path, config.staging_cleanup_days)
             )
 
-        # Start staging watcher if enabled
-        if config.staging_watch_enabled and config.staging_path:
-            self._staging_watcher = StagingWatcher(config.staging_path, config=config)
+        # Start staging/import watcher if either feature is enabled
+        need_watcher = (
+            config.staging_watch_enabled and config.staging_path
+        ) or config.import_watch_path
+        if need_watcher:
+            self._staging_watcher = StagingWatcher(
+                config.staging_path if config.staging_watch_enabled else "",
+                import_watch_path=config.import_watch_path or None,
+                import_destination_mode=config.import_destination_mode,
+                config=config,
+            )
             self._staging_watcher.set_async_callback(self._on_staging_event, self._loop)
             self._staging_watcher.start()
 
@@ -271,17 +279,25 @@ class JobManager:
                 logger.error(f"Failed to cancel jobs for {safe_drive}", exc_info=True)
             await event_broadcaster.broadcast_drive_removed(drive_letter, volume_label)
 
-    async def _on_staging_event(self, event: str, staging_dir: str, label: str) -> None:
+    async def _on_staging_event(
+        self, event: str, staging_dir: str, label: str, metadata: dict | None = None
+    ) -> None:
         """Handle new staging directory detection from StagingWatcher."""
-        logger.info(f"Staging event: {event} dir={staging_dir} label={label}")
+        source = metadata.get("source") if metadata else "staging"
+        logger.info(f"Staging event: {event} dir={staging_dir} label={label} source={source}")
         if event == "staging_ready":
             try:
+                is_import = bool(metadata and metadata.get("source") == "import")
                 await self.create_job_from_staging(
                     staging_path=staging_dir,
                     volume_label=label,
                     content_type="unknown",
-                    detected_title=None,
-                    detected_season=None,
+                    detected_title=metadata.get("show_name") if is_import else None,
+                    detected_season=metadata.get("season") if is_import else None,
+                    destination_mode=metadata.get("destination_mode", "library")
+                    if is_import
+                    else "library",
+                    drive_id="import" if is_import else "staging",
                 )
             except Exception as e:
                 logger.error(
@@ -357,19 +373,32 @@ class JobManager:
         content_type: str = "unknown",
         detected_title: str | None = None,
         detected_season: int | None = None,
+        destination_mode: str = "library",
+        drive_id: str = "staging",
     ) -> int:
         """Create a job from pre-ripped MKV files in a staging directory."""
+        from sqlmodel import select as sa_select
+
         staging_dir = Path(staging_path)
 
         if not volume_label:
             volume_label = staging_dir.name.upper().replace(" ", "_")
 
         async with async_session() as session:
+            # Guard: don't create a duplicate job for the same staging directory
+            existing = await session.execute(
+                sa_select(DiscJob).where(DiscJob.staging_path == str(staging_dir))
+            )
+            if existing.scalar_one_or_none():
+                logger.info(f"Job already exists for staging path {staging_dir}, skipping")
+                return -1
+
             job = DiscJob(
-                drive_id="staging",
+                drive_id=drive_id,
                 volume_label=volume_label,
                 staging_path=str(staging_dir),
                 state=JobState.IDENTIFYING,
+                destination_mode=destination_mode,
             )
 
             if content_type in ("tv", "movie"):
@@ -385,10 +414,11 @@ class JobManager:
 
             job_id = job.id
             logger.info(
-                f"Created staging import job {job_id} from {staging_path} (label: {volume_label})"
+                f"Created {'import' if drive_id == 'import' else 'staging'} job {job_id} "
+                f"from {staging_path} (label: {volume_label}, destination: {destination_mode})"
             )
 
-        await event_broadcaster.broadcast_drive_inserted("staging", volume_label)
+        await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)
 
         task = asyncio.create_task(
             with_job_log_context(job_id, self._identification.identify_from_staging(job_id))

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -415,7 +415,8 @@ class JobManager:
                 sa_select(DiscJob).where(DiscJob.staging_path == str(staging_dir))
             )
             if existing.scalar_one_or_none():
-                logger.info(f"Job already exists for staging path {staging_dir}, skipping")
+                safe_path = str(staging_dir).replace("\n", "").replace("\r", "")
+                logger.info("Job already exists for staging path %s, skipping", safe_path)
                 return -1
 
             job = DiscJob(
@@ -438,9 +439,15 @@ class JobManager:
             await session.refresh(job)
 
             job_id = job.id
+            safe_path = str(staging_path).replace("\n", "").replace("\r", "")
+            safe_label = str(volume_label).replace("\n", "").replace("\r", "")
             logger.info(
-                f"Created {'import' if drive_id == 'import' else 'staging'} job {job_id} "
-                f"from {staging_path} (label: {volume_label}, destination: {destination_mode})"
+                "Created %s job %s from %s (label: %s, destination: %s)",
+                "import" if drive_id == "import" else "staging",
+                job_id,
+                safe_path,
+                safe_label,
+                destination_mode,
             )
 
         await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -219,6 +219,31 @@ class JobManager:
                 )
                 logger.info(f"Restored {len(mappings_data)} DiscDB mappings for job {job.id}")
 
+    async def reload_staging_watcher(self) -> None:
+        """Stop and restart the staging/import watcher with the current DB config."""
+        from app.services.config_service import get_config as get_db_config
+
+        if self._staging_watcher:
+            self._staging_watcher.stop()
+            self._staging_watcher = None
+
+        config = await get_db_config()
+        need_watcher = (
+            config.staging_watch_enabled and config.staging_path
+        ) or config.import_watch_path
+        if need_watcher:
+            self._staging_watcher = StagingWatcher(
+                config.staging_path if config.staging_watch_enabled else "",
+                import_watch_path=config.import_watch_path or None,
+                import_destination_mode=config.import_destination_mode,
+                config=config,
+            )
+            self._staging_watcher.set_async_callback(self._on_staging_event, self._loop)
+            self._staging_watcher.start()
+            logger.info(
+                f"Staging watcher reloaded (import_watch_path={config.import_watch_path!r})"
+            )
+
     async def stop(self) -> None:
         """Stop the job manager and clean up."""
         self._drive_monitor.stop()

--- a/backend/tests/unit/test_staging_watcher.py
+++ b/backend/tests/unit/test_staging_watcher.py
@@ -259,3 +259,118 @@ class TestStagingWatcherLifecycle:
         watcher.stop()
         watcher.stop()  # Should be no-op, no error
         assert watcher._running is False
+
+
+class TestImportWatcherStructureDetection:
+    """Tests for ARM output structure detection in _scan_import_dir."""
+
+    async def test_pattern_a_per_disc_subfolders(self, tmp_path):
+        """Direct subdirectory with MKVs → one import unit per subdir."""
+        watch_root = tmp_path / "arm_output"
+        watch_root.mkdir()
+        disc1 = watch_root / "THE_OFFICE_S1D1"
+        disc1.mkdir()
+        (disc1 / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+        (disc1 / "title_t02.mkv").write_bytes(b"\x00" * 2048)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(watch_root))
+        units = watcher._scan_import_dir(watch_root)
+
+        assert len(units) == 1
+        path, mkv_count, total_size, meta = units[0]
+        assert path == disc1
+        assert mkv_count == 2
+        assert total_size == 3072
+        assert meta["structure"] == "disc_folder"
+        assert meta["show_name"] is None
+        assert meta["season"] is None
+
+    async def test_pattern_b_show_organised(self, tmp_path):
+        """Show dir with Season subdirs → one job unit per season."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        show = watch_root / "The Office"
+        show.mkdir()
+        s1 = show / "Season 1"
+        s1.mkdir()
+        (s1 / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+        s2 = show / "Season 2"
+        s2.mkdir()
+        (s2 / "title_t01.mkv").write_bytes(b"\x00" * 2048)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(watch_root))
+        units = watcher._scan_import_dir(watch_root)
+
+        assert len(units) == 2
+        seasons = {meta["season"]: (path, meta) for path, _, _, meta in units}
+        assert 1 in seasons and 2 in seasons
+        assert seasons[1][1]["show_name"] == "The Office"
+        assert seasons[1][1]["structure"] == "show_organised"
+        assert seasons[1][0] == s1
+        assert seasons[2][0] == s2
+
+    async def test_pattern_c_flat(self, tmp_path):
+        """MKVs directly in root → single job unit for whole directory."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        (watch_root / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+        (watch_root / "title_t02.mkv").write_bytes(b"\x00" * 2048)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(watch_root))
+        units = watcher._scan_import_dir(watch_root)
+
+        assert len(units) == 1
+        path, mkv_count, total_size, meta = units[0]
+        assert path == watch_root
+        assert mkv_count == 2
+        assert total_size == 3072
+        assert meta["structure"] == "flat"
+
+    async def test_mixed_patterns_in_root(self, tmp_path):
+        """Root can contain both per-disc subfolders and show-organised subdirs."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        disc = watch_root / "BOB_S1D1"
+        disc.mkdir()
+        (disc / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+        show = watch_root / "The Wire"
+        show.mkdir()
+        s1 = show / "Season 1"
+        s1.mkdir()
+        (s1 / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(watch_root))
+        units = watcher._scan_import_dir(watch_root)
+
+        assert len(units) == 2
+        structures = {meta["structure"] for _, _, _, meta in units}
+        assert structures == {"disc_folder", "show_organised"}
+
+    async def test_empty_subdir_ignored(self, tmp_path):
+        """Subdirectories with no MKV files are not returned."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        empty = watch_root / "EMPTY_DIR"
+        empty.mkdir()
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(watch_root))
+        units = watcher._scan_import_dir(watch_root)
+
+        assert units == []
+
+    async def test_destination_mode_in_metadata(self, tmp_path):
+        """destination_mode from constructor appears in metadata."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        disc = watch_root / "DISC1"
+        disc.mkdir()
+        (disc / "t.mkv").write_bytes(b"\x00" * 100)
+
+        watcher = StagingWatcher(
+            "/tmp/staging",
+            import_watch_path=str(watch_root),
+            import_destination_mode="in_place",
+        )
+        units = watcher._scan_import_dir(watch_root)
+
+        assert units[0][3]["destination_mode"] == "in_place"

--- a/backend/tests/unit/test_staging_watcher.py
+++ b/backend/tests/unit/test_staging_watcher.py
@@ -374,3 +374,113 @@ class TestImportWatcherStructureDetection:
         units = watcher._scan_import_dir(watch_root)
 
         assert units[0][3]["destination_mode"] == "in_place"
+
+
+class TestImportWatcherPolling:
+    """Tests for the full poll loop with import paths."""
+
+    async def test_import_dir_fires_after_stability(self, tmp_path):
+        """Import unit fires callback after STABILITY_THRESHOLD stable polls."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        disc = watch_root / "THE_OFFICE_S1D1"
+        disc.mkdir()
+        (disc / "title_t01.mkv").write_bytes(b"\x00" * 1024)
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        watcher = StagingWatcher(str(staging), import_watch_path=str(watch_root))
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        await watcher._check_staging()
+        callback.assert_not_called()
+
+        await watcher._check_staging()
+        callback.assert_called_once()
+
+        args = callback.call_args[0]
+        assert args[0] == "staging_ready"
+        assert args[1] == str(disc)
+        metadata = args[3] if len(args) > 3 else None
+        assert metadata is not None
+        assert metadata["source"] == "import"
+        assert metadata["structure"] == "disc_folder"
+
+    async def test_import_not_retriggered_after_fire(self, tmp_path):
+        """Import unit is not re-triggered in subsequent polls."""
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+        disc = watch_root / "DISC1"
+        disc.mkdir()
+        (disc / "t.mkv").write_bytes(b"\x00" * 100)
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        watcher = StagingWatcher(str(staging), import_watch_path=str(watch_root))
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        for _ in range(3):
+            await watcher._check_staging()
+        assert callback.call_count == 1
+
+        for _ in range(5):
+            await watcher._check_staging()
+        assert callback.call_count == 1
+
+    async def test_staging_and_import_fire_independently(self, tmp_path):
+        """Existing staging scan and import scan are both active simultaneously."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        watch_root = tmp_path / "arm"
+        watch_root.mkdir()
+
+        disc = watch_root / "IMPORT_DISC"
+        disc.mkdir()
+        (disc / "t.mkv").write_bytes(b"\x00" * 100)
+
+        staging_sub = staging / "STAGING_DISC"
+        staging_sub.mkdir()
+        (staging_sub / "t.mkv").write_bytes(b"\x00" * 100)
+
+        watcher = StagingWatcher(str(staging), import_watch_path=str(watch_root))
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        for _ in range(3):
+            await watcher._check_staging()
+
+        assert callback.call_count == 2
+        # One call should have metadata with source="import", other with metadata=None
+        sources = set()
+        for call in callback.call_args_list:
+            args = call[0]
+            meta = args[3] if len(args) > 3 else None
+            sources.add(meta["source"] if meta else "staging")
+        assert "import" in sources
+        assert "staging" in sources
+
+    async def test_metadata_fourth_arg_is_none_for_staging(self, tmp_path):
+        """Existing staging path callback passes None as fourth argument."""
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        sub = staging / "DISC"
+        sub.mkdir()
+        (sub / "t.mkv").write_bytes(b"\x00" * 100)
+
+        watcher = StagingWatcher(str(staging))
+        callback = AsyncMock()
+        watcher._async_callback = callback
+
+        for _ in range(3):
+            await watcher._check_staging()
+
+        callback.assert_called_once()
+        args = callback.call_args[0]
+        # Fourth arg should be None for staging-path callbacks
+        assert len(args) == 4
+        assert args[3] is None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -642,29 +642,6 @@
             "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
             "license": "MIT"
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -642,6 +642,29 @@
             "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
             "license": "MIT"
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -292,6 +292,8 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
               {/* Source badge — folder icon for watch-folder-imported jobs */}
               {disc.sourceType === 'import' && (
                 <div
+                  role="img"
+                  aria-label="Imported from watch folder"
                   title="Imported from watch folder"
                   style={{
                     position: "absolute",

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion } from "motion/react";
-import { CheckCircle2, Clock, Database } from "lucide-react";
+import { CheckCircle2, Clock, Database, Folder } from "lucide-react";
 import { IcoDisc, IcoRetry } from "./icons";
 import { StateIndicator } from "./StateIndicator";
 import { TrackGrid } from "./TrackGrid";
@@ -58,6 +58,7 @@ export interface DiscData {
   title: string;
   subtitle?: string;
   discLabel?: string;
+  sourceType?: 'disc' | 'import' | 'staging';
   coverUrl: string;
   mediaType: MediaType;
   state: DiscState;
@@ -287,6 +288,28 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
               <div style={{ position: "absolute", top: 6, left: 6, zIndex: 2 }}>
                 <MediaTypeBadge mediaType={disc.mediaType} />
               </div>
+
+              {/* Source badge — folder icon for watch-folder-imported jobs */}
+              {disc.sourceType === 'import' && (
+                <div
+                  title="Imported from watch folder"
+                  style={{
+                    position: "absolute",
+                    top: 6,
+                    right: 6,
+                    zIndex: 2,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 24,
+                    height: 24,
+                    background: `${sv.bg2}cc`,
+                    border: `1px solid ${sv.line}`,
+                  }}
+                >
+                  <Folder size={13} color={sv.cyanHi} />
+                </div>
+              )}
             </motion.div>
 
             {/* Content */}

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -505,7 +505,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                         </div>
 
                         <div className="form-group" style={{ marginTop: '1.5rem' }}>
-                            <label>Import Watch Folder</label>
+                            <label htmlFor="importWatchPath">Import Watch Folder</label>
                             <span className="form-hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
                                 Automatically import MKV files ripped by AutomaticRippingMachine or similar tools.
                                 Engram detects per-disc subfolders, show-organised trees, and flat layouts.
@@ -543,9 +543,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                                     padding: '0.375rem 0.875rem',
                                                     fontSize: '0.85rem',
                                                     cursor: 'pointer',
-                                                    background: config.importDestinationMode === mode ? 'var(--accent-cyan, #00b4d8)' : 'transparent',
-                                                    color: config.importDestinationMode === mode ? '#000' : 'inherit',
-                                                    border: '1px solid var(--border-faint, #444)',
+                                                    background: config.importDestinationMode === mode ? 'var(--color-sv-cyan)' : 'transparent',
+                                                    color: config.importDestinationMode === mode ? 'var(--color-sv-bg0)' : 'inherit',
+                                                    border: '1px solid var(--color-sv-line-mid)',
                                                     fontWeight: config.importDestinationMode === mode ? 700 : 400,
                                                     marginRight: mode === 'library' ? -1 : 0,
                                                 }}

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -81,6 +81,8 @@ interface ConfigData {
     opensubtitlesUsername: string;
     opensubtitlesPassword: string;
     allowLanAccess: boolean;
+    importWatchPath: string;
+    importDestinationMode: string;
 }
 
 interface NetworkInfo {
@@ -142,6 +144,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         opensubtitlesUsername: '',
         opensubtitlesPassword: '',
         allowLanAccess: false,
+        importWatchPath: '',
+        importDestinationMode: 'library',
     });
     const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
     const [isSaving, setIsSaving] = useState(false);
@@ -224,6 +228,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     opensubtitlesUsername: data.opensubtitles_username || '',
                     opensubtitlesPassword: data.opensubtitles_password === '***' ? '' : (data.opensubtitles_password || ''),
                     allowLanAccess: data.allow_lan_access ?? false,
+                    importWatchPath: data.import_watch_path || '',
+                    importDestinationMode: data.import_destination_mode || 'library',
                 });
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -328,6 +334,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     opensubtitles_username: config.opensubtitlesUsername,
                     ...optional('opensubtitles_password', config.opensubtitlesPassword),
                     allow_lan_access: config.allowLanAccess,
+                    import_watch_path: config.importWatchPath || null,
+                    import_destination_mode: config.importDestinationMode,
                     setup_complete: true,
                 }),
             });
@@ -494,6 +502,65 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 onChange={(e) => handleInputChange('libraryTvPath', e.target.value)}
                                 placeholder="e.g., D:\Media\TV Shows"
                             />
+                        </div>
+
+                        <div className="form-group" style={{ marginTop: '1.5rem' }}>
+                            <label>Import Watch Folder</label>
+                            <span className="form-hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
+                                Automatically import MKV files ripped by AutomaticRippingMachine or similar tools.
+                                Engram detects per-disc subfolders, show-organised trees, and flat layouts.
+                            </span>
+                            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+                                <input
+                                    id="importWatchPath"
+                                    type="text"
+                                    value={config.importWatchPath}
+                                    onChange={(e) => handleInputChange('importWatchPath', e.target.value)}
+                                    placeholder="Not configured (e.g., D:\ARM-Output or /mnt/arm)"
+                                    style={{ flex: 1 }}
+                                />
+                                {config.importWatchPath && (
+                                    <button
+                                        type="button"
+                                        className="btn-secondary"
+                                        onClick={() => handleInputChange('importWatchPath', '')}
+                                        style={{ whiteSpace: 'nowrap', padding: '0.375rem 0.75rem', fontSize: '0.85rem' }}
+                                    >
+                                        Clear
+                                    </button>
+                                )}
+                            </div>
+                            {config.importWatchPath && (
+                                <div style={{ marginTop: '0.75rem' }}>
+                                    <label style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.85rem', fontWeight: 600 }}>Destination</label>
+                                    <div style={{ display: 'flex', gap: 0, flexWrap: 'wrap' }}>
+                                        {(['library', 'in_place'] as const).map(mode => (
+                                            <button
+                                                key={mode}
+                                                type="button"
+                                                onClick={() => handleInputChange('importDestinationMode', mode)}
+                                                style={{
+                                                    padding: '0.375rem 0.875rem',
+                                                    fontSize: '0.85rem',
+                                                    cursor: 'pointer',
+                                                    background: config.importDestinationMode === mode ? 'var(--accent-cyan, #00b4d8)' : 'transparent',
+                                                    color: config.importDestinationMode === mode ? '#000' : 'inherit',
+                                                    border: '1px solid var(--border-faint, #444)',
+                                                    fontWeight: config.importDestinationMode === mode ? 700 : 400,
+                                                    marginRight: mode === 'library' ? -1 : 0,
+                                                }}
+                                            >
+                                                {mode === 'library' ? 'Organize into library' : 'Organize in place'}
+                                            </button>
+                                        ))}
+                                    </div>
+                                    <span className="form-hint">
+                                        {config.importDestinationMode === 'library'
+                                            ? 'Files are moved into your configured TV and movie library paths.'
+                                            : 'Files are organized within the watch folder itself (TV/ and Movies/ subdirectories).'}
+                                    </span>
+                                </div>
+                            )}
                         </div>
                     </div>
                 );

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -55,6 +55,9 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     title: job.detected_title || job.volume_label,
     subtitle: `${displayType} • ${job.volume_label}`,
     discLabel: job.volume_label,
+    sourceType: job.drive_id === 'import' ? 'import'
+      : job.drive_id === 'staging' ? 'staging'
+      : 'disc',
     coverUrl: `/api/jobs/${job.id}/poster`,
     mediaType: mediaType,
     state: mapJobStateToDiscState(job.state),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,6 +37,7 @@ export interface Job {
     subtitles_failed?: number;
     review_reason?: string | null;
     conflict_status?: string | null;
+    destination_mode?: string;
     created_at?: string;
 }
 


### PR DESCRIPTION
## Summary

- Adds an **Import Watch Folder** config option: point Engram at an ARM output directory (or any folder of MKVs) and it automatically creates identification → matching → organisation jobs, just like physical discs
- Detects three ARM output layouts: per-disc subfolders (Pattern A), show-organised Season directories (Pattern B), and flat MKVs (Pattern C)
- Two destination modes: `library` (organise into the configured TV/movie library paths) and `in_place` (organise within the watch root itself, useful when ARM output is your library)
- Import jobs appear on the dashboard with a folder icon badge distinguishing them from disc-originated jobs

## What Changed

**Backend**
- `AppConfig` gains `import_watch_path` and `import_destination_mode` fields (auto-added via `_add_missing_columns`)
- `DiscJob` gains `destination_mode` field (defaults `"library"`)
- `StagingWatcher` gains `_scan_import_path()` — runs alongside the existing staging scan, detects all three ARM patterns, fires extended `staging_ready` events carrying `show_name`, `season`, and `destination_mode` metadata; includes DB-level duplicate guard that survives server restarts
- `JobManager._on_staging_event()` routes import metadata into `create_job_from_staging()` with `drive_id="import"`
- `JobManager.reload_staging_watcher()` — stops and restarts the watcher on config change; called from `PUT /api/config` when any watch-related field changes
- `FinalizationCoordinator` checks `job.destination_mode`; `in_place` jobs route through bare organiser functions (`organize_tv_episode`, `organize_movie`, `organize_tv_extras`) with the watch root as `library_path` override
- `GET /api/config` and `PUT /api/config` expose the two new fields; `import_watch_path` is exempt from the "skip None" filter so it can be cleared

**Frontend**
- `ConfigWizard` step 1 gets an **Import Watch Folder** section: path input, Clear button, and a two-option destination toggle (only visible when a path is entered)
- `DiscCard` shows a `Folder` icon badge (top-right of cover art, mirroring the media-type badge) for jobs with `drive_id === "import"`
- `types/index.ts`: `Job.destination_mode` added; `adapters.ts`: `sourceType` derived from `drive_id`

## Test Plan
- [ ] Configure import watch path in Settings → path persists across page reload
- [ ] Drop a per-disc subfolder of MKVs into the watch path → job appears on dashboard within ~5 s with folder icon badge
- [ ] Show-organised tree (show/Season N/\*.mkv) → one job per season folder with correct detected title and season hint
- [ ] Flat MKVs at watch root → single job covering all files
- [ ] `in_place` mode → organised files land under `{watch_root}/TV/Show/Season 01/` instead of global library
- [ ] `library` mode → organised files land in configured TV/movie library paths
- [ ] Clear path in Settings → watcher stops; no new jobs created from that path
- [ ] Server restart with import path configured → already-processed folders are not re-queued (DB duplicate guard)
- [ ] 1305 backend tests pass: `cd backend && uv run pytest`
- [ ] TypeScript compiles: `cd frontend && npm run build`

## Spec / Plan

Design spec: `docs/superpowers/specs/2026-05-26-import-watch-folder-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-26-import-watch-folder.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)