### PR TITLE
fix: wire Synapse brand icon to Windows .exe

### DIFF
--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -116,7 +116,7 @@ exe = EXE(
     strip=False,
     upx=True,
     console=True,
-    icon="../frontend/public/brand/app-icons/windows/engram.ico",
+    icon=os.path.join(SPECPATH, "../frontend/public/brand/app-icons/windows/engram.ico"),
 )
 
 coll = COLLECT(

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -116,6 +116,7 @@ exe = EXE(
     strip=False,
     upx=True,
     console=True,
+    icon="../frontend/public/brand/app-icons/windows/engram.ico",
 )
 
 coll = COLLECT(


### PR DESCRIPTION
## Summary

- Adds icon= parameter to the EXE() section in ackend/engram.spec
- Points PyInstaller at the already-committed multi-resolution Synapse v2 app icon (rontend/public/brand/app-icons/windows/engram.ico)
- The .ico is a 16–256px multi-resolution file generated by 
pm run brand:export from pp-icon-dark.svg

Previously the packaged .exe displayed PyInstaller's default feather icon because the brand asset pipeline had generated and committed the icon file but the spec was never updated to reference it.

## Test Plan
- [ ] Run uv run pyinstaller engram.spec from ackend/
- [ ] Right-click dist/engram/engram.exe → Properties → confirm Engram three-arc mark appears
- [ ] Verify icon at taskbar / Explorer at 16px, 32px, 48px sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)