### PR TITLE
fix(extractor): require 3 consecutive stable size polls before title completion

### DIFF
--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -28,6 +28,11 @@ _CREATED_MKV_PATTERN = re.compile(r'["\']([^"\']+\.mkv)["\']')
 # callback and the job_manager fallback so the live update and History agree.
 STALL_FAILURE_REASON = "Ripping stalled — no progress; the disc may be dirty or damaged."
 
+# Consecutive stable-size polls required before declaring in-flight title completion.
+# Each poll is ~3 s apart, so STABLE_CHECKS_REQUIRED=3 means ~9 s of write-silence.
+# Post-process force checks bypass this requirement (process exit guarantees write done).
+STABLE_CHECKS_REQUIRED = 3
+
 
 def _to_drive_spec(drive: str) -> str:
     """Normalize a drive identifier into a MakeMKV drive spec.
@@ -450,10 +455,7 @@ class MakeMKVExtractor:
         # by brief MakeMKV write pauses (e.g. buffering or disc seeking) that
         # may hold the file size constant for one polling interval (~3 s).
         stable_counts: dict[str, int] = {}
-        # How many consecutive stable size polls are needed to declare a file
-        # complete *while the MakeMKV process is still running*.  Post-process
-        # force checks bypass this requirement entirely.
-        STABLE_CHECKS_REQUIRED = 3  # 3 × 3 s ≈ 9 s of write-silence needed
+        # STABLE_CHECKS_REQUIRED is a module-level constant (see top of file).
         _fs_lock = threading.Lock()
 
         def _fire_title_complete(fname: str, size: int) -> None:
@@ -701,8 +703,9 @@ class MakeMKVExtractor:
                         if len(commands) > 1:
                             break
 
-                    # Final fs check for this command — process has exited so
-                    # the write is guaranteed done; bypass stability counter.
+                    # Final fs check for this command.  process.wait() has
+                    # returned (success *or* error exit) so MakeMKV is no longer
+                    # writing; bypass the stability counter.
                     _check_for_completed_files(force=True)
 
                 # End of all commands

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -444,10 +444,45 @@ class MakeMKVExtractor:
         # Shared state for filesystem-based title completion detection.
         known_files: dict[str, int] = {}  # filename -> last known size
         completed_files: set[str] = set()
+        # Tracks consecutive polls where the file size has been stable.  We
+        # require STABLE_CHECKS_REQUIRED consecutive stable readings before
+        # declaring in-flight completion, which avoids false positives caused
+        # by brief MakeMKV write pauses (e.g. buffering or disc seeking) that
+        # may hold the file size constant for one polling interval (~3 s).
+        stable_counts: dict[str, int] = {}
+        # How many consecutive stable size polls are needed to declare a file
+        # complete *while the MakeMKV process is still running*.  Post-process
+        # force checks bypass this requirement entirely.
+        STABLE_CHECKS_REQUIRED = 3  # 3 × 3 s ≈ 9 s of write-silence needed
         _fs_lock = threading.Lock()
 
-        def _check_for_completed_files():
-            """Scan output dir for newly completed .mkv files."""
+        def _fire_title_complete(fname: str, size: int) -> None:
+            """Mark *fname* complete and invoke the title callback (lock held)."""
+            completed_files.add(fname)
+            stable_counts.pop(fname, None)
+            filepath = output_dir / fname
+            output_files.append(filepath)
+            logger.info(f"Title file completed: {fname} ({size / 1024 / 1024:.0f} MB)")
+            if title_complete_callback:
+                _safe_callback(
+                    title_complete_callback,
+                    len(completed_files),
+                    filepath,
+                    label="title complete callback",
+                )
+
+        def _check_for_completed_files(force: bool = False) -> None:
+            """Scan output dir for newly completed .mkv files.
+
+            In-flight (``force=False``): requires *STABLE_CHECKS_REQUIRED*
+            consecutive polls with an identical, non-zero size before firing.
+            This prevents false positives from MakeMKV briefly pausing writes
+            between disc segments or while buffering.
+
+            Post-process (``force=True``): fires immediately for any file with
+            a non-zero size not yet marked complete.  Called after
+            ``process.wait()`` returns so the write is guaranteed finished.
+            """
             with _fs_lock:
                 try:
                     for mkv in output_dir.glob("*.mkv"):
@@ -456,22 +491,18 @@ class MakeMKVExtractor:
                             continue
                         current_size = mkv.stat().st_size
                         if fname in known_files:
-                            if current_size == known_files[fname] and current_size > 0:
-                                # Size stable between checks = file is complete
-                                completed_files.add(fname)
-                                filepath = output_dir / fname
-                                output_files.append(filepath)
-                                logger.info(
-                                    f"Title file completed: {fname} "
-                                    f"({current_size / 1024 / 1024:.0f} MB)"
-                                )
-                                if title_complete_callback:
-                                    _safe_callback(
-                                        title_complete_callback,
-                                        len(completed_files),
-                                        filepath,
-                                        label="title complete callback",
-                                    )
+                            if current_size > 0:
+                                if force:
+                                    # Process exited: write is guaranteed done.
+                                    _fire_title_complete(fname, current_size)
+                                elif current_size == known_files[fname]:
+                                    # Size unchanged since last check — increment counter.
+                                    stable_counts[fname] = stable_counts.get(fname, 0) + 1
+                                    if stable_counts[fname] >= STABLE_CHECKS_REQUIRED:
+                                        _fire_title_complete(fname, current_size)
+                                else:
+                                    # File is still growing — reset stability counter.
+                                    stable_counts[fname] = 0
                         known_files[fname] = current_size
                 except (OSError, PermissionError) as e:
                     logger.exception(f"Error checking for completed files: {e}")
@@ -670,8 +701,9 @@ class MakeMKVExtractor:
                         if len(commands) > 1:
                             break
 
-                    # Final fs check for this command
-                    _check_for_completed_files()
+                    # Final fs check for this command — process has exited so
+                    # the write is guaranteed done; bypass stability counter.
+                    _check_for_completed_files(force=True)
 
                 # End of all commands
                 return (final_returncode, combined_stderr, stalled_commands)
@@ -706,8 +738,9 @@ class MakeMKVExtractor:
 
                     await asyncio.sleep(0.1)  # Yield to other tasks
 
-                # Final filesystem check after process exits
-                await asyncio.to_thread(_check_for_completed_files)
+                # Final filesystem check after process exits — force mode so
+                # any title not yet fired by the stability counter is caught.
+                await asyncio.to_thread(lambda: _check_for_completed_files(force=True))
 
                 returncode, stderr, stalled = future.result()
 

--- a/backend/tests/unit/test_extractor_callbacks.py
+++ b/backend/tests/unit/test_extractor_callbacks.py
@@ -1,13 +1,18 @@
 """Tests for extractor callback behavior.
 
 Verifies that the 'created' message from MakeMKV does NOT fire
