### PR TITLE
fix: vote-ratio confidence path for dominant chunk-count wins + review UI best-guess

### DIFF
--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -247,6 +247,21 @@ W_COVERAGE = 0.25
 # Floor so a decisive sweep with thin evidence still reads meaningfully, while
 # minimal evidence lands just under the 0.7 review gate.
 EVIDENCE_FLOOR = 0.30
+# Vote-boost parameters: when many independent chunks agree on a winner AND
+# the match is at least somewhat decisive (separation > NEAR_TIE_FLOOR), vote
+# evidence can relax the separation requirement.
+#   NEAR_TIE_FLOOR  — below this separation, no boost is applied. A close
+#     runner-up at any vote count is genuinely ambiguous.
+#   HIGH_CONSENSUS_REF — proportion of scan points for "full consensus" credit.
+#   HIGH_VOTE_REF   — absolute chunk count for "full vote" credit. Deep re-match
+#     uses 25 scan points; 15 chunks agreeing is strong absolute evidence.
+#   MAX_VOTE_BOOST  — maximum separation added by combined consensus + vote credit.
+#     At max boost, separation can be lifted by up to 0.30, which allows a match
+#     with separation ~0.52 to clear the 0.7 review gate (vs ~0.82 previously).
+NEAR_TIE_FLOOR = 0.15
+HIGH_CONSENSUS_REF = 0.60
+HIGH_VOTE_REF = 15
+MAX_VOTE_BOOST = 0.30
 
 
 def _clamp01(value: float) -> float:
