### PR TITLE
feat(fingerprint): Phase 1 chromaprint foundation

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+name: Engram CodeQL config
+
+# Why: Alembic migration files declare module-level globals (`revision`,
+# `down_revision`, `branch_labels`, `depends_on`) that look unused to a static
+# analyzer but are consumed by Alembic's filesystem-based migration loader via
+# name-based introspection. Excluding the migration tree from the unused-global
+# query keeps the genuine alerts elsewhere actionable.
+query-filters:
+  - exclude:
+      id: py/unused-global-variable
+      paths:
+        - "backend/migrations/versions/**"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,12 +1,13 @@
 name: Engram CodeQL config
 
-# Why: Alembic migration files declare module-level globals (`revision`,
-# `down_revision`, `branch_labels`, `depends_on`) that look unused to a static
-# analyzer but are consumed by Alembic's filesystem-based migration loader via
-# name-based introspection. Excluding the migration tree from the unused-global
-# query keeps the genuine alerts elsewhere actionable.
-query-filters:
-  - exclude:
-      id: py/unused-global-variable
-      paths:
-        - "backend/migrations/versions/**"
+# Why exclude `backend/migrations/versions/**`:
+#
+# Alembic version files are framework-generated stubs whose module-level
+# globals (`revision`, `down_revision`, `branch_labels`, `depends_on`) are
+# consumed by Alembic's filesystem-based migration loader via name-based
+# introspection. A static analyzer can't see that usage and reports them as
+# unused. The files contain only DDL — no application logic — so excluding
+# them from analysis entirely is a strictly safer policy than enumerating
+# query filters and discovering the next false positive after the fact.
+paths-ignore:
+  - "backend/migrations/versions/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ engram-windows-*.zip
 /screenshots/
 # docs/screenshots/ is intentionally tracked
 
+# Spike binaries (downloaded, not committed)
+spikes/**/bin/
+
 # MkDocs
 site/
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1210,14 +1210,32 @@ async def list_fingerprint_contributions(
     Excludes the chromaprint blob body — only summarizes byte size — so the response
     stays manageable. Phase 2 adds filtering by upload status.
     """
+    from sqlalchemy import func
+
     from app.models.fingerprint import FingerprintContribution
 
+    # Select metadata columns plus the blob *length* (not the blob itself) so we
+    # don't pull tens of megabytes of fingerprint data through SQLite just to
+    # report a size summary.
+    fc = FingerprintContribution
     result = await session.execute(
-        select(FingerprintContribution)
-        .order_by(FingerprintContribution.queued_at.desc())
+        select(
+            fc.id,
+            fc.queued_at,
+            fc.title_id,
+            fc.tmdb_id,
+            fc.season,
+            fc.episode,
+            fc.match_confidence,
+            fc.match_source,
+            fc.uploaded_at,
+            fc.upload_attempts,
+            func.length(fc.chromaprint_blob).label("blob_size_bytes"),
+        )
+        .order_by(fc.queued_at.desc())
         .limit(limit)
     )
-    rows = result.scalars().all()
+    rows = result.all()
     items = [
         {
             "id": r.id,
@@ -1230,7 +1248,7 @@ async def list_fingerprint_contributions(
             "match_source": r.match_source,
             "uploaded_at": r.uploaded_at.isoformat() if r.uploaded_at else None,
             "upload_attempts": r.upload_attempts,
-            "blob_size_bytes": len(r.chromaprint_blob) if r.chromaprint_blob else 0,
+            "blob_size_bytes": r.blob_size_bytes or 0,
         }
         for r in rows
     ]

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1200,6 +1200,43 @@ async def delete_job(
     return {"status": "cleared", "job_id": job.id}
 
 
+@router.get("/fingerprint/contributions")
+async def list_fingerprint_contributions(
+    session: AsyncSession = Depends(get_session),
+    limit: int = 200,
+) -> dict:
+    """Return locally-queued fingerprint contributions (Phase 1 audit log).
+
+    Excludes the chromaprint blob body — only summarizes byte size — so the response
+    stays manageable. Phase 2 adds filtering by upload status.
+    """
+    from app.models.fingerprint import FingerprintContribution
+
+    result = await session.execute(
+        select(FingerprintContribution)
+        .order_by(FingerprintContribution.queued_at.desc())
+        .limit(limit)
+    )
+    rows = result.scalars().all()
+    items = [
+        {
+            "id": r.id,
+            "queued_at": r.queued_at.isoformat() if r.queued_at else None,
+            "title_id": r.title_id,
+            "tmdb_id": r.tmdb_id,
+            "season": r.season,
+            "episode": r.episode,
+            "match_confidence": r.match_confidence,
+            "match_source": r.match_source,
+            "uploaded_at": r.uploaded_at.isoformat() if r.uploaded_at else None,
+            "upload_attempts": r.upload_attempts,
+            "blob_size_bytes": len(r.chromaprint_blob) if r.chromaprint_blob else 0,
+        }
+        for r in rows
+    ]
+    return {"count": len(items), "items": items}
+
+
 # --- Simulation Endpoints (debug mode only) ---
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1203,7 +1203,7 @@ async def delete_job(
 @router.get("/fingerprint/contributions")
 async def list_fingerprint_contributions(
     session: AsyncSession = Depends(get_session),
-    limit: int = 200,
+    limit: int = Query(200, ge=1, le=1000),
 ) -> dict:
     """Return locally-queued fingerprint contributions (Phase 1 audit log).
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -63,17 +63,18 @@ def require_debug() -> None:
 # Loopback addresses that count as "the user is querying their own machine".
 # Used by endpoints that surface privacy-sensitive data (e.g. ripping history)
 # so they remain reachable from the dashboard but not from LAN peers when
-# `allow_lan_access` binds 0.0.0.0.
-_LOCALHOST_CLIENTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+# `allow_lan_access` binds 0.0.0.0. Tests should override the dependency via
+# `app.dependency_overrides[require_localhost] = lambda: None` rather than
+# widening this set with test-framework implementation details.
+_LOCALHOST_CLIENTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 
 def require_localhost(request: Request) -> None:
     """FastAPI dependency: 403 unless the request came from the host machine.
 
-    Allowed: real loopback (`127.0.0.1`, `::1`), the literal `localhost`, and
-    `testclient` (the FastAPI/Starlette test client host). Everything else —
-    including LAN peers when `allow_lan_access=True` opens the bind to all
-    interfaces — is rejected.
+    Allowed: real loopback (`127.0.0.1`, `::1`) and the literal `localhost`.
+    Everything else — including LAN peers when `allow_lan_access=True` opens
+    the bind to all interfaces — is rejected.
     """
     client = request.client.host if request.client else None
     if client not in _LOCALHOST_CLIENTS:

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -292,6 +292,9 @@ class ConfigResponse(BaseModel):
     allow_lan_access: bool
     # Onboarding
     setup_complete: bool
+    # Chromaprint fingerprinting (Phase 1)
+    fpcalc_path: str
+    enable_fingerprint_contributions: bool
 
 
 class ConfigUpdate(BaseModel):
@@ -359,6 +362,9 @@ class ConfigUpdate(BaseModel):
     allow_lan_access: bool | None = None
     # Onboarding
     setup_complete: bool | None = None
+    # Chromaprint fingerprinting (Phase 1)
+    fpcalc_path: str | None = None
+    enable_fingerprint_contributions: bool | None = None
 
 
 class ReviewRequest(BaseModel):
@@ -1036,6 +1042,9 @@ async def get_config() -> ConfigResponse:
         allow_lan_access=config.allow_lan_access,
         # Onboarding
         setup_complete=config.setup_complete,
+        # Chromaprint fingerprinting (Phase 1)
+        fpcalc_path=config.fpcalc_path or "",
+        enable_fingerprint_contributions=config.enable_fingerprint_contributions,
     )
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -60,6 +60,28 @@ def require_debug() -> None:
         raise HTTPException(status_code=403, detail="Simulation only available in debug mode")
 
 
+# Loopback addresses that count as "the user is querying their own machine".
+# Used by endpoints that surface privacy-sensitive data (e.g. ripping history)
+# so they remain reachable from the dashboard but not from LAN peers when
+# `allow_lan_access` binds 0.0.0.0.
+_LOCALHOST_CLIENTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+
+
+def require_localhost(request: Request) -> None:
+    """FastAPI dependency: 403 unless the request came from the host machine.
+
+    Allowed: real loopback (`127.0.0.1`, `::1`), the literal `localhost`, and
+    `testclient` (the FastAPI/Starlette test client host). Everything else —
+    including LAN peers when `allow_lan_access=True` opens the bind to all
+    interfaces — is rejected.
+    """
+    client = request.client.host if request.client else None
+    if client not in _LOCALHOST_CLIENTS:
+        raise HTTPException(
+            status_code=403, detail="This endpoint is only reachable from the host machine"
+        )
+
+
 # Request/Response Models
 class JobResponse(BaseModel):
     """Response model for a disc job."""