-title_complete_callback, and that stable file size detection DOES.
+title_complete_callback, and that stable file size detection DOES — but
+only after STABLE_CHECKS_REQUIRED consecutive stable polls (in-flight) or
+immediately on a forced post-process check.
 """
 
 import re
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock
+
+# Match the constant used in extractor.py
+STABLE_CHECKS_REQUIRED = 3
 
 
 class TestCreatedMessageDoesNotFireCallback:
@@ -64,72 +69,187 @@ class TestCreatedMessageDoesNotFireCallback:
 
 
 class TestStableSizeDetection:
-    """Stable file size detection SHOULD fire title_complete_callback.
-
-    When a file's size is the same across two consecutive checks and > 0,
-    it means MakeMKV has finished writing to it.
+    """Stable file size detection SHOULD fire title_complete_callback — but only
+    after STABLE_CHECKS_REQUIRED consecutive stable polls (not after just one).
     """
 
-    def test_stable_size_fires_callback(self):
-        """Simulates _check_for_completed_files detecting a stable file."""
-        known_files: dict[str, int] = {"title00.mkv": 1_000_000}
-        completed_files: set[str] = set()
-        output_files: list[Path] = []
-        callback = MagicMock()
+    # ------------------------------------------------------------------
+    # Helper: simulate _check_for_completed_files with the new multi-check
+    # logic.  This mirrors the closure in extractor.py so tests stay in sync
+    # with production behaviour without needing to call rip_titles().
+    # ------------------------------------------------------------------
+
+    def _make_state(self):
+        """Return a fresh shared-state dict used by _simulate_check."""
+        return {
+            "known_files": {},
+            "completed_files": set(),
+            "stable_counts": {},
+            "output_files": [],
+        }
+
+    def _simulate_check(self, state, sizes: dict[str, int], callback, *, force: bool = False):
+        """Simulate one call to _check_for_completed_files with the given file sizes.
+
+        ``sizes`` maps filename → current size (as if returned by stat().st_size).
+        Mirrors the new closure logic in extractor.py exactly.
+        """
         output_dir = Path("/output")
