### PR TITLE
fix(finalization): set organized_from/organized_to on title in movie review path

### DIFF
--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -914,19 +914,24 @@ class FinalizationCoordinator:
                             title.state = TitleState.COMPLETED
                             title.organized_from = source_file.name
                             title.organized_to = str(org_result["main_file"])
+                            session.add(title)
+                            _org_from = title.organized_from
+                            _org_to = title.organized_to
+                            _out = title.output_filename
+                            _state = title.state.value
+                            await ws_manager.broadcast_title_update(
+                                job_id,
+                                title.id,
+                                _state,
+                                organized_from=_org_from,
+                                organized_to=_org_to,
+                                output_filename=_out,
+                            )
                             job.progress_percent = 100.0
                             job.error_message = None
                             job.final_path = str(org_result["main_file"])
                             await self._state_machine.transition_to_completed(job, session)
                             logger.info(f"Organized movie: {org_result['main_file']}")
-                            await ws_manager.broadcast_title_update(
-                                job_id,
-                                title.id,
-                                title.state.value,
-                                organized_from=title.organized_from,
-                                organized_to=title.organized_to,
-                                output_filename=title.output_filename,
-                            )
                         elif org_result.get("error_code") == "FILE_EXISTS":
                             title.state = TitleState.REVIEW
                             title.match_details = _merge_match_details(

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -912,11 +912,21 @@ class FinalizationCoordinator:
 
                         if org_result["success"]:
                             title.state = TitleState.COMPLETED
+                            title.organized_from = source_file.name
+                            title.organized_to = str(org_result["main_file"])
                             job.progress_percent = 100.0
                             job.error_message = None
                             job.final_path = str(org_result["main_file"])
                             await self._state_machine.transition_to_completed(job, session)
                             logger.info(f"Organized movie: {org_result['main_file']}")
+                            await ws_manager.broadcast_title_update(
+                                job_id,
+                                title.id,
+                                title.state.value,
+                                organized_from=title.organized_from,
+                                organized_to=title.organized_to,
+                                output_filename=title.output_filename,
+                            )
                         elif org_result.get("error_code") == "FILE_EXISTS":
                             title.state = TitleState.REVIEW
                             title.match_details = _merge_match_details(

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -220,6 +220,41 @@ class TestFinalizeDiscJob:
 
 
 @pytest.mark.unit
+class TestApplyReviewDecisionMovie:
+    """Test the post-rip movie review path in apply_review."""
+
+    async def test_organized_fields_set_on_movie_review_success(self, tmp_path, monkeypatch):
+        """title.organized_from and organized_to must be populated after a successful movie review."""
+        import app.core.organizer as org
+
+        source = tmp_path / "INCEPTION_2010_t00.mkv"
+        source.write_bytes(b"x" * 1024)
+        dest = tmp_path / "movies" / "Inception (2010)" / "Inception (2010).mkv"
+
+        monkeypatch.setattr(
+            org.movie_organizer,
+            "organize",
+            Mock(return_value={"success": True, "main_file": dest}),
+        )
+
+        job_id = await _seed_job(
+            [(0, None, str(source), TitleState.REVIEW)],
+            staging=str(tmp_path),
+            content_type=ContentType.MOVIE,
+            state=JobState.REVIEW_NEEDED,
+        )
+        _, titles = await _load(job_id)
+        title_id = titles[0].id
+
+        await _make_coord().apply_review(job_id, title_id)
+
+        _, titles = await _load(job_id)
+        t = titles[0]
+        assert t.organized_from == source.name
+        assert t.organized_to == str(dest)
+
+
+@pytest.mark.unit
 class TestCheckJobCompletion:
     async def test_active_title_returns_without_finalizing(self, tmp_path):
         job_id = await _seed_job([(0, "S01E01", None, TitleState.RIPPING)], staging=str(tmp_path))

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -224,7 +224,7 @@ class TestApplyReviewDecisionMovie:
     """Test the post-rip movie review path in apply_review."""
 
     async def test_organized_fields_set_on_movie_review_success(self, tmp_path, monkeypatch):
-        """title.organized_from and organized_to must be populated after a successful movie review."""
+        """title.organized_from/organized_to are persisted and broadcast after a movie review."""
         import app.core.organizer as org
 
         source = tmp_path / "INCEPTION_2010_t00.mkv"
@@ -246,12 +246,24 @@ class TestApplyReviewDecisionMovie:
         _, titles = await _load(job_id)
         title_id = titles[0].id
 
+        broadcast_spy = AsyncMock()
+        monkeypatch.setattr(ws_manager, "broadcast_title_update", broadcast_spy)
+
         await _make_coord().apply_review(job_id, title_id)
 
         _, titles = await _load(job_id)
         t = titles[0]
         assert t.organized_from == source.name
         assert t.organized_to == str(dest)
+
+        broadcast_spy.assert_called_once_with(
+            job_id,
+            title_id,
+            TitleState.COMPLETED.value,
+            organized_from=source.name,
+            organized_to=str(dest),
+            output_filename=str(source),
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- After `apply_review` succeeds for a movie with an already-ripped file, `title.organized_from` and `title.organized_to` were never set — only `job.final_path` was updated.
- This is the same class of bug fixed in #245 (extras showing wrong `organized_to` in job history) but in the human-review code path.
- Fix assigns both fields and broadcasts a `broadcast_title_update` via `ws_manager`, matching the pattern used by the TV organize path (lines 726-749 of `finalization_coordinator.py`).

## Changes

- [`backend/app/services/finalization_coordinator.py`](backend/app/services/finalization_coordinator.py) — set `title.organized_from = source_file.name` and `title.organized_to = str(org_result["main_file"])` after a successful movie review organize, then call `ws_manager.broadcast_title_update`
- [`backend/tests/unit/test_finalization_coordinator.py`](backend/tests/unit/test_finalization_coordinator.py) — new `TestApplyReviewDecisionMovie` class with a test that confirms both fields are populated after `apply_review` succeeds

## Test Plan

- [x] New unit test `test_organized_fields_set_on_movie_review_success` watches `organized_from` and `organized_to` stay `None` before the fix, then pass after
- [x] All 1269 unit tests pass (`uv run pytest tests/unit/`)
- [x] `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)