### PR TITLE
feat(fingerprint): Phase 2 — contribution uploader, privacy endpoints, JSONL audit log

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -295,6 +295,8 @@ class ConfigResponse(BaseModel):
     # Chromaprint fingerprinting (Phase 1)
     fpcalc_path: str
     enable_fingerprint_contributions: bool
+    # Chromaprint Phase 2
+    fingerprint_server_url: str | None = None
 
 
 class ConfigUpdate(BaseModel):
@@ -365,6 +367,8 @@ class ConfigUpdate(BaseModel):
     # Chromaprint fingerprinting (Phase 1)
     fpcalc_path: str | None = None
     enable_fingerprint_contributions: bool | None = None
+    # Chromaprint Phase 2
+    fingerprint_server_url: str | None = None
 
 
 class ReviewRequest(BaseModel):
@@ -1045,6 +1049,8 @@ async def get_config() -> ConfigResponse:
         # Chromaprint fingerprinting (Phase 1)
         fpcalc_path=config.fpcalc_path or "",
         enable_fingerprint_contributions=config.enable_fingerprint_contributions,
+        # Chromaprint Phase 2
+        fingerprint_server_url=config.fingerprint_server_url,
     )
 
 
@@ -1092,8 +1098,8 @@ async def update_config(config: ConfigUpdate) -> dict:
     from app.services.config_service import update_config as update_db_config
 
     # Build kwargs from non-None fields
-    # Allow None through for import_watch_path so users can clear the field
-    _nullable_fields = {"import_watch_path"}
+    # Allow None through for fields that can be cleared to null
+    _nullable_fields = {"import_watch_path", "fingerprint_server_url"}
     update_data = {
         k: v for k, v in config.model_dump().items() if v is not None or k in _nullable_fields
     }
@@ -1290,6 +1296,72 @@ async def list_fingerprint_contributions(
         for r in rows
     ]
     return {"count": len(items), "items": items}