+        known_files = state["known_files"]
+        completed_files = state["completed_files"]
+        stable_counts = state["stable_counts"]
+        output_files = state["output_files"]
 
-        # Simulate _check_for_completed_files logic:
-        # File exists with same size as last check → stable → complete
-        fname = "title00.mkv"
-        current_size = 1_000_000  # Same as known_files
+        def _fire(fname, size):
+            completed_files.add(fname)
+            stable_counts.pop(fname, None)
+            filepath = output_dir / fname
+            output_files.append(filepath)
+            callback(len(completed_files), filepath)
 
-        if fname in known_files:
-            if current_size == known_files[fname] and current_size > 0:
-                if fname not in completed_files:
-                    completed_files.add(fname)
-                    filepath = output_dir / fname
-                    output_files.append(filepath)
-                    if callback:
-                        callback(len(completed_files), filepath)
+        for fname, current_size in sizes.items():
+            if fname in completed_files:
+                continue
+            if fname in known_files:
+                if current_size > 0:
+                    if force:
+                        _fire(fname, current_size)
+                    elif current_size == known_files[fname]:
+                        stable_counts[fname] = stable_counts.get(fname, 0) + 1
+                        if stable_counts[fname] >= STABLE_CHECKS_REQUIRED:
+                            _fire(fname, current_size)
+                    else:
+                        stable_counts[fname] = 0
+            known_files[fname] = current_size
 