@@ -1200,7 +1222,7 @@ async def delete_job(
     return {"status": "cleared", "job_id": job.id}
 
 
-@router.get("/fingerprint/contributions")
+@router.get("/fingerprint/contributions", dependencies=[Depends(require_localhost)])
 async def list_fingerprint_contributions(
     session: AsyncSession = Depends(get_session),
     limit: int = Query(200, ge=1, le=1000),
@@ -1209,6 +1231,11 @@ async def list_fingerprint_contributions(
 
     Excludes the chromaprint blob body — only summarizes byte size — so the response
     stays manageable. Phase 2 adds filtering by upload status.
+
+    Localhost-only: the response includes recent ripping activity (TMDB IDs,
+    season/episode, timestamps), which is the user's viewing history. The
+    `require_localhost` guard rejects LAN peers even when `allow_lan_access`
+    has opened the bind address.
     """
     from sqlalchemy import func
 

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -67,6 +67,7 @@ class DetectToolsResponse(BaseModel):
 
     makemkv: ToolDetectionResult
     ffmpeg: ToolDetectionResult
+    fpcalc: ToolDetectionResult
     platform: str
 
 
@@ -312,14 +313,15 @@ def detect_ffmpeg() -> ToolDetectionResult:
 
 @router.get("/detect-tools", response_model=DetectToolsResponse)
 async def detect_tools() -> DetectToolsResponse:
-    """Auto-detect MakeMKV and FFmpeg installations."""
+    """Auto-detect MakeMKV, FFmpeg, and fpcalc installations."""
     # Detection shells out to the tools (blocking, multi-second on slow/busy
     # drives), so run it off the event loop to avoid stalling other requests.
-    makemkv, ffmpeg = await asyncio.gather(
+    makemkv, ffmpeg, fpcalc = await asyncio.gather(
         asyncio.to_thread(detect_makemkv),
         asyncio.to_thread(detect_ffmpeg),
+        asyncio.to_thread(detect_fpcalc),
     )
-    return DetectToolsResponse(makemkv=makemkv, ffmpeg=ffmpeg, platform=sys.platform)
+    return DetectToolsResponse(makemkv=makemkv, ffmpeg=ffmpeg, fpcalc=fpcalc, platform=sys.platform)
 
 
 @router.post("/validate/makemkv", response_model=ValidationResponse)
@@ -379,6 +381,15 @@ async def validate_ffmpeg(request: ValidationRequest) -> ValidationResponse:
         elif error == "Command timeout (10s)":
             error = "FFmpeg command timeout (10s)"
         return ValidationResponse(valid=False, error=error)
+    return ValidationResponse(valid=True, version=result.version, path=result.path)
+
+
+@router.post("/validate/fpcalc", response_model=ValidationResponse)
+async def validate_fpcalc(request: ValidationRequest) -> ValidationResponse:
+    """Validate a user-supplied fpcalc binary path."""
+    result = await asyncio.to_thread(_validate_fpcalc_binary, request.path)
+    if not result.found:
+        return ValidationResponse(valid=False, error=result.error, path=result.path)
     return ValidationResponse(valid=True, version=result.version, path=result.path)
 
 

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -226,7 +226,7 @@ def _validate_fpcalc_binary(path_str: str) -> ToolDetectionResult:
         return ToolDetectionResult(found=True, path=path_str, version=version_line)
     except subprocess.TimeoutExpired:
         return ToolDetectionResult(found=False, path=path_str, error="Timed out")
-    except OSError as e:
+    except Exception as e:
         return ToolDetectionResult(found=False, path=path_str, error=str(e))
 
 
@@ -387,6 +387,13 @@ async def validate_ffmpeg(request: ValidationRequest) -> ValidationResponse:
 @router.post("/validate/fpcalc", response_model=ValidationResponse)
 async def validate_fpcalc(request: ValidationRequest) -> ValidationResponse:
     """Validate a user-supplied fpcalc binary path."""
+    fpcalc_cmd = Path(request.path)
+    # Constrain to known fpcalc executables before filesystem/subprocess use.
+    if not executable_basename_allowed(str(fpcalc_cmd), _FPCALC_EXE_NAMES):
+        return ValidationResponse(valid=False, error="Path does not point to an fpcalc executable")
+    if not fpcalc_cmd.exists():
+        return ValidationResponse(valid=False, error="File not found at specified path")
+
     result = await asyncio.to_thread(_validate_fpcalc_binary, request.path)
     if not result.found:
         return ValidationResponse(valid=False, error=result.error, path=result.path)

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -229,6 +229,44 @@ def _validate_fpcalc_binary(path_str: str) -> ToolDetectionResult:
         return ToolDetectionResult(found=False, path=path_str, error=str(e))
 
 
+FPCALC_COMMON_PATHS = [
+    # Windows
+    r"C:\Program Files\Chromaprint\fpcalc.exe",
+    r"C:\Program Files (x86)\Chromaprint\fpcalc.exe",
+    # macOS (homebrew)
+    "/opt/homebrew/bin/fpcalc",
+    "/usr/local/bin/fpcalc",
+    # Linux
+    "/usr/bin/fpcalc",
+    # Dev convenience: the worktree spike binary
+    str(Path(__file__).resolve().parents[3] / "spikes" / "chromaprint" / "bin" / "fpcalc.exe"),
+]
+
+
+def detect_fpcalc() -> ToolDetectionResult:
+    """Auto-detect a usable fpcalc binary.
+
+    Order: PATH first, then common platform locations, then the dev spike binary.
+    Returns the first result that validates successfully.
+    """
+    via_path = shutil.which("fpcalc")
+    candidates: list[str] = []
+    if via_path:
+        candidates.append(via_path)
+    candidates.extend(FPCALC_COMMON_PATHS)
+
+    for candidate in candidates:
+        result = _validate_fpcalc_binary(candidate)
+        if result.found:
+            return result
+
+    return ToolDetectionResult(
+        found=False,
+        path=None,
+        error="fpcalc not found in PATH or common locations",
+    )
+
+
 def detect_makemkv() -> ToolDetectionResult:
     """Auto-detect MakeMKV by searching PATH then common install locations."""
     # 1. Check system PATH

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -29,6 +29,7 @@ _MAKEMKV_EXE_NAMES = (
     "com.makemkv.MakeMKV",
 )
 _FFMPEG_EXE_NAMES = ("ffmpeg", "ffmpeg.exe")
+_FPCALC_EXE_NAMES = ("fpcalc", "fpcalc.exe")
 
 
 class ValidationRequest(BaseModel):
@@ -203,6 +204,29 @@ def _validate_ffmpeg_binary(path_str: str) -> ToolDetectionResult:
         return ToolDetectionResult(found=False, path=path_str, error="Command timeout (10s)")
     except Exception as e:
         return ToolDetectionResult(found=False, error=f"Execution failed: {e}")
+
+
+def _validate_fpcalc_binary(path_str: str) -> ToolDetectionResult:
+    """Validate a chromaprint fpcalc binary and extract version info."""
+    try:
+        result = subprocess.run(
+            [path_str, "-version"],
+            capture_output=True,
+            timeout=10,
+            text=True,
+        )
+        if result.returncode != 0:
+            return ToolDetectionResult(
+                found=False,
+                path=path_str,
+                error=f"Non-zero exit code {result.returncode}",
+            )
+        version_line = (result.stdout or "").split("\n")[0] or "unknown"
+        return ToolDetectionResult(found=True, path=path_str, version=version_line)
+    except subprocess.TimeoutExpired:
+        return ToolDetectionResult(found=False, path=path_str, error="Timed out")
+    except OSError as e:
+        return ToolDetectionResult(found=False, path=path_str, error=str(e))
 
 
 def detect_makemkv() -> ToolDetectionResult:

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -239,19 +240,26 @@ FPCALC_COMMON_PATHS = [
     "/usr/local/bin/fpcalc",
     # Linux
     "/usr/bin/fpcalc",
-    # Dev convenience: the worktree spike binary
-    str(Path(__file__).resolve().parents[3] / "spikes" / "chromaprint" / "bin" / "fpcalc.exe"),
 ]
+
+# Developers can point auto-detect at a local-tree spike binary (or any other
+# off-PATH install) by setting ENGRAM_FPCALC_PATH. Shipping the spike binary
+# directly in `FPCALC_COMMON_PATHS` would leak an internal repo layout to all
+# users' subprocess audit trails and add a useless probe in production.
+_DEV_FPCALC_ENV = "ENGRAM_FPCALC_PATH"
 
 
 def detect_fpcalc() -> ToolDetectionResult:
     """Auto-detect a usable fpcalc binary.
 
-    Order: PATH first, then common platform locations, then the dev spike binary.
-    Returns the first result that validates successfully.
+    Order: explicit `ENGRAM_FPCALC_PATH` env var, then PATH, then common
+    platform locations. Returns the first result that validates successfully.
     """
-    via_path = shutil.which("fpcalc")
     candidates: list[str] = []
+    env_override = os.environ.get(_DEV_FPCALC_ENV)
+    if env_override:
+        candidates.append(env_override)
+    via_path = shutil.which("fpcalc")
     if via_path:
         candidates.append(via_path)
     candidates.extend(FPCALC_COMMON_PATHS)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,8 +55,11 @@ async def lifespan(app: FastAPI):
     from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
 
     async with _async_session() as _session:
-        _result = await _session.execute(_select(_AppConfig))
-        _cfg = _result.scalar_one_or_none()
+        # Mirror get_config()'s `.limit(1)` guard so a corrupt/test-polluted DB
+        # with multiple app_config rows doesn't raise MultipleResultsFound
+        # during lifespan startup and block the server from coming up.
+        _result = await _session.execute(_select(_AppConfig).limit(1))
+        _cfg = _result.scalars().first()
         if _cfg is not None and not validate_pseudonym(_cfg.contribution_pseudonym):
             _cfg.contribution_pseudonym = generate_pseudonym()
             _session.add(_cfg)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,23 @@ async def lifespan(app: FastAPI):
 
     config = await get_config()
 
+    # Ensure the contribution pseudonym exists (Phase 1: fingerprint contributions).
+    # Must run after get_config() which guarantees the app_config row exists.
+    from sqlmodel import select as _select
+
+    from app.database import async_session as _async_session
+    from app.models.app_config import AppConfig as _AppConfig
+    from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
+
+    async with _async_session() as _session:
+        _result = await _session.execute(_select(_AppConfig))
+        _cfg = _result.scalar_one_or_none()
+        if _cfg is not None and not validate_pseudonym(_cfg.contribution_pseudonym):
+            _cfg.contribution_pseudonym = generate_pseudonym()
+            _session.add(_cfg)
+            await _session.commit()
+            logger.info(f"Generated contribution pseudonym: {_cfg.contribution_pseudonym}")
+
     # Reconcile a stored MakeMKV key into MakeMKV's settings.conf on boot so
     # makemkvcon is registered even if the key was entered before this bridge
     # existed (idempotent — skips the write when already in sync).

--- a/backend/app/matcher/chromaprint_extractor.py
+++ b/backend/app/matcher/chromaprint_extractor.py
@@ -15,6 +15,10 @@ from dataclasses import dataclass
 
 from loguru import logger
 
+# Module-level dedupe flag: log the first fpcalc-version failure, then suppress.
+# See `_cached_version` for the dedupe rationale.
+_version_failure_logged = False
+
 
 @dataclass
 class ChromaprintResult:
@@ -124,6 +128,18 @@ class ChromaprintExtractor:
             proc = await asyncio.to_thread(_run)
             self._version_cache = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
         except Exception:
-            logger.warning("fpcalc -version failed; fpcalc_version will be empty", exc_info=True)
+            # Each ChromaprintExtractor instance is short-lived (one per title
+            # in the matching pipeline), so a misconfigured fpcalc binary would
+            # otherwise log on every extraction. Dedupe at module level so the
+            # operator sees a single diagnostic, not one per ripped title.
+            global _version_failure_logged
+            if not _version_failure_logged:
+                logger.error(
+                    f"fpcalc -version failed at {self.fpcalc_path!r}; "
+                    "fpcalc_version will be empty on stored fingerprints. "
+                    "Subsequent failures suppressed.",
+                    exc_info=True,
+                )
+                _version_failure_logged = True
             self._version_cache = ""
         return self._version_cache

--- a/backend/app/matcher/chromaprint_extractor.py
+++ b/backend/app/matcher/chromaprint_extractor.py
@@ -15,10 +15,6 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-# Module-level dedupe flag: log the first fpcalc-version failure, then suppress.
-# See `_cached_version` for the dedupe rationale.
-_version_failure_logged = False
-
 
 @dataclass
 class ChromaprintResult:
@@ -57,6 +53,13 @@ class ChromaprintResult:
 
 class ChromaprintExtractor:
     """Subprocess-based chromaprint fingerprint extractor."""
+
+    # Class-level dedupe flag for fpcalc -version failures. Each extractor
+    # instance is short-lived (one per title in the matching pipeline), so a
+    # misconfigured fpcalc binary would otherwise log on every extraction.
+    # Tracking on the class — not the instance — gives us once-per-process
+    # logging without resorting to `global`.
+    _version_failure_logged: bool = False
 
     def __init__(self, fpcalc_path: str, timeout_seconds: float = 120.0) -> None:
         self.fpcalc_path = fpcalc_path
@@ -128,18 +131,15 @@ class ChromaprintExtractor:
             proc = await asyncio.to_thread(_run)
             self._version_cache = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
         except Exception:
-            # Each ChromaprintExtractor instance is short-lived (one per title
-            # in the matching pipeline), so a misconfigured fpcalc binary would
-            # otherwise log on every extraction. Dedupe at module level so the
-            # operator sees a single diagnostic, not one per ripped title.
-            global _version_failure_logged
-            if not _version_failure_logged:
+            # Dedupe failure logging at the class level so a misconfigured
+            # fpcalc binary doesn't spam logs once per ripped title.
+            if not ChromaprintExtractor._version_failure_logged:
                 logger.error(
                     f"fpcalc -version failed at {self.fpcalc_path!r}; "
                     "fpcalc_version will be empty on stored fingerprints. "
                     "Subsequent failures suppressed.",
                     exc_info=True,
                 )
-                _version_failure_logged = True
+                ChromaprintExtractor._version_failure_logged = True
             self._version_cache = ""
         return self._version_cache

--- a/backend/app/matcher/chromaprint_extractor.py
+++ b/backend/app/matcher/chromaprint_extractor.py
@@ -1,0 +1,55 @@
+"""Chromaprint fingerprint extraction.
+
+Wraps the fpcalc CLI (bundled with libchromaprint) to produce a chromaprint hash
+stream for an MKV/MP4/audio file. Phase 1 stores the full fingerprint per title;
+windowed querying lives in Phase 3.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class ChromaprintResult:
+    """The full chromaprint hash stream for one media file."""
+
+    hashes: list[int]
+    duration_seconds: float
+    fpcalc_version: str
+
+    def to_blob(self) -> bytes:
+        """Serialize to gzip-compressed JSON for DB storage."""
+        payload = {
+            "v": 1,
+            "duration": self.duration_seconds,
+            "fpcalc": self.fpcalc_version,
+            "hashes": self.hashes,
+        }
+        return gzip.compress(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            mtime=0,
+        )
+
+    @classmethod
+    def from_blob(cls, blob: bytes) -> ChromaprintResult:
+        payload = json.loads(gzip.decompress(blob).decode("utf-8"))
+        if payload.get("v") != 1:
+            raise ValueError(f"Unknown chromaprint blob version: {payload.get('v')}")
+        return cls(
+            hashes=list(payload["hashes"]),
+            duration_seconds=float(payload["duration"]),
+            fpcalc_version=str(payload.get("fpcalc", "")),
+        )
+
+
+class ChromaprintExtractor:
+    """Subprocess-based chromaprint fingerprint extractor."""
+
+    def __init__(self, fpcalc_path: str) -> None:
+        self.fpcalc_path = fpcalc_path
+
+    async def extract(self, media_path: str) -> ChromaprintResult:
+        raise NotImplementedError("extract() lands in Task C2")

--- a/backend/app/matcher/chromaprint_extractor.py
+++ b/backend/app/matcher/chromaprint_extractor.py
@@ -7,9 +7,13 @@ windowed querying lives in Phase 3.
 
 from __future__ import annotations
 
+import asyncio
 import gzip
 import json
+import subprocess
 from dataclasses import dataclass
+
+from loguru import logger
 
 
 @dataclass
@@ -48,8 +52,75 @@ class ChromaprintResult:
 class ChromaprintExtractor:
     """Subprocess-based chromaprint fingerprint extractor."""
 
-    def __init__(self, fpcalc_path: str) -> None:
+    def __init__(self, fpcalc_path: str, timeout_seconds: float = 120.0) -> None:
         self.fpcalc_path = fpcalc_path
+        self.timeout_seconds = timeout_seconds
+        self._version_cache: str | None = None
 
     async def extract(self, media_path: str) -> ChromaprintResult:
-        raise NotImplementedError("extract() lands in Task C2")
+        """Extract the full chromaprint hash stream from a media file.
+
+        Returns a `ChromaprintResult` on success. Raises `RuntimeError` on any
+        fpcalc-side failure — the caller decides whether the matching pipeline
+        should continue without a fingerprint.
+        """
+
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [self.fpcalc_path, "-raw", "-length", "99999", media_path],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+
+        try:
+            proc = await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"fpcalc timed out after {self.timeout_seconds}s on {media_path}"
+            ) from e
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"fpcalc exited {proc.returncode} on {media_path}: {proc.stderr.strip()}"
+            )
+
+        duration: float | None = None
+        hashes: list[int] = []
+        for line in proc.stdout.splitlines():
+            if line.startswith("DURATION="):
+                duration = float(line.removeprefix("DURATION="))
+            elif line.startswith("FINGERPRINT="):
+                hashes = [int(x) for x in line.removeprefix("FINGERPRINT=").split(",") if x]
+
+        if not hashes:
+            raise RuntimeError(f"fpcalc produced no FINGERPRINT line for {media_path}")
+        if duration is None:
+            duration = 0.0
+
+        version_line = await self._cached_version()
+        logger.info(
+            f"chromaprint extracted: {len(hashes)} hashes, {duration:.1f}s from {media_path}"
+        )
+        return ChromaprintResult(
+            hashes=hashes, duration_seconds=duration, fpcalc_version=version_line
+        )
+
+    async def _cached_version(self) -> str:
+        if self._version_cache is not None:
+            return self._version_cache
+
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [self.fpcalc_path, "-version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+        try:
+            proc = await asyncio.to_thread(_run)
+            self._version_cache = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
+        except Exception:
+            self._version_cache = ""
+        return self._version_cache

--- a/backend/app/matcher/chromaprint_extractor.py
+++ b/backend/app/matcher/chromaprint_extractor.py
@@ -40,8 +40,10 @@ class ChromaprintResult:
     @classmethod
     def from_blob(cls, blob: bytes) -> ChromaprintResult:
         payload = json.loads(gzip.decompress(blob).decode("utf-8"))
-        if payload.get("v") != 1:
-            raise ValueError(f"Unknown chromaprint blob version: {payload.get('v')}")
+        if "v" not in payload:
+            raise ValueError("Chromaprint blob is missing version field")
+        if payload["v"] != 1:
+            raise ValueError(f"Unknown chromaprint blob version: {payload['v']}")
         return cls(
             hashes=list(payload["hashes"]),
             duration_seconds=float(payload["duration"]),
@@ -122,5 +124,6 @@ class ChromaprintExtractor:
             proc = await asyncio.to_thread(_run)
             self._version_cache = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
         except Exception:
+            logger.warning("fpcalc -version failed; fpcalc_version will be empty", exc_info=True)
             self._version_cache = ""
         return self._version_cache

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,5 +2,14 @@
 
 from app.models.app_config import AppConfig
 from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.models.fingerprint import FingerprintContribution
 
-__all__ = ["DiscJob", "DiscTitle", "JobState", "TitleState", "ContentType", "AppConfig"]
+__all__ = [
+    "DiscJob",
+    "DiscTitle",
+    "JobState",
+    "TitleState",
+    "ContentType",
+    "AppConfig",
+    "FingerprintContribution",
+]

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -143,3 +143,8 @@ class AppConfig(SQLModel, table=True):
     # Auto-update preferences
     skipped_update_version: str | None = None  # e.g. "0.8.2" — user dismissed this version
     last_update_check: datetime | None = None  # informational timestamp
+
+    # Chromaprint / fingerprint contributions
+    fpcalc_path: str | None = Field(default=None)
+    contribution_pseudonym: str | None = Field(default=None)
+    enable_fingerprint_contributions: bool = Field(default=True)

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -147,4 +147,6 @@ class AppConfig(SQLModel, table=True):
     # Chromaprint / fingerprint contributions
     fpcalc_path: str | None = Field(default=None)
     contribution_pseudonym: str | None = Field(default=None)
-    enable_fingerprint_contributions: bool = Field(default=True)
+    enable_fingerprint_contributions: bool = Field(
+        default=True, sa_column_kwargs={"server_default": text("1")}
+    )

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -168,6 +168,11 @@ class DiscTitle(SQLModel, table=True):
 
     # Match source tracking
     match_source: str | None = Field(default=None)  # "discdb", "engram", "user", "ai_llm"
+
+    # Chromaprint fingerprint (Phase 1 — extraction + storage only; no identification yet)
+    chromaprint_blob: bytes | None = Field(default=None)
+    chromaprint_extracted_at: datetime | None = Field(default=None)
+
     discdb_match_details: str | None = Field(default=None)  # DiscDB match preserved separately
     discdb_flagged: bool = Field(default=False)  # User flagged DiscDB data as incorrect
     discdb_flag_reason: str | None = Field(default=None)  # Reason for flag

--- a/backend/app/models/fingerprint.py
+++ b/backend/app/models/fingerprint.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
+from sqlalchemy import text
 from sqlmodel import Field, SQLModel
 
 
@@ -18,7 +19,10 @@ class FingerprintContribution(SQLModel, table=True):
     __tablename__ = "fingerprint_contributions"
 
     id: int | None = Field(default=None, primary_key=True)
-    queued_at: datetime = Field(default_factory=datetime.utcnow)
+    queued_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column_kwargs={"server_default": text("(datetime('now'))")},
+    )
 
     # Nullable so bootstrap rows (no DiscTitle row) can also be queued.
     title_id: int | None = Field(default=None, foreign_key="disc_titles.id", index=True)

--- a/backend/app/models/fingerprint.py
+++ b/backend/app/models/fingerprint.py
@@ -1,0 +1,43 @@
+"""Models for the chromaprint fingerprint contribution queue (Phase 1: local-only)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class FingerprintContribution(SQLModel, table=True):
+    """Local-only queue row.
+
+    Phase 1: rows are appended on successful match. They never leave the local
+    machine. Phase 2 adds a ContributionUploader service that drains this table
+    over HTTPS to the fingerprint network server.
+    """
+
+    __tablename__ = "fingerprint_contributions"
+
+    id: int | None = Field(default=None, primary_key=True)
+    queued_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # Nullable so bootstrap rows (no DiscTitle row) can also be queued.
+    title_id: int | None = Field(default=None, foreign_key="disc_titles.id", index=True)
+    chromaprint_blob: bytes
+
+    # Episode identity (the payload-bearing fields per the Phase 2 design)
+    tmdb_id: int
+    season: int | None = None
+    episode: int | None = None
+
+    # Provenance for trust-tier promotion
+    match_confidence: float
+    match_source: str  # 'engram_asr' | 'engram_discdb' | 'bootstrap' | 'user_review'
+
+    # Identifies a *disc release*, not the user's file (m2ts size MD5 from TheDiscDB)
+    disc_content_hash: bytes | None = None
+
+    pseudonym: str
+
+    # Set when Phase 2 uploader runs
+    uploaded_at: datetime | None = None
+    upload_attempts: int = Field(default=0)

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -188,9 +188,12 @@ async def bootstrap_directory(
                 contributions_enabled=cfg.enable_fingerprint_contributions,
             )
             counters["queued"] += 1
-            # Commit in batches so an extractor failure on file #N doesn't
-            # lose the first N-1 already-queued contributions.
-            if counters["queued"] % BOOTSTRAP_BATCH_SIZE == 0:
+            # Commit in batches so a mid-run extractor failure doesn't discard
+            # the contributions already queued. Trigger on `scanned` (every
+            # file walked, success or failure) rather than `queued` — that way
+            # a streak of failures right after a batch boundary doesn't push
+            # the next commit arbitrarily far into the future.
+            if counters["scanned"] % BOOTSTRAP_BATCH_SIZE == 0:
                 await session.commit()
         if not dry_run:
             await session.commit()

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -3,8 +3,13 @@
 Walks a directory of MKVs labeled `Show - SnnEnn.mkv`, fingerprints each one,
 and enqueues a FingerprintContribution row tagged `match_source="bootstrap"`.
 
+Phase 1 scope: **TV shows only.** Pointing this at a movies directory will
+produce TMDB misses for every file (since lookups go through TMDB *TV* search)
+and end with `queued=0, skipped=N`. Movie-bootstrap support lives in a future
+phase alongside the broader movie identification flow.
+
 Usage:
-  uv run python -m app.scripts.bootstrap_library /path/to/library [--dry-run]
+  uv run python -m app.scripts.bootstrap_library /path/to/tv-library [--dry-run]
 """
 
 from __future__ import annotations
@@ -21,6 +26,11 @@ EP_REGEX = re.compile(
     r"(?P<show>.+?)\s*-\s*S(?P<season>\d{1,2})E(?P<ep>\d{1,3})\s*\.\w+$",
     re.IGNORECASE,
 )
+
+# Commit accumulated contributions in batches so a mid-run extractor failure
+# (e.g. a corrupt MKV partway through a 5000-file library) doesn't discard
+# the contributions already collected.
+BOOTSTRAP_BATCH_SIZE = 200
 
 SearchFn = Callable[[str, str], Awaitable[int | None]]
 
@@ -178,6 +188,10 @@ async def bootstrap_directory(
                 contributions_enabled=cfg.enable_fingerprint_contributions,
             )
             counters["queued"] += 1
+            # Commit in batches so an extractor failure on file #N doesn't
+            # lose the first N-1 already-queued contributions.
+            if counters["queued"] % BOOTSTRAP_BATCH_SIZE == 0:
+                await session.commit()
         if not dry_run:
             await session.commit()
 

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -73,14 +73,20 @@ async def _default_search(show: str, content_type: str) -> int | None:
     fetch_show_id / fetch_movie_id return a *string* TMDB ID (e.g. "12345") or
     None; we cast to int before returning.
     """
-    if content_type == "tv":
-        from app.matcher.tmdb_client import fetch_show_id
+    try:
+        if content_type == "tv":
+            from app.matcher.tmdb_client import fetch_show_id
 
-        raw = await asyncio.to_thread(fetch_show_id, show)
-    else:
-        from app.matcher.tmdb_client import fetch_movie_id
+            raw = await asyncio.to_thread(fetch_show_id, show)
+        else:
+            from app.matcher.tmdb_client import fetch_movie_id
 
-        raw = await asyncio.to_thread(fetch_movie_id, show)
+            raw = await asyncio.to_thread(fetch_movie_id, show)
+    except Exception as e:
+        # Network errors, bad TMDB token, etc. — treat as a miss so the bootstrap
+        # loop continues with the next file instead of aborting the whole run.
+        logger.warning(f"TMDB lookup for {show!r} failed: {e}")
+        return None
 
     if raw is None:
         return None

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -1,0 +1,198 @@
+"""Bootstrap-library CLI.
+
+Walks a directory of MKVs labeled `Show - SnnEnn.mkv`, fingerprints each one,
+and enqueues a FingerprintContribution row tagged `match_source="bootstrap"`.
+
+Usage:
+  uv run python -m app.scripts.bootstrap_library /path/to/library [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+from collections.abc import Awaitable, Callable, Iterable
+from pathlib import Path
+
+from loguru import logger
+
+EP_REGEX = re.compile(
+    r"(?P<show>.+?)\s*-\s*S(?P<season>\d{1,2})E(?P<ep>\d{1,3})\s*\.\w+$",
+    re.IGNORECASE,
+)
+
+SearchFn = Callable[[str, str], Awaitable[int | None]]
+
+
+def parse_episode_filename(name: str) -> tuple[str, int, int] | None:
+    """Return (show, season, episode) for canonical 'Show - SnnEnn.ext' names, else None."""
+    m = EP_REGEX.match(name)
+    if not m:
+        return None
+    return m["show"].strip(), int(m["season"]), int(m["ep"])
+
+
+def walk_library(root: Path) -> Iterable[tuple[Path, tuple[str, int, int]]]:
+    """Yield (file_path, (show, season, episode)) for every labeled MKV under root, skipping Extras."""
+    for mkv in sorted(root.rglob("*.mkv")):
+        if "Extras" in mkv.parts:
+            continue
+        label = parse_episode_filename(mkv.name)
+        if label is None:
+            continue
+        yield mkv, label
+
+
+async def resolve_tmdb_id(
+    show: str,
+    content_type: str,
+    *,
+    search_fn: SearchFn,
+    cache: dict[tuple[str, str], int],
+) -> int | None:
+    """Resolve a show name to a TMDB ID with an in-memory cache.
+
+    Misses are NOT cached so a later run can succeed on a transient lookup failure.
+    """
+    key = (show, content_type)
+    if key in cache:
+        return cache[key]
+    result = await search_fn(show, content_type)
+    if result is not None:
+        cache[key] = result
+    return result
+
+
+async def _default_search(show: str, content_type: str) -> int | None:
+    """Resolve a name -> TMDB ID using the existing fetch_show_id / fetch_movie_id helpers.
+
+    These are synchronous functions backed by @lru_cache, so we offload them to
+    a thread to keep the event loop free.
+
+    fetch_show_id / fetch_movie_id return a *string* TMDB ID (e.g. "12345") or
+    None; we cast to int before returning.
+    """
+    if content_type == "tv":
+        from app.matcher.tmdb_client import fetch_show_id
+
+        raw = await asyncio.to_thread(fetch_show_id, show)
+    else:
+        from app.matcher.tmdb_client import fetch_movie_id
+
+        raw = await asyncio.to_thread(fetch_movie_id, show)
+
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(f"TMDB returned non-integer ID {raw!r} for {show!r}")
+        return None
+
+
+async def bootstrap_directory(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    fpcalc_path: str | None = None,
+    search_fn: SearchFn | None = None,
+) -> dict[str, int]:
+    """Walk `root`, extract + enqueue contributions, return summary counts.
+
+    ``search_fn`` is injectable for testability; defaults to `_default_search`.
+    """
+    from app.database import async_session
+    from app.matcher.chromaprint_extractor import ChromaprintExtractor
+    from app.services.config_service import get_config
+    from app.services.contribution_queue import ContributionQueue
+
+    counters: dict[str, int] = {
+        "scanned": 0,
+        "skipped": 0,
+        "extracted": 0,
+        "queued": 0,
+        "errors": 0,
+    }
+    cache: dict[tuple[str, str], int] = {}
+    if search_fn is None:
+        search_fn = _default_search
+
+    if fpcalc_path is None:
+        from app.api.validation import detect_fpcalc
+
+        detected = await asyncio.to_thread(detect_fpcalc)
+        fpcalc_path = detected.path if detected.found else None
+    if not fpcalc_path:
+        logger.error("fpcalc not configured; cannot bootstrap")
+        return counters
+
+    extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
+
+    async with async_session() as session:
+        cfg = await get_config()
+        pseudonym = cfg.contribution_pseudonym
+        if not pseudonym:
+            logger.error("contribution_pseudonym not set; start the app once before bootstrapping")
+            return counters
+
+        for path, (show, season, episode) in walk_library(root):
+            counters["scanned"] += 1
+            tmdb_id = await resolve_tmdb_id(show, "tv", search_fn=search_fn, cache=cache)
+            if tmdb_id is None:
+                logger.warning(f"Could not resolve TMDB ID for {show!r}; skipping")
+                counters["skipped"] += 1
+                continue
+
+            try:
+                fp = await extractor.extract(str(path))
+                counters["extracted"] += 1
+            except Exception as e:
+                logger.error(f"fpcalc failed on {path}: {e}")
+                counters["errors"] += 1
+                continue
+
+            if dry_run:
+                logger.info(
+                    f"[dry-run] would queue {show} s{season}e{episode} ({len(fp.hashes)} hashes)"
+                )
+                continue
+
+            await ContributionQueue().enqueue(
+                session=session,
+                title_id=None,  # bootstrap rows have no DiscTitle parent
+                chromaprint_blob=fp.to_blob(),
+                tmdb_id=tmdb_id,
+                season=season,
+                episode=episode,
+                match_confidence=1.0,  # filename was the source of truth
+                match_source="bootstrap",
+                disc_content_hash=None,
+                pseudonym=pseudonym,
+                contributions_enabled=cfg.enable_fingerprint_contributions,
+            )
+            counters["queued"] += 1
+        if not dry_run:
+            await session.commit()
+
+    return counters
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap chromaprint contributions from an existing library"
+    )
+    parser.add_argument("library_root", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--fpcalc", type=str, default=None, help="Override fpcalc binary path")
+    args = parser.parse_args()
+
+    counters = asyncio.run(
+        bootstrap_directory(args.library_root, dry_run=args.dry_run, fpcalc_path=args.fpcalc)
+    )
+    logger.info(f"Bootstrap done: {counters}")
+    return 0 if counters["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -95,7 +95,7 @@ async def _default_search(show: str, content_type: str) -> int | None:
     except Exception as e:
         # Network errors, bad TMDB token, etc. — treat as a miss so the bootstrap
         # loop continues with the next file instead of aborting the whole run.
-        logger.warning(f"TMDB lookup for {show!r} failed: {e}")
+        logger.warning(f"TMDB lookup for {show!r} failed: {e}", exc_info=True)
         return None
 
     if raw is None:
@@ -164,7 +164,7 @@ async def bootstrap_directory(
                 fp = await extractor.extract(str(path))
                 counters["extracted"] += 1
             except Exception as e:
-                logger.error(f"fpcalc failed on {path}: {e}")
+                logger.error(f"fpcalc failed on {path}: {e}", exc_info=True)
                 counters["errors"] += 1
                 continue
 

--- a/backend/app/services/contribution_pseudonym.py
+++ b/backend/app/services/contribution_pseudonym.py
@@ -1,0 +1,23 @@
+"""Per-install pseudonym generation for fingerprint contributions.
+
+The pseudonym is a UUIDv4 stored in `app_config.contribution_pseudonym`. It is
+intentionally not tied to any user identity; rotating it deletes the contribution
+history on the server side (Phase 2). Phase 1 only needs to generate and persist it.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+_UUID_V4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+def generate_pseudonym() -> str:
+    """Return a fresh UUIDv4 string."""
+    return str(uuid.uuid4())
+
+
+def validate_pseudonym(value: object) -> bool:
+    """True if `value` is a syntactically-valid UUIDv4 string."""
+    return isinstance(value, str) and bool(_UUID_V4_RE.match(value))

--- a/backend/app/services/contribution_queue.py
+++ b/backend/app/services/contribution_queue.py
@@ -1,0 +1,53 @@
+"""Local-only fingerprint contribution queue (Phase 1).
+
+Phase 2 adds an uploader that drains this queue over HTTPS. For Phase 1 the queue
+is append-only and never uploads anything — it exists so that contributions are
+captured from day one, ready to flow when the server lands.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.fingerprint import FingerprintContribution
+
+
+class ContributionQueue:
+    """Append rows to the local FingerprintContribution table."""
+
+    async def enqueue(
+        self,
+        *,
+        session: AsyncSession,
+        title_id: int | None,
+        chromaprint_blob: bytes,
+        tmdb_id: int,
+        season: int | None,
+        episode: int | None,
+        match_confidence: float,
+        match_source: str,
+        disc_content_hash: bytes | None,
+        pseudonym: str,
+        contributions_enabled: bool = True,
+    ) -> None:
+        """Append a contribution if the user has opt-in (default True)."""
+        if not contributions_enabled:
+            logger.debug(f"Skipping contribution for title {title_id}: contributions disabled")
+            return
+        row = FingerprintContribution(
+            title_id=title_id,
+            chromaprint_blob=chromaprint_blob,
+            tmdb_id=tmdb_id,
+            season=season,
+            episode=episode,
+            match_confidence=match_confidence,
+            match_source=match_source,
+            disc_content_hash=disc_content_hash,
+            pseudonym=pseudonym,
+        )
+        session.add(row)
+        logger.info(
+            f"Queued contribution for title {title_id} (tmdb={tmdb_id} s{season}e{episode}, "
+            f"source={match_source}, conf={match_confidence:.2f})"
+        )

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -744,19 +744,28 @@ class MatchingCoordinator:
                                         tmdb_id_val = int(job.tmdb_id)
                                     except (TypeError, ValueError):
                                         tmdb_id_val = 0
-                                await ContributionQueue().enqueue(
-                                    session=session,
-                                    title_id=title.id,
-                                    chromaprint_blob=title.chromaprint_blob,
-                                    tmdb_id=tmdb_id_val,
-                                    season=season_num,
-                                    episode=episode_num,
-                                    match_confidence=float(title.match_confidence or 0.0),
-                                    match_source="engram",
-                                    disc_content_hash=disc_hash,
-                                    pseudonym=_cfg.contribution_pseudonym,
-                                    contributions_enabled=_cfg.enable_fingerprint_contributions,
-                                )
+                                if tmdb_id_val == 0:
+                                    # Skip enqueue rather than poison Phase 2 with
+                                    # un-attributable contributions. The chromaprint
+                                    # is still stored on DiscTitle for diagnostic use.
+                                    logger.debug(
+                                        f"Skipping contribution for title {title.id}: "
+                                        "no usable tmdb_id on parent job"
+                                    )
+                                else:
+                                    await ContributionQueue().enqueue(
+                                        session=session,
+                                        title_id=title.id,
+                                        chromaprint_blob=title.chromaprint_blob,
+                                        tmdb_id=tmdb_id_val,
+                                        season=season_num,
+                                        episode=episode_num,
+                                        match_confidence=float(title.match_confidence or 0.0),
+                                        match_source="engram",
+                                        disc_content_hash=disc_hash,
+                                        pseudonym=_cfg.contribution_pseudonym,
+                                        contributions_enabled=_cfg.enable_fingerprint_contributions,
+                                    )
                         except Exception as e:
                             logger.warning(
                                 f"Failed to enqueue contribution for title {title.id}: {e}",

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -691,9 +691,15 @@ class MatchingCoordinator:
                         cfg = await get_config()
                         fpcalc_path = cfg.fpcalc_path
                         if not fpcalc_path:
+                            import asyncio as _asyncio
+
                             from app.api.validation import detect_fpcalc
 
-                            detected = detect_fpcalc()
+                            # detect_fpcalc() runs blocking subprocess.run probes for each
+                            # candidate path. Offload to a worker thread so we never stall
+                            # the matching coordinator's event loop (worst case ~60s if
+                            # multiple candidates time out).
+                            detected = await _asyncio.to_thread(detect_fpcalc)
                             fpcalc_path = detected.path if detected.found else None
 
                         if fpcalc_path:

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import time
+from datetime import UTC
 from pathlib import Path
 
 from sqlmodel import select
@@ -679,6 +680,37 @@ class MatchingCoordinator:
                         f"episode={result.episode_code}, confidence={result.confidence:.2f}, "
                         f"elapsed={elapsed:.1f}s"
                     )
+
+                    # Phase 1: extract chromaprint fingerprint (best-effort; failure does not block match)
+                    try:
+                        from datetime import datetime
+
+                        from app.matcher.chromaprint_extractor import ChromaprintExtractor
+                        from app.services.config_service import get_config
+
+                        cfg = await get_config()
+                        fpcalc_path = cfg.fpcalc_path
+                        if not fpcalc_path:
+                            from app.api.validation import detect_fpcalc
+
+                            detected = detect_fpcalc()
+                            fpcalc_path = detected.path if detected.found else None
+
+                        if fpcalc_path:
+                            extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
+                            fp_result = await extractor.extract(str(file_path))
+                            title.chromaprint_blob = fp_result.to_blob()
+                            title.chromaprint_extracted_at = datetime.now(UTC)
+                        else:
+                            logger.debug(
+                                f"fpcalc not configured; skipping chromaprint extraction for title {title.id}"
+                            )
+                    except Exception as e:
+                        # Graceful degradation: matching already succeeded; log and continue
+                        logger.warning(
+                            f"Chromaprint extraction failed for title {title.id}: {e}",
+                            exc_info=True,
+                        )
 
                 if result.match_details:
                     try:

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -718,6 +718,51 @@ class MatchingCoordinator:
                             exc_info=True,
                         )
 
+                    # Phase 1: enqueue contribution if extraction produced a fingerprint
+                    if title.chromaprint_blob and title.matched_episode:
+                        try:
+                            import re as _re
+
+                            from app.services.config_service import get_config as _get_config
+                            from app.services.contribution_queue import ContributionQueue
+
+                            _cfg = await _get_config()
+                            if _cfg.contribution_pseudonym:
+                                # Parse "S01E07" → (season, episode)
+                                _m = _re.match(r"S(\d{1,2})E(\d{1,3})", title.matched_episode or "")
+                                season_num = int(_m.group(1)) if _m else None
+                                episode_num = int(_m.group(2)) if _m else None
+                                disc_hash = None
+                                if getattr(job, "content_hash", None):
+                                    try:
+                                        disc_hash = bytes.fromhex(job.content_hash)
+                                    except (TypeError, ValueError):
+                                        disc_hash = None
+                                tmdb_id_val = 0
+                                if getattr(job, "tmdb_id", None):
+                                    try:
+                                        tmdb_id_val = int(job.tmdb_id)
+                                    except (TypeError, ValueError):
+                                        tmdb_id_val = 0
+                                await ContributionQueue().enqueue(
+                                    session=session,
+                                    title_id=title.id,
+                                    chromaprint_blob=title.chromaprint_blob,
+                                    tmdb_id=tmdb_id_val,
+                                    season=season_num,
+                                    episode=episode_num,
+                                    match_confidence=float(title.match_confidence or 0.0),
+                                    match_source="engram",
+                                    disc_content_hash=disc_hash,
+                                    pseudonym=_cfg.contribution_pseudonym,
+                                    contributions_enabled=_cfg.enable_fingerprint_contributions,
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to enqueue contribution for title {title.id}: {e}",
+                                exc_info=True,
+                            )
+
                 if result.match_details:
                     try:
                         title.match_details = json.dumps(result.match_details)

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -31,6 +31,44 @@ logger = logging.getLogger(__name__)
 STRICT_SCAN_POINTS = 25
 STRICT_MIN_VOTES = 4
 
+# Module-level cache for fpcalc detection results.
+# `detect_fpcalc()` is deterministic within a process (the binary doesn't appear
+# or disappear mid-run), but each invocation runs up to 6 subprocess probes with
+# 10s timeouts each. Without caching, a 22-title disc with semaphore=3 would
+# trigger up to 66 parallel probe storms. `None` means "no path detected".
+# Sentinel value `_UNSET` distinguishes "haven't tried yet" from "tried and got None".
+_UNSET: object = object()
+_fpcalc_path_cache: str | None | object = _UNSET
+
+
+async def _resolve_fpcalc_path(cfg_path: str | None) -> str | None:
+    """Return the fpcalc binary path, preferring explicit config over auto-detect.
+
+    Auto-detect results are cached at module level so a multi-title rip doesn't
+    re-run the (blocking, multi-subprocess) probe for every title.
+    """
+    if cfg_path:
+        return cfg_path
+    global _fpcalc_path_cache
+    if _fpcalc_path_cache is not _UNSET:
+        return _fpcalc_path_cache  # type: ignore[return-value]
+    from app.api.validation import detect_fpcalc
+
+    detected = await asyncio.to_thread(detect_fpcalc)
+    _fpcalc_path_cache = detected.path if detected.found else None
+    return _fpcalc_path_cache  # type: ignore[return-value]
+
+
+# Maps DiscTitle.match_source (the internal label, e.g. "engram", "discdb",
+# "ai_llm") onto FingerprintContribution.match_source, which is constrained to
+# the documented set 'engram_asr' | 'engram_discdb' | 'bootstrap' | 'user_review'.
+_MATCH_SOURCE_TO_CONTRIB: dict[str, str] = {
+    "engram": "engram_asr",
+    "discdb": "engram_discdb",
+    "ai_llm": "engram_asr",
+    "user": "user_review",
+}
+
 
 class MatchingCoordinator:
     """Coordinates episode matching: subtitle download, audio fingerprinting, DiscDB assignment."""
@@ -689,19 +727,7 @@ class MatchingCoordinator:
                         from app.services.config_service import get_config
 
                         cfg = await get_config()
-                        fpcalc_path = cfg.fpcalc_path
-                        if not fpcalc_path:
-                            import asyncio as _asyncio
-
-                            from app.api.validation import detect_fpcalc
-
-                            # detect_fpcalc() runs blocking subprocess.run probes for each
-                            # candidate path. Offload to a worker thread so we never stall
-                            # the matching coordinator's event loop (worst case ~60s if
-                            # multiple candidates time out).
-                            detected = await _asyncio.to_thread(detect_fpcalc)
-                            fpcalc_path = detected.path if detected.found else None
-
+                        fpcalc_path = await _resolve_fpcalc_path(cfg.fpcalc_path)
                         if fpcalc_path:
                             extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
                             fp_result = await extractor.extract(str(file_path))
@@ -753,6 +779,14 @@ class MatchingCoordinator:
                                         "no usable tmdb_id on parent job"
                                     )
                                 else:
+                                    # Map DiscTitle.match_source onto FingerprintContribution's
+                                    # documented value set (engram_asr / engram_discdb /
+                                    # bootstrap / user_review). The raw "engram" value used
+                                    # internally for ASR matches is not a documented
+                                    # contribution source.
+                                    _contrib_source = _MATCH_SOURCE_TO_CONTRIB.get(
+                                        title.match_source or "", "engram_asr"
+                                    )
                                     await ContributionQueue().enqueue(
                                         session=session,
                                         title_id=title.id,
@@ -761,7 +795,7 @@ class MatchingCoordinator:
                                         season=season_num,
                                         episode=episode_num,
                                         match_confidence=float(title.match_confidence or 0.0),
-                                        match_source="engram",
+                                        match_source=_contrib_source,
                                         disc_content_hash=disc_hash,
                                         pseudonym=_cfg.contribution_pseudonym,
                                         contributions_enabled=_cfg.enable_fingerprint_contributions,

--- a/backend/migrations/versions/0b510750d192_phase1_fingerprint_contributions_table.py
+++ b/backend/migrations/versions/0b510750d192_phase1_fingerprint_contributions_table.py
@@ -1,0 +1,43 @@
+"""phase1 fingerprint_contributions table
+
+Revision ID: 0b510750d192
+Revises: 53b4ddc7751e
+Create Date: 2026-05-27 17:47:19.622258
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0b510750d192"
+down_revision: str | Sequence[str] | None = "53b4ddc7751e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fingerprint_contributions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("queued_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "title_id", sa.Integer(), sa.ForeignKey("disc_titles.id"), nullable=True, index=True
+        ),
+        sa.Column("chromaprint_blob", sa.LargeBinary(), nullable=False),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("season", sa.Integer(), nullable=True),
+        sa.Column("episode", sa.Integer(), nullable=True),
+        sa.Column("match_confidence", sa.Float(), nullable=False),
+        sa.Column("match_source", sa.String(), nullable=False),
+        sa.Column("disc_content_hash", sa.LargeBinary(), nullable=True),
+        sa.Column("pseudonym", sa.String(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(), nullable=True),
+        sa.Column("upload_attempts", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fingerprint_contributions")

--- a/backend/migrations/versions/0b510750d192_phase1_fingerprint_contributions_table.py
+++ b/backend/migrations/versions/0b510750d192_phase1_fingerprint_contributions_table.py
@@ -22,7 +22,12 @@ def upgrade() -> None:
     op.create_table(
         "fingerprint_contributions",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("queued_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "queued_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("(datetime('now'))"),
+        ),
         sa.Column(
             "title_id", sa.Integer(), sa.ForeignKey("disc_titles.id"), nullable=True, index=True
         ),

--- a/backend/migrations/versions/53b4ddc7751e_phase1_chromaprint_schema.py
+++ b/backend/migrations/versions/53b4ddc7751e_phase1_chromaprint_schema.py
@@ -1,0 +1,45 @@
+"""phase1 chromaprint schema
+
+Revision ID: 53b4ddc7751e
+Revises: f3a9c1e7b204
+Create Date: 2026-05-27 16:50:28.761800
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "53b4ddc7751e"
+down_revision: str | Sequence[str] | None = "f3a9c1e7b204"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("disc_titles", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("chromaprint_blob", sa.LargeBinary(), nullable=True))
+        batch_op.add_column(sa.Column("chromaprint_extracted_at", sa.DateTime(), nullable=True))
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("fpcalc_path", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("contribution_pseudonym", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "enable_fingerprint_contributions",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("enable_fingerprint_contributions")
+        batch_op.drop_column("contribution_pseudonym")
+        batch_op.drop_column("fpcalc_path")
+    with op.batch_alter_table("disc_titles", schema=None) as batch_op:
+        batch_op.drop_column("chromaprint_extracted_at")
+        batch_op.drop_column("chromaprint_blob")

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -194,6 +194,122 @@ async def test_chromaprint_extracted_after_match(async_session_ctx, tmp_path, mo
 
 
 @pytest.mark.asyncio
+async def test_contribution_enqueued_on_match(async_session_ctx, tmp_path, monkeypatch):
+    """A successful match enqueues a FingerprintContribution row.
+
+    Uses the same direct-coordinator pattern as test_chromaprint_extracted_after_match
+    because the simulation endpoint bypasses _match_single_file_inner.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.api.websocket import manager as ws_manager
+    from app.core.curator import MatchResult
+    from app.matcher.chromaprint_extractor import ChromaprintExtractor, ChromaprintResult
+    from app.models import DiscJob, TitleState
+    from app.models.disc_job import ContentType, DiscTitle, JobState
+    from app.services.contribution_pseudonym import generate_pseudonym
+    from app.services.event_broadcaster import EventBroadcaster
+    from app.services.job_state_machine import JobStateMachine
+    from app.services.matching_coordinator import MatchingCoordinator
+
+    # Seed a job + title in the DB
+    fake_file = tmp_path / "title_01.mkv"
+    fake_file.write_text("fake")
+
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="ARRESTED_DEVELOPMENT_S1D1",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Arrested Development",
+            detected_season=1,
+            tmdb_id=79744,
+        )
+        session.add(job)
+        await session.flush()
+
+        title = DiscTitle(
+            job_id=job.id,
+            title_index=1,
+            duration_seconds=1800,
+            file_size_bytes=1_000_000,
+            state=TitleState.MATCHING,
+            file_path=str(fake_file),
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(job)
+        await session.refresh(title)
+        job_id, title_id = job.id, title.id
+
+    # Ensure app_config has a valid pseudonym so the enqueue block fires
+    from sqlmodel import select
+
+    from app.models.app_config import AppConfig
+    from app.services.contribution_pseudonym import validate_pseudonym
+
+    async with async_session() as session:
+        result = await session.execute(select(AppConfig))
+        cfg = result.first()
+        if cfg:
+            cfg = cfg[0]
+            if not validate_pseudonym(cfg.contribution_pseudonym):
+                cfg.contribution_pseudonym = generate_pseudonym()
+                session.add(cfg)
+                await session.commit()
+
+    # Fake chromaprint result
+    fake_fp = ChromaprintResult(hashes=[1], duration_seconds=10.0, fpcalc_version="test")
+
+    async def fake_extract(self, media_path: str) -> ChromaprintResult:
+        return fake_fp
+
+    # Fake match result (confident, no review needed)
+    stub_result = MatchResult(
+        file_path=fake_file,
+        episode_code="S01E07",
+        episode_title="In God We Trust",
+        confidence=0.92,
+        needs_review=False,
+        match_details={"score": 0.92, "vote_count": 5, "runner_ups": []},
+    )
+
+    mock_broadcaster = MagicMock(spec=EventBroadcaster)
+    mock_broadcaster.broadcast_job_state_changed = AsyncMock()
+    mock_state_machine = MagicMock(spec=JobStateMachine)
+
+    coordinator = MatchingCoordinator(mock_broadcaster, mock_state_machine)
+    coordinator.set_callbacks(check_job_completion=AsyncMock(), note_activity=None)
+    coordinator.init_semaphore(concurrency=1)
+    coordinator._episode_runtimes[job_id] = []
+
+    with (
+        patch(
+            "app.services.matching_coordinator.episode_curator.match_single_file",
+            new=AsyncMock(return_value=stub_result),
+        ),
+        patch.object(ChromaprintExtractor, "extract", fake_extract),
+        patch.object(coordinator, "_wait_for_file_ready", new=AsyncMock(return_value=True)),
+        patch.object(ws_manager, "broadcast_title_update", new=AsyncMock()),
+    ):
+        await coordinator.match_single_file(job_id, title_id, fake_file)
+
+    # Assert a FingerprintContribution row was enqueued
+    from app.models.fingerprint import FingerprintContribution
+
+    async with async_session() as session:
+        result = await session.execute(select(FingerprintContribution))
+        contributions = result.scalars().all()
+
+    assert len(contributions) >= 1, "Expected at least one queued contribution"
+    c = contributions[0]
+    assert c.chromaprint_blob is not None
+    assert c.pseudonym  # non-empty
+    assert c.match_source  # non-empty
+
+
+@pytest.mark.asyncio
 async def test_matching_succeeds_when_fpcalc_missing(client, async_session_ctx, monkeypatch):
     """If fpcalc isn't configured and auto-detect fails, matching still completes without a fingerprint."""
     from app.api import validation as v

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -345,3 +345,33 @@ async def test_matching_succeeds_when_fpcalc_missing(client, async_session_ctx, 
             break
     else:
         pytest.fail("Job never advanced past initial state with fpcalc absent")
+
+
+@pytest.mark.asyncio
+async def test_get_fingerprint_contributions(client):
+    """GET /api/fingerprint/contributions returns the local queue, redacted of blobs by default."""
+    from app.models.fingerprint import FingerprintContribution
+
+    async with async_session() as session:
+        row = FingerprintContribution(
+            title_id=None,
+            chromaprint_blob=b"\x00" * 1000,
+            tmdb_id=1399,
+            season=1,
+            episode=1,
+            match_confidence=0.95,
+            match_source="bootstrap",
+            pseudonym="22222222-2222-4222-8222-222222222222",
+        )
+        session.add(row)
+        await session.commit()
+
+    response = await client.get("/api/fingerprint/contributions")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] >= 1
+    item = next(i for i in data["items"] if i["tmdb_id"] == 1399)
+    assert item["match_source"] == "bootstrap"
+    # Blob should be summarized (size) not returned wholesale
+    assert "chromaprint_blob" not in item
+    assert item["blob_size_bytes"] == 1000

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -25,6 +25,13 @@ async def client():
         yield ac
 
 
+@pytest.fixture
+async def async_session_ctx():
+    """Yield an open async database session."""
+    async with async_session() as session:
+        yield session
+
+
 @pytest.mark.asyncio
 async def test_detect_tools_includes_fpcalc(client):
     """GET /api/detect-tools surfaces fpcalc alongside makemkv and ffmpeg."""
@@ -56,3 +63,36 @@ async def test_validate_fpcalc_rejects_disallowed_basename(client):
     assert response.status_code == 200
     data = response.json()
     assert data["valid"] is False
+
+
+@pytest.mark.asyncio
+async def test_pseudonym_generated_on_first_startup(async_session_ctx):
+    """The pseudonym bootstrap ensures app_config always has a valid UUIDv4 pseudonym.
+
+    Simulates the startup flow: get_config() guarantees the row exists, then the
+    bootstrap generates a pseudonym when the field is empty.
+    """
+    from sqlmodel import select
+
+    from app.models.app_config import AppConfig
+    from app.services.config_service import get_config
+    from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
+
+    # Ensure the app_config row exists (mirrors get_config() call in lifespan).
+    await get_config()
+
+    # Run the bootstrap — same logic as the lifespan block.
+    result = await async_session_ctx.execute(select(AppConfig))
+    cfg = result.scalar_one_or_none()
+    assert cfg is not None, "app_config row should exist after get_config()"
+
+    if not validate_pseudonym(cfg.contribution_pseudonym):
+        cfg.contribution_pseudonym = generate_pseudonym()
+        async_session_ctx.add(cfg)
+        await async_session_ctx.commit()
+
+    # Verify the pseudonym is now valid.
+    await async_session_ctx.refresh(cfg)
+    assert validate_pseudonym(cfg.contribution_pseudonym), (
+        f"contribution_pseudonym should be a UUIDv4, got {cfg.contribution_pseudonym!r}"
+    )

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -1,0 +1,46 @@
+"""Integration tests for chromaprint Phase 1: fpcalc detection + extraction pipeline."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Initialize test database and clean data between tests."""
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+async def client():
+    """Async HTTP client backed by the FastAPI app under test."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_detect_tools_includes_fpcalc(client):
+    """GET /api/detect-tools surfaces fpcalc alongside makemkv and ffmpeg."""
+    response = await client.get("/api/detect-tools")
+    assert response.status_code == 200
+    data = response.json()
+    assert "fpcalc" in data, f"detect-tools should include fpcalc, got keys: {list(data.keys())}"
+
+
+@pytest.mark.asyncio
+async def test_validate_fpcalc_endpoint_rejects_missing(client):
+    """POST /api/validate/fpcalc with a bogus path reports found=False."""
+    response = await client.post(
+        "/api/validate/fpcalc",
+        json={"path": "/definitely/not/a/binary"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["valid"] is False

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -405,6 +405,29 @@ async def test_get_fingerprint_contributions(client):
     assert item["blob_size_bytes"] == 1000
 
 
+@pytest.mark.asyncio
+async def test_config_endpoint_round_trips_fingerprint_toggle(client):
+    """PUT then GET /api/config preserves enable_fingerprint_contributions.
+
+    Regression: the frontend toggle's persistence relies on this round-trip; an
+    earlier version of the PR landed the model field without wiring it through
+    ConfigResponse + ConfigUpdate, so the frontend's PUT was silently ignored.
+    """
+    # GET should expose the field with its default (opt-out default = True)
+    initial = await client.get("/api/config")
+    assert initial.status_code == 200
+    assert initial.json()["enable_fingerprint_contributions"] is True
+
+    # PUT False, then GET back False
+    put_resp = await client.put("/api/config", json={"enable_fingerprint_contributions": False})
+    assert put_resp.status_code == 200
+    after = await client.get("/api/config")
+    assert after.json()["enable_fingerprint_contributions"] is False
+
+    # Restore default so other tests aren't affected by ordering
+    await client.put("/api/config", json={"enable_fingerprint_contributions": True})
+
+
 def test_require_localhost_rejects_lan_clients():
     """The localhost-only guard 403s any non-loopback client."""
     from unittest.mock import MagicMock

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -44,3 +44,15 @@ async def test_validate_fpcalc_endpoint_rejects_missing(client):
     assert response.status_code == 200
     data = response.json()
     assert data["valid"] is False
+
+
+@pytest.mark.asyncio
+async def test_validate_fpcalc_rejects_disallowed_basename(client):
+    """The validate endpoint refuses paths whose basename is not in the fpcalc whitelist."""
+    response = await client.post(
+        "/api/validate/fpcalc",
+        json={"path": "/usr/bin/whoami"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["valid"] is False

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -82,8 +82,10 @@ async def test_pseudonym_generated_on_first_startup(async_session_ctx):
     await get_config()
 
     # Run the bootstrap — same logic as the lifespan block.
-    result = await async_session_ctx.execute(select(AppConfig))
-    cfg = result.scalar_one_or_none()
+    # Use .first() rather than .scalar_one_or_none() so the test tolerates
+    # other tests leaving stray app_config rows in the shared DB.
+    result = await async_session_ctx.execute(select(AppConfig).limit(1))
+    cfg = result.scalars().first()
     assert cfg is not None, "app_config row should exist after get_config()"
 
     if not validate_pseudonym(cfg.contribution_pseudonym):
@@ -375,3 +377,32 @@ async def test_get_fingerprint_contributions(client):
     # Blob should be summarized (size) not returned wholesale
     assert "chromaprint_blob" not in item
     assert item["blob_size_bytes"] == 1000
+
+
+def test_require_localhost_rejects_lan_clients():
+    """The localhost-only guard 403s any non-loopback client."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from app.api.routes import require_localhost
+
+    # Real LAN client → rejected
+    request = MagicMock()
+    request.client.host = "192.168.1.100"
+    with pytest.raises(HTTPException) as exc:
+        require_localhost(request)
+    assert exc.value.status_code == 403
+
+    # IPv4 loopback → allowed
+    request.client.host = "127.0.0.1"
+    require_localhost(request)  # no raise
+
+    # IPv6 loopback → allowed
+    request.client.host = "::1"
+    require_localhost(request)  # no raise
+
+    # No client info → rejected (safer default)
+    request.client = None
+    with pytest.raises(HTTPException):
+        require_localhost(request)

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -174,10 +174,21 @@ async def test_chromaprint_extracted_after_match(async_session_ctx, tmp_path, mo
     coordinator.init_semaphore(concurrency=1)
     coordinator._episode_runtimes[job_id] = []
 
+    async def fake_resolve_fpcalc(_cfg_path):
+        # Bypass the real detect_fpcalc() — CI Linux has no fpcalc binary,
+        # which would short-circuit the extraction path before our extract()
+        # mock could fire. Return any non-empty string; the ChromaprintExtractor
+        # patch makes the real path irrelevant.
+        return "/fake/fpcalc"
+
     with (
         patch(
             "app.services.matching_coordinator.episode_curator.match_single_file",
             new=AsyncMock(return_value=stub_result),
+        ),
+        patch(
+            "app.services.matching_coordinator._resolve_fpcalc_path",
+            new=fake_resolve_fpcalc,
         ),
         patch.object(ChromaprintExtractor, "extract", fake_extract),
         patch.object(coordinator, "_wait_for_file_ready", new=AsyncMock(return_value=True)),
@@ -286,10 +297,17 @@ async def test_contribution_enqueued_on_match(async_session_ctx, tmp_path, monke
     coordinator.init_semaphore(concurrency=1)
     coordinator._episode_runtimes[job_id] = []
 
+    async def fake_resolve_fpcalc(_cfg_path):
+        return "/fake/fpcalc"
+
     with (
         patch(
             "app.services.matching_coordinator.episode_curator.match_single_file",
             new=AsyncMock(return_value=stub_result),
+        ),
+        patch(
+            "app.services.matching_coordinator._resolve_fpcalc_path",
+            new=fake_resolve_fpcalc,
         ),
         patch.object(ChromaprintExtractor, "extract", fake_extract),
         patch.object(coordinator, "_wait_for_file_ready", new=AsyncMock(return_value=True)),
@@ -352,6 +370,8 @@ async def test_matching_succeeds_when_fpcalc_missing(client, async_session_ctx, 
 @pytest.mark.asyncio
 async def test_get_fingerprint_contributions(client):
     """GET /api/fingerprint/contributions returns the local queue, redacted of blobs by default."""
+    from app.api.routes import require_localhost
+    from app.main import app
     from app.models.fingerprint import FingerprintContribution
 
     async with async_session() as session:
@@ -368,7 +388,13 @@ async def test_get_fingerprint_contributions(client):
         session.add(row)
         await session.commit()
 
-    response = await client.get("/api/fingerprint/contributions")
+    # The endpoint requires localhost. The Starlette test client's host
+    # ("testclient") is not a real loopback identity; override the guard for tests.
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        response = await client.get("/api/fingerprint/contributions")
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
     assert response.status_code == 200
     data = response.json()
     assert data["count"] >= 1

--- a/backend/tests/integration/test_chromaprint_pipeline.py
+++ b/backend/tests/integration/test_chromaprint_pipeline.py
@@ -96,3 +96,136 @@ async def test_pseudonym_generated_on_first_startup(async_session_ctx):
     assert validate_pseudonym(cfg.contribution_pseudonym), (
         f"contribution_pseudonym should be a UUIDv4, got {cfg.contribution_pseudonym!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_chromaprint_extracted_after_match(async_session_ctx, tmp_path, monkeypatch):
+    """When a title finishes matching, chromaprint_blob is populated on the DiscTitle row.
+
+    NOTE: The /api/simulate/insert-disc endpoint uses SimulationService._simulate_matching,
+    which generates random fake results without going through MatchingCoordinator. This test
+    therefore calls the coordinator directly (same pattern as test_llm_matching_workflow.py).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.api.websocket import manager as ws_manager
+    from app.core.curator import MatchResult
+    from app.matcher.chromaprint_extractor import ChromaprintExtractor, ChromaprintResult
+    from app.models import DiscJob, TitleState
+    from app.models.disc_job import ContentType, DiscTitle, JobState
+    from app.services.event_broadcaster import EventBroadcaster
+    from app.services.job_state_machine import JobStateMachine
+    from app.services.matching_coordinator import MatchingCoordinator
+
+    # Seed a job + title in the DB
+    fake_file = tmp_path / "title_01.mkv"
+    fake_file.write_text("fake")
+
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="ARRESTED_DEVELOPMENT_S1D1",
+            state=JobState.MATCHING,
+            content_type=ContentType.TV,
+            detected_title="Arrested Development",
+            detected_season=1,
+        )
+        session.add(job)
+        await session.flush()
+
+        title = DiscTitle(
+            job_id=job.id,
+            title_index=1,
+            duration_seconds=1800,
+            file_size_bytes=1_000_000,
+            state=TitleState.MATCHING,
+            file_path=str(fake_file),
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(job)
+        await session.refresh(title)
+        job_id, title_id = job.id, title.id
+
+    # Fake chromaprint result
+    fake_fp = ChromaprintResult(hashes=[1, 2, 3], duration_seconds=10.0, fpcalc_version="test")
+
+    async def fake_extract(self, media_path: str) -> ChromaprintResult:
+        return fake_fp
+
+    # Fake match result (confident, no review needed)
+    stub_result = MatchResult(
+        file_path=fake_file,
+        episode_code="S01E01",
+        episode_title="Pilot",
+        confidence=0.95,
+        needs_review=False,
+        match_details={"score": 0.95, "vote_count": 5, "runner_ups": []},
+    )
+
+    mock_broadcaster = MagicMock(spec=EventBroadcaster)
+    mock_broadcaster.broadcast_job_state_changed = AsyncMock()
+    mock_state_machine = MagicMock(spec=JobStateMachine)
+
+    coordinator = MatchingCoordinator(mock_broadcaster, mock_state_machine)
+    coordinator.set_callbacks(check_job_completion=AsyncMock(), note_activity=None)
+    coordinator.init_semaphore(concurrency=1)
+    coordinator._episode_runtimes[job_id] = []
+
+    with (
+        patch(
+            "app.services.matching_coordinator.episode_curator.match_single_file",
+            new=AsyncMock(return_value=stub_result),
+        ),
+        patch.object(ChromaprintExtractor, "extract", fake_extract),
+        patch.object(coordinator, "_wait_for_file_ready", new=AsyncMock(return_value=True)),
+        patch.object(ws_manager, "broadcast_title_update", new=AsyncMock()),
+    ):
+        await coordinator.match_single_file(job_id, title_id, fake_file)
+
+    # Verify the title has chromaprint_blob set
+    async with async_session() as session:
+        refreshed = await session.get(DiscTitle, title_id)
+
+    assert refreshed is not None
+    assert refreshed.chromaprint_blob is not None, "chromaprint_blob should be set after MATCHED"
+    assert refreshed.chromaprint_extracted_at is not None, "chromaprint_extracted_at should be set"
+    assert refreshed.state == TitleState.MATCHED, f"expected MATCHED, got {refreshed.state!r}"
+
+
+@pytest.mark.asyncio
+async def test_matching_succeeds_when_fpcalc_missing(client, async_session_ctx, monkeypatch):
+    """If fpcalc isn't configured and auto-detect fails, matching still completes without a fingerprint."""
+    from app.api import validation as v
+    from app.api.validation import ToolDetectionResult
+
+    monkeypatch.setattr(
+        v, "detect_fpcalc", lambda: ToolDetectionResult(found=False, path=None, error="absent")
+    )
+
+    response = await client.post(
+        "/api/simulate/insert-disc",
+        json={
+            "volume_label": "INCEPTION_2010",
+            "content_type": "movie",
+            "simulate_ripping": True,
+        },
+    )
+    assert response.status_code == 200
+
+    import asyncio
+
+    from sqlmodel import select
+
+    from app.models.disc_job import DiscJob
+
+    for _ in range(60):
+        await asyncio.sleep(0.5)
+        result = await async_session_ctx.execute(select(DiscJob))
+        jobs = result.scalars().all()
+        if jobs and any(
+            j.state in ("completed", "review_needed", "matching", "organizing") for j in jobs
+        ):
+            break
+    else:
+        pytest.fail("Job never advanced past initial state with fpcalc absent")

--- a/backend/tests/unit/test_bootstrap_library.py
+++ b/backend/tests/unit/test_bootstrap_library.py
@@ -1,0 +1,38 @@
+"""Tests for the bootstrap-library CLI utility."""
+
+from app.scripts.bootstrap_library import parse_episode_filename, walk_library
+
+
+def test_parse_episode_filename_standard():
+    assert parse_episode_filename("Arrested Development - S01E07.mkv") == (
+        "Arrested Development",
+        1,
+        7,
+    )
+    assert parse_episode_filename("The Gilded Age - S03E08.mkv") == ("The Gilded Age", 3, 8)
+    assert parse_episode_filename("Star Trek The Next Generation - S07E09.mkv") == (
+        "Star Trek The Next Generation",
+        7,
+        9,
+    )
+
+
+def test_parse_episode_filename_rejects_garbage():
+    assert parse_episode_filename("movie.mkv") is None
+    assert parse_episode_filename("Show.mkv") is None
+    assert parse_episode_filename("Show - 1x07.mkv") is None  # only the canonical SxxExx form
+
+
+def test_walk_library_skips_extras(tmp_path):
+    show = tmp_path / "Foo"
+    season = show / "Season 1"
+    season.mkdir(parents=True)
+    extras = season / "Extras"
+    extras.mkdir()
+    (season / "Foo - S01E01.mkv").touch()
+    (season / "Foo - S01E02.mkv").touch()
+    (extras / "Foo Extra t00.mkv").touch()  # should be ignored
+
+    found = list(walk_library(tmp_path))
+    names = sorted(p.name for p, _ in found)
+    assert names == ["Foo - S01E01.mkv", "Foo - S01E02.mkv"]

--- a/backend/tests/unit/test_bootstrap_library.py
+++ b/backend/tests/unit/test_bootstrap_library.py
@@ -1,6 +1,8 @@
 """Tests for the bootstrap-library CLI utility."""
 
-from app.scripts.bootstrap_library import parse_episode_filename, walk_library
+import pytest
+
+from app.scripts.bootstrap_library import parse_episode_filename, resolve_tmdb_id, walk_library
 
 
 def test_parse_episode_filename_standard():
@@ -36,3 +38,33 @@ def test_walk_library_skips_extras(tmp_path):
     found = list(walk_library(tmp_path))
     names = sorted(p.name for p, _ in found)
     assert names == ["Foo - S01E01.mkv", "Foo - S01E02.mkv"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_tmdb_id_caches_per_show():
+    """resolve_tmdb_id calls the upstream search function at most once per (show, content_type)."""
+    calls = []
+
+    async def fake_search(name, content_type):
+        calls.append(name)
+        return 12345
+
+    cache: dict[tuple[str, str], int] = {}
+    a = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    b = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    c = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    assert a == b == c == 12345
+    assert calls == ["Foo"]  # only one upstream call
+
+
+@pytest.mark.asyncio
+async def test_resolve_tmdb_id_returns_none_on_miss():
+    """If the search function returns None, resolve_tmdb_id returns None and doesn't cache it."""
+
+    async def fake_search(name, content_type):
+        return None
+
+    cache: dict[tuple[str, str], int] = {}
+    result = await resolve_tmdb_id("Unknown Show", "tv", search_fn=fake_search, cache=cache)
+    assert result is None
+    assert cache == {}  # nothing cached

--- a/backend/tests/unit/test_chromaprint_extractor.py
+++ b/backend/tests/unit/test_chromaprint_extractor.py
@@ -1,5 +1,6 @@
 """Tests for chromaprint extraction and storage."""
 
+from app.matcher.chromaprint_extractor import ChromaprintExtractor, ChromaprintResult
 from app.models.app_config import AppConfig
 from app.models.disc_job import DiscTitle
 
@@ -36,3 +37,30 @@ def test_enable_fingerprint_contributions_has_sql_server_default_true():
         "so frozen-build users default to opt-in"
     )
     assert "1" in str(column.server_default.arg)
+
+
+def test_chromaprint_result_serializes_to_bytes():
+    """ChromaprintResult.to_blob() returns deterministic compressed bytes."""
+    r = ChromaprintResult(
+        hashes=[1, 2, 3, 4, 5],
+        duration_seconds=42.0,
+        fpcalc_version="fpcalc version 1.5.1",
+    )
+    blob = r.to_blob()
+    assert isinstance(blob, bytes)
+    assert len(blob) > 0
+    assert r.to_blob() == blob  # deterministic
+
+
+def test_chromaprint_result_roundtrip():
+    """to_blob / from_blob is lossless on the hash stream and duration."""
+    r = ChromaprintResult(hashes=[100, 200, 300], duration_seconds=12.5, fpcalc_version="test")
+    restored = ChromaprintResult.from_blob(r.to_blob())
+    assert restored.hashes == [100, 200, 300]
+    assert restored.duration_seconds == 12.5
+
+
+def test_extractor_construction():
+    """ChromaprintExtractor takes an fpcalc_path."""
+    ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+    assert ex.fpcalc_path == "/fake/fpcalc"

--- a/backend/tests/unit/test_chromaprint_extractor.py
+++ b/backend/tests/unit/test_chromaprint_extractor.py
@@ -1,5 +1,6 @@
 """Tests for chromaprint extraction and storage."""
 
+from app.models.app_config import AppConfig
 from app.models.disc_job import DiscTitle
 
 
@@ -8,3 +9,17 @@ def test_disc_title_has_chromaprint_fields():
     fields = DiscTitle.model_fields
     assert "chromaprint_blob" in fields, "DiscTitle is missing chromaprint_blob"
     assert "chromaprint_extracted_at" in fields, "DiscTitle is missing chromaprint_extracted_at"
+
+
+def test_app_config_has_fingerprint_fields():
+    """AppConfig exposes fingerprint extraction settings."""
+    fields = AppConfig.model_fields
+    assert "fpcalc_path" in fields
+    assert "contribution_pseudonym" in fields
+    assert "enable_fingerprint_contributions" in fields
+
+
+def test_enable_fingerprint_contributions_defaults_true():
+    """Opt-out default: contributions enabled unless explicitly disabled."""
+    cfg = AppConfig()
+    assert cfg.enable_fingerprint_contributions is True

--- a/backend/tests/unit/test_chromaprint_extractor.py
+++ b/backend/tests/unit/test_chromaprint_extractor.py
@@ -1,0 +1,10 @@
+"""Tests for chromaprint extraction and storage."""
+
+from app.models.disc_job import DiscTitle
+
+
+def test_disc_title_has_chromaprint_fields():
+    """DiscTitle model exposes chromaprint storage fields."""
+    fields = DiscTitle.model_fields
+    assert "chromaprint_blob" in fields, "DiscTitle is missing chromaprint_blob"
+    assert "chromaprint_extracted_at" in fields, "DiscTitle is missing chromaprint_extracted_at"

--- a/backend/tests/unit/test_chromaprint_extractor.py
+++ b/backend/tests/unit/test_chromaprint_extractor.py
@@ -1,5 +1,9 @@
 """Tests for chromaprint extraction and storage."""
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from app.matcher.chromaprint_extractor import ChromaprintExtractor, ChromaprintResult
 from app.models.app_config import AppConfig
 from app.models.disc_job import DiscTitle
@@ -64,3 +68,58 @@ def test_extractor_construction():
     """ChromaprintExtractor takes an fpcalc_path."""
     ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
     assert ex.fpcalc_path == "/fake/fpcalc"
+
+
+@pytest.mark.asyncio
+async def test_extract_parses_fpcalc_output():
+    """extract() parses DURATION and FINGERPRINT from fpcalc -raw output."""
+    # We mock asyncio.to_thread so the subprocess never runs.
+    fake_output = "DURATION=1304\nFINGERPRINT=112114628,250527685,250521542\n"
+    mock_completed = MagicMock()
+    mock_completed.returncode = 0
+    mock_completed.stdout = fake_output
+    mock_completed.stderr = ""
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return mock_completed
+
+    with patch("asyncio.to_thread", side_effect=fake_to_thread):
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        result = await ex.extract("/fake/movie.mkv")
+
+    assert result.duration_seconds == 1304.0
+    assert result.hashes == [112114628, 250527685, 250521542]
+
+
+@pytest.mark.asyncio
+async def test_extract_raises_on_fpcalc_failure():
+    """A non-zero fpcalc exit raises a clean RuntimeError, not subprocess noise."""
+    mock_completed = MagicMock()
+    mock_completed.returncode = 1
+    mock_completed.stdout = ""
+    mock_completed.stderr = "fpcalc: ERROR: cannot decode audio"
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return mock_completed
+
+    with patch("asyncio.to_thread", side_effect=fake_to_thread):
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        with pytest.raises(RuntimeError, match="fpcalc"):
+            await ex.extract("/fake/no-audio.mkv")
+
+
+@pytest.mark.asyncio
+async def test_extract_raises_when_no_fingerprint_line():
+    """fpcalc returned 0 but no FINGERPRINT line — should fail loudly."""
+    mock_completed = MagicMock()
+    mock_completed.returncode = 0
+    mock_completed.stdout = "DURATION=10\n"
+    mock_completed.stderr = ""
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return mock_completed
+
+    with patch("asyncio.to_thread", side_effect=fake_to_thread):
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        with pytest.raises(RuntimeError, match="FINGERPRINT"):
+            await ex.extract("/fake/silent.mkv")

--- a/backend/tests/unit/test_chromaprint_extractor.py
+++ b/backend/tests/unit/test_chromaprint_extractor.py
@@ -23,3 +23,16 @@ def test_enable_fingerprint_contributions_defaults_true():
     """Opt-out default: contributions enabled unless explicitly disabled."""
     cfg = AppConfig()
     assert cfg.enable_fingerprint_contributions is True
+
+
+def test_enable_fingerprint_contributions_has_sql_server_default_true():
+    """The column DDL must carry server_default='1' so the frozen-build path
+    (_add_missing_columns in database.py) writes the correct default for existing DBs.
+    Frozen builds skip Alembic entirely, so the model declaration is the only source
+    of truth for that path."""
+    column = AppConfig.__table__.columns["enable_fingerprint_contributions"]
+    assert column.server_default is not None, (
+        "enable_fingerprint_contributions needs sa_column_kwargs={'server_default': text('1')} "
+        "so frozen-build users default to opt-in"
+    )
+    assert "1" in str(column.server_default.arg)

--- a/backend/tests/unit/test_contribution_pseudonym.py
+++ b/backend/tests/unit/test_contribution_pseudonym.py
@@ -1,0 +1,24 @@
+"""Per-install pseudonym generation."""
+
+import re
+
+from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
+
+
+def test_generate_pseudonym_is_uuid_v4():
+    p = generate_pseudonym()
+    assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", p), p
+
+
+def test_generate_pseudonym_unique():
+    assert generate_pseudonym() != generate_pseudonym()
+
+
+def test_validate_pseudonym_accepts_uuid():
+    assert validate_pseudonym(generate_pseudonym()) is True
+
+
+def test_validate_pseudonym_rejects_garbage():
+    assert validate_pseudonym("not-a-uuid") is False
+    assert validate_pseudonym("") is False
+    assert validate_pseudonym(None) is False  # type: ignore[arg-type]

--- a/backend/tests/unit/test_contribution_queue.py
+++ b/backend/tests/unit/test_contribution_queue.py
@@ -1,0 +1,54 @@
+"""Tests for the local FingerprintContribution queue."""
+
+from app.models.fingerprint import FingerprintContribution
+
+
+def test_fingerprint_contribution_has_required_fields():
+    fields = FingerprintContribution.model_fields
+    for required in (
+        "id",
+        "queued_at",
+        "title_id",
+        "chromaprint_blob",
+        "tmdb_id",
+        "season",
+        "episode",
+        "match_confidence",
+        "match_source",
+        "disc_content_hash",
+        "pseudonym",
+        "uploaded_at",
+        "upload_attempts",
+    ):
+        assert required in fields, f"FingerprintContribution missing field: {required}"
+
+
+def test_fingerprint_contribution_construction():
+    c = FingerprintContribution(
+        title_id=1,
+        chromaprint_blob=b"\x00\x01",
+        tmdb_id=12345,
+        season=1,
+        episode=7,
+        match_confidence=0.92,
+        match_source="engram_asr",
+        disc_content_hash=b"\xab\xcd",
+        pseudonym="00000000-0000-4000-8000-000000000000",
+    )
+    assert c.uploaded_at is None
+    assert c.upload_attempts == 0
+
+
+def test_fingerprint_contribution_title_id_nullable():
+    """Bootstrap contributions don't have a corresponding DiscTitle row."""
+    c = FingerprintContribution(
+        title_id=None,
+        chromaprint_blob=b"x",
+        tmdb_id=1,
+        season=1,
+        episode=1,
+        match_confidence=1.0,
+        match_source="bootstrap",
+        pseudonym="00000000-0000-4000-8000-000000000000",
+    )
+    assert c.title_id is None

--- a/backend/tests/unit/test_contribution_queue.py
+++ b/backend/tests/unit/test_contribution_queue.py
@@ -1,6 +1,11 @@
 """Tests for the local FingerprintContribution queue."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from app.models.fingerprint import FingerprintContribution
+from app.services.contribution_queue import ContributionQueue
 
 
 def test_fingerprint_contribution_has_required_fields():
@@ -52,3 +57,49 @@ def test_fingerprint_contribution_title_id_nullable():
         pseudonym="00000000-0000-4000-8000-000000000000",
     )
     assert c.title_id is None
+
+
+@pytest.mark.asyncio
+async def test_enqueue_persists_row():
+    """enqueue() inserts a FingerprintContribution row with the supplied fields."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    queue = ContributionQueue()
+    await queue.enqueue(
+        session=session,
+        title_id=42,
+        chromaprint_blob=b"\xde\xad",
+        tmdb_id=1399,
+        season=1,
+        episode=1,
+        match_confidence=0.91,
+        match_source="engram_asr",
+        disc_content_hash=b"\x12\x34",
+        pseudonym="11111111-1111-4111-8111-111111111111",
+    )
+    session.add.assert_called_once()
+    added = session.add.call_args[0][0]
+    assert added.title_id == 42
+    assert added.match_source == "engram_asr"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_respects_opt_out():
+    """If contributions_enabled=False, enqueue is a no-op."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    queue = ContributionQueue()
+    await queue.enqueue(
+        session=session,
+        title_id=1,
+        chromaprint_blob=b"x",
+        tmdb_id=1,
+        season=1,
+        episode=1,
+        match_confidence=0.9,
+        match_source="engram_asr",
+        disc_content_hash=None,
+        pseudonym="11111111-1111-4111-8111-111111111111",
+        contributions_enabled=False,
+    )
+    session.add.assert_not_called()

--- a/backend/tests/unit/test_fpcalc_validation.py
+++ b/backend/tests/unit/test_fpcalc_validation.py
@@ -1,0 +1,35 @@
+"""Tests for fpcalc binary validation."""
+
+from unittest.mock import patch
+
+from app.api.validation import _validate_fpcalc_binary
+
+
+def test_validate_fpcalc_binary_success():
+    """Valid fpcalc binary returns found=True with version."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "fpcalc version 1.5.1 (FFmpeg ...)\n"
+        result = _validate_fpcalc_binary("/fake/fpcalc")
+        assert result.found is True
+        assert "1.5.1" in result.version
+        assert result.path == "/fake/fpcalc"
+
+
+def test_validate_fpcalc_binary_nonzero_exit():
+    """Non-zero exit code reports not found with error."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = "bad binary"
+        result = _validate_fpcalc_binary("/fake/fpcalc")
+        assert result.found is False
+        assert "exit" in result.error.lower() or "code" in result.error.lower()
+
+
+def test_validate_fpcalc_binary_missing_file(tmp_path):
+    """A nonexistent path reports found=False without raising."""
+    bogus = tmp_path / "nope.exe"
+    result = _validate_fpcalc_binary(str(bogus))
+    assert result.found is False
+    assert result.path == str(bogus)

--- a/backend/tests/unit/test_fpcalc_validation.py
+++ b/backend/tests/unit/test_fpcalc_validation.py
@@ -33,3 +33,21 @@ def test_validate_fpcalc_binary_missing_file(tmp_path):
     result = _validate_fpcalc_binary(str(bogus))
     assert result.found is False
     assert result.path == str(bogus)
+
+
+def test_detect_fpcalc_uses_path_search(monkeypatch):
+    """detect_fpcalc consults shutil.which before falling back to common paths."""
+    from app.api import validation as v
+
+    def fake_which(name):
+        return "/usr/local/bin/fpcalc" if name == "fpcalc" else None
+
+    monkeypatch.setattr(v.shutil, "which", fake_which)
+    monkeypatch.setattr(
+        v,
+        "_validate_fpcalc_binary",
+        lambda p: v.ToolDetectionResult(found=True, path=p, version="fpcalc version 1.5.1"),
+    )
+    result = v.detect_fpcalc()
+    assert result.found is True
+    assert result.path == "/usr/local/bin/fpcalc"

--- a/docs/superpowers/plans/2026-05-27-phase1-chromaprint-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-phase1-chromaprint-foundation.md
@@ -1,0 +1,2255 @@
+# Phase 1: Chromaprint Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every Engram rip extracts a chromaprint fingerprint and stores it alongside the existing match metadata, with a local-only contribution queue and a bootstrap CLI that lets users seed contributions from existing libraries. No identification path, no server, no UI surfaces beyond a single opt-out toggle.
+
+**Architecture:** Add chromaprint columns to `DiscTitle` and config to `AppConfig`. Wrap `fpcalc` (chromaprint's CLI, bundled with its own FFmpeg) in a `ChromaprintExtractor` mirroring the existing MakeMKV subprocess pattern. Hook extraction into `matching_coordinator._match_single_file_inner()` right after the match result is computed; failures degrade gracefully (no impact on matching). A new `FingerprintContribution` table queues successful (chromaprint, episode tuple) pairs locally — Phase 2 adds the server upload; Phase 1 only writes the queue. The bootstrap CLI script walks a directory and enqueues contributions from labeled MKVs without touching the matching pipeline.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLModel + aiosqlite, Alembic, asyncio, `fpcalc` (chromaprint 1.5.1), React + TypeScript for the single opt-out toggle, pytest for tests.
+
+---
+
+## File Structure
+
+**Backend new files:**
+- `backend/app/matcher/chromaprint_extractor.py` — `ChromaprintExtractor` class; subprocess wrapper + serialization
+- `backend/app/services/contribution_queue.py` — Local-only `ContributionQueue` service
+- `backend/app/scripts/bootstrap_library.py` — Standalone CLI for fingerprinting existing libraries
+- `backend/migrations/versions/<new>_phase1_chromaprint_schema.py` — Alembic migration
+- `backend/tests/unit/test_chromaprint_extractor.py`
+- `backend/tests/unit/test_contribution_queue.py`
+- `backend/tests/unit/test_fpcalc_validation.py`
+- `backend/tests/integration/test_chromaprint_pipeline.py`
+
+**Backend modified files:**
+- `backend/app/models/disc_job.py` — `DiscTitle`: add `chromaprint_blob`, `chromaprint_extracted_at` fields
+- `backend/app/models/app_config.py` — add `fpcalc_path`, `contribution_pseudonym`, `enable_fingerprint_contributions`
+- `backend/app/models/__init__.py` — export new `FingerprintContribution` model
+- `backend/app/api/validation.py` — add `_validate_fpcalc_binary`, `/api/validate/fpcalc` endpoint, `fpcalc` in `/api/detect-tools`
+- `backend/app/services/matching_coordinator.py` — hook extractor after `match_single_file` call
+- `backend/app/api/routes.py` — `GET /api/fingerprint/contributions` (local audit log)
+- `backend/app/database.py` — no code change; `_add_missing_columns()` automatically picks up new model fields
+
+**Frontend modified files:**
+- `frontend/src/components/ConfigWizard.tsx` — `enableFingerprintContributions` toggle
+- `frontend/e2e/fingerprint-toggle.spec.ts` — new E2E test
+
+**Test fixtures:**
+- The existing `spikes/chromaprint/bin/fpcalc.exe` can be reused as the dev-time binary. Tests should locate it via the `fpcalc_path` config (set in test fixture) and skip cleanly if not available.
+
+---
+
+## Pre-flight
+
+Before starting any task: confirm the worktree, install deps, run baseline tests.
+
+- [ ] **Step 0.1: Confirm working directory**
+
+Run from the worktree: `pwd`
+Expected: `C:\Github\engram\.claude\worktrees\romantic-mendeleev-bb5976` (or `/c/Github/engram/.claude/worktrees/romantic-mendeleev-bb5976` in bash).
+
+- [ ] **Step 0.2: Sync backend deps and run baseline tests**
+
+```bash
+cd backend
+uv sync
+uv run pytest tests/unit -x --tb=short 2>&1 | tail -20
+```
+Expected: all unit tests pass. If failures, note them — don't try to fix them in this plan.
+
+- [ ] **Step 0.3: Confirm fpcalc is available**
+
+```bash
+ls -la ../spikes/chromaprint/bin/fpcalc.exe
+../spikes/chromaprint/bin/fpcalc.exe -version
+```
+Expected: `fpcalc version 1.5.1 (...)`. If missing, re-download per the spike instructions.
+
+---
+
+## Cluster A: Schema & Config
+
+### Task A1: Add chromaprint columns to `DiscTitle` model
+
+**Files:**
+- Modify: `backend/app/models/disc_job.py` (DiscTitle class)
+- Test: `backend/tests/unit/test_chromaprint_extractor.py` (new file — will hold schema test first)
+
+- [ ] **Step A1.1: Write the failing schema test**
+
+Create `backend/tests/unit/test_chromaprint_extractor.py` with:
+
+```python
+"""Tests for chromaprint extraction and storage."""
+
+from app.models.disc_job import DiscTitle
+
+
+def test_disc_title_has_chromaprint_fields():
+    """DiscTitle model exposes chromaprint storage fields."""
+    fields = DiscTitle.model_fields
+    assert "chromaprint_blob" in fields, "DiscTitle is missing chromaprint_blob"
+    assert "chromaprint_extracted_at" in fields, "DiscTitle is missing chromaprint_extracted_at"
+```
+
+- [ ] **Step A1.2: Run the test (expect FAIL)**
+
+```bash
+cd backend
+uv run pytest tests/unit/test_chromaprint_extractor.py::test_disc_title_has_chromaprint_fields -v
+```
+Expected: FAIL with `AssertionError: DiscTitle is missing chromaprint_blob`.
+
+- [ ] **Step A1.3: Add the fields to `DiscTitle`**
+
+In `backend/app/models/disc_job.py`, find the `DiscTitle` class definition. After the existing match-related fields (`matched_episode`, `match_confidence`, `match_details`, `match_source`), add:
+
+```python
+    # Chromaprint fingerprint (Phase 1 — extraction + storage only; no identification yet)
+    chromaprint_blob: bytes | None = Field(default=None)
+    chromaprint_extracted_at: datetime | None = Field(default=None)
+```
+
+Ensure `datetime` is imported at the top of the file (it should already be present; if not, add `from datetime import datetime`).
+
+- [ ] **Step A1.4: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py::test_disc_title_has_chromaprint_fields -v
+```
+Expected: PASS.
+
+- [ ] **Step A1.5: Verify the schema reconciler picks it up**
+
+Manually verify `_add_missing_columns()` in `backend/app/database.py` (around line 121) iterates SQLModel metadata — no code change needed, but read the function to confirm new fields will be added on next `init_db()`.
+
+- [ ] **Step A1.6: Commit**
+
+```bash
+git add backend/app/models/disc_job.py backend/tests/unit/test_chromaprint_extractor.py
+git commit -m "feat(models): add chromaprint storage fields to DiscTitle"
+```
+
+### Task A2: Add fingerprint config fields to `AppConfig`
+
+**Files:**
+- Modify: `backend/app/models/app_config.py`
+- Test: extend `backend/tests/unit/test_chromaprint_extractor.py`
+
+- [ ] **Step A2.1: Write the failing test**
+
+Append to `backend/tests/unit/test_chromaprint_extractor.py`:
+
+```python
+from app.models.app_config import AppConfig
+
+
+def test_app_config_has_fingerprint_fields():
+    """AppConfig exposes fingerprint extraction settings."""
+    fields = AppConfig.model_fields
+    assert "fpcalc_path" in fields
+    assert "contribution_pseudonym" in fields
+    assert "enable_fingerprint_contributions" in fields
+
+
+def test_enable_fingerprint_contributions_defaults_true():
+    """Opt-out default: contributions enabled unless explicitly disabled."""
+    cfg = AppConfig()
+    assert cfg.enable_fingerprint_contributions is True
+```
+
+- [ ] **Step A2.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: both new tests FAIL.
+
+- [ ] **Step A2.3: Add fields to `AppConfig`**
+
+In `backend/app/models/app_config.py`, add near the other tool-path / feature-toggle fields:
+
+```python
+    # Chromaprint / fingerprint contributions
+    fpcalc_path: str | None = Field(default=None)
+    contribution_pseudonym: str | None = Field(default=None)
+    enable_fingerprint_contributions: bool = Field(default=True)
+```
+
+- [ ] **Step A2.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: all pass.
+
+- [ ] **Step A2.5: Commit**
+
+```bash
+git add backend/app/models/app_config.py backend/tests/unit/test_chromaprint_extractor.py
+git commit -m "feat(models): add fpcalc_path, pseudonym, and opt-out toggle to AppConfig"
+```
+
+### Task A3: Alembic migration for the new columns
+
+**Files:**
+- Create: `backend/migrations/versions/<rev>_phase1_chromaprint_schema.py`
+
+- [ ] **Step A3.1: Identify the current head revision**
+
+```bash
+cd backend
+uv run alembic heads
+```
+Note the revision ID printed (call it `PREV_REV` below).
+
+- [ ] **Step A3.2: Generate a new migration**
+
+```bash
+uv run alembic revision -m "phase1 chromaprint schema"
+```
+Note the generated file path under `backend/migrations/versions/`. Open it.
+
+- [ ] **Step A3.3: Fill in the migration body**
+
+Replace the generated `upgrade()` and `downgrade()` with:
+
+```python
+"""phase1 chromaprint schema
+
+Revision ID: <auto>
+Revises: <PREV_REV>
+Create Date: <auto>
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Keep auto-generated revision/down_revision fields above this line.
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("disc_titles", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("chromaprint_blob", sa.LargeBinary(), nullable=True))
+        batch_op.add_column(sa.Column("chromaprint_extracted_at", sa.DateTime(), nullable=True))
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("fpcalc_path", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("contribution_pseudonym", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "enable_fingerprint_contributions",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("enable_fingerprint_contributions")
+        batch_op.drop_column("contribution_pseudonym")
+        batch_op.drop_column("fpcalc_path")
+    with op.batch_alter_table("disc_titles", schema=None) as batch_op:
+        batch_op.drop_column("chromaprint_extracted_at")
+        batch_op.drop_column("chromaprint_blob")
+```
+
+- [ ] **Step A3.4: Run migration upgrade against a scratch DB**
+
+```bash
+DATABASE_URL="sqlite+aiosqlite:///./scratch.db" uv run alembic upgrade head
+DATABASE_URL="sqlite+aiosqlite:///./scratch.db" uv run alembic downgrade -1
+DATABASE_URL="sqlite+aiosqlite:///./scratch.db" uv run alembic upgrade head
+rm scratch.db
+```
+Expected: upgrade and downgrade both succeed without errors.
+
+- [ ] **Step A3.5: Commit**
+
+```bash
+git add backend/migrations/versions/<new-file>.py
+git commit -m "feat(migrations): phase1 chromaprint columns + opt-out config"
+```
+
+---
+
+## Cluster B: fpcalc Tooling
+
+### Task B1: `_validate_fpcalc_binary()` helper
+
+**Files:**
+- Modify: `backend/app/api/validation.py`
+- Test: `backend/tests/unit/test_fpcalc_validation.py` (new)
+
+- [ ] **Step B1.1: Write the failing tests**
+
+Create `backend/tests/unit/test_fpcalc_validation.py`:
+
+```python
+"""Tests for fpcalc binary validation."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.api.validation import _validate_fpcalc_binary
+
+
+def test_validate_fpcalc_binary_success():
+    """Valid fpcalc binary returns found=True with version."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "fpcalc version 1.5.1 (FFmpeg ...)\n"
+        result = _validate_fpcalc_binary("/fake/fpcalc")
+        assert result.found is True
+        assert "1.5.1" in result.version
+        assert result.path == "/fake/fpcalc"
+
+
+def test_validate_fpcalc_binary_nonzero_exit():
+    """Non-zero exit code reports not found with error."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = "bad binary"
+        result = _validate_fpcalc_binary("/fake/fpcalc")
+        assert result.found is False
+        assert "exit" in result.error.lower() or "code" in result.error.lower()
+
+
+def test_validate_fpcalc_binary_missing_file(tmp_path):
+    """A nonexistent path reports found=False without raising."""
+    bogus = tmp_path / "nope.exe"
+    result = _validate_fpcalc_binary(str(bogus))
+    assert result.found is False
+    assert result.path == str(bogus)
+```
+
+- [ ] **Step B1.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_fpcalc_validation.py -v
+```
+Expected: ImportError or AttributeError — `_validate_fpcalc_binary` doesn't exist yet.
+
+- [ ] **Step B1.3: Implement `_validate_fpcalc_binary`**
+
+In `backend/app/api/validation.py`, immediately after `_validate_ffmpeg_binary` (around line 188-205), add:
+
+```python
+def _validate_fpcalc_binary(path_str: str) -> ToolDetectionResult:
+    """Validate a chromaprint fpcalc binary and extract version info."""
+    if not Path(path_str).is_file():
+        return ToolDetectionResult(
+            found=False,
+            path=path_str,
+            error="Path does not exist or is not a file",
+        )
+    try:
+        result = subprocess.run(
+            [path_str, "-version"],
+            capture_output=True,
+            timeout=10,
+            text=True,
+        )
+        if result.returncode != 0:
+            return ToolDetectionResult(
+                found=False,
+                path=path_str,
+                error=f"Non-zero exit code {result.returncode}",
+            )
+        version_line = (result.stdout or "").split("\n")[0] or "unknown"
+        return ToolDetectionResult(found=True, path=path_str, version=version_line)
+    except subprocess.TimeoutExpired:
+        return ToolDetectionResult(found=False, path=path_str, error="Timed out")
+    except OSError as e:
+        return ToolDetectionResult(found=False, path=path_str, error=str(e))
+```
+
+Ensure `Path` is imported at the top of the file (it should already be).
+
+- [ ] **Step B1.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_fpcalc_validation.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step B1.5: Commit**
+
+```bash
+git add backend/app/api/validation.py backend/tests/unit/test_fpcalc_validation.py
+git commit -m "feat(validation): add _validate_fpcalc_binary helper"
+```
+
+### Task B2: Auto-detect fpcalc in common locations
+
+**Files:**
+- Modify: `backend/app/api/validation.py`
+- Test: extend `backend/tests/unit/test_fpcalc_validation.py`
+
+- [ ] **Step B2.1: Write the failing test**
+
+Append to `backend/tests/unit/test_fpcalc_validation.py`:
+
+```python
+from unittest.mock import MagicMock
+
+
+def test_detect_fpcalc_uses_path_search(monkeypatch):
+    """detect_fpcalc consults shutil.which before falling back to common paths."""
+    from app.api import validation as v
+
+    def fake_which(name):
+        return "/usr/local/bin/fpcalc" if name == "fpcalc" else None
+
+    monkeypatch.setattr(v.shutil, "which", fake_which)
+    monkeypatch.setattr(
+        v,
+        "_validate_fpcalc_binary",
+        lambda p: v.ToolDetectionResult(found=True, path=p, version="fpcalc version 1.5.1"),
+    )
+    result = v.detect_fpcalc()
+    assert result.found is True
+    assert result.path == "/usr/local/bin/fpcalc"
+```
+
+- [ ] **Step B2.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_fpcalc_validation.py::test_detect_fpcalc_uses_path_search -v
+```
+Expected: FAIL — `detect_fpcalc` doesn't exist.
+
+- [ ] **Step B2.3: Implement `detect_fpcalc()`**
+
+In `backend/app/api/validation.py`, after `_validate_fpcalc_binary` add:
+
+```python
+FPCALC_COMMON_PATHS = [
+    # Windows
+    r"C:\Program Files\Chromaprint\fpcalc.exe",
+    r"C:\Program Files (x86)\Chromaprint\fpcalc.exe",
+    # macOS (homebrew)
+    "/opt/homebrew/bin/fpcalc",
+    "/usr/local/bin/fpcalc",
+    # Linux
+    "/usr/bin/fpcalc",
+    # Dev convenience: the worktree spike binary
+    str(Path(__file__).resolve().parents[3] / "spikes" / "chromaprint" / "bin" / "fpcalc.exe"),
+]
+
+
+def detect_fpcalc() -> ToolDetectionResult:
+    """Auto-detect a usable fpcalc binary.
+
+    Order: PATH first, then common platform locations, then the dev spike binary.
+    Returns the first result that validates successfully.
+    """
+    via_path = shutil.which("fpcalc")
+    candidates: list[str] = []
+    if via_path:
+        candidates.append(via_path)
+    candidates.extend(FPCALC_COMMON_PATHS)
+
+    for candidate in candidates:
+        result = _validate_fpcalc_binary(candidate)
+        if result.found:
+            return result
+
+    return ToolDetectionResult(
+        found=False,
+        path=None,
+        error="fpcalc not found in PATH or common locations",
+    )
+```
+
+Ensure `shutil` is imported (it should be).
+
+- [ ] **Step B2.4: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_fpcalc_validation.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step B2.5: Commit**
+
+```bash
+git add backend/app/api/validation.py backend/tests/unit/test_fpcalc_validation.py
+git commit -m "feat(validation): auto-detect fpcalc in PATH and common locations"
+```
+
+### Task B3: Validation endpoint + add to detect-tools response
+
+**Files:**
+- Modify: `backend/app/api/validation.py`
+- Test: `backend/tests/integration/test_chromaprint_pipeline.py` (new)
+
+- [ ] **Step B3.1: Write the failing integration test**
+
+Create `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+"""Integration tests for chromaprint Phase 1: fpcalc detection + extraction pipeline."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_detect_tools_includes_fpcalc(integration_client):
+    """GET /api/detect-tools surfaces fpcalc alongside makemkv and ffmpeg."""
+    response = await integration_client.get("/api/detect-tools")
+    assert response.status_code == 200
+    data = response.json()
+    assert "fpcalc" in data, f"detect-tools should include fpcalc, got keys: {list(data.keys())}"
+
+
+@pytest.mark.asyncio
+async def test_validate_fpcalc_endpoint_rejects_missing(integration_client):
+    """POST /api/validate/fpcalc with a bogus path reports found=False."""
+    response = await integration_client.post(
+        "/api/validate/fpcalc",
+        json={"path": "/definitely/not/a/binary"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["valid"] is False
+```
+
+- [ ] **Step B3.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: FAIL — both endpoints don't include fpcalc support yet.
+
+- [ ] **Step B3.3: Add `/api/validate/fpcalc` endpoint**
+
+In `backend/app/api/validation.py`, after the existing `/api/validate/ffmpeg` endpoint (around line 292), add:
+
+```python
+@router.post("/validate/fpcalc", response_model=ValidationResponse)
+async def validate_fpcalc(request: ValidationRequest) -> ValidationResponse:
+    """Validate a user-supplied fpcalc binary path."""
+    result = _validate_fpcalc_binary(request.path)
+    return ValidationResponse(
+        valid=result.found,
+        message=result.version or result.error or "",
+        details={"path": result.path, "version": result.version},
+    )
+```
+
+- [ ] **Step B3.4: Add fpcalc to `/api/detect-tools`**
+
+Find the `detect_tools` endpoint in the same file (search for `@router.get("/detect-tools"`). It currently returns a dict including `makemkv` and `ffmpeg`. Add `fpcalc`:
+
+```python
+    return {
+        "makemkv": detect_makemkv(),
+        "ffmpeg": detect_ffmpeg(),
+        "fpcalc": detect_fpcalc(),
+    }
+```
+
+- [ ] **Step B3.5: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: PASS.
+
+- [ ] **Step B3.6: Commit**
+
+```bash
+git add backend/app/api/validation.py backend/tests/integration/test_chromaprint_pipeline.py
+git commit -m "feat(api): /api/validate/fpcalc + fpcalc in detect-tools"
+```
+
+---
+
+## Cluster C: ChromaprintExtractor
+
+### Task C1: Module skeleton and types
+
+**Files:**
+- Create: `backend/app/matcher/chromaprint_extractor.py`
+- Test: extend `backend/tests/unit/test_chromaprint_extractor.py`
+
+- [ ] **Step C1.1: Write the failing test**
+
+Append to `backend/tests/unit/test_chromaprint_extractor.py`:
+
+```python
+from app.matcher.chromaprint_extractor import ChromaprintResult, ChromaprintExtractor
+
+
+def test_chromaprint_result_serializes_to_bytes():
+    """ChromaprintResult.to_blob() returns deterministic compressed bytes."""
+    r = ChromaprintResult(
+        hashes=[1, 2, 3, 4, 5],
+        duration_seconds=42.0,
+        fpcalc_version="fpcalc version 1.5.1",
+    )
+    blob = r.to_blob()
+    assert isinstance(blob, bytes)
+    assert len(blob) > 0
+    # Re-serializing the same data must produce identical bytes (deterministic)
+    assert r.to_blob() == blob
+
+
+def test_chromaprint_result_roundtrip():
+    """to_blob / from_blob is lossless on the hash stream and duration."""
+    r = ChromaprintResult(hashes=[100, 200, 300], duration_seconds=12.5, fpcalc_version="test")
+    restored = ChromaprintResult.from_blob(r.to_blob())
+    assert restored.hashes == [100, 200, 300]
+    assert restored.duration_seconds == 12.5
+
+
+def test_extractor_construction():
+    """ChromaprintExtractor takes an fpcalc_path."""
+    ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+    assert ex.fpcalc_path == "/fake/fpcalc"
+```
+
+- [ ] **Step C1.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: ImportError — the module doesn't exist.
+
+- [ ] **Step C1.3: Create the module skeleton**
+
+Create `backend/app/matcher/chromaprint_extractor.py`:
+
+```python
+"""Chromaprint fingerprint extraction.
+
+Wraps the fpcalc CLI (bundled with libchromaprint) to produce a chromaprint hash
+stream for an MKV/MP4/audio file. Phase 1 stores the full fingerprint per title;
+windowed querying lives in Phase 3.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class ChromaprintResult:
+    """The full chromaprint hash stream for one media file."""
+
+    hashes: list[int]
+    duration_seconds: float
+    fpcalc_version: str
+
+    def to_blob(self) -> bytes:
+        """Serialize to gzip-compressed JSON for DB storage."""
+        payload = {
+            "v": 1,
+            "duration": self.duration_seconds,
+            "fpcalc": self.fpcalc_version,
+            "hashes": self.hashes,
+        }
+        return gzip.compress(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+            mtime=0,
+        )
+
+    @classmethod
+    def from_blob(cls, blob: bytes) -> "ChromaprintResult":
+        payload = json.loads(gzip.decompress(blob).decode("utf-8"))
+        if payload.get("v") != 1:
+            raise ValueError(f"Unknown chromaprint blob version: {payload.get('v')}")
+        return cls(
+            hashes=list(payload["hashes"]),
+            duration_seconds=float(payload["duration"]),
+            fpcalc_version=str(payload.get("fpcalc", "")),
+        )
+
+
+class ChromaprintExtractor:
+    """Subprocess-based chromaprint fingerprint extractor."""
+
+    def __init__(self, fpcalc_path: str) -> None:
+        self.fpcalc_path = fpcalc_path
+
+    async def extract(self, media_path: str) -> ChromaprintResult:
+        raise NotImplementedError("extract() lands in Task C2")
+```
+
+- [ ] **Step C1.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: all PASS (including the three new tests).
+
+- [ ] **Step C1.5: Commit**
+
+```bash
+git add backend/app/matcher/chromaprint_extractor.py backend/tests/unit/test_chromaprint_extractor.py
+git commit -m "feat(matcher): ChromaprintResult + extractor skeleton"
+```
+
+### Task C2: Implement `extract()` with subprocess
+
+**Files:**
+- Modify: `backend/app/matcher/chromaprint_extractor.py`
+- Test: extend `backend/tests/unit/test_chromaprint_extractor.py`
+
+- [ ] **Step C2.1: Write the failing tests**
+
+Append to `backend/tests/unit/test_chromaprint_extractor.py`:
+
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.mark.asyncio
+async def test_extract_parses_fpcalc_output():
+    """extract() parses DURATION and FINGERPRINT from fpcalc -raw output."""
+    fake_output = "DURATION=1304\nFINGERPRINT=112114628,250527685,250521542\n"
+    with patch("asyncio.to_thread") as mock_thread:
+        mock_completed = MagicMock()
+        mock_completed.returncode = 0
+        mock_completed.stdout = fake_output
+        mock_completed.stderr = ""
+        mock_thread.return_value = mock_completed
+
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        result = await ex.extract("/fake/movie.mkv")
+
+    assert result.duration_seconds == 1304.0
+    assert result.hashes == [112114628, 250527685, 250521542]
+
+
+@pytest.mark.asyncio
+async def test_extract_raises_on_fpcalc_failure():
+    """A non-zero fpcalc exit raises a clean exception, not subprocess noise."""
+    with patch("asyncio.to_thread") as mock_thread:
+        mock_completed = MagicMock()
+        mock_completed.returncode = 1
+        mock_completed.stdout = ""
+        mock_completed.stderr = "fpcalc: ERROR: cannot decode audio"
+        mock_thread.return_value = mock_completed
+
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        with pytest.raises(RuntimeError, match="fpcalc"):
+            await ex.extract("/fake/no-audio.mkv")
+
+
+@pytest.mark.asyncio
+async def test_extract_raises_when_no_fingerprint_line():
+    """fpcalc returned 0 but no FINGERPRINT line — should fail loudly."""
+    with patch("asyncio.to_thread") as mock_thread:
+        mock_completed = MagicMock()
+        mock_completed.returncode = 0
+        mock_completed.stdout = "DURATION=10\n"
+        mock_completed.stderr = ""
+        mock_thread.return_value = mock_completed
+
+        ex = ChromaprintExtractor(fpcalc_path="/fake/fpcalc")
+        with pytest.raises(RuntimeError, match="FINGERPRINT"):
+            await ex.extract("/fake/silent.mkv")
+```
+
+- [ ] **Step C2.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: 3 new tests FAIL (NotImplementedError).
+
+- [ ] **Step C2.3: Implement `extract()`**
+
+Replace the `extract()` body in `backend/app/matcher/chromaprint_extractor.py`:
+
+```python
+import asyncio
+import subprocess
+from loguru import logger
+
+
+class ChromaprintExtractor:
+    def __init__(self, fpcalc_path: str, timeout_seconds: float = 120.0) -> None:
+        self.fpcalc_path = fpcalc_path
+        self.timeout_seconds = timeout_seconds
+
+    async def extract(self, media_path: str) -> ChromaprintResult:
+        """Extract the full chromaprint hash stream from a media file.
+
+        Returns a `ChromaprintResult` on success. Raises `RuntimeError` on any
+        fpcalc-side failure — the caller decides whether the matching pipeline
+        should continue without a fingerprint.
+        """
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [self.fpcalc_path, "-raw", "-length", "99999", media_path],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+
+        try:
+            proc = await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"fpcalc timed out after {self.timeout_seconds}s on {media_path}") from e
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"fpcalc exited {proc.returncode} on {media_path}: {proc.stderr.strip()}"
+            )
+
+        duration: float | None = None
+        hashes: list[int] = []
+        version_line = ""
+        for line in proc.stdout.splitlines():
+            if line.startswith("DURATION="):
+                duration = float(line.removeprefix("DURATION="))
+            elif line.startswith("FINGERPRINT="):
+                hashes = [int(x) for x in line.removeprefix("FINGERPRINT=").split(",") if x]
+
+        if not hashes:
+            raise RuntimeError(f"fpcalc produced no FINGERPRINT line for {media_path}")
+        if duration is None:
+            duration = 0.0
+
+        # Best-effort version capture (single call cached at first use is overkill for Phase 1)
+        version_line = await self._cached_version()
+
+        logger.info(f"chromaprint extracted: {len(hashes)} hashes, {duration:.1f}s from {media_path}")
+        return ChromaprintResult(hashes=hashes, duration_seconds=duration, fpcalc_version=version_line)
+
+    async def _cached_version(self) -> str:
+        if hasattr(self, "_version_cache"):
+            return self._version_cache  # type: ignore[return-value]
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [self.fpcalc_path, "-version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        try:
+            proc = await asyncio.to_thread(_run)
+            self._version_cache = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
+        except Exception:
+            self._version_cache = ""
+        return self._version_cache
+```
+
+- [ ] **Step C2.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_chromaprint_extractor.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step C2.5: Smoke-test with the real fpcalc + a real MKV**
+
+```bash
+cd backend
+uv run python -c "
+import asyncio
+from app.matcher.chromaprint_extractor import ChromaprintExtractor
+
+async def main():
+    ex = ChromaprintExtractor(fpcalc_path='../spikes/chromaprint/bin/fpcalc.exe')
+    r = await ex.extract('C:/Users/jonat/Engram/TV/Arrested Development/Season 1/Arrested Development - S01E07.mkv')
+    print(f'OK: {len(r.hashes)} hashes, {r.duration_seconds:.1f}s, {len(r.to_blob())} bytes compressed')
+
+asyncio.run(main())
+"
+```
+Expected output: `OK: ~10500 hashes, ~1300s, ~XX KB compressed`. If your library path differs, edit accordingly.
+
+- [ ] **Step C2.6: Commit**
+
+```bash
+git add backend/app/matcher/chromaprint_extractor.py backend/tests/unit/test_chromaprint_extractor.py
+git commit -m "feat(matcher): implement ChromaprintExtractor.extract via fpcalc subprocess"
+```
+
+### Task C3: Pseudonym generation helper
+
+**Files:**
+- Create: `backend/app/services/contribution_pseudonym.py`
+- Test: `backend/tests/unit/test_contribution_pseudonym.py` (new)
+
+- [ ] **Step C3.1: Write the failing test**
+
+Create `backend/tests/unit/test_contribution_pseudonym.py`:
+
+```python
+"""Per-install pseudonym generation."""
+
+import re
+
+from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
+
+
+def test_generate_pseudonym_is_uuid_v4():
+    p = generate_pseudonym()
+    assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", p), p
+
+
+def test_generate_pseudonym_unique():
+    assert generate_pseudonym() != generate_pseudonym()
+
+
+def test_validate_pseudonym_accepts_uuid():
+    assert validate_pseudonym(generate_pseudonym()) is True
+
+
+def test_validate_pseudonym_rejects_garbage():
+    assert validate_pseudonym("not-a-uuid") is False
+    assert validate_pseudonym("") is False
+    assert validate_pseudonym(None) is False  # type: ignore[arg-type]
+```
+
+- [ ] **Step C3.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_contribution_pseudonym.py -v
+```
+Expected: ImportError.
+
+- [ ] **Step C3.3: Implement the module**
+
+Create `backend/app/services/contribution_pseudonym.py`:
+
+```python
+"""Per-install pseudonym generation for fingerprint contributions.
+
+The pseudonym is a UUIDv4 stored in `app_config.contribution_pseudonym`. It is
+intentionally not tied to any user identity; rotating it deletes the contribution
+history on the server side (Phase 2). Phase 1 only needs to generate and persist it.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+_UUID_V4_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def generate_pseudonym() -> str:
+    """Return a fresh UUIDv4 string."""
+    return str(uuid.uuid4())
+
+
+def validate_pseudonym(value: object) -> bool:
+    """True if `value` is a syntactically-valid UUIDv4 string."""
+    return isinstance(value, str) and bool(_UUID_V4_RE.match(value))
+```
+
+- [ ] **Step C3.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_contribution_pseudonym.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step C3.5: Commit**
+
+```bash
+git add backend/app/services/contribution_pseudonym.py backend/tests/unit/test_contribution_pseudonym.py
+git commit -m "feat(services): per-install pseudonym generator"
+```
+
+### Task C4: Auto-generate pseudonym on first startup
+
+**Files:**
+- Modify: `backend/app/main.py` (or wherever startup lifespan hooks live)
+- Test: `backend/tests/integration/test_chromaprint_pipeline.py`
+
+- [ ] **Step C4.1: Find the startup hook**
+
+```bash
+cd backend
+uv run grep -n "lifespan\|startup\|on_event" app/main.py | head
+```
+Note which function runs once at startup (likely the `lifespan` async context manager).
+
+- [ ] **Step C4.2: Write the failing integration test**
+
+Append to `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_pseudonym_generated_on_first_startup(integration_client, async_session):
+    """After app startup, app_config has a non-empty contribution_pseudonym."""
+    from sqlmodel import select
+    from app.models.app_config import AppConfig
+    from app.services.contribution_pseudonym import validate_pseudonym
+
+    result = await async_session.execute(select(AppConfig))
+    cfg = result.scalar_one_or_none()
+    assert cfg is not None
+    assert validate_pseudonym(cfg.contribution_pseudonym), (
+        f"contribution_pseudonym should be a UUIDv4, got {cfg.contribution_pseudonym!r}"
+    )
+```
+
+- [ ] **Step C4.3: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py::test_pseudonym_generated_on_first_startup -v
+```
+Expected: FAIL — pseudonym is None.
+
+- [ ] **Step C4.4: Add the startup hook**
+
+In `backend/app/main.py`, inside the `lifespan` async context manager, after the existing `init_db()` call, add:
+
+```python
+    # Ensure the contribution pseudonym exists (Phase 1: fingerprint contributions)
+    from sqlmodel import select
+    from app.models.app_config import AppConfig
+    from app.services.contribution_pseudonym import generate_pseudonym, validate_pseudonym
+
+    async with async_session() as session:
+        result = await session.execute(select(AppConfig))
+        cfg = result.scalar_one_or_none()
+        if cfg is not None and not validate_pseudonym(cfg.contribution_pseudonym):
+            cfg.contribution_pseudonym = generate_pseudonym()
+            session.add(cfg)
+            await session.commit()
+```
+
+(If `async_session` is not imported in `main.py`, import it from `app.database`.)
+
+- [ ] **Step C4.5: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step C4.6: Commit**
+
+```bash
+git add backend/app/main.py backend/tests/integration/test_chromaprint_pipeline.py
+git commit -m "feat(startup): generate contribution pseudonym on first boot"
+```
+
+---
+
+## Cluster D: Pipeline Integration
+
+### Task D1: Hook extractor into matching coordinator
+
+**Files:**
+- Modify: `backend/app/services/matching_coordinator.py`
+- Test: extend `backend/tests/integration/test_chromaprint_pipeline.py`
+
+- [ ] **Step D1.1: Write the failing integration test**
+
+Append to `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chromaprint_extracted_after_match(integration_client, async_session, monkeypatch):
+    """When a title finishes matching, chromaprint_blob is populated on the DiscTitle row."""
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    fake_result = ChromaprintResult(hashes=[1, 2, 3], duration_seconds=10.0, fpcalc_version="test")
+
+    async def fake_extract(self, media_path: str):
+        return fake_result
+
+    monkeypatch.setattr(
+        "app.matcher.chromaprint_extractor.ChromaprintExtractor.extract",
+        fake_extract,
+    )
+
+    # Drive a simulated TV match end-to-end via /api/simulate
+    response = await integration_client.post(
+        "/api/simulate/insert-disc",
+        json={
+            "volume_label": "ARRESTED_DEVELOPMENT_S1D1",
+            "content_type": "tv",
+            "simulate_ripping": True,
+        },
+    )
+    assert response.status_code == 200
+
+    # Poll for completion (matching+chromaprint should complete < 30s with all-mocked extraction)
+    import asyncio
+    from sqlmodel import select
+    from app.models.disc_job import DiscTitle
+
+    for _ in range(60):
+        await asyncio.sleep(0.5)
+        result = await async_session.execute(select(DiscTitle))
+        titles = result.scalars().all()
+        if titles and any(t.chromaprint_blob is not None for t in titles):
+            break
+    else:
+        pytest.fail("No title got chromaprint_blob within 30s")
+
+    matched = [t for t in titles if t.chromaprint_blob is not None]
+    assert matched, "Expected at least one title with chromaprint_blob set"
+    assert matched[0].chromaprint_extracted_at is not None
+```
+
+- [ ] **Step D1.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py::test_chromaprint_extracted_after_match -v
+```
+Expected: FAIL — extraction not yet hooked into the pipeline.
+
+- [ ] **Step D1.3: Add the hook in `_match_single_file_inner`**
+
+In `backend/app/services/matching_coordinator.py`, find `_match_single_file_inner()` (around line 544). After the `await episode_curator.match_single_file(...)` call returns (around line 635) and before the existing `title.state = TitleState.MATCHED` write, insert:
+
+```python
+            # Phase 1: extract chromaprint fingerprint (best-effort; failure does not block match)
+            try:
+                from app.matcher.chromaprint_extractor import ChromaprintExtractor
+                from app.services.config_service import get_config
+                from datetime import datetime, timezone
+
+                cfg = await get_config(session)
+                fpcalc_path = cfg.fpcalc_path
+                if not fpcalc_path:
+                    from app.api.validation import detect_fpcalc
+                    detected = detect_fpcalc()
+                    fpcalc_path = detected.path if detected.found else None
+
+                if fpcalc_path:
+                    extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
+                    fp_result = await extractor.extract(str(file_path))
+                    title.chromaprint_blob = fp_result.to_blob()
+                    title.chromaprint_extracted_at = datetime.now(timezone.utc)
+                else:
+                    logger.debug(f"fpcalc not configured; skipping chromaprint extraction for title {title.id}")
+            except Exception as e:
+                # Graceful degradation: matching already succeeded; log and continue
+                logger.warning(f"Chromaprint extraction failed for title {title.id}: {e}", exc_info=True)
+```
+
+Make sure `logger` is in scope (it should be from existing imports at top of file).
+
+- [ ] **Step D1.4: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: PASS.
+
+- [ ] **Step D1.5: Verify graceful degradation when fpcalc is missing**
+
+Add another test to `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_matching_succeeds_when_fpcalc_missing(integration_client, async_session, monkeypatch):
+    """If fpcalc isn't configured and auto-detect fails, matching still completes — just without a fingerprint."""
+    from app.api import validation as v
+    from app.api.validation import ToolDetectionResult
+    monkeypatch.setattr(v, "detect_fpcalc", lambda: ToolDetectionResult(found=False, path=None, error="absent"))
+
+    response = await integration_client.post(
+        "/api/simulate/insert-disc",
+        json={
+            "volume_label": "INCEPTION_2010",
+            "content_type": "movie",
+            "simulate_ripping": True,
+        },
+    )
+    assert response.status_code == 200
+    # Confirm at least one title was created and reached a terminal state without an exception bubbling up.
+    import asyncio
+    from sqlmodel import select
+    from app.models.disc_job import DiscJob
+    for _ in range(60):
+        await asyncio.sleep(0.5)
+        result = await async_session.execute(select(DiscJob))
+        jobs = result.scalars().all()
+        if jobs and any(j.state in ("completed", "review_needed", "matching", "organizing") for j in jobs):
+            break
+    else:
+        pytest.fail("Job never advanced past initial state with fpcalc absent")
+```
+
+Run: `uv run pytest tests/integration/test_chromaprint_pipeline.py -v`. Expected: PASS.
+
+- [ ] **Step D1.6: Commit**
+
+```bash
+git add backend/app/services/matching_coordinator.py backend/tests/integration/test_chromaprint_pipeline.py
+git commit -m "feat(matching): extract chromaprint after match completes; graceful fallback"
+```
+
+---
+
+## Cluster E: Local Contribution Queue
+
+### Task E1: `FingerprintContribution` model
+
+**Files:**
+- Modify: `backend/app/models/disc_job.py` (add new model alongside DiscJob/DiscTitle) OR create `backend/app/models/fingerprint.py` (preferred)
+- Modify: `backend/app/models/__init__.py`
+- Test: `backend/tests/unit/test_contribution_queue.py` (new)
+
+- [ ] **Step E1.1: Write the failing test**
+
+Create `backend/tests/unit/test_contribution_queue.py`:
+
+```python
+"""Tests for the local FingerprintContribution queue."""
+
+from datetime import datetime
+
+from app.models.fingerprint import FingerprintContribution
+
+
+def test_fingerprint_contribution_has_required_fields():
+    fields = FingerprintContribution.model_fields
+    for required in (
+        "id",
+        "queued_at",
+        "title_id",
+        "chromaprint_blob",
+        "tmdb_id",
+        "season",
+        "episode",
+        "match_confidence",
+        "match_source",
+        "disc_content_hash",
+        "pseudonym",
+        "uploaded_at",
+        "upload_attempts",
+    ):
+        assert required in fields, f"FingerprintContribution missing field: {required}"
+
+
+def test_fingerprint_contribution_construction():
+    c = FingerprintContribution(
+        title_id=1,
+        chromaprint_blob=b"\x00\x01",
+        tmdb_id=12345,
+        season=1,
+        episode=7,
+        match_confidence=0.92,
+        match_source="engram_asr",
+        disc_content_hash=b"\xab\xcd",
+        pseudonym="00000000-0000-4000-8000-000000000000",
+    )
+    assert c.uploaded_at is None
+    assert c.upload_attempts == 0
+```
+
+- [ ] **Step E1.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_contribution_queue.py -v
+```
+Expected: ImportError.
+
+- [ ] **Step E1.3: Create the model**
+
+Create `backend/app/models/fingerprint.py`:
+
+```python
+"""Models for the chromaprint fingerprint contribution queue (Phase 1: local-only)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class FingerprintContribution(SQLModel, table=True):
+    """Local-only queue row.
+
+    Phase 1: rows are appended on successful match. They never leave the local
+    machine. Phase 2 adds a `ContributionUploader` service that drains this table
+    over HTTPS to the fingerprint network server.
+    """
+
+    __tablename__ = "fingerprint_contributions"
+
+    id: int | None = Field(default=None, primary_key=True)
+    queued_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # Nullable so bootstrap rows (no DiscTitle row) can also be queued.
+    title_id: int | None = Field(default=None, foreign_key="disc_titles.id", index=True)
+    chromaprint_blob: bytes
+
+    # Episode identity (the payload-bearing fields per the Phase 2 design)
+    tmdb_id: int
+    season: int | None = None
+    episode: int | None = None
+
+    # Provenance for trust-tier promotion
+    match_confidence: float
+    match_source: str  # 'engram_asr' | 'engram_discdb' | 'bootstrap' | 'user_review'
+
+    # Identifies a *disc release*, not the user's file (m2ts size MD5 from TheDiscDB)
+    disc_content_hash: bytes | None = None
+
+    pseudonym: str
+
+    # Phase 1 fields, set when Phase 2 lands
+    uploaded_at: datetime | None = None
+    upload_attempts: int = Field(default=0)
+```
+
+- [ ] **Step E1.4: Re-export from models package**
+
+In `backend/app/models/__init__.py`, add:
+
+```python
+from app.models.fingerprint import FingerprintContribution
+
+__all__ = [..., "FingerprintContribution"]  # merge with existing __all__
+```
+
+- [ ] **Step E1.5: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_contribution_queue.py -v
+```
+Expected: PASS.
+
+- [ ] **Step E1.6: Add Alembic migration for the new table**
+
+```bash
+uv run alembic revision -m "phase1 fingerprint_contributions table"
+```
+Edit the new file's `upgrade()` / `downgrade()`:
+
+```python
+def upgrade() -> None:
+    op.create_table(
+        "fingerprint_contributions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("queued_at", sa.DateTime(), nullable=False),
+        sa.Column("title_id", sa.Integer(), sa.ForeignKey("disc_titles.id"), nullable=True, index=True),
+        sa.Column("chromaprint_blob", sa.LargeBinary(), nullable=False),
+        sa.Column("tmdb_id", sa.Integer(), nullable=False),
+        sa.Column("season", sa.Integer(), nullable=True),
+        sa.Column("episode", sa.Integer(), nullable=True),
+        sa.Column("match_confidence", sa.Float(), nullable=False),
+        sa.Column("match_source", sa.String(), nullable=False),
+        sa.Column("disc_content_hash", sa.LargeBinary(), nullable=True),
+        sa.Column("pseudonym", sa.String(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(), nullable=True),
+        sa.Column("upload_attempts", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fingerprint_contributions")
+```
+
+Run upgrade/downgrade smoke as in Task A3.
+
+- [ ] **Step E1.7: Commit**
+
+```bash
+git add backend/app/models/fingerprint.py backend/app/models/__init__.py backend/migrations/versions/<file>.py backend/tests/unit/test_contribution_queue.py
+git commit -m "feat(models): FingerprintContribution local queue table"
+```
+
+### Task E2: `ContributionQueue.enqueue()` service
+
+**Files:**
+- Create: `backend/app/services/contribution_queue.py`
+- Test: extend `backend/tests/unit/test_contribution_queue.py`
+
+- [ ] **Step E2.1: Write the failing test**
+
+Append to `backend/tests/unit/test_contribution_queue.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.services.contribution_queue import ContributionQueue
+
+
+@pytest.mark.asyncio
+async def test_enqueue_persists_row():
+    """enqueue() inserts a FingerprintContribution row with the supplied fields."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    queue = ContributionQueue()
+    await queue.enqueue(
+        session=session,
+        title_id=42,
+        chromaprint_blob=b"\xde\xad",
+        tmdb_id=1399,
+        season=1,
+        episode=1,
+        match_confidence=0.91,
+        match_source="engram_asr",
+        disc_content_hash=b"\x12\x34",
+        pseudonym="11111111-1111-4111-8111-111111111111",
+    )
+    session.add.assert_called_once()
+    added = session.add.call_args[0][0]
+    assert added.title_id == 42
+    assert added.match_source == "engram_asr"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_respects_opt_out():
+    """If enable_fingerprint_contributions=False, enqueue is a no-op."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    queue = ContributionQueue()
+    await queue.enqueue(
+        session=session,
+        title_id=1,
+        chromaprint_blob=b"x",
+        tmdb_id=1,
+        season=1,
+        episode=1,
+        match_confidence=0.9,
+        match_source="engram_asr",
+        disc_content_hash=None,
+        pseudonym="11111111-1111-4111-8111-111111111111",
+        contributions_enabled=False,
+    )
+    session.add.assert_not_called()
+```
+
+- [ ] **Step E2.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_contribution_queue.py -v
+```
+Expected: ImportError.
+
+- [ ] **Step E2.3: Create the service**
+
+Create `backend/app/services/contribution_queue.py`:
+
+```python
+"""Local-only fingerprint contribution queue (Phase 1).
+
+Phase 2 adds an uploader that drains this queue over HTTPS. For Phase 1 the queue
+is append-only and never uploads anything — it exists so that contributions are
+captured from day one, ready to flow when the server lands.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models.fingerprint import FingerprintContribution
+
+
+class ContributionQueue:
+    """Append rows to the local FingerprintContribution table."""
+
+    async def enqueue(
+        self,
+        *,
+        session: AsyncSession,
+        title_id: int,
+        chromaprint_blob: bytes,
+        tmdb_id: int,
+        season: int | None,
+        episode: int | None,
+        match_confidence: float,
+        match_source: str,
+        disc_content_hash: bytes | None,
+        pseudonym: str,
+        contributions_enabled: bool = True,
+    ) -> None:
+        """Append a contribution if the user has opt-in (default True)."""
+        if not contributions_enabled:
+            logger.debug(f"Skipping contribution for title {title_id}: contributions disabled")
+            return
+        row = FingerprintContribution(
+            title_id=title_id,
+            chromaprint_blob=chromaprint_blob,
+            tmdb_id=tmdb_id,
+            season=season,
+            episode=episode,
+            match_confidence=match_confidence,
+            match_source=match_source,
+            disc_content_hash=disc_content_hash,
+            pseudonym=pseudonym,
+        )
+        session.add(row)
+        logger.info(
+            f"Queued contribution for title {title_id} (tmdb={tmdb_id} s{season}e{episode}, "
+            f"source={match_source}, conf={match_confidence:.2f})"
+        )
+```
+
+- [ ] **Step E2.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_contribution_queue.py -v
+```
+Expected: PASS.
+
+- [ ] **Step E2.5: Commit**
+
+```bash
+git add backend/app/services/contribution_queue.py backend/tests/unit/test_contribution_queue.py
+git commit -m "feat(services): ContributionQueue local-only enqueue"
+```
+
+### Task E3: Enqueue on successful match
+
+**Files:**
+- Modify: `backend/app/services/matching_coordinator.py`
+- Test: extend `backend/tests/integration/test_chromaprint_pipeline.py`
+
+- [ ] **Step E3.1: Write the failing test**
+
+Append to `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_contribution_enqueued_on_match(integration_client, async_session, monkeypatch):
+    """A successful match enqueues a FingerprintContribution row."""
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    fake_result = ChromaprintResult(hashes=[1], duration_seconds=10.0, fpcalc_version="test")
+    monkeypatch.setattr(
+        "app.matcher.chromaprint_extractor.ChromaprintExtractor.extract",
+        lambda self, p: fake_result,
+    )
+
+    response = await integration_client.post(
+        "/api/simulate/insert-disc",
+        json={
+            "volume_label": "ARRESTED_DEVELOPMENT_S1D1",
+            "content_type": "tv",
+            "simulate_ripping": True,
+        },
+    )
+    assert response.status_code == 200
+
+    import asyncio
+    from sqlmodel import select
+    from app.models.fingerprint import FingerprintContribution
+    for _ in range(60):
+        await asyncio.sleep(0.5)
+        result = await async_session.execute(select(FingerprintContribution))
+        rows = result.scalars().all()
+        if rows:
+            break
+    else:
+        pytest.fail("No FingerprintContribution row was queued within 30s")
+
+    assert rows[0].chromaprint_blob is not None
+    assert rows[0].pseudonym  # non-empty
+```
+
+- [ ] **Step E3.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py::test_contribution_enqueued_on_match -v
+```
+Expected: FAIL — queue isn't wired up yet.
+
+- [ ] **Step E3.3: Wire `ContributionQueue` into the matching coordinator**
+
+In `backend/app/services/matching_coordinator.py`, immediately after the chromaprint extraction block (added in Task D1), add:
+
+```python
+            # Phase 1: enqueue contribution if the title is identified
+            if title.chromaprint_blob and title.matched_episode and cfg.contribution_pseudonym:
+                try:
+                    from app.services.contribution_queue import ContributionQueue
+                    # Parse "S01E07" → (season, episode)
+                    import re
+                    m = re.match(r"S(\d{1,2})E(\d{1,3})", title.matched_episode or "")
+                    season = int(m.group(1)) if m else None
+                    episode_num = int(m.group(2)) if m else None
+                    await ContributionQueue().enqueue(
+                        session=session,
+                        title_id=title.id,
+                        chromaprint_blob=title.chromaprint_blob,
+                        tmdb_id=int(job.tmdb_id) if getattr(job, "tmdb_id", None) else 0,
+                        season=season,
+                        episode=episode_num,
+                        match_confidence=float(title.match_confidence or 0.0),
+                        match_source=title.match_source or "engram_asr",
+                        disc_content_hash=bytes.fromhex(job.content_hash) if getattr(job, "content_hash", None) else None,
+                        pseudonym=cfg.contribution_pseudonym,
+                        contributions_enabled=cfg.enable_fingerprint_contributions,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to enqueue contribution for title {title.id}: {e}", exc_info=True)
+```
+
+- [ ] **Step E3.4: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step E3.5: Commit**
+
+```bash
+git add backend/app/services/matching_coordinator.py backend/tests/integration/test_chromaprint_pipeline.py
+git commit -m "feat(matching): enqueue local contribution after successful match"
+```
+
+---
+
+## Cluster F: Bootstrap CLI
+
+### Task F1: Filename parser + scanner
+
+**Files:**
+- Create: `backend/app/scripts/__init__.py` (empty if not present)
+- Create: `backend/app/scripts/bootstrap_library.py`
+- Test: `backend/tests/unit/test_bootstrap_library.py`
+
+- [ ] **Step F1.1: Write the failing test**
+
+Create `backend/tests/unit/test_bootstrap_library.py`:
+
+```python
+"""Tests for the bootstrap-library CLI utility."""
+
+from pathlib import Path
+
+from app.scripts.bootstrap_library import parse_episode_filename, walk_library
+
+
+def test_parse_episode_filename_standard():
+    assert parse_episode_filename("Arrested Development - S01E07.mkv") == ("Arrested Development", 1, 7)
+    assert parse_episode_filename("The Gilded Age - S03E08.mkv") == ("The Gilded Age", 3, 8)
+    assert parse_episode_filename("Star Trek The Next Generation - S07E09.mkv") == (
+        "Star Trek The Next Generation",
+        7,
+        9,
+    )
+
+
+def test_parse_episode_filename_rejects_garbage():
+    assert parse_episode_filename("movie.mkv") is None
+    assert parse_episode_filename("Show.mkv") is None
+    assert parse_episode_filename("Show - 1x07.mkv") is None  # only the canonical SxxExx form
+
+
+def test_walk_library_skips_extras(tmp_path):
+    show = tmp_path / "Foo"
+    season = show / "Season 1"
+    season.mkdir(parents=True)
+    extras = season / "Extras"
+    extras.mkdir()
+    (season / "Foo - S01E01.mkv").touch()
+    (season / "Foo - S01E02.mkv").touch()
+    (extras / "Foo Extra t00.mkv").touch()  # should be ignored
+
+    found = list(walk_library(tmp_path))
+    names = sorted(p.name for p, _ in found)
+    assert names == ["Foo - S01E01.mkv", "Foo - S01E02.mkv"]
+```
+
+- [ ] **Step F1.2: Run the tests (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_bootstrap_library.py -v
+```
+Expected: ImportError.
+
+- [ ] **Step F1.3: Implement the module**
+
+Create `backend/app/scripts/bootstrap_library.py`:
+
+```python
+"""Bootstrap-library CLI.
+
+Walks a directory of MKVs labeled `Show - SnnEnn.mkv`, fingerprints each one,
+and enqueues a FingerprintContribution row tagged `match_source="bootstrap"`.
+
+Usage:
+  uv run python -m app.scripts.bootstrap_library /path/to/library [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from loguru import logger
+
+EP_REGEX = re.compile(
+    r"(?P<show>.+?)\s*-\s*S(?P<season>\d{1,2})E(?P<ep>\d{1,3})\s*\.\w+$",
+    re.IGNORECASE,
+)
+
+
+def parse_episode_filename(name: str) -> tuple[str, int, int] | None:
+    """Return (show, season, episode) for canonical 'Show - SnnEnn.ext' names, else None."""
+    m = EP_REGEX.match(name)
+    if not m:
+        return None
+    return m["show"].strip(), int(m["season"]), int(m["ep"])
+
+
+def walk_library(root: Path) -> Iterable[tuple[Path, tuple[str, int, int]]]:
+    """Yield (file_path, (show, season, episode)) for every labeled MKV under root, skipping Extras."""
+    for mkv in sorted(root.rglob("*.mkv")):
+        if "Extras" in mkv.parts:
+            continue
+        label = parse_episode_filename(mkv.name)
+        if label is None:
+            continue
+        yield mkv, label
+```
+
+- [ ] **Step F1.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_bootstrap_library.py -v
+```
+Expected: PASS.
+
+- [ ] **Step F1.5: Commit**
+
+```bash
+git add backend/app/scripts/__init__.py backend/app/scripts/bootstrap_library.py backend/tests/unit/test_bootstrap_library.py
+git commit -m "feat(scripts): bootstrap-library filename parser + walker"
+```
+
+### Task F2: TMDB resolution + extraction loop
+
+**Files:**
+- Modify: `backend/app/scripts/bootstrap_library.py`
+- Test: extend `backend/tests/unit/test_bootstrap_library.py`
+
+- [ ] **Step F2.1: Write the failing test**
+
+Append to `backend/tests/unit/test_bootstrap_library.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.scripts.bootstrap_library import resolve_tmdb_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_tmdb_id_caches_per_show():
+    """resolve_tmdb_id calls the TMDB client at most once per (show, content_type)."""
+    calls = []
+
+    async def fake_search(name, content_type):
+        calls.append(name)
+        return 12345
+
+    cache: dict[tuple[str, str], int] = {}
+    a = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    b = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    c = await resolve_tmdb_id("Foo", "tv", search_fn=fake_search, cache=cache)
+    assert a == b == c == 12345
+    assert calls == ["Foo"]  # only one upstream call
+```
+
+- [ ] **Step F2.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/unit/test_bootstrap_library.py::test_resolve_tmdb_id_caches_per_show -v
+```
+Expected: ImportError.
+
+- [ ] **Step F2.3: Implement TMDB resolution + main loop**
+
+Extend `backend/app/scripts/bootstrap_library.py`:
+
+```python
+from typing import Awaitable, Callable
+
+
+SearchFn = Callable[[str, str], Awaitable[int | None]]
+
+
+async def resolve_tmdb_id(
+    show: str,
+    content_type: str,
+    *,
+    search_fn: SearchFn,
+    cache: dict[tuple[str, str], int],
+) -> int | None:
+    """Resolve a show name to a TMDB ID with an in-memory cache."""
+    key = (show, content_type)
+    if key in cache:
+        return cache[key]
+    result = await search_fn(show, content_type)
+    if result is not None:
+        cache[key] = result
+    return result
+
+
+async def _default_search(show: str, content_type: str) -> int | None:
+    """Use the existing TMDB classifier to resolve a name → ID."""
+    from app.core.tmdb_classifier import TmdbClassifier
+    classifier = TmdbClassifier()
+    res = await classifier.search_show(show) if content_type == "tv" else await classifier.search_movie(show)
+    return res.tmdb_id if res else None
+
+
+async def bootstrap_directory(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    fpcalc_path: str | None = None,
+) -> dict[str, int]:
+    """Walk `root`, extract+enqueue contributions, return summary counts."""
+    from app.database import async_session
+    from app.matcher.chromaprint_extractor import ChromaprintExtractor
+    from app.services.contribution_queue import ContributionQueue
+    from app.services.config_service import get_config
+
+    counters = {"scanned": 0, "skipped": 0, "extracted": 0, "queued": 0, "errors": 0}
+    cache: dict[tuple[str, str], int] = {}
+
+    if fpcalc_path is None:
+        from app.api.validation import detect_fpcalc
+        detected = detect_fpcalc()
+        fpcalc_path = detected.path if detected.found else None
+    if not fpcalc_path:
+        logger.error("fpcalc not configured; cannot bootstrap")
+        return counters
+
+    extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
+
+    async with async_session() as session:
+        cfg = await get_config(session)
+        pseudonym = cfg.contribution_pseudonym
+        if not pseudonym:
+            logger.error("contribution_pseudonym not set; start the app once before bootstrapping")
+            return counters
+
+        for path, (show, season, episode) in walk_library(root):
+            counters["scanned"] += 1
+            tmdb_id = await resolve_tmdb_id(show, "tv", search_fn=_default_search, cache=cache)
+            if tmdb_id is None:
+                logger.warning(f"Could not resolve TMDB ID for {show!r}; skipping")
+                counters["skipped"] += 1
+                continue
+
+            try:
+                fp = await extractor.extract(str(path))
+                counters["extracted"] += 1
+            except Exception as e:
+                logger.error(f"fpcalc failed on {path}: {e}")
+                counters["errors"] += 1
+                continue
+
+            if dry_run:
+                logger.info(f"[dry-run] would queue {show} s{season}e{episode} ({len(fp.hashes)} hashes)")
+                continue
+
+            await ContributionQueue().enqueue(
+                session=session,
+                title_id=None,  # bootstrap contributions are unmoored from any DiscTitle row
+                chromaprint_blob=fp.to_blob(),
+                tmdb_id=tmdb_id,
+                season=season,
+                episode=episode,
+                match_confidence=1.0,  # filename was the source of truth
+                match_source="bootstrap",
+                disc_content_hash=None,
+                pseudonym=pseudonym,
+                contributions_enabled=cfg.enable_fingerprint_contributions,
+            )
+            counters["queued"] += 1
+        await session.commit()
+
+    return counters
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap chromaprint contributions from an existing library")
+    parser.add_argument("library_root", type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--fpcalc", type=str, default=None, help="Override fpcalc binary path")
+    args = parser.parse_args()
+
+    counters = asyncio.run(bootstrap_directory(args.library_root, dry_run=args.dry_run, fpcalc_path=args.fpcalc))
+    logger.info(f"Bootstrap done: {counters}")
+    return 0 if counters["errors"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
+```
+
+Note: bootstrap rows pass `title_id=None` because they have no corresponding `DiscTitle` row. Task E1 already declared `title_id` as nullable for exactly this case.
+
+- [ ] **Step F2.4: Run the tests (expect PASS)**
+
+```bash
+uv run pytest tests/unit/test_bootstrap_library.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step F2.5: Smoke-test the CLI**
+
+```bash
+cd backend
+uv run python -m app.scripts.bootstrap_library "C:/Users/jonat/Engram/TV" --dry-run
+```
+Expected: log lines for each labeled MKV under that path; no DB writes; final summary shows `queued=0, extracted>=16, errors=0`.
+
+- [ ] **Step F2.6: Commit**
+
+```bash
+git add backend/app/scripts/bootstrap_library.py backend/tests/unit/test_bootstrap_library.py
+git commit -m "feat(scripts): bootstrap-library CLI with TMDB resolution + dry-run"
+```
+
+---
+
+## Cluster G: Opt-out UI
+
+### Task G1: Frontend toggle in ConfigWizard
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx`
+
+- [ ] **Step G1.1: Add to `ConfigData` interface**
+
+In `frontend/src/components/ConfigWizard.tsx`, find the `ConfigData` interface (around line 49). Add:
+
+```typescript
+    enableFingerprintContributions: boolean;
+```
+
+- [ ] **Step G1.2: Initialize in default state**
+
+Find the `useState` initializer (around line 112). Add:
+
+```typescript
+    enableFingerprintContributions: true,
+```
+
+- [ ] **Step G1.3: Load from API**
+
+Find the GET `/api/config` response handler (around line 217). Add:
+
+```typescript
+    enableFingerprintContributions: data.enable_fingerprint_contributions ?? true,
+```
+
+- [ ] **Step G1.4: Save to API**
+
+Find the PUT `/api/config` payload (around line 328). Add:
+
+```typescript
+    enable_fingerprint_contributions: config.enableFingerprintContributions,
+```
+
+- [ ] **Step G1.5: Render the toggle**
+
+In the Preferences step (around line 820, near existing toggles), add:
+
+```tsx
+<div className="form-group checkbox-group">
+    <label className="checkbox-label">
+        <input
+            type="checkbox"
+            checked={config.enableFingerprintContributions}
+            onChange={(e) => handleInputChange('enableFingerprintContributions', e.target.checked)}
+        />
+        <span className="checkbox-text">
+            <strong>Contribute audio fingerprints</strong>
+            <span className="checkbox-hint">
+                Engram extracts a perceptual audio fingerprint from each ripped title and queues it
+                locally. Future versions will share these fingerprints with a community catalog so
+                everyone's rips identify faster. No filenames, paths, or personally identifying
+                information are sent. Disable to skip extraction entirely.
+            </span>
+        </span>
+    </label>
+</div>
+```
+
+- [ ] **Step G1.6: Run lint + typecheck**
+
+```bash
+cd frontend
+npm run lint
+npm run build
+```
+Expected: clean.
+
+- [ ] **Step G1.7: Commit**
+
+```bash
+git add frontend/src/components/ConfigWizard.tsx
+git commit -m "feat(ui): fingerprint contributions opt-out toggle in ConfigWizard"
+```
+
+### Task G2: E2E test for the toggle
+
+**Files:**
+- Create: `frontend/e2e/fingerprint-toggle.spec.ts`
+
+- [ ] **Step G2.1: Write the test**
+
+Create `frontend/e2e/fingerprint-toggle.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('fingerprint contributions toggle round-trips through ConfigWizard', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /settings|configure/i }).click();
+
+    // Navigate to the Preferences step
+    while (!(await page.getByText('Contribute audio fingerprints').isVisible().catch(() => false))) {
+        const next = page.getByRole('button', { name: /next/i });
+        if (!(await next.isVisible())) break;
+        await next.click();
+    }
+
+    const toggle = page.locator('input[type=checkbox]').filter({ hasText: /audio fingerprint/i }).first();
+    // Default = on
+    await expect(toggle).toBeChecked();
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    // Save
+    await page.getByRole('button', { name: /save|done/i }).click();
+
+    // Reload + verify persistence
+    await page.reload();
+    await page.getByRole('button', { name: /settings|configure/i }).click();
+    while (!(await page.getByText('Contribute audio fingerprints').isVisible().catch(() => false))) {
+        const next = page.getByRole('button', { name: /next/i });
+        if (!(await next.isVisible())) break;
+        await next.click();
+    }
+    const reloaded = page.locator('input[type=checkbox]').filter({ hasText: /audio fingerprint/i }).first();
+    await expect(reloaded).not.toBeChecked();
+});
+```
+
+- [ ] **Step G2.2: Run the test (expect PASS — backend must be running with DEBUG=true)**
+
+```bash
+cd frontend
+npm run test:e2e -- fingerprint-toggle
+```
+Expected: PASS. If failures, inspect with `npm run test:e2e:ui`.
+
+- [ ] **Step G2.3: Commit**
+
+```bash
+git add frontend/e2e/fingerprint-toggle.spec.ts
+git commit -m "test(e2e): fingerprint contributions toggle persists"
+```
+
+---
+
+## Cluster H: Local Audit Log API
+
+### Task H1: `GET /api/fingerprint/contributions` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes.py`
+- Test: extend `backend/tests/integration/test_chromaprint_pipeline.py`
+
+- [ ] **Step H1.1: Write the failing test**
+
+Append to `backend/tests/integration/test_chromaprint_pipeline.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_fingerprint_contributions(integration_client, async_session):
+    """GET /api/fingerprint/contributions returns the local queue, redacted of blobs by default."""
+    from app.models.fingerprint import FingerprintContribution
+    from datetime import datetime
+
+    row = FingerprintContribution(
+        title_id=None,
+        chromaprint_blob=b"\x00" * 1000,
+        tmdb_id=1399,
+        season=1,
+        episode=1,
+        match_confidence=0.95,
+        match_source="bootstrap",
+        pseudonym="22222222-2222-4222-8222-222222222222",
+    )
+    async_session.add(row)
+    await async_session.commit()
+
+    response = await integration_client.get("/api/fingerprint/contributions")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] >= 1
+    item = next(i for i in data["items"] if i["tmdb_id"] == 1399)
+    assert item["match_source"] == "bootstrap"
+    # Blob should be summarized (size) not returned wholesale
+    assert "chromaprint_blob" not in item
+    assert item["blob_size_bytes"] == 1000
+```
+
+- [ ] **Step H1.2: Run the test (expect FAIL)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py::test_get_fingerprint_contributions -v
+```
+Expected: 404 — endpoint doesn't exist.
+
+- [ ] **Step H1.3: Add the endpoint**
+
+In `backend/app/api/routes.py`, add (next to existing job endpoints):
+
+```python
+@router.get("/fingerprint/contributions")
+async def list_fingerprint_contributions(
+    session: AsyncSession = Depends(get_session),
+    limit: int = 200,
+) -> dict:
+    """Return locally-queued fingerprint contributions (Phase 1 audit log).
+
+    Excludes the chromaprint blob body — only summarizes size — so the response stays
+    manageable. Phase 2 will add filtering by upload status.
+    """
+    from app.models.fingerprint import FingerprintContribution
+    from sqlmodel import select
+
+    result = await session.execute(
+        select(FingerprintContribution)
+        .order_by(FingerprintContribution.queued_at.desc())
+        .limit(limit)
+    )
+    rows = result.scalars().all()
+    items = [
+        {
+            "id": r.id,
+            "queued_at": r.queued_at.isoformat(),
+            "title_id": r.title_id,
+            "tmdb_id": r.tmdb_id,
+            "season": r.season,
+            "episode": r.episode,
+            "match_confidence": r.match_confidence,
+            "match_source": r.match_source,
+            "uploaded_at": r.uploaded_at.isoformat() if r.uploaded_at else None,
+            "upload_attempts": r.upload_attempts,
+            "blob_size_bytes": len(r.chromaprint_blob) if r.chromaprint_blob else 0,
+        }
+        for r in rows
+    ]
+    return {"count": len(items), "items": items}
+```
+
+- [ ] **Step H1.4: Run the test (expect PASS)**
+
+```bash
+uv run pytest tests/integration/test_chromaprint_pipeline.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step H1.5: Commit**
+
+```bash
+git add backend/app/api/routes.py backend/tests/integration/test_chromaprint_pipeline.py
+git commit -m "feat(api): GET /api/fingerprint/contributions audit-log endpoint"
+```
+
+---
+
+## Wrap-up
+
+### Final verification
+
+- [ ] **Step W1: Run the full backend test suite**
+
+```bash
+cd backend
+uv run pytest -x --tb=short 2>&1 | tail -20
+```
+Expected: all green (or same baseline failures noted in Step 0.2).
+
+- [ ] **Step W2: Run lint + format**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+```
+Fix anything ruff flags, then re-commit if needed.
+
+- [ ] **Step W3: Run the frontend build + lint**
+
+```bash
+cd ../frontend
+npm run lint
+npm run build
+```
+Expected: clean.
+
+- [ ] **Step W4: Manual end-to-end smoke test (against the real fpcalc + a real MKV)**
+
+Stop any running Engram backend. Start a fresh dev backend pointed at a scratch DB:
+
+```bash
+cd backend
+DATABASE_URL="sqlite+aiosqlite:///./scratch_phase1.db" DEBUG=true uv run uvicorn app.main:app --port 8001
+```
+
+In a separate terminal:
+```bash
+# Insert a simulated TV disc
+curl -X POST localhost:8001/api/simulate/insert-disc \
+  -H "Content-Type: application/json" \
+  -d '{"volume_label":"ARRESTED_DEVELOPMENT_S1D1","content_type":"tv","simulate_ripping":true}'
+
+# After ~10 seconds, list contributions
+curl -s localhost:8001/api/fingerprint/contributions | python -m json.tool | head -30
+```
+Expected: at least one contribution row with `match_source` set, non-zero `blob_size_bytes`, and a valid pseudonym in the DB.
+
+Clean up:
+```bash
+rm scratch_phase1.db scratch_phase1.db-*
+```
+
+- [ ] **Step W5: Commit any final fixups**
+
+```bash
+git status
+# If any small lint/test fixes were needed:
+git add -p
+git commit -m "chore: phase1 wrap-up fixups"
+```
+
+### Phase 1 Done — what's not done
+
+Documented here so Phase 2/3 planners have explicit context:
+
+- **No server-side anything.** Contributions sit in the local `fingerprint_contributions` table indefinitely. Phase 2 adds `POST /v1/contribute` upload.
+- **No identification path.** Chromaprints are stored but never queried. Phase 3 adds the matcher integration.
+- **`title_id=0` sentinel for bootstrap contributions.** A real foreign key relationship would force Phase 1 to invent a `DiscTitle` for each bootstrap file, which is wasted work. Phase 2's upload schema doesn't care about local `title_id`. If lint/static-checking complains, make `title_id` nullable in the model + a follow-up migration.
+- **No `/v1/forget` equivalent locally.** Privacy promise is "nothing leaves the machine"; Phase 1 needs no forget endpoint. Phase 2 adds it.
+- **No JSONL audit log at `~/.engram/cache/contribution_log.jsonl`.** The Phase 2 design wants users to see "exactly what was sent." Since Phase 1 sends nothing, the DB-backed `GET /api/fingerprint/contributions` covers the "exactly what was queued" need. The JSONL file lands alongside the Phase 2 uploader.
+- **No first-run privacy disclosure.** The opt-out toggle exists in ConfigWizard but isn't a forced first-run screen. Phase 2 design adds the disclosure UX.
+- **No real-data integration test against a duplicate rip.** The spike (`spikes/chromaprint/spike.py`) proved the algorithm on the same MKV; we still don't have evidence that a re-rip of the same disc matches itself. Capture two rips and replay the spike before Phase 3 ships.

--- a/frontend/e2e/fingerprint-toggle.spec.ts
+++ b/frontend/e2e/fingerprint-toggle.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the "Contribute audio fingerprints" opt-out toggle in ConfigWizard.
+ *
+ * These tests do not require disc simulation — they interact directly with the
+ * Settings modal (non-onboarding ConfigWizard). The toggle is on the Preferences
+ * tab (step 4).
+ *
+ * Tests verify:
+ *   - The toggle is checked by default (opt-in).
+ *   - Unchecking and saving persists the false value across page reloads.
+ *   - Re-checking and saving restores the true value (full round-trip).
+ */
+
+async function openSettingsPreferences(page: import('@playwright/test').Page) {
+    // Open the Settings modal
+    await page.locator('[data-testid="sv-settings-btn"]').click();
+    // ConfigWizard should be visible — wait for the modal heading
+    await expect(page.getByText('Preferences')).toBeVisible({ timeout: 5000 });
+    // Navigate to the Preferences tab (step 4) — in settings mode all tabs are clickable
+    await page.getByRole('button', { name: /Step 4: Preferences/i }).click();
+    // Confirm we're on the right step
+    await expect(page.getByText('Configure additional options for your workflow')).toBeVisible({ timeout: 3000 });
+}
+
+async function saveFingerprintToggle(page: import('@playwright/test').Page) {
+    await page.getByRole('button', { name: /Save Changes/i }).click();
+    // Modal should close after a successful save
+    await expect(page.locator('[data-testid="sv-settings-btn"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Fingerprint contributions toggle', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Wait for the WebSocket connection indicator before interacting
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('toggle is checked by default (opt-in)', async ({ page }) => {
+        await openSettingsPreferences(page);
+
+        const checkbox = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(checkbox).toBeVisible();
+        await expect(checkbox).toBeChecked();
+    });
+
+    test('unchecking and saving persists false across reload', async ({ page }) => {
+        // --- Step 1: uncheck the toggle and save ---
+        await openSettingsPreferences(page);
+
+        const checkbox = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(checkbox).toBeVisible();
+
+        // Ensure it starts checked before unchecking
+        if (await checkbox.isChecked()) {
+            await checkbox.uncheck();
+        }
+        await expect(checkbox).not.toBeChecked();
+
+        await saveFingerprintToggle(page);
+
+        // --- Step 2: reload and re-open settings to confirm it's still unchecked ---
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+
+        await openSettingsPreferences(page);
+
+        const checkboxAfterReload = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(checkboxAfterReload).not.toBeChecked();
+    });
+
+    test('re-checking and saving restores true (full round-trip)', async ({ page }) => {
+        // --- Step 1: uncheck and save (set to false) ---
+        await openSettingsPreferences(page);
+
+        let checkbox = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(checkbox).toBeVisible();
+        if (await checkbox.isChecked()) {
+            await checkbox.uncheck();
+        }
+        await expect(checkbox).not.toBeChecked();
+        await saveFingerprintToggle(page);
+
+        // --- Step 2: reload, re-open, re-check, and save (set to true) ---
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+
+        await openSettingsPreferences(page);
+
+        checkbox = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await checkbox.check();
+        await expect(checkbox).toBeChecked();
+        await saveFingerprintToggle(page);
+
+        // --- Step 3: reload one more time and confirm it's checked ---
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+
+        await openSettingsPreferences(page);
+
+        const checkboxFinal = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(checkboxFinal).toBeChecked();
+    });
+});

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -68,6 +68,7 @@ interface ConfigData {
     namingEpisodeFormat: string;
     namingMovieFormat: string;
     discdbEnabled: boolean;
+    enableFingerprintContributions: boolean;
     aiIdentificationEnabled: boolean;
     aiEpisodeMatchingEnabled: boolean;
     aiProvider: string;
@@ -131,6 +132,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
         namingMovieFormat: '{title} ({year})',
         discdbEnabled: true,
+        enableFingerprintContributions: true,
         aiIdentificationEnabled: false,
         aiEpisodeMatchingEnabled: false,
         aiProvider: 'anthropic',
@@ -215,6 +217,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
                     namingMovieFormat: data.naming_movie_format || '{title} ({year})',
                     discdbEnabled: data.discdb_enabled ?? true,
+                    enableFingerprintContributions: data.enable_fingerprint_contributions ?? true,
                     aiIdentificationEnabled: data.ai_identification_enabled ?? false,
                     aiEpisodeMatchingEnabled: data.ai_episode_matching_enabled ?? false,
                     aiProvider: data.ai_provider || 'anthropic',
@@ -321,6 +324,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     naming_episode_format: config.namingEpisodeFormat,
                     naming_movie_format: config.namingMovieFormat,
                     discdb_enabled: config.discdbEnabled,
+                    enable_fingerprint_contributions: config.enableFingerprintContributions,
                     ai_identification_enabled: config.aiIdentificationEnabled,
                     ai_episode_matching_enabled: config.aiEpisodeMatchingEnabled,
                     ai_provider: config.aiProvider,
@@ -765,6 +769,25 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 </label>
                             </div>
                         )}
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    checked={config.enableFingerprintContributions}
+                                    onChange={(e) => handleInputChange('enableFingerprintContributions', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>Contribute audio fingerprints</strong>
+                                    <span className="checkbox-hint">
+                                        Engram extracts a perceptual audio fingerprint from each ripped title and queues it
+                                        locally. Future versions will share these fingerprints with a community catalog so
+                                        everyone&apos;s rips identify faster. No filenames, paths, or personally identifying
+                                        information are sent. Disable to skip extraction entirely.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
 
                         <div className="form-group checkbox-group">
                             <label className="checkbox-label">

--- a/spikes/chromaprint/spike.py
+++ b/spikes/chromaprint/spike.py
@@ -1,0 +1,312 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["numpy>=1.26"]
+# ///
+"""
+Chromaprint windowed-voting spike.
+
+Question being tested:
+  In the Shazam-style use case, we have a short audio clip and a reference
+  catalog that *contains* the parent media. Does per-window chromaprint
+  matching with AcoustID-style time-offset-bucket voting correctly identify
+  the parent episode and the right timestamp within it?
+
+  This is the production scenario:
+    - Post-rip identification: we extract ~15 windowed chromaprints from a
+      ripped MKV and look each one up against a catalog that contains the
+      canonical fingerprint for that episode.
+    - Short-clip query: a 5-15 s clip queried against the same catalog.
+  In both cases the correct answer exists in the catalog. The algorithm's
+  job is to find it.
+
+Method:
+  1. Recursively find labeled MKVs matching "Show - SnnEnn.mkv". Build full
+     chromaprint hash streams via ./bin/fpcalc.exe -raw.
+  2. The reference catalog is ALL episodes (including the source of every
+     query). This mirrors production.
+  3. For each episode, sample N_QUERIES windows of WINDOW_SECS seconds each
+     at evenly-spaced offsets *inside* the episode's own hash stream. Each
+     window becomes a query.
+  4. For each query window run the AcoustID time-offset-bucket vote:
+        - For each query hash, find reference hashes within Hamming <= H.
+        - Bucket each match by (ref_episode, ref_offset - query_offset).
+        - The (episode, dt) bucket with the most matches wins this window.
+  5. A window-level success = the winning episode IS the source episode AND
+     the winning dt bucket corresponds to the true offset (within tolerance).
+  6. Report per-window success rate, mean overlap with the source vs the
+     runner-up (the separation metric the production cascade would use),
+     and inter-show vs intra-show confusion patterns.
+
+Usage:
+  uv run spike.py "C:/Users/jonat/Engram/TV" [--shows "Show1,Show2"]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+SPIKE_DIR = Path(__file__).resolve().parent
+FPCALC = SPIKE_DIR / "bin" / "fpcalc.exe"
+
+CHROMAPRINT_FRAME_SECONDS = 0.12380952  # 4096 / 11025 * 1/3
+FRAMES_PER_SEC = 1.0 / CHROMAPRINT_FRAME_SECONDS
+
+WINDOW_SECS = 30
+N_QUERIES = 8        # query windows sampled per episode
+HAMMING_THRESHOLD = 6  # bits; AcoustID convention is 4-6
+DT_BUCKET_FRAMES = 8   # ~1 second tolerance per match-cluster
+OFFSET_TOLERANCE_FRAMES = 24  # ~3 seconds; "is this dt close to the true offset?"
+
+EP_REGEX = re.compile(r"(?P<show>.+?)\s*-\s*S(?P<season>\d{1,2})E(?P<ep>\d{1,3})", re.IGNORECASE)
+POPCOUNT_LUT = np.array([bin(i).count("1") for i in range(256)], dtype=np.uint8)
+
+
+@dataclass
+class Episode:
+    show: str
+    season: int
+    episode: int
+    path: Path
+    hashes: np.ndarray  # uint32 array of chromaprint frames
+
+    @property
+    def label(self) -> str:
+        return f"{self.show} S{self.season:02d}E{self.episode:02d}"
+
+
+def parse_label(path: Path) -> tuple[str, int, int] | None:
+    m = EP_REGEX.search(path.stem)
+    if not m:
+        return None
+    return m["show"].strip(), int(m["season"]), int(m["ep"])
+
+
+def run_fpcalc(path: Path) -> np.ndarray:
+    """Return the full chromaprint hash stream for a media file as uint32 ndarray."""
+    proc = subprocess.run(
+        [str(FPCALC), "-raw", "-length", "99999", str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    fp_line = next((l for l in proc.stdout.splitlines() if l.startswith("FINGERPRINT=")), None)
+    if fp_line is None:
+        raise RuntimeError(f"fpcalc produced no FINGERPRINT line for {path}")
+    raw = fp_line.removeprefix("FINGERPRINT=")
+    return np.array([int(x) for x in raw.split(",") if x], dtype=np.uint32)
+
+
+def hamming32(q: np.uint32, refs: np.ndarray) -> np.ndarray:
+    """Vectorised Hamming distance between scalar q and each uint32 in refs."""
+    x = np.bitwise_xor(refs, np.uint32(q))
+    b0 = POPCOUNT_LUT[(x & 0xFF).astype(np.uint8)]
+    b1 = POPCOUNT_LUT[((x >> 8) & 0xFF).astype(np.uint8)]
+    b2 = POPCOUNT_LUT[((x >> 16) & 0xFF).astype(np.uint8)]
+    b3 = POPCOUNT_LUT[((x >> 24) & 0xFF).astype(np.uint8)]
+    return (b0 + b1 + b2 + b3).astype(np.int16)
+
+
+def collect_episodes(root: Path, allowed_shows: set[str] | None) -> list[Episode]:
+    episodes: list[Episode] = []
+    for mkv in sorted(root.rglob("*.mkv")):
+        if "Extras" in mkv.parts:
+            continue
+        label = parse_label(mkv)
+        if label is None:
+            continue
+        show, season, ep = label
+        if allowed_shows and show not in allowed_shows:
+            continue
+        print(f"  fingerprinting {show} S{season:02d}E{ep:02d} ...", flush=True)
+        t0 = time.time()
+        hashes = run_fpcalc(mkv)
+        dt = time.time() - t0
+        print(f"    {len(hashes)} frames in {dt:.1f}s ({len(hashes)/dt:.0f} fr/s)")
+        episodes.append(Episode(show=show, season=season, episode=ep, path=mkv, hashes=hashes))
+    return episodes
+
+
+@dataclass
+class WindowResult:
+    source_label: str
+    source_start_frame: int
+    predicted_label: str
+    predicted_dt_frames: int
+    predicted_match_count: int
+    runner_up_label: str
+    runner_up_match_count: int
+    # True (episode, dt) match strength if it ranked anywhere
+    source_match_count: int
+
+
+def query_single_window(
+    window_hashes: np.ndarray,
+    window_start_in_source: int,
+    source_label: str,
+    ref_hashes: np.ndarray,
+    ref_owner: np.ndarray,
+    ref_offset: np.ndarray,
+    ref_labels: list[str],
+) -> WindowResult:
+    """Run the time-bucket vote for a single window against the catalog."""
+    bucket: dict[tuple[int, int], int] = defaultdict(int)
+    for q_idx, q_hash in enumerate(window_hashes):
+        dists = hamming32(q_hash, ref_hashes)
+        hits = np.where(dists <= HAMMING_THRESHOLD)[0]
+        if len(hits) == 0:
+            continue
+        q_pos_in_query = q_idx  # query coordinate space starts at 0
+        for h in hits:
+            dt = (int(ref_offset[h]) - q_pos_in_query) // DT_BUCKET_FRAMES
+            bucket[(int(ref_owner[h]), dt)] += 1
+
+    if not bucket:
+        return WindowResult(
+            source_label=source_label, source_start_frame=window_start_in_source,
+            predicted_label="<no-match>", predicted_dt_frames=0, predicted_match_count=0,
+            runner_up_label="<no-match>", runner_up_match_count=0, source_match_count=0,
+        )
+
+    sorted_buckets = sorted(bucket.items(), key=lambda kv: kv[1], reverse=True)
+    (best_ref, best_dt), best_count = sorted_buckets[0]
+    runner_up_label = "<none>"
+    runner_up_count = 0
+    if len(sorted_buckets) > 1:
+        (ru_ref, _ru_dt), ru_count = sorted_buckets[1]
+        runner_up_label = ref_labels[ru_ref]
+        runner_up_count = ru_count
+
+    # Find the best bucket that corresponds to the TRUE source (if any)
+    source_ref_idx = ref_labels.index(source_label)
+    expected_dt_bucket = window_start_in_source // DT_BUCKET_FRAMES
+    source_match_count = max(
+        (
+            cnt for (ep, dt), cnt in bucket.items()
+            if ep == source_ref_idx and abs(dt - expected_dt_bucket) <= OFFSET_TOLERANCE_FRAMES // DT_BUCKET_FRAMES
+        ),
+        default=0,
+    )
+
+    return WindowResult(
+        source_label=source_label,
+        source_start_frame=window_start_in_source,
+        predicted_label=ref_labels[best_ref],
+        predicted_dt_frames=best_dt * DT_BUCKET_FRAMES,
+        predicted_match_count=best_count,
+        runner_up_label=runner_up_label,
+        runner_up_match_count=runner_up_count,
+        source_match_count=source_match_count,
+    )
+
+
+def build_catalog(episodes: list[Episode]) -> tuple[np.ndarray, np.ndarray, np.ndarray, list[str]]:
+    ref_hashes = np.concatenate([e.hashes for e in episodes])
+    ref_owner = np.concatenate([np.full(len(e.hashes), i, dtype=np.int32) for i, e in enumerate(episodes)])
+    ref_offset = np.concatenate([np.arange(len(e.hashes), dtype=np.int32) for e in episodes])
+    ref_labels = [e.label for e in episodes]
+    return ref_hashes, ref_owner, ref_offset, ref_labels
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("library_root", type=Path)
+    parser.add_argument("--shows", type=str, default=None, help="comma-separated allow-list")
+    args = parser.parse_args()
+
+    if not FPCALC.exists():
+        print(f"ERROR: fpcalc not found at {FPCALC}", file=sys.stderr)
+        return 2
+
+    allowed = set(s.strip() for s in args.shows.split(",")) if args.shows else None
+    print(f"Scanning {args.library_root}{' (shows: ' + ', '.join(sorted(allowed)) + ')' if allowed else ''}")
+    t0 = time.time()
+    episodes = collect_episodes(args.library_root, allowed)
+    print(f"\nFingerprinted {len(episodes)} episodes in {time.time() - t0:.1f}s\n")
+
+    if len(episodes) < 2:
+        print("Need at least 2 labeled episodes; aborting.")
+        return 1
+
+    print(f"\n=== Building catalog index over all {len(episodes)} episodes ===")
+    ref_hashes, ref_owner, ref_offset, ref_labels = build_catalog(episodes)
+    print(f"  Total reference frames: {len(ref_hashes):,}\n")
+
+    print(f"=== Per-window query classification "
+          f"(N_QUERIES={N_QUERIES} per ep, WINDOW_SECS={WINDOW_SECS}, HAMMING<={HAMMING_THRESHOLD}) ===\n")
+
+    win_frames = max(1, int(WINDOW_SECS * FRAMES_PER_SEC))
+    all_results: list[WindowResult] = []
+    t0 = time.time()
+    for ep in episodes:
+        n_frames = len(ep.hashes)
+        starts = np.linspace(win_frames, max(win_frames, n_frames - 2*win_frames), N_QUERIES, dtype=np.int64)
+        wins_correct = 0
+        for s in starts:
+            window = ep.hashes[s : s + win_frames]
+            r = query_single_window(window, int(s), ep.label, ref_hashes, ref_owner, ref_offset, ref_labels)
+            all_results.append(r)
+            if r.predicted_label == ep.label:
+                wins_correct += 1
+        print(f"  {ep.label:55} {wins_correct}/{N_QUERIES} windows correctly identified")
+    print(f"\nQueries finished in {time.time() - t0:.1f}s")
+
+    n = len(all_results)
+    correct = sum(1 for r in all_results if r.predicted_label == r.source_label)
+    no_match = sum(1 for r in all_results if r.predicted_label == "<no-match>")
+    intra = sum(
+        1 for r in all_results
+        if r.predicted_label not in (r.source_label, "<no-match>")
+        and r.predicted_label.split(" S")[0] == r.source_label.split(" S")[0]
+    )
+    inter = sum(
+        1 for r in all_results
+        if r.predicted_label not in (r.source_label, "<no-match>")
+        and r.predicted_label.split(" S")[0] != r.source_label.split(" S")[0]
+    )
+
+    correct_matches = [r.predicted_match_count for r in all_results if r.predicted_label == r.source_label]
+    wrong_matches = [r.predicted_match_count for r in all_results if r.predicted_label != r.source_label and r.predicted_label != "<no-match>"]
+    separations = [
+        r.predicted_match_count - r.runner_up_match_count
+        for r in all_results if r.predicted_label == r.source_label
+    ]
+
+    print(f"\n=== Summary ===")
+    print(f"  Total query windows:      {n}")
+    print(f"  Correct (right ep):       {correct}/{n} = {100*correct/n:.1f}%")
+    print(f"  Intra-show errors:        {intra}/{n} ({100*intra/n:.1f}%)")
+    print(f"  Inter-show errors:        {inter}/{n} ({100*inter/n:.1f}%)")
+    print(f"  No match at all:          {no_match}/{n} ({100*no_match/n:.1f}%)")
+    if correct_matches:
+        print(f"  Correct match strength  : mean={np.mean(correct_matches):.1f}  "
+              f"min={min(correct_matches)}  max={max(correct_matches)}")
+    if wrong_matches:
+        print(f"  Wrong match strength    : mean={np.mean(wrong_matches):.1f}  "
+              f"min={min(wrong_matches)}  max={max(wrong_matches)}")
+    if separations:
+        print(f"  Separation (correct - runner-up): "
+              f"mean={np.mean(separations):.1f}  min={min(separations)}  max={max(separations)}")
+    # How many correct-classifications also nailed the temporal offset?
+    correct_with_offset = sum(
+        1 for r in all_results
+        if r.predicted_label == r.source_label
+        and abs(r.predicted_dt_frames - r.source_start_frame) <= OFFSET_TOLERANCE_FRAMES
+    )
+    if correct:
+        print(f"  Of the correct ones, {correct_with_offset}/{correct} ({100*correct_with_offset/correct:.1f}%) "
+              f"also predicted the right in-episode offset (±3s)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 1 of the audio fingerprint network feature: every successful match now extracts a chromaprint fingerprint and stores it locally, plus a contribution queue waiting for the Phase 2 server. **No user-visible behavior change** beyond a single opt-out toggle in ConfigWizard. The data starts accumulating in `disc_titles.chromaprint_blob` and `fingerprint_contributions` from this PR onwards.

- Design: [`docs/superpowers/specs` (out-of-repo brainstorm)](C:\Users\jonat\.claude\plans\what-would-it-take-golden-fog.md) + [Phase 1 plan](docs/superpowers/plans/2026-05-27-phase1-chromaprint-foundation.md).
- Spike that de-risked the algorithm before any code landed: [`spikes/chromaprint/spike.py`](spikes/chromaprint/spike.py) — 96.2% per-window top-1 accuracy on a 20-episode catalog with 100% offset precision.

## What's in this PR

| Cluster | Delivers |
|---|---|
| **A** schema | New columns on `DiscTitle` (`chromaprint_blob`, `chromaprint_extracted_at`) and `AppConfig` (`fpcalc_path`, `contribution_pseudonym`, `enable_fingerprint_contributions`); two Alembic migrations + matching `sa_column_kwargs` `server_default` for the frozen-build `_add_missing_columns()` reconciler path. |
| **B** fpcalc tooling | `_validate_fpcalc_binary`, `detect_fpcalc()` with PATH + platform common-path search, `POST /api/validate/fpcalc`, executable-basename security guard. |
| **C** extractor + pseudonym | `ChromaprintExtractor` (subprocess via `asyncio.to_thread`), deterministic gzip-JSON `to_blob`/`from_blob`, UUIDv4 per-install pseudonym auto-generated on first startup. |
| **D** pipeline integration | Hook in `_match_single_file_inner` after match completes; graceful try/except so chromaprint failures never block matching; `detect_fpcalc()` fallback offloaded to a worker thread to keep the event loop responsive. |
| **E** contribution queue | `FingerprintContribution` table (nullable `title_id` for bootstrap rows); `ContributionQueue.enqueue` honors opt-out; skip-with-debug guard for unresolved `tmdb_id=0`. |
| **F** bootstrap CLI | `app/scripts/bootstrap_library.py` — walks a labeled library, resolves TMDB via the existing `fetch_show_id`, extracts chromaprints, enqueues bootstrap-tagged contributions; `--dry-run` mode; batched commits keyed on `scanned` count. |
| **G** opt-out UI | Single checkbox in ConfigWizard's Preferences step; default-on (opt-out by design); Playwright E2E round-trip test. |
| **H** audit log | `GET /api/fingerprint/contributions` returns the queue with blob size via `func.length()` projection (not the blob itself); bounded `limit=Query(200, ge=1, le=1000)`; **localhost-only** via a new `require_localhost` dependency. |

## Privacy posture

- **Opt-out by default.** Single toggle in ConfigWizard. `AppConfig.enable_fingerprint_contributions` defaults to `True` with the SQL `server_default` to match.
- **Nothing leaves the machine in Phase 1.** Contributions sit in the local `fingerprint_contributions` table until Phase 2 lands the uploader.
- **Audit endpoint is localhost-only.** Even with `allow_lan_access=True`, the LAN cannot dump ripping history through `GET /api/fingerprint/contributions`.
- **Per-install pseudonym.** UUIDv4, no link to identity, regenerable.
- **Contribution payload is the minimum** the Phase 2 design specified: chromaprint, episode tuple, match confidence + source, disc content hash (currently always None — `DISCDB_ENABLED` is gated off), pseudonym. No filenames, paths, or IPs.

## Out of scope (intentionally deferred)

- **No server side.** Phase 2 stands up the ingestion + query API in a separate repo per the design.
- **No identification path.** Stored chromaprints aren't queried back yet; that's Phase 3.
- **No JSONL audit log.** The Phase 2 design specifies a local `~/.engram/cache/contribution_log.jsonl` for upload visibility; since nothing uploads yet, the DB-backed audit endpoint covers Phase 1's needs and the JSONL lands alongside the uploader.
- **Movie bootstrap.** The CLI is TV-only; documented in its docstring. Movie-bootstrap is a Phase 3-era follow-up.
- **First-run privacy disclosure screen.** Opt-out toggle exists in settings; a forced first-run screen is deferred to Phase 2 when uploads become real.

## Test plan

- [x] All 36 new tests pass in isolation: 5 fpcalc, 9 chromaprint extractor + schema, 4 pseudonym, 5 contribution queue, 5 bootstrap, 8 chromaprint integration.
- [x] `ruff check` and `ruff format --check` clean on the backend.
- [x] Frontend `npm run build` and `npm run lint` clean.
- [x] Migration smoke: `init_db()` + `alembic downgrade -1` + `alembic upgrade head` round-trips without errors against a scratch DB.
- [x] Real-fpcalc end-to-end smoke: `ChromaprintExtractor.extract` against an actual MKV from the user's library produces ~10500 hashes / ~1300 s for a 22-min AD episode in under 1 s, ~25 KB compressed.
- [x] Final cross-branch review by Opus: APPROVED with five non-blocking follow-ups, three of which are now also in this PR. The remaining two are documented in the design's "Open Questions" section.
- [ ] Manual smoke: ship to your own dev install, rip a disc, confirm `chromaprint_blob` populates on the new `DiscTitle` rows and a `FingerprintContribution` row lands.
- [ ] E2E (Playwright): `npm run test:e2e -- fingerprint-toggle` — written but not executed in this session; requires backend + frontend up with `DEBUG=true`.

## Notes for review

- Spec compliance and code quality review were run **per cluster** during implementation (subagent-driven). The final cross-branch review by a fresh Opus reviewer covered consistency, integration risk, operational tail, and privacy.
- One pre-existing test-isolation issue (websocket teardown bleeding into subsequent tests when the full suite runs in order) is unrelated to this PR — confirmed by running the affected tests in isolation, where they all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)