+
+
+@router.delete("/fingerprint/contributions/{contrib_id}", dependencies=[Depends(require_localhost)])
+async def forget_fingerprint_contribution(
+    contrib_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Delete a locally-queued fingerprint contribution (forget).
+
+    Returns 400 if the contribution was already uploaded — the data already
+    exists on the server and cannot be recalled from here.
+    """
+    from app.models.fingerprint import FingerprintContribution
+
+    contrib = await session.get(FingerprintContribution, contrib_id)
+    if contrib is None:
+        raise HTTPException(status_code=404, detail="Contribution not found")
+    if contrib.upload_status == "success":
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot delete an already-uploaded contribution; the data is already on the server.",
+        )
+    await session.delete(contrib)
+    await session.commit()
+    return {"status": "deleted", "contrib_id": contrib_id}
+
+
+@router.post(
+    "/fingerprint/contributions/rotate-pseudonym", dependencies=[Depends(require_localhost)]
+)
+async def rotate_contribution_pseudonym(
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Generate a fresh pseudonym and re-tag all pending contributions.
+
+    Already-uploaded rows retain their old pseudonym (server already has them
+    under that identity). Pending rows get the new pseudonym so future uploads
+    are unlinkable to past ones.
+    """
+    from app.models.app_config import AppConfig
+    from app.models.fingerprint import FingerprintContribution
+    from app.services.contribution_pseudonym import generate_pseudonym
+
+    new_pseudonym = generate_pseudonym()
+
+    cfg = (await session.execute(select(AppConfig).limit(1))).scalar_one_or_none()
+    if cfg is not None:
+        cfg.contribution_pseudonym = new_pseudonym
+        session.add(cfg)
+
+    pending = (
+        (
+            await session.execute(
+                select(FingerprintContribution).where(
+                    FingerprintContribution.upload_status.is_(None)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in pending:
+        row.pseudonym = new_pseudonym
+
+    await session.commit()
+    return {"pseudonym": new_pseudonym, "pending_retagged": len(pending)}
 
 
 # --- Simulation Endpoints (debug mode only) ---

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1104,6 +1104,16 @@ async def update_config(config: ConfigUpdate) -> dict:
         k: v for k, v in config.model_dump().items() if v is not None or k in _nullable_fields
     }
 
+    # Validate fingerprint_server_url against SSRF before persisting
+    if update_data.get("fingerprint_server_url"):
+        from app.core.security import is_safe_remote_url
+
+        if not is_safe_remote_url(update_data["fingerprint_server_url"]):
+            raise HTTPException(
+                status_code=422,
+                detail="fingerprint_server_url must be an http/https URL pointing to a non-internal host",
+            )
+
     # Validate naming format strings before persisting
     from app.core.organizer import (
         ALLOWED_MOVIE_PLACEHOLDERS,
@@ -1318,6 +1328,14 @@ async def forget_fingerprint_contribution(
             status_code=400,
             detail="Cannot delete an already-uploaded contribution; the data is already on the server.",
         )
+    if contrib.upload_status is None and contrib.upload_attempts > 0:
+        # upload_attempts > 0 means the background uploader has already tried
+        # this row at least once and may be holding it in an active HTTP call.
+        # Deleting now would cause a silent no-op UPDATE on a ghost row.
+        raise HTTPException(
+            status_code=409,
+            detail="Contribution may be in-flight (upload already attempted). Try again after the next poll cycle or wait for it to succeed or fail.",
+        )
     await session.delete(contrib)
     await session.commit()
     return {"status": "deleted", "contrib_id": contrib_id}
@@ -1335,16 +1353,15 @@ async def rotate_contribution_pseudonym(
     under that identity). Pending rows get the new pseudonym so future uploads
     are unlinkable to past ones.
     """
-    from app.models.app_config import AppConfig
     from app.models.fingerprint import FingerprintContribution
+    from app.services.config_service import update_config as update_db_config
     from app.services.contribution_pseudonym import generate_pseudonym
 
     new_pseudonym = generate_pseudonym()
 
-    cfg = (await session.execute(select(AppConfig).limit(1))).scalar_one_or_none()
-    if cfg is not None:
-        cfg.contribution_pseudonym = new_pseudonym
-        session.add(cfg)
+    # update_db_config auto-creates the app_config row when absent, so the
+    # pseudonym is always persisted even on a fresh database.
+    await update_db_config(contribution_pseudonym=new_pseudonym)
 
     pending = (
         (

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -94,6 +94,45 @@ def executable_basename_allowed(path: str, allowed_basenames: Sequence[str]) -> 
     return name in {allowed.lower() for allowed in allowed_basenames}
 
 
+_DISALLOWED_HOSTNAMES: frozenset[str] = frozenset(
+    {"localhost", "metadata.google.internal", "169.254.169.254", "::1"}
+)
+
+
+def is_safe_remote_url(url: str) -> bool:
+    """Return True if ``url`` is safe to use as a user-configured remote endpoint.
+
+    Guards SSRF: rejects non-http(s) schemes, missing or IP-literal hosts
+    (including all private/loopback/link-local ranges and cloud metadata IPs),
+    and a small list of well-known internal hostnames.
+    """
+    try:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+    except ValueError:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        return False
+
+    if not host:
+        return False
+
+    if host in _DISALLOWED_HOSTNAMES:
+        return False
+
+    # Reject all IP-literal hosts — legitimate remote servers use DNS names.
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_loopback or addr.is_link_local or addr.is_private or addr.is_reserved:
+            return False
+        return False  # reject even public IPs — servers should have hostnames
+    except ValueError:
+        pass  # Not an IP literal; falls through.
+
+    return True
+
+
 def sanitize_log_value(value: object) -> str:
     """Strip line breaks and control characters from a value before logging.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -121,6 +121,12 @@ async def lifespan(app: FastAPI):
     await job_manager.start()
     logger.info("Job manager started")
 
+    # Start the fingerprint contribution uploader (Phase 2).
+    from app.services.contribution_uploader import ContributionUploader
+
+    app.state.contribution_uploader = ContributionUploader()
+    await app.state.contribution_uploader.start()
+
     # Download/refresh the precomputed subtitle-vector cache in the background.
     # Fire-and-forget: a slow or failed download must never block startup, and
     # subtitle scraping remains the fallback until the cache lands.
@@ -139,6 +145,9 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     logger.info("Shutting down Engram Backend...")
+    uploader = getattr(app.state, "contribution_uploader", None)
+    if uploader is not None:
+        await uploader.stop()
     cache_task = getattr(app.state, "precomputed_cache_task", None)
     if cache_task and not cache_task.done():
         cache_task.cancel()

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -150,3 +150,4 @@ class AppConfig(SQLModel, table=True):
     enable_fingerprint_contributions: bool = Field(
         default=True, sa_column_kwargs={"server_default": text("1")}
     )
+    fingerprint_server_url: str | None = Field(default=None)

--- a/backend/app/models/fingerprint.py
+++ b/backend/app/models/fingerprint.py
@@ -42,6 +42,8 @@ class FingerprintContribution(SQLModel, table=True):
 
     pseudonym: str
 
-    # Set when Phase 2 uploader runs
+    # Phase 2 uploader state
     uploaded_at: datetime | None = None
     upload_attempts: int = Field(default=0)
+    upload_status: str | None = Field(default=None)  # None=pending, "success", "failed"
+    upload_error_msg: str | None = Field(default=None)  # last error text for UI

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -111,7 +111,7 @@ async def update_config(**kwargs) -> AppConfig:
         # Special handling for sensitive fields: don't overwrite with empty strings
         sensitive_fields = {"makemkv_key", "tmdb_api_key"}
 
-        _nullable_fields = {"import_watch_path"}
+        _nullable_fields = {"import_watch_path", "fingerprint_server_url"}
         for key, value in kwargs.items():
             if not hasattr(config, key):
                 continue

--- a/backend/app/services/contribution_uploader.py
+++ b/backend/app/services/contribution_uploader.py
@@ -1,0 +1,175 @@
+"""Phase 2 fingerprint contribution uploader.
+
+Drains the local FingerprintContribution queue by POST-ing to a remote
+fingerprint network server. Phase 1 built the queue; this service drains it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+from loguru import logger
+from sqlmodel import select
+
+from app.database import async_session
+from app.models.fingerprint import FingerprintContribution
+from app.services.config_service import get_config
+
+CONTRIBUTION_LOG_PATH = Path("~/.engram/cache/contribution_log.jsonl").expanduser()
+
+_BATCH_SIZE = 50
+_MAX_ATTEMPTS = 5
+_UPLOAD_TIMEOUT = 30.0
+
+
+class ContributionUploader:
+    """Background service: drain FingerprintContribution queue over HTTPS."""
+
+    def __init__(self, poll_interval_seconds: int = 3600) -> None:
+        self.poll_interval = poll_interval_seconds
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._upload_loop(), name="contribution_uploader")
+        logger.info("ContributionUploader started (poll interval: {}s)", self.poll_interval)
+
+    async def stop(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("ContributionUploader stopped")
+
+    async def _upload_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self.poll_interval)
+                await self._process_batch()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("ContributionUploader loop error — will retry next interval")
+
+    async def _process_batch(self) -> None:
+        """Fetch up to _BATCH_SIZE pending rows and upload each one."""
+        cfg = await get_config()
+        if not cfg.fingerprint_server_url:
+            logger.debug("fingerprint_server_url not configured; skipping upload batch")
+            return
+
+        async with async_session() as session:
+            stmt = (
+                select(FingerprintContribution)
+                .where(FingerprintContribution.upload_status.is_(None))
+                .where(FingerprintContribution.upload_attempts < _MAX_ATTEMPTS)
+                .limit(_BATCH_SIZE)
+            )
+            rows = (await session.execute(stmt)).scalars().all()
+            for row in rows:
+                await self._upload_one(row, session, server_url=cfg.fingerprint_server_url)
+
+    async def _upload_one(
+        self,
+        contrib: FingerprintContribution,
+        session,
+        server_url: str,
+    ) -> None:
+        from app.matcher.chromaprint_extractor import ChromaprintResult
+
+        try:
+            fp = ChromaprintResult.from_blob(contrib.chromaprint_blob)
+            payload = {
+                "pseudonym": contrib.pseudonym,
+                "tmdb_id": contrib.tmdb_id,
+                "season": contrib.season,
+                "episode": contrib.episode,
+                "match_confidence": contrib.match_confidence,
+                "match_source": contrib.match_source,
+                "disc_content_hash": (
+                    contrib.disc_content_hash.hex() if contrib.disc_content_hash else None
+                ),
+                "chromaprint": {
+                    "v": 1,
+                    "duration": fp.duration_seconds,
+                    "hashes": fp.hashes,
+                },
+            }
+        except Exception as e:
+            logger.error(f"Failed to deserialize chromaprint blob for contrib {contrib.id}: {e}")
+            contrib.upload_status = "failed"
+            contrib.upload_error_msg = f"Blob deserialization error: {e}"
+            await session.commit()
+            return
+
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
+                    resp = await client.post(
+                        f"{server_url.rstrip('/')}/v1/contribute",
+                        json=payload,
+                    )
+                    resp.raise_for_status()
+
+                contrib.upload_status = "success"
+                contrib.uploaded_at = datetime.now(UTC)
+                await session.commit()
+                self._append_audit_log(contrib)
+                logger.info(
+                    f"Uploaded contribution {contrib.id} "
+                    f"(tmdb={contrib.tmdb_id} s{contrib.season}e{contrib.episode})"
+                )
+                return
+
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if 400 <= status < 500:
+                    contrib.upload_status = "failed"
+                    contrib.upload_error_msg = f"HTTP {status} (permanent)"
+                    contrib.upload_attempts += 1
+                    await session.commit()
+                    logger.warning(f"Contrib {contrib.id}: permanent HTTP {status}; marking failed")
+                    return
+                # 5xx — transient, fall through to retry
+                contrib.upload_attempts += 1
+                await session.commit()
+                logger.warning(
+                    f"Contrib {contrib.id}: transient HTTP {status}, attempt {attempt + 1}"
+                )
+
+            except httpx.HTTPError as e:
+                contrib.upload_attempts += 1
+                await session.commit()
+                logger.warning(f"Contrib {contrib.id}: network error, attempt {attempt + 1}: {e}")
+
+            if attempt < _MAX_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+
+        # Exhausted retries
+        contrib.upload_status = "failed"
+        contrib.upload_error_msg = f"Retries exhausted after {_MAX_ATTEMPTS} attempts"
+        await session.commit()
+        logger.error(f"Contrib {contrib.id}: upload failed after {_MAX_ATTEMPTS} attempts")
+
+    @staticmethod
+    def _append_audit_log(contrib: FingerprintContribution) -> None:
+        """Append a redacted audit line to the JSONL contribution log."""
+        try:
+            CONTRIBUTION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+            entry = {
+                "ts": datetime.now(UTC).isoformat(),
+                "contrib_id": contrib.id,
+                "tmdb_id": contrib.tmdb_id,
+                "season": contrib.season,
+                "episode": contrib.episode,
+                "pseudonym_prefix": (contrib.pseudonym or "")[:8],
+            }
+            with CONTRIBUTION_LOG_PATH.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry) + "\n")
+        except Exception:
+            logger.warning("Failed to write contribution audit log", exc_info=True)

--- a/backend/app/services/contribution_uploader.py
+++ b/backend/app/services/contribution_uploader.py
@@ -43,7 +43,7 @@ class ContributionUploader:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected — we just cancelled the task ourselves.
         logger.info("ContributionUploader stopped")
 
     async def _upload_loop(self) -> None:

--- a/backend/app/services/contribution_uploader.py
+++ b/backend/app/services/contribution_uploader.py
@@ -49,8 +49,8 @@ class ContributionUploader:
     async def _upload_loop(self) -> None:
         while True:
             try:
-                await asyncio.sleep(self.poll_interval)
                 await self._process_batch()
+                await asyncio.sleep(self.poll_interval)
             except asyncio.CancelledError:
                 break
             except Exception:
@@ -63,15 +63,22 @@ class ContributionUploader:
             logger.debug("fingerprint_server_url not configured; skipping upload batch")
             return
 
+        # Collect IDs in a short-lived session so the connection is released
+        # before any per-row exponential backoff sleep.
         async with async_session() as session:
             stmt = (
-                select(FingerprintContribution)
+                select(FingerprintContribution.id)
                 .where(FingerprintContribution.upload_status.is_(None))
                 .where(FingerprintContribution.upload_attempts < _MAX_ATTEMPTS)
                 .limit(_BATCH_SIZE)
             )
-            rows = (await session.execute(stmt)).scalars().all()
-            for row in rows:
+            row_ids = (await session.execute(stmt)).scalars().all()
+
+        for row_id in row_ids:
+            async with async_session() as session:
+                row = await session.get(FingerprintContribution, row_id)
+                if row is None:
+                    continue  # deleted between the ID query and now
                 await self._upload_one(row, session, server_url=cfg.fingerprint_server_url)
 
     async def _upload_one(
@@ -107,7 +114,9 @@ class ContributionUploader:
             await session.commit()
             return
 
-        for attempt in range(_MAX_ATTEMPTS):
+        # Honour the lifetime attempt cap: prior failures consumed some budget.
+        remaining = _MAX_ATTEMPTS - contrib.upload_attempts
+        for attempt in range(remaining):
             try:
                 async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
                     resp = await client.post(
@@ -147,7 +156,7 @@ class ContributionUploader:
                 await session.commit()
                 logger.warning(f"Contrib {contrib.id}: network error, attempt {attempt + 1}: {e}")
 
-            if attempt < _MAX_ATTEMPTS - 1:
+            if attempt < remaining - 1:
                 await asyncio.sleep(2**attempt)
 
         # Exhausted retries

--- a/backend/migrations/versions/7d7a3fc6a743_phase2_uploader_fields.py
+++ b/backend/migrations/versions/7d7a3fc6a743_phase2_uploader_fields.py
@@ -1,0 +1,34 @@
+"""phase2_uploader_fields
+
+Revision ID: 7d7a3fc6a743
+Revises: 0b510750d192
+Create Date: 2026-05-28 09:26:48.064320
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7d7a3fc6a743"
+down_revision: str | Sequence[str] | None = "0b510750d192"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("fingerprint_contributions", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("upload_status", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("upload_error_msg", sa.String(), nullable=True))
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("fingerprint_server_url", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("fingerprint_server_url")
+    with op.batch_alter_table("fingerprint_contributions", schema=None) as batch_op:
+        batch_op.drop_column("upload_error_msg")
+        batch_op.drop_column("upload_status")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "scikit-learn>=1.4.0",
     "numpy>=1.26.0",
     "loguru>=0.7.0",
+    "httpx>=0.26.0",
     "rich>=13.7.0",
     "librosa>=0.10.1",
     "soundfile>=0.12.1",
@@ -54,7 +55,6 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.12.0",
-    "httpx>=0.26.0",
     "ruff>=0.2.0",
     "hypothesis>=6.151.9",
 ]

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -1,0 +1,430 @@
+"""Integration tests for Phase 2: ContributionUploader + privacy endpoints."""
+
+import json
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+from app.models.app_config import AppConfig
+from app.models.fingerprint import FingerprintContribution
+from app.services.contribution_uploader import _MAX_ATTEMPTS, ContributionUploader
+
+
+def _make_valid_blob() -> bytes:
+    """Create a minimal valid ChromaprintResult blob for tests."""
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    return ChromaprintResult(
+        hashes=[1, 2, 3], duration_seconds=42.0, fpcalc_version="test"
+    ).to_blob()
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Initialize test database and clean data between tests."""
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM fingerprint_contributions"))
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+async def client():
+    """Async HTTP client backed by the FastAPI app under test."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+
+def test_fingerprint_contribution_has_upload_status_fields():
+    """FingerprintContribution model has upload_status and upload_error_msg."""
+    row = FingerprintContribution(
+        chromaprint_blob=b"\x01\x02",
+        tmdb_id=1399,
+        season=1,
+        episode=7,
+        match_confidence=0.9,
+        match_source="engram_asr",
+        pseudonym="11111111-1111-4111-8111-111111111111",
+    )
+    assert hasattr(row, "upload_status"), "FingerprintContribution missing upload_status"
+    assert hasattr(row, "upload_error_msg"), "FingerprintContribution missing upload_error_msg"
+    assert row.upload_status is None
+    assert row.upload_error_msg is None
+
+
+def test_app_config_has_fingerprint_server_url():
+    """AppConfig exposes fingerprint_server_url (None by default)."""
+    cfg = AppConfig()
+    assert hasattr(cfg, "fingerprint_server_url")
+    assert cfg.fingerprint_server_url is None
+
+
+@pytest.mark.asyncio
+async def test_uploader_skips_when_no_server_url(setup_db):
+    """If fingerprint_server_url is not set, _process_batch is a no-op."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.database import async_session
+
+    async with async_session() as session:
+        row = FingerprintContribution(
+            chromaprint_blob=b"\xde\xad",
+            tmdb_id=1399,
+            season=1,
+            episode=1,
+            match_confidence=0.9,
+            match_source="engram_asr",
+            pseudonym="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        )
+        session.add(row)
+        await session.commit()
+
+    uploader = ContributionUploader()
+    post_mock = AsyncMock()
+    with patch("httpx.AsyncClient.post", post_mock):
+        await uploader._process_batch()
+
+    post_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_uploader_posts_pending_contributions(setup_db, tmp_path, monkeypatch):
+    """Successful POST marks row upload_status='success' and writes audit log."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import app.services.contribution_uploader as uploader_mod
+    from app.database import async_session
+
+    monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", tmp_path / "contrib.jsonl")
+
+    async with async_session() as session:
+        row = FingerprintContribution(
+            chromaprint_blob=_make_valid_blob(),
+            tmdb_id=1399,
+            season=1,
+            episode=7,
+            match_confidence=0.95,
+            match_source="engram_asr",
+            pseudonym="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        contrib_id = row.id
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        MockClient.return_value = mock_client
+
+        import app.services.contribution_uploader as uploader_mod
+
+        monkeypatch.setattr(
+            uploader_mod,
+            "get_config",
+            AsyncMock(
+                return_value=MagicMock(
+                    fingerprint_server_url="https://fp.example.com",
+                    contribution_pseudonym="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                )
+            ),
+        )
+        uploader = ContributionUploader()
+        await uploader._process_batch()
+
+    async with async_session() as session:
+        refreshed = await session.get(FingerprintContribution, contrib_id)
+
+    assert refreshed.upload_status == "success"
+    assert refreshed.uploaded_at is not None
+
+    log_path = tmp_path / "contrib.jsonl"
+    assert log_path.exists()
+    line = json.loads(log_path.read_text().strip())
+    assert line["contrib_id"] == contrib_id
+    assert len(line["pseudonym_prefix"]) == 8
+
+
+@pytest.mark.asyncio
+async def test_uploader_marks_failed_on_4xx(setup_db, monkeypatch):
+    """A 4xx response permanently marks the row upload_status='failed'."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import app.services.contribution_uploader as uploader_mod
+    from app.database import async_session
+
+    async with async_session() as session:
+        row = FingerprintContribution(
+            chromaprint_blob=_make_valid_blob(),
+            tmdb_id=1,
+            season=1,
+            episode=1,
+            match_confidence=0.5,
+            match_source="engram_asr",
+            pseudonym="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        contrib_id = row.id
+
+    exc = httpx.HTTPStatusError("422", request=MagicMock(), response=MagicMock(status_code=422))
+
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=exc)
+        MockClient.return_value = mock_client
+
+        monkeypatch.setattr(
+            uploader_mod,
+            "get_config",
+            AsyncMock(
+                return_value=MagicMock(
+                    fingerprint_server_url="https://fp.example.com",
+                    contribution_pseudonym="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+                )
+            ),
+        )
+        uploader = ContributionUploader()
+        await uploader._process_batch()
+
+    async with async_session() as session:
+        refreshed = await session.get(FingerprintContribution, contrib_id)
+
+    assert refreshed.upload_status == "failed"
+    assert "422" in (refreshed.upload_error_msg or "")
+
+
+@pytest.mark.asyncio
+async def test_uploader_starts_and_stops_cleanly():
+    """ContributionUploader.start() spawns a task; stop() cancels it cleanly.
+
+    This validates the lifespan interface: main.py calls start() on startup
+    and stop() on shutdown. ASGITransport does not trigger lifespan events,
+    so we test the uploader's own lifecycle directly.
+    """
+    uploader = ContributionUploader(poll_interval_seconds=3600)
+    await uploader.start()
+    assert uploader._task is not None
+    assert not uploader._task.done()
+    await uploader.stop()
+    assert uploader._task.done()
+
+
+@pytest.mark.asyncio
+async def test_forget_endpoint_deletes_pending_contribution(setup_db, client):
+    """DELETE /api/fingerprint/contributions/{id} removes a pending row."""
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            row = FingerprintContribution(
+                chromaprint_blob=b"\x01",
+                tmdb_id=99,
+                season=1,
+                episode=1,
+                match_confidence=0.8,
+                match_source="engram_asr",
+                pseudonym="dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            contrib_id = row.id
+
+        resp = await client.delete(f"/api/fingerprint/contributions/{contrib_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # Second delete → 404
+        resp2 = await client.delete(f"/api/fingerprint/contributions/{contrib_id}")
+        assert resp2.status_code == 404
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
+
+
+@pytest.mark.asyncio
+async def test_forget_endpoint_rejects_uploaded_contribution(setup_db, client):
+    """Cannot delete an already-uploaded contribution (data already on server)."""
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            row = FingerprintContribution(
+                chromaprint_blob=b"\x02",
+                tmdb_id=88,
+                season=2,
+                episode=3,
+                match_confidence=0.9,
+                match_source="engram_asr",
+                pseudonym="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+                upload_status="success",
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            contrib_id = row.id
+
+        resp = await client.delete(f"/api/fingerprint/contributions/{contrib_id}")
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
+
+
+@pytest.mark.asyncio
+async def test_rotate_pseudonym_resets_pending_rows(setup_db, client):
+    """POST rotate-pseudonym updates pending rows and app_config; leaves uploaded rows."""
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+    from app.services.contribution_pseudonym import validate_pseudonym
+
+    old_pseudonym = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            pending = FingerprintContribution(
+                chromaprint_blob=b"\x03",
+                tmdb_id=7,
+                season=1,
+                episode=1,
+                match_confidence=0.9,
+                match_source="engram_asr",
+                pseudonym=old_pseudonym,
+            )
+            uploaded = FingerprintContribution(
+                chromaprint_blob=b"\x04",
+                tmdb_id=8,
+                season=1,
+                episode=2,
+                match_confidence=0.9,
+                match_source="engram_asr",
+                pseudonym=old_pseudonym,
+                upload_status="success",
+            )
+            session.add(pending)
+            session.add(uploaded)
+            await session.commit()
+            await session.refresh(pending)
+            await session.refresh(uploaded)
+            pending_id = pending.id
+            uploaded_id = uploaded.id
+
+        resp = await client.post("/api/fingerprint/contributions/rotate-pseudonym")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert validate_pseudonym(data["pseudonym"])
+        assert data["pseudonym"] != old_pseudonym
+        assert data["pending_retagged"] >= 1
+
+        async with async_session() as session:
+            p = await session.get(FingerprintContribution, pending_id)
+            u = await session.get(FingerprintContribution, uploaded_id)
+
+        assert p.pseudonym == data["pseudonym"]  # retagged
+        assert u.pseudonym == old_pseudonym  # unchanged
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
+
+
+def test_append_audit_log_writes_correct_fields(tmp_path, monkeypatch):
+    """_append_audit_log writes a JSON line with expected fields; pseudonym_prefix is 8 chars."""
+    from datetime import UTC, datetime
+
+    import app.services.contribution_uploader as uploader_mod
+
+    log_path = tmp_path / "contrib.jsonl"
+    monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", log_path)
+
+    contrib = FingerprintContribution(
+        id=42,
+        chromaprint_blob=b"\x00",
+        tmdb_id=1399,
+        season=3,
+        episode=5,
+        match_confidence=0.97,
+        match_source="bootstrap",
+        pseudonym="12345678-1234-4234-8234-123456789abc",
+        uploaded_at=datetime.now(UTC),
+    )
+    ContributionUploader._append_audit_log(contrib)
+
+    assert log_path.exists()
+    line = json.loads(log_path.read_text().strip())
+    assert line["contrib_id"] == 42
+    assert line["tmdb_id"] == 1399
+    assert line["season"] == 3
+    assert line["episode"] == 5
+    assert line["pseudonym_prefix"] == "12345678"  # first 8 chars only
+    assert "ts" in line
+
+
+@pytest.mark.asyncio
+async def test_uploader_increments_attempts_on_5xx(setup_db, monkeypatch):
+    """A 5xx response exhausts retries and marks upload_status='failed'."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import app.services.contribution_uploader as uploader_mod
+    from app.database import async_session
+
+    async with async_session() as session:
+        row = FingerprintContribution(
+            chromaprint_blob=_make_valid_blob(),
+            tmdb_id=2,
+            season=1,
+            episode=1,
+            match_confidence=0.8,
+            match_source="engram_asr",
+            pseudonym="gggggggg-gggg-4ggg-8ggg-gggggggggggg",
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        contrib_id = row.id
+
+    exc = httpx.HTTPStatusError("503", request=MagicMock(), response=MagicMock(status_code=503))
+    with patch("httpx.AsyncClient") as MockClient, patch("asyncio.sleep", AsyncMock()):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=exc)
+        MockClient.return_value = mock_client
+
+        monkeypatch.setattr(
+            uploader_mod,
+            "get_config",
+            AsyncMock(
+                return_value=MagicMock(
+                    fingerprint_server_url="https://fp.example.com",
+                    contribution_pseudonym="gggggggg-gggg-4ggg-8ggg-gggggggggggg",
+                )
+            ),
+        )
+        uploader = ContributionUploader()
+        await uploader._process_batch()
+
+    async with async_session() as session:
+        refreshed = await session.get(FingerprintContribution, contrib_id)
+
+    # After _MAX_ATTEMPTS transient failures the row is permanently failed
+    assert refreshed.upload_status == "failed"
+    assert refreshed.upload_attempts == _MAX_ATTEMPTS

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -290,6 +290,37 @@ async def test_forget_endpoint_rejects_uploaded_contribution(setup_db, client):
 
 
 @pytest.mark.asyncio
+async def test_forget_endpoint_rejects_in_flight_contribution(setup_db, client):
+    """Cannot delete a row with upload_attempts > 0 (may be in-flight)."""
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            row = FingerprintContribution(
+                chromaprint_blob=b"\x05",
+                tmdb_id=77,
+                season=1,
+                episode=1,
+                match_confidence=0.7,
+                match_source="engram_asr",
+                pseudonym="hhhhhhhh-hhhh-4hhh-8hhh-hhhhhhhhhhhh",
+                upload_attempts=1,  # attempted at least once → treat as in-flight
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            contrib_id = row.id
+
+        resp = await client.delete(f"/api/fingerprint/contributions/{contrib_id}")
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
+
+
+@pytest.mark.asyncio
 async def test_rotate_pseudonym_resets_pending_rows(setup_db, client):
     """POST rotate-pseudonym updates pending rows and app_config; leaves uploaded rows."""
     from app.api.routes import require_localhost

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -7,6 +7,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 
+import app.services.contribution_uploader as uploader_mod
 from app.database import async_session, init_db
 from app.main import app
 from app.models.app_config import AppConfig
@@ -98,7 +99,6 @@ async def test_uploader_posts_pending_contributions(setup_db, tmp_path, monkeypa
     """Successful POST marks row upload_status='success' and writes audit log."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
-    import app.services.contribution_uploader as uploader_mod
     from app.database import async_session
 
     monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", tmp_path / "contrib.jsonl")
@@ -127,8 +127,6 @@ async def test_uploader_posts_pending_contributions(setup_db, tmp_path, monkeypa
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client.post = AsyncMock(return_value=mock_resp)
         MockClient.return_value = mock_client
-
-        import app.services.contribution_uploader as uploader_mod
 
         monkeypatch.setattr(
             uploader_mod,
@@ -161,7 +159,6 @@ async def test_uploader_marks_failed_on_4xx(setup_db, monkeypatch):
     """A 4xx response permanently marks the row upload_status='failed'."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
-    import app.services.contribution_uploader as uploader_mod
     from app.database import async_session
 
     async with async_session() as session:
@@ -350,8 +347,6 @@ def test_append_audit_log_writes_correct_fields(tmp_path, monkeypatch):
     """_append_audit_log writes a JSON line with expected fields; pseudonym_prefix is 8 chars."""
     from datetime import UTC, datetime
 
-    import app.services.contribution_uploader as uploader_mod
-
     log_path = tmp_path / "contrib.jsonl"
     monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", log_path)
 
@@ -383,7 +378,6 @@ async def test_uploader_increments_attempts_on_5xx(setup_db, monkeypatch):
     """A 5xx response exhausts retries and marks upload_status='failed'."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
-    import app.services.contribution_uploader as uploader_mod
     from app.database import async_session
 
     async with async_session() as session:

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -12,7 +12,9 @@ from app.database import async_session, init_db
 from app.main import app
 from app.models.app_config import AppConfig
 from app.models.fingerprint import FingerprintContribution
-from app.services.contribution_uploader import _MAX_ATTEMPTS, ContributionUploader
+
+ContributionUploader = uploader_mod.ContributionUploader
+_MAX_ATTEMPTS = uploader_mod._MAX_ATTEMPTS
 
 
 def _make_valid_blob() -> bytes:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.9.0"
+version = "0.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -507,6 +507,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "greenlet" },
+    { name = "httpx" },
     { name = "librosa" },
     { name = "loguru" },
     { name = "numpy" },
@@ -540,7 +541,6 @@ gpu = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -560,6 +560,7 @@ requires-dist = [
     { name = "faster-whisper", specifier = ">=1.0.0" },
     { name = "gputil", marker = "extra == 'gpu'", specifier = ">=1.4.0" },
     { name = "greenlet", specifier = ">=3.0.0" },
+    { name = "httpx", specifier = ">=0.26.0" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.2.0" },
     { name = "librosa", specifier = ">=0.10.1" },
     { name = "loguru", specifier = ">=0.7.0" },
@@ -585,7 +586,6 @@ provides-extras = ["gpu", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.26.0" },
     { name = "hypothesis", specifier = ">=6.151.9" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },


### PR DESCRIPTION
## Summary

- **`ContributionUploader` service** — drains the `fingerprint_contributions` queue by POSTing to `POST /v1/contribute` on a remote fingerprint server; runs on a 1-hour poll loop with exponential retry/backoff (up to 5 attempts), permanent-fail on 4xx, retry on 5xx/network errors
- **New DB columns** — `upload_status` + `upload_error_msg` on `fingerprint_contributions`; `fingerprint_server_url` on `app_config`; Alembic migration `7d7a3fc6a743` (down_revision → Phase 1 head `0b510750d192`)
- **Privacy endpoints** — `DELETE /api/fingerprint/contributions/{id}` (forget a pending row; 400 if already uploaded) and `POST /api/fingerprint/contributions/rotate-pseudonym` (generate fresh UUID, re-tag pending rows, leave uploaded rows unchanged)
- **JSONL audit log** — one redacted JSON line per successful upload at `~/.engram/cache/contribution_log.jsonl` (fields: `ts`, `contrib_id`, `tmdb_id`, `season`, `episode`, `pseudonym_prefix` — first 8 chars only)
- **httpx promoted** to `[project].dependencies` (was dev-only); both `_nullable_fields` sets in `routes.py` and `config_service.py` updated for `fingerprint_server_url`
- Uploader registered in `main.py` lifespan (`start()` on startup, `stop()` on shutdown)

## What this does NOT include

- Server-side `POST /v1/contribute` handler (separate service)
- Frontend settings for `fingerprint_server_url` (follow-up)
- Phase 3 identification using the network

## Test Plan

- [x] 11 new integration tests in `tests/integration/test_contribution_uploader.py` — all passing
- [x] Phase 1 tests (`test_chromaprint_pipeline.py`) still green (10/10)
- [x] Full backend suite: 387 passed, 0 new failures (1 pre-existing `test_build_subtitle_cache` tarball teardown failure unrelated to this PR)
- [x] Alembic migration smoke-tested: upgrade → downgrade → upgrade without errors
- [x] Route registration verified: both privacy endpoints appear in `app.routes`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)