@@ -277,15 +292,23 @@ def calibrate_confidence(
         derived evidence term, each in [0, 1].
 
     Formula:
-        confidence = separation * evidence
+        confidence = effective_separation * evidence
+        effective_separation = separation + vote_boost
+        vote_boost = MAX_VOTE_BOOST * (consensus / HIGH_CONSENSUS_REF)
+                                     * (vote_count / HIGH_VOTE_REF)
+                     only when separation > NEAR_TIE_FLOOR, else 0
         evidence   = EVIDENCE_FLOOR + (1-FLOOR) * (
                          W_CONSENSUS*consensus
                        + W_NORMALIZED_SCORE*normalized_score
                        + W_COVERAGE*coverage_norm)
 
-    Separation is the safety gate: a near-tie (two plausible episodes) craters
-    confidence regardless of how strong the evidence is, because none of the
-    evidence metrics looks at the runner-up.
+    Separation is the primary safety gate. For near-tie matches
+    (separation ≤ NEAR_TIE_FLOOR, i.e. the runner-up scored ≥ 85 % of the
+    winner), no boost is applied — a close runner-up is genuinely ambiguous
+    regardless of vote count. Above the floor, accumulated vote evidence from
+    many agreeing chunks can raise effective_separation by up to MAX_VOTE_BOOST,
+    allowing moderate-separation high-vote matches to clear the 0.7 review gate
+    without requiring a near-sweep.
     """
     eps = 1e-9
     separation = _clamp01(score_gap / score) if score > eps else 0.0
@@ -297,10 +320,27 @@ def calibrate_confidence(
         W_CONSENSUS * consensus + W_NORMALIZED_SCORE * normalized_score + W_COVERAGE * coverage_norm
     )
     evidence = EVIDENCE_FLOOR + (1.0 - EVIDENCE_FLOOR) * evidence_raw
-    confidence = _clamp01(separation * evidence)
+
+    # Vote-driven separation boost: near-ties are excluded (runner-up too close
+    # to trust vote count alone). Above the floor, both consensus fraction and
+    # absolute vote count must be high to earn the full boost — requiring many
+    # independent chunks to agree, not just a high proportion of a small sample.
+    if separation > NEAR_TIE_FLOOR:
+        vote_boost = (
+            MAX_VOTE_BOOST
+            * _clamp01(consensus / HIGH_CONSENSUS_REF)
+            * _clamp01(vote_count / HIGH_VOTE_REF)
+        )
+        effective_separation = _clamp01(separation + vote_boost)
+    else:
+        vote_boost = 0.0
+        effective_separation = separation
+    confidence = _clamp01(effective_separation * evidence)
 
     components = {
         "separation": separation,
+        "vote_boost": vote_boost,
+        "effective_separation": effective_separation,
         "consensus": consensus,
         "normalized_score": normalized_score,
         # Report the actual processed fraction (the metric), not the normalized

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -303,8 +303,11 @@ def calibrate_confidence(
     Returns:
         (confidence, components) where components reports the independent
         metrics (separation, consensus, normalized_score, coverage, evidence,
-        vote_boost, effective_separation, vote_ratio, ratio_confidence), each
-        in [0, 1].
+        vote_boost, effective_separation, vote_ratio_score, ratio_confidence),
+        each in [0, 1].  ``vote_ratio`` is also included as a *raw* diagnostic
+        (winner_votes / runner_up_votes) and is NOT bounded to [0, 1] — it
+        equals 0.0 when the ratio path is inactive and can exceed 1.0
+        (e.g. 3.32 for 103 vs 31 votes) when it fires.
 
     Two independent confidence paths — the higher wins:
 
@@ -443,6 +446,8 @@ def _attach_calibrated_confidence(
     md["confidence"] = confidence
     md["score_gap"] = score_gap
     md["separation"] = components["separation"]
+    md["vote_boost"] = components["vote_boost"]
+    md["effective_separation"] = components["effective_separation"]
     md["normalized_score"] = components["normalized_score"]
     md["consensus"] = components["consensus"]
     md["vote_ratio"] = components["vote_ratio"]

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -258,10 +258,20 @@ EVIDENCE_FLOOR = 0.30
 #   MAX_VOTE_BOOST  — maximum separation added by combined consensus + vote credit.
 #     At max boost, separation can be lifted by up to 0.30, which allows a match
 #     with separation ~0.52 to clear the 0.7 review gate (vs ~0.82 previously).
+# Vote-ratio path: a second independent confidence route that fires when the
+# winner matched far more chunks than the runner-up. score_gap (mean-cosine
+# difference) misses this signal because both candidates may score similarly
+# per-chunk even when one matched 3× more chunks overall.
+#   HIGH_VOTE_RATIO         — winner must have this many times the runner-up's
+#     vote count for full ratio credit (e.g. 103 vs 31 = 3.3×).
+#   MIN_CONSENSUS_FOR_RATIO — minimum winner consensus before the ratio path
+#     activates; prevents very sparse matches (e.g. 3/119) from passing.
 NEAR_TIE_FLOOR = 0.15
 HIGH_CONSENSUS_REF = 0.60
 HIGH_VOTE_REF = 15
 MAX_VOTE_BOOST = 0.30
+HIGH_VOTE_RATIO = 3.0
+MIN_CONSENSUS_FOR_RATIO = 0.50
 
 
 def _clamp01(value: float) -> float:
@@ -275,6 +285,7 @@ def calibrate_confidence(
     vote_count: int,
     target_votes: int,
     processed_coverage: float,
+    runner_up_votes: int = 0,
 ) -> tuple[float, dict[str, float]]:
     """Translate raw match signals into a 0-1 reviewer-facing confidence.
 
@@ -285,30 +296,41 @@ def calibrate_confidence(
         target_votes: total chunks sampled.
         processed_coverage: fraction of the file run through the matcher
             (samples * chunk_len / video_duration), NOT the matched fraction.
+        runner_up_votes: chunks that voted for the best alternative candidate.
+            When provided, enables the vote-ratio confidence path. Default 0
+            (ratio path disabled) for backward compatibility.
 
     Returns:
-        (confidence, components) where components reports the three independent
-        metrics (separation, consensus, normalized_score, coverage) plus the
-        derived evidence term, each in [0, 1].
+        (confidence, components) where components reports the independent
+        metrics (separation, consensus, normalized_score, coverage, evidence,
+        vote_boost, effective_separation, vote_ratio, ratio_confidence), each
+        in [0, 1].
 
-    Formula:
-        confidence = effective_separation * evidence
+    Two independent confidence paths — the higher wins:
+
+    Path 1 — separation-based (score_gap signal):
         effective_separation = separation + vote_boost
         vote_boost = MAX_VOTE_BOOST * (consensus / HIGH_CONSENSUS_REF)
                                      * (vote_count / HIGH_VOTE_REF)
                      only when separation > NEAR_TIE_FLOOR, else 0
-        evidence   = EVIDENCE_FLOOR + (1-FLOOR) * (
-                         W_CONSENSUS*consensus
-                       + W_NORMALIZED_SCORE*normalized_score
-                       + W_COVERAGE*coverage_norm)
+        base_confidence = effective_separation * evidence
 
-    Separation is the primary safety gate. For near-tie matches
-    (separation ≤ NEAR_TIE_FLOOR, i.e. the runner-up scored ≥ 85 % of the
-    winner), no boost is applied — a close runner-up is genuinely ambiguous
-    regardless of vote count. Above the floor, accumulated vote evidence from
-    many agreeing chunks can raise effective_separation by up to MAX_VOTE_BOOST,
-    allowing moderate-separation high-vote matches to clear the 0.7 review gate
-    without requiring a near-sweep.
+    Path 2 — vote-ratio (chunk-count signal, requires runner_up_votes > 0):
+        Fires when winner matched HIGH_VOTE_RATIO× more chunks than runner-up
+        AND overall consensus >= MIN_CONSENSUS_FOR_RATIO.
+        ratio_confidence = evidence
+                         * clamp(vote_ratio_score)
+                         * clamp(consensus / HIGH_CONSENSUS_REF)
+        where vote_ratio_score scales (vote_count/runner_up_votes) from 1× to
+        HIGH_VOTE_RATIO× into [0, 1].
+
+    confidence = max(base_confidence, ratio_confidence)
+
+    Rationale for Path 2: ranked_voting_score is a per-chunk mean cosine, so
+    a runner-up that matched ⅓ as many chunks as the winner may still produce
+    a similar mean cosine (and thus a small score_gap). Path 1 alone then
+    underestimates confidence. The vote-ratio path captures this: 103 vs 31
+    chunk matches is decisive regardless of whether the mean cosines are close.
     """
     eps = 1e-9
     separation = _clamp01(score_gap / score) if score > eps else 0.0
@@ -321,7 +343,7 @@ def calibrate_confidence(
     )
     evidence = EVIDENCE_FLOOR + (1.0 - EVIDENCE_FLOOR) * evidence_raw
 
-    # Vote-driven separation boost: near-ties are excluded (runner-up too close
+    # Path 1 — separation-based: near-ties are excluded (runner-up too close
     # to trust vote count alone). Above the floor, both consensus fraction and
     # absolute vote count must be high to earn the full boost — requiring many
     # independent chunks to agree, not just a high proportion of a small sample.
@@ -335,7 +357,24 @@ def calibrate_confidence(
     else:
         vote_boost = 0.0
         effective_separation = separation
-    confidence = _clamp01(effective_separation * evidence)
+    base_confidence = _clamp01(effective_separation * evidence)
+
+    # Path 2 — vote-ratio: fires when the winner matched significantly more
+    # chunks than the runner-up AND the overall consensus is strong. This
+    # captures cases where score_gap is small despite decisive chunk-count
+    # dominance (e.g. 103 vs 31 votes with similar per-chunk cosines).
+    vote_ratio = 0.0
+    vote_ratio_score = 0.0
+    ratio_confidence = 0.0
+    if runner_up_votes > 0 and consensus >= MIN_CONSENSUS_FOR_RATIO:
+        vote_ratio = vote_count / runner_up_votes
+        # Scale from [1×, HIGH_VOTE_RATIO×] → [0, 1]; below 1× impossible, above clamps to 1.
+        vote_ratio_score = _clamp01((vote_ratio - 1.0) / (HIGH_VOTE_RATIO - 1.0))
+        ratio_confidence = _clamp01(
+            evidence * vote_ratio_score * _clamp01(consensus / HIGH_CONSENSUS_REF)
+        )
+
+    confidence = max(base_confidence, ratio_confidence)
 
     components = {
         "separation": separation,
@@ -347,6 +386,9 @@ def calibrate_confidence(
         # form used inside the formula.
         "coverage": _clamp01(processed_coverage),
         "evidence": evidence,
+        "vote_ratio": vote_ratio,
+        "vote_ratio_score": vote_ratio_score,
+        "ratio_confidence": ratio_confidence,
     }
     return confidence, components
 
@@ -374,8 +416,10 @@ def _attach_calibrated_confidence(
     top1 = results_summary[0]["score"]
     if len(results_summary) >= 2:
         score_gap = top1 - results_summary[1]["score"]
+        runner_up_votes = results_summary[1].get("vote_count", 0)
     else:
         score_gap = top1
+        runner_up_votes = 0
 
     md = best_match.setdefault("match_details", {})
     target_votes = md.get("target_votes", 0)
@@ -392,6 +436,7 @@ def _attach_calibrated_confidence(
         vote_count=vote_count,
         target_votes=target_votes,
         processed_coverage=processed_coverage,
+        runner_up_votes=runner_up_votes,
     )
 
     best_match["confidence"] = confidence
@@ -400,6 +445,8 @@ def _attach_calibrated_confidence(
     md["separation"] = components["separation"]
     md["normalized_score"] = components["normalized_score"]
     md["consensus"] = components["consensus"]
+    md["vote_ratio"] = components["vote_ratio"]
+    md["ratio_confidence"] = components["ratio_confidence"]
     md["coverage"] = components["coverage"]
 
     runner_ups = []

--- a/backend/tests/unit/test_confidence_calibration.py
+++ b/backend/tests/unit/test_confidence_calibration.py
@@ -177,10 +177,13 @@ def test_longer_file_not_more_confident():
 
 
 def test_components_reported_and_in_range():
-    conf, comp = calibrate_confidence(
-        score=0.18, score_gap=0.18, vote_count=8, target_votes=10, processed_coverage=AD_COVERAGE
-    )
-    for key in (
+    """All components are present; all except vote_ratio are bounded [0, 1].
+
+    vote_ratio is the raw winner/runner-up chunk count ratio — a diagnostic
+    value intentionally not clamped (e.g. 103/31 = 3.32 for Gilded Age).
+    vote_ratio_score is its [0, 1] projection used inside the formula.
+    """
+    bounded_keys = (
         "separation",
         "consensus",
         "normalized_score",
@@ -188,13 +191,36 @@ def test_components_reported_and_in_range():
         "evidence",
         "vote_boost",
         "effective_separation",
-        "vote_ratio",
         "vote_ratio_score",
         "ratio_confidence",
-    ):
+    )
+    all_keys = bounded_keys + ("vote_ratio",)
+
+    # Path 1 only (no runner_up_votes) — vote_ratio stays 0.0
+    conf, comp = calibrate_confidence(
+        score=0.18, score_gap=0.18, vote_count=8, target_votes=10, processed_coverage=AD_COVERAGE
+    )
+    for key in all_keys:
         assert key in comp, f"missing component {key}"
+    for key in bounded_keys:
         assert 0.0 <= comp[key] <= 1.0, f"{key} out of range: {comp[key]}"
+    assert comp["vote_ratio"] == 0.0
     assert 0.0 <= conf <= 1.0
+
+    # Path 2 active (Gilded Age anchor) — vote_ratio is raw (> 1 is expected)
+    _, comp2 = calibrate_confidence(
+        score=0.203,
+        score_gap=0.042,
+        vote_count=103,
+        target_votes=119,
+        processed_coverage=1.0,
+        runner_up_votes=31,
+    )
+    for key in all_keys:
+        assert key in comp2, f"missing component {key} (ratio path)"
+    for key in bounded_keys:
+        assert 0.0 <= comp2[key] <= 1.0, f"{key} out of range (ratio path): {comp2[key]}"
+    assert comp2["vote_ratio"] > 1.0, "vote_ratio should be the raw >1 ratio when ratio path fires"
 
 
 def test_zero_target_votes_is_safe():
@@ -302,6 +328,8 @@ def test_attach_reports_independent_metrics():
     md = best["match_details"]
     for key in (
         "separation",
+        "vote_boost",
+        "effective_separation",
         "normalized_score",
         "consensus",
         "coverage",

--- a/backend/tests/unit/test_confidence_calibration.py
+++ b/backend/tests/unit/test_confidence_calibration.py
@@ -89,6 +89,65 @@ def test_weak_uncontested_sweep_is_borderline():
     assert conf < 0.75, f"weak thin sweep should be modest, got {conf:.3f}"
 
 
+# --- Vote-ratio path ----------------------------------------------------------
+# ranked_voting_score is a per-chunk mean cosine. Two candidates with similar
+# per-chunk quality but very different chunk counts produce a small score_gap,
+# so Path 1 alone under-reports confidence. Path 2 (vote-ratio) captures this.
+
+
+def test_overwhelming_vote_ratio_clears_review():
+    """Real Gilded Age S03E01: 103/119 winner votes, 31 runner-up, score_gap tiny.
+
+    Without runner_up_votes the old formula gave ~0.20 (review). With vote_ratio
+    this should auto-match (>= 0.70).
+    """
+    conf, _ = calibrate_confidence(
+        score=0.203,
+        score_gap=0.042,
+        vote_count=103,
+        target_votes=119,
+        processed_coverage=1.0,
+        runner_up_votes=31,
+    )
+    assert conf >= 0.70, f"103 vs 31 votes (3.3x) should clear review, got {conf:.3f}"
+
+
+def test_close_vote_ratio_stays_review():
+    """Winner barely ahead in raw votes (10 vs 8) -> ratio path not triggered."""
+    conf, _ = calibrate_confidence(
+        score=0.18,
+        score_gap=0.04,
+        vote_count=10,
+        target_votes=25,
+        processed_coverage=0.30,
+        runner_up_votes=8,
+    )
+    assert conf < 0.70, f"1.25x vote ratio should not auto-match, got {conf:.3f}"
+
+
+def test_vote_ratio_requires_minimum_consensus():
+    """3/119 winner, 1/119 runner-up: 3x ratio but ~2% consensus -> still review."""
+    conf, _ = calibrate_confidence(
+        score=0.18,
+        score_gap=0.04,
+        vote_count=3,
+        target_votes=119,
+        processed_coverage=0.05,
+        runner_up_votes=1,
+    )
+    assert conf < 0.70, f"low consensus (2.5%%) must block ratio path, got {conf:.3f}"
+
+
+def test_vote_ratio_disabled_without_runner_up():
+    """Default runner_up_votes=0 must give the same result as omitting the arg."""
+    common = dict(
+        score=0.18, score_gap=0.04, vote_count=10, target_votes=25, processed_coverage=0.30
+    )
+    conf_explicit, _ = calibrate_confidence(**common, runner_up_votes=0)
+    conf_default, _ = calibrate_confidence(**common)
+    assert conf_explicit == conf_default
+
+
 # --- Monotonicity: the formula must move the right way ------------------------
 
 
@@ -121,7 +180,18 @@ def test_components_reported_and_in_range():
     conf, comp = calibrate_confidence(
         score=0.18, score_gap=0.18, vote_count=8, target_votes=10, processed_coverage=AD_COVERAGE
     )
-    for key in ("separation", "consensus", "normalized_score", "coverage", "evidence"):
+    for key in (
+        "separation",
+        "consensus",
+        "normalized_score",
+        "coverage",
+        "evidence",
+        "vote_boost",
+        "effective_separation",
+        "vote_ratio",
+        "vote_ratio_score",
+        "ratio_confidence",
+    ):
         assert key in comp, f"missing component {key}"
         assert 0.0 <= comp[key] <= 1.0, f"{key} out of range: {comp[key]}"
     assert 0.0 <= conf <= 1.0
@@ -230,5 +300,13 @@ def test_attach_reports_independent_metrics():
     rs = _results_summary(("S1E13", 0.165, 8))
     _attach_calibrated_confidence(best, rs, video_duration=1320)
     md = best["match_details"]
-    for key in ("separation", "normalized_score", "consensus", "coverage", "score_gap"):
+    for key in (
+        "separation",
+        "normalized_score",
+        "consensus",
+        "coverage",
+        "score_gap",
+        "vote_ratio",
+        "ratio_confidence",
+    ):
         assert key in md, f"missing reported metric {key}"

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -206,15 +206,28 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus 
                 </div>
               )}
 
-              {/* Review: no confident match — needs manual episode assignment */}
+              {/* Review: show best-guess episode when available, or "no match found" */}
               {track.state === "review" && (
                 <div style={{ marginTop: 4 }}>
                   <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.yellow, letterSpacing: "0.18em", fontWeight: 700 }}>
                     NEEDS REVIEW
                   </span>
-                  <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8 }}>
-                    no confident match — assign in review queue
-                  </span>
+                  {track.finalMatch ? (
+                    <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8 }}>
+                      best guess {track.finalMatch}
+                      {track.finalMatchConfidence != null && (
+                        <> — {Math.round(track.finalMatchConfidence * 100)}% confidence</>
+                      )}
+                      {track.finalMatchVotes != null && track.finalMatchTargetVotes != null && (
+                        <> ({track.finalMatchVotes}/{track.finalMatchTargetVotes} votes)</>
+                      )}
+                      {" — confirm in review queue"}
+                    </span>
+                  ) : (
+                    <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8 }}>
+                      no match found — assign in review queue
+                    </span>
+                  )}
                 </div>
               )}
 

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -215,10 +215,10 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus 
                   {track.finalMatch ? (
                     <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8 }}>
                       best guess {track.finalMatch}
-                      {track.finalMatchConfidence != null && (
+                      {track.finalMatchConfidence !== undefined && (
                         <> — {Math.round(track.finalMatchConfidence * 100)}% confidence</>
                       )}
-                      {track.finalMatchVotes != null && track.finalMatchTargetVotes != null && (
+                      {track.finalMatchVotes !== undefined && track.finalMatchTargetVotes !== undefined && (
                         <> ({track.finalMatchVotes}/{track.finalMatchTargetVotes} votes)</>
                       )}
                       {" — confirm in review queue"}


### PR DESCRIPTION
## Problem

The Gilded Age (and other episodic TV with consistent audio production) triggered
"Needs Review — no confident match" even after deep re-matching with high vote counts
(103/119, 106/119, 100/119). The calibrated confidence formula was:

```
confidence = separation x evidence
separation = score_gap / winner_score
```

**Root cause**: `score_gap` is a *per-chunk mean cosine* difference. For same-show
episodic TV, all episodes score in a compressed 12–22% TF-IDF band (shared characters,
settings, recurring vocabulary). Even when the winner has 103 chunks agreeing vs 31
for the runner-up, the *per-chunk mean* cosines are nearly equal -> score_gap ~= 0.042 ->
separation ~= 0.207 -> confidence ~= 0.20. The correct discriminator is the vote ratio
(3.3x), which captures chunk-count dominance that score_gap misses entirely.

**UI problem**: The TrackGrid showed a static "no confident match — assign in review queue"
string for ALL `TitleState.REVIEW` tracks, even when the system had a strong best-guess
episode stored in `matched_episode`.

## Fix 1 — Confidence Formula (backend)

Two-path formula in `calibrate_confidence()`:

**Path 1 — separation-based with vote boost** (original formula, hardened):
- When `separation > NEAR_TIE_FLOOR (0.15)`, add a vote boost of up to +0.30
- Boost scales with consensus and absolute vote count
- `NEAR_TIE_FLOOR` guard prevents boost on genuine near-ties

**Path 2 — vote-ratio path** (new):
- When winner has >= 3x runner-up chunk count AND consensus >= 50% -> use vote_ratio to
  produce a direct evidence-weighted confidence score
- `consensus < MIN_CONSENSUS_FOR_RATIO (0.50)` blocks the path for sparse matches
- Final confidence = `max(path1, path2)`

**New constants**:
```python
NEAR_TIE_FLOOR = 0.15        # below this, no boost -- genuine ambiguity
HIGH_CONSENSUS_REF = 0.60    # 60% consensus -> full boost
HIGH_VOTE_REF = 15           # absolute votes for full boost
MAX_VOTE_BOOST = 0.30        # cap on boost applied to separation
HIGH_VOTE_RATIO = 3.0        # 3x ratio -> full ratio path score
MIN_CONSENSUS_FOR_RATIO = 0.50  # ratio path requires majority consensus
```

**Worked examples** (Gilded Age S03):

| Title | score | score_gap | votes | runner_up | old conf | new conf |
|-------|-------|-----------|-------|-----------|----------|----------|
| C1_t01 (S03E01) | 0.203 | 0.042 | 103/119 | 31 votes | 0.20 | **0.95** |
| C2_t02 (S03E04) | 0.198 | 0.038 | 106/119 | 16 votes | 0.18 | **0.97** |
| C3_t03 (S03E07) | 0.165 | 0.030 | 100/119 | 15 votes | 0.14 | **0.95** |

**Arrested Development S1** (regression check, no runner_up_votes):

| Episode | votes | old conf | new conf |
|---------|-------|----------|----------|
| S01E13  | 8/10  | 0.88     | 0.91     |
| S01E12  | 5/10  | 0.77     | 0.80     |
| S01E14  | 4/10  | 0.73     | 0.76     |

## Fix 2 — TrackGrid review display (frontend)

Replaced static string with conditional display using existing track props
(`finalMatch`, `finalMatchConfidence`, `finalMatchVotes`, `finalMatchTargetVotes` —
all already mapped from backend in `adapters.ts`):

- **Has best guess**: `NEEDS REVIEW  best guess S02E04 — 56% confidence (10/25 votes) — confirm in review queue`
- **No match found**: `NEEDS REVIEW  no match found — assign in review queue`

No backend or adapter changes needed.

## Tests

Added 4 new unit tests for the vote-ratio path, all anchored to real log data:
- `test_overwhelming_vote_ratio_clears_review` — 103 vs 31 votes (3.3x) -> >= 0.70
- `test_close_vote_ratio_stays_review` — 10 vs 8 votes (1.25x) -> < 0.70 (not decisive)
- `test_vote_ratio_requires_minimum_consensus` — 3 vs 1 votes with 2.5% consensus -> < 0.70
- `test_vote_ratio_disabled_without_runner_up` — `runner_up_votes=0` equals omitting arg

All 22 calibration tests pass; all 1234 unit tests pass.

## Files Changed

| File | Change |
|------|--------|
| `backend/app/matcher/episode_identification.py` | Two-path confidence formula, `runner_up_votes` param, new constants, diagnostics |
| `backend/tests/unit/test_confidence_calibration.py` | 4 new vote-ratio tests + updated component assertions |
| `frontend/src/app/components/TrackGrid.tsx` | Dynamic best-guess display for REVIEW state |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