-        callback.assert_called_once_with(1, output_dir / "title00.mkv")
-        assert fname in completed_files
-        assert len(output_files) == 1
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_single_stable_check_does_not_fire(self):
+        """One stable poll is no longer enough — callback must NOT fire yet."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # First check: file appears at 96 MB
+        self._simulate_check(state, {"C1_t01.mkv": 96_000_000}, callback)
+        callback.assert_not_called()
+
+        # Second check: same size — one stable interval — still not enough
+        self._simulate_check(state, {"C1_t01.mkv": 96_000_000}, callback)
+        callback.assert_not_called()
+
+    def test_multi_stable_checks_fires_callback(self):
+        """Exactly STABLE_CHECKS_REQUIRED consecutive stable polls must fire."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # Seed known_files with first appearance
+        self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)
+        callback.assert_not_called()  # first appearance, not yet stable
+
+        # Stable polls 1 … STABLE_CHECKS_REQUIRED-1: still not fired
+        for i in range(1, STABLE_CHECKS_REQUIRED):
+            self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)
+            callback.assert_not_called(), f"should not fire after {i} stable checks"
+
+        # The Nth consecutive stable poll fires
+        self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)
+        callback.assert_called_once()
+        assert "C1_t01.mkv" in state["completed_files"]
+
+    def test_size_change_resets_stable_count(self):
+        """A size increase mid-rip resets the stability counter to zero."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # File appears (baseline — no count increment), then one stable check
+        self._simulate_check(state, {"C1_t01.mkv": 96_000_000}, callback)
+        self._simulate_check(state, {"C1_t01.mkv": 96_000_000}, callback)
+        # First call sets the baseline; second call is the 1st stable observation
+        assert state["stable_counts"].get("C1_t01.mkv", 0) == 1
+
+        # File grows — counter must reset
+        self._simulate_check(state, {"C1_t01.mkv": 500_000_000}, callback)
+        assert state["stable_counts"].get("C1_t01.mkv", 0) == 0
+        callback.assert_not_called()
+
+        # Stable counts restart from zero
+        self._simulate_check(state, {"C1_t01.mkv": 500_000_000}, callback)
+        assert state["stable_counts"].get("C1_t01.mkv", 0) == 1
+        callback.assert_not_called()
+
+    def test_stable_count_cleared_after_callback(self):
+        """stable_counts entry is removed once a file fires its callback."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # Seed + STABLE_CHECKS_REQUIRED stable polls
+        self._simulate_check(state, {"t01.mkv": 1_000_000_000}, callback)
+        for _ in range(STABLE_CHECKS_REQUIRED):
+            self._simulate_check(state, {"t01.mkv": 1_000_000_000}, callback)
+
+        callback.assert_called_once()
+        assert "t01.mkv" not in state["stable_counts"]
+
+    def test_force_fires_immediately_without_stability(self):
+        """force=True fires with only one look — process exit guarantees completeness."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # Seed the file so it's in known_files
+        self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)
+        callback.assert_not_called()
+
+        # force=True — fires immediately
+        self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback, force=True)
+        callback.assert_called_once()
+        assert "C1_t01.mkv" in state["completed_files"]
+
+    def test_force_does_not_double_fire(self):
+        """force=True skips files already in completed_files."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # Seed + first forced completion
+        self._simulate_check(state, {"t01.mkv": 1_000_000_000}, callback)
+        self._simulate_check(state, {"t01.mkv": 1_000_000_000}, callback, force=True)
+        assert callback.call_count == 1
+
+        # Second force call must be a no-op
+        self._simulate_check(state, {"t01.mkv": 1_000_000_000}, callback, force=True)
+        assert callback.call_count == 1  # unchanged
+
+    def test_force_does_not_fire_for_zero_size(self):
+        """force=True must NOT fire for a 0-byte file (MakeMKV opened but didn't write)."""
+        state = self._make_state()
+        callback = MagicMock()
+
+        # File created at 0 bytes (MSG 'created' path seeds it at 0)
+        state["known_files"]["t01.mkv"] = 0
+
+        self._simulate_check(state, {"t01.mkv": 0}, callback, force=True)
+        callback.assert_not_called()
+        assert "t01.mkv" not in state["completed_files"]
 
     def test_growing_file_does_not_fire_callback(self):
         """A file whose size is still changing should NOT fire callback."""
-        known_files: dict[str, int] = {"title00.mkv": 500_000}
-        completed_files: set[str] = set()
+        state = self._make_state()
         callback = MagicMock()
 
-        fname = "title00.mkv"
-        current_size = 1_000_000  # Larger than last check — still growing
-
-        if fname in known_files:
-            if current_size == known_files[fname] and current_size > 0:
-                if fname not in completed_files:
-                    completed_files.add(fname)
-                    callback(len(completed_files), Path("/output") / fname)
-
-        # Update known size
-        known_files[fname] = current_size
+        self._simulate_check(state, {"title00.mkv": 500_000}, callback)
+        self._simulate_check(state, {"title00.mkv": 1_000_000}, callback)  # still growing
 
         callback.assert_not_called()
-        assert fname not in completed_files
+        assert "title00.mkv" not in state["completed_files"]
 
     def test_zero_size_file_does_not_fire_callback(self):
         """A file with 0 bytes should NOT be considered complete."""
-        known_files: dict[str, int] = {"title00.mkv": 0}
-        completed_files: set[str] = set()
+        state = self._make_state()
         callback = MagicMock()
 
-        fname = "title00.mkv"
-        current_size = 0
-
-        if fname in known_files:
-            if current_size == known_files[fname] and current_size > 0:
-                if fname not in completed_files:
-                    completed_files.add(fname)
-                    callback(len(completed_files), Path("/output") / fname)
+        # Seed at 0, check at 0 — size > 0 guard prevents firing
+        self._simulate_check(state, {"title00.mkv": 0}, callback)
+        self._simulate_check(state, {"title00.mkv": 0}, callback)
 
         callback.assert_not_called()

