### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-26
+
+### Added
+- **Import Watch Folder** — point Engram at any folder of pre-ripped MKV files (ARM output, NAS share, etc.) and it ingests them through the same identification → matching → organizing pipeline as a freshly ripped disc. Configured in Settings → Import Watch Folder; the watcher polls on a configurable interval and skips files still being written. (#233)
+- **Auto-update** — Engram now checks for new releases at startup, silently downloads the update in the background, verifies the SHA256 checksum, and prompts with a banner to "Restart to apply." Updates can be skipped per-version. Works for frozen (packaged) builds on Windows, macOS, and Linux; no-ops in development mode. (#235)
+
+### Fixed
+- **TVsubtitles show mislabeling** — the resolver previously took the first search hit without verifying the show name, so e.g. "2 Broke Girls" could be matched to Gilmore Girls, corrupting the cache. Results are now filtered by title similarity before accepting a match. Adds `audit_subtitle_cache.py` and `verify_cache_content.py` scripts for cache health checks. (#202)
+- **Docker image not published on release** — the `release.yml` dispatch in `tag-release.yml` was missing the `docker.yml` dispatch step, so Docker images were never pushed to GHCR on tagged releases. Also adds a manual `tag` input to `docker.yml` so a specific release can be re-published without re-running the full pipeline. (#231, #232)
+- **CI permission error on `tag-release.yml`** — the `actions: write` permission required to dispatch `release.yml` and `docker.yml` was missing, causing workflow dispatch to fail with a 403. (#230)
+
 ## [0.8.1] - 2026-05-26
 
 ### Fixed

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.8.1"
+version = "0.9.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.8.0",
+    "version": "0.9.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Bumps version to 0.9.0 and updates CHANGELOG.

## Changes in this release

- **Import Watch Folder** ([#233](https://github.com/Jsakkos/engram/pull/233)) — ingest pre-ripped MKV files from ARM output folders or any external watch folder through the full identification → matching → organizing pipeline.
- **Auto-update** ([#235](https://github.com/Jsakkos/engram/pull/235)) — startup check, silent download, SHA256 verification, and restart-to-apply banner. Skippable per-version. Frozen builds only (no-op in dev mode).
- **TVsubtitles show mislabeling fix** ([#202](https://github.com/Jsakkos/engram/pull/202)) — first search result no longer accepted without name verification; adds cache audit scripts.
- **Docker release publishing fixed** ([#231](https://github.com/Jsakkos/engram/pull/231), [#232](https://github.com/Jsakkos/engram/pull/232)) — `docker.yml` dispatch was missing from `tag-release.yml`; adds manual tag input for targeted re-publishes.
- **CI permission error fixed** ([#230](https://github.com/Jsakkos/engram/pull/230)) — `actions: write` permission added to `tag-release.yml`.

## Release process

Merging this PR (squash) triggers `tag-release.yml`, which creates the `v0.9.0` tag and dispatches `release.yml` to build platform executables and `docker.yml` to publish the Docker image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)