--- a/backend/tests/unit/test_extractor_callbacks.py
+++ b/backend/tests/unit/test_extractor_callbacks.py
@@ -11,8 +11,7 @@ import threading
 from pathlib import Path
 from unittest.mock import MagicMock
 
-# Match the constant used in extractor.py
-STABLE_CHECKS_REQUIRED = 3
+from app.core.extractor import STABLE_CHECKS_REQUIRED
 
 
 class TestCreatedMessageDoesNotFireCallback:
@@ -92,7 +91,17 @@ class TestStableSizeDetection:
         """Simulate one call to _check_for_completed_files with the given file sizes.
 
         ``sizes`` maps filename → current size (as if returned by stat().st_size).
-        Mirrors the new closure logic in extractor.py exactly.
+
+        .. warning::
+            This helper **mirrors** the closure logic inside
+            ``_rip_titles_unlocked._check_for_completed_files`` rather than
+            calling the real function directly.  The closure captures many
+            variables (``output_dir``, ``_fs_lock``, the callbacks, …) that
+            can't be constructed in isolation without running ``rip_titles()``.
+            If the production logic changes, this mirror must be kept in sync
+            manually.  Consider extracting ``_check_for_completed_files`` into
+            a ``TitleCompletionDetector`` class (module-level) so tests can
+            exercise the real implementation.
         """
         output_dir = Path("/output")
         known_files = state["known_files"]
@@ -151,7 +160,7 @@ class TestStableSizeDetection:
         # Stable polls 1 … STABLE_CHECKS_REQUIRED-1: still not fired
         for i in range(1, STABLE_CHECKS_REQUIRED):
             self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)
-            callback.assert_not_called(), f"should not fire after {i} stable checks"
+            assert callback.call_count == 0, f"should not fire after {i} stable checks"
 
         # The Nth consecutive stable poll fires
         self._simulate_check(state, {"C1_t01.mkv": 2_193_000_000}, callback)


### PR DESCRIPTION
## Problem

During sequential per-title ripping (`makemkvcon` called once per title), a brief MakeMKV write pause (buffering or disc-seeking) could hold the output file's size constant for one 3-second polling interval. The previous `_check_for_completed_files()` required only **one stable interval** to fire, so at 96 MB of a 2193 MB file the title-complete callback fired prematurely.

Downstream cascade:
- `_on_title_ripped()` set the title to `TitleState.MATCHING` and broadcast that state to the UI — the card showed "matching" while the file was still being written
- `match_single_file()` queued and called `_wait_for_file_ready()`, which correctly defended against a partial file (85%-size guard), but the wrong UI state had already been sent

## Root Cause

`_check_for_completed_files()` in `backend/app/core/extractor.py`:

```python
# Before — one stable 3-second interval was enough
if current_size == known_files[fname] and current_size > 0:
    # fires at 96 MB for a 2193 MB file during a write pause
```

## Fix

Two-part change, all in `extractor.py`:

**1. Multi-poll stability requirement (in-flight)**
Added `stable_counts` dict. Now requires `STABLE_CHECKS_REQUIRED = 3` consecutive stable polls (~9 seconds) before the in-flight callback fires. Size changes reset the counter to zero.

**2. Force-complete after process exits**
Added `force=True` parameter — bypasses the counter and fires immediately for any file with `size > 0`. Called at both post-`process.wait()` sites, since process exit guarantees the write is complete for sequential-per-title rips.

| Scenario | Before | After |
|---|---|---|
| Brief write pause mid-rip (the bug) | False positive at 96 MB | counter reaches 1/3, no fire; `force=True` fires at full size after process exits |
| Rip-all mode (legitimate mid-run completion) | Fires after 3 s | Fires after 9 s (slightly delayed, still correct) |
| Sequential per-title rip (normal path) | May fire prematurely | `force=True` fires exactly once, after `process.wait()` |

## Tests

Updated `test_extractor_callbacks.py` with 7 new/revised cases covering: single-check no-fire, multi-check fires-at-N, size-change resets counter, stable-count cleared on fire, `force=True` fires immediately, `force=True` no double-fire, `force=True` skips zero-byte files.

```
1236 passed in 66.45s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
