### PR TITLE
feat: bootstrap-library wizard — seed the fingerprint network from an existing library

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1851,9 +1851,8 @@ async def bootstrap_accept(
     # then push duplicate rows to the network). Skip any (tmdb_id, season,
     # episode) already present as a bootstrap row, plus duplicates within this
     # request. Keyed off episode identity since the filename was ground truth.
-    EpisodeKey = tuple[int, int | None, int | None]
     request_tmdb_ids = {item.tmdb_id for item in req.items}
-    existing_keys: set[EpisodeKey] = set()
+    existing_keys: set[tuple[int, int | None, int | None]] = set()
     if request_tmdb_ids:
         existing_rows = await session.execute(
             select(
@@ -1869,10 +1868,10 @@ async def bootstrap_accept(
 
     queued = 0
     failed = 0
-    seen: set[EpisodeKey] = set()
+    seen: set[tuple[int, int | None, int | None]] = set()
 
     for item in req.items:
-        key: EpisodeKey = (item.tmdb_id, item.season, item.episode)
+        key = (item.tmdb_id, item.season, item.episode)
         if key in existing_keys or key in seen:
             # Already queued by a prior call or earlier in this batch — count it
             # as queued (the episode is in the queue) but don't duplicate it.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1548,6 +1548,297 @@ async def forget_fingerprint_on_server(
     }
 
 
+# --- Bootstrap Library Endpoints ---
+# NOTE: The accept endpoint processes items synchronously. Very large libraries
+# should be chunked by the caller (e.g. 50–100 items per request). A future
+# enhancement could background the extraction work for very large batches.
+
+
+class BootstrapScanRequest(BaseModel):
+    """Request body for /fingerprint/bootstrap/scan."""
+
+    path: str
+
+
+class BootstrapEpisodeItem(BaseModel):
+    """A single parseable episode found during a library scan."""
+
+    file: str
+    season: int
+    episode: int
+
+
+class BootstrapShowResult(BaseModel):
+    """Per-show grouping returned by /fingerprint/bootstrap/scan."""
+
+    folder_name: str
+    tmdb_id: int | None
+    tmdb_name: str | None
+    tmdb_year: int | None
+    resolved: bool
+    episode_count: int
+    episodes: list[BootstrapEpisodeItem]
+
+
+class BootstrapUnparseableItem(BaseModel):
+    """A media file whose name could not be parsed as Show - SnnEnn."""
+
+    file: str
+
+
+class BootstrapScanSummary(BaseModel):
+    total_files: int
+    parsed: int
+    shows: int
+    unparseable: int
+
+
+class BootstrapScanResponse(BaseModel):
+    shows: list[BootstrapShowResult]
+    unparseable: list[BootstrapUnparseableItem]
+    summary: BootstrapScanSummary
+
+
+class BootstrapAcceptItem(BaseModel):
+    """One file + resolved metadata the user confirmed for fingerprinting."""
+
+    file: str
+    tmdb_id: int
+    season: int
+    episode: int
+
+
+class BootstrapAcceptRequest(BaseModel):
+    """Request body for /fingerprint/bootstrap/accept."""
+
+    items: list[BootstrapAcceptItem]
+
+
+@router.post(
+    "/fingerprint/bootstrap/scan",
+    dependencies=[Depends(require_localhost)],
+    response_model=BootstrapScanResponse,
+)
+async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
+    """Walk an existing TV library and group files by show for TMDB resolution.
+
+    The caller supplies the root directory of a TV library whose files are
+    already correctly labeled with the canonical ``Show - SnnEnn.ext`` naming
+    convention.  The endpoint:
+
+    1. Validates that the path exists and is a directory (400 otherwise).
+    2. Globs all ``.mkv``/``.mp4``/``.m2ts`` files under the path (excluding
+       ``Extras`` directories).
+    3. Uses ``walk_library`` + ``parse_episode_filename`` to distinguish
+       parseable episodes from unparseable files.
+    4. Groups parseable episodes by show name and tries ``fetch_show_id`` for
+       each unique show (TMDB lookups are cached within the request).
+    5. Returns a per-show breakdown so the UI can confirm auto-resolved shows
+       and offer a manual TMDB picker for the rest.
+
+    Localhost-only: the response includes the user's local library paths.
+    """
+    from app.matcher.tmdb_client import fetch_show_details, fetch_show_id
+    from app.scripts.bootstrap_library import parse_episode_filename, walk_library
+
+    root = Path(req.path)
+    if not root.exists() or not root.is_dir():
+        raise HTTPException(
+            status_code=400, detail=f"Path does not exist or is not a directory: {req.path}"
+        )
+
+    # --- Collect all media files, skipping Extras ---
+    _MEDIA_EXTENSIONS = {".mkv", ".mp4", ".m2ts"}
+
+    all_media: set[Path] = set()
+    for ext in _MEDIA_EXTENSIONS:
+        for p in root.rglob(f"*{ext}"):
+            if "Extras" not in p.parts:
+                all_media.add(p)
+
+    # --- Separate parseable from unparseable ---
+    # walk_library yields (path, (show, season, ep)) for parseable MKV files;
+    # any media file not returned by walk_library is unparseable.
+    parseable_paths: set[Path] = set()
+    # show_name -> list of (path, season, episode)
+    show_episodes: dict[str, list[tuple[Path, int, int]]] = {}
+
+    for file_path, (show, season, episode) in walk_library(root):
+        parseable_paths.add(file_path)
+        show_episodes.setdefault(show, []).append((file_path, season, episode))
+
+    # Non-MKV parseable files: check mp4/m2ts against parse_episode_filename
+    for p in all_media:
+        if p in parseable_paths:
+            continue
+        if p.suffix.lower() in (".mp4", ".m2ts"):
+            label = parse_episode_filename(p.name)
+            if label is not None:
+                show, season, episode = label
+                parseable_paths.add(p)
+                show_episodes.setdefault(show, []).append((p, season, episode))
+
+    unparseable_files = [p for p in all_media if p not in parseable_paths]
+
+    # --- TMDB resolution with per-request cache ---
+    tmdb_id_cache: dict[str, str | None] = {}
+
+    async def _resolve_show(show_name: str) -> str | None:
+        if show_name not in tmdb_id_cache:
+            raw = await asyncio.to_thread(fetch_show_id, show_name)
+            tmdb_id_cache[show_name] = raw
+        return tmdb_id_cache[show_name]
+
+    # Fetch details (name + year) for resolved shows; cache by id string.
+    tmdb_details_cache: dict[str, dict | None] = {}
+
+    async def _get_details(tmdb_id_str: str) -> dict | None:
+        if tmdb_id_str not in tmdb_details_cache:
+            try:
+                details = await asyncio.to_thread(fetch_show_details, int(tmdb_id_str))
+            except Exception:
+                details = None
+            tmdb_details_cache[tmdb_id_str] = details
+        return tmdb_details_cache[tmdb_id_str]
+
+    # --- Build per-show results ---
+    shows: list[BootstrapShowResult] = []
+    for show_name, episodes in sorted(show_episodes.items()):
+        raw_id = await _resolve_show(show_name)
+
+        tmdb_id: int | None = None
+        tmdb_name: str | None = None
+        tmdb_year: int | None = None
+        resolved = False
+
+        if raw_id is not None:
+            try:
+                tmdb_id = int(raw_id)
+                resolved = True
+            except (TypeError, ValueError):
+                pass
+
+        if tmdb_id is not None:
+            details = await _get_details(str(tmdb_id))
+            if details:
+                tmdb_name = details.get("name") or details.get("original_name")
+                first_air = details.get("first_air_date") or ""
+                if first_air and len(first_air) >= 4:
+                    try:
+                        tmdb_year = int(first_air[:4])
+                    except ValueError:
+                        pass
+
+        episode_items = [
+            BootstrapEpisodeItem(file=str(p), season=s, episode=e)
+            for p, s, e in sorted(episodes, key=lambda x: (x[1], x[2]))
+        ]
+
+        shows.append(
+            BootstrapShowResult(
+                folder_name=show_name,
+                tmdb_id=tmdb_id,
+                tmdb_name=tmdb_name,
+                tmdb_year=tmdb_year,
+                resolved=resolved,
+                episode_count=len(episode_items),
+                episodes=episode_items,
+            )
+        )
+
+    parsed_count = sum(len(eps) for eps in show_episodes.values())
+    total_files = parsed_count + len(unparseable_files)
+
+    return BootstrapScanResponse(
+        shows=shows,
+        unparseable=[BootstrapUnparseableItem(file=str(p)) for p in sorted(unparseable_files)],
+        summary=BootstrapScanSummary(
+            total_files=total_files,
+            parsed=parsed_count,
+            shows=len(shows),
+            unparseable=len(unparseable_files),
+        ),
+    )
+
+
+@router.post("/fingerprint/bootstrap/accept", dependencies=[Depends(require_localhost)])
+async def bootstrap_accept(
+    req: BootstrapAcceptRequest,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Fingerprint a confirmed set of library files and enqueue contributions.
+
+    The UI calls this after the user reviews the scan results and confirms
+    (or manually corrects) each show's TMDB mapping.  For each item the
+    endpoint:
+
+    1. Extracts a chromaprint fingerprint via fpcalc (from ``cfg.fpcalc_path``
+       or ``detect_fpcalc()``).
+    2. Enqueues a ``FingerprintContribution`` row tagged ``match_source="bootstrap"``
+       and ``match_confidence=1.0`` (filename was ground truth).
+    3. Per-file extraction failures are counted and do NOT abort the batch.
+
+    Returns ``{"queued": N, "failed": M}``.
+
+    Localhost-only: processes local library files on behalf of the user.
+    """
+    from app.api.validation import detect_fpcalc
+    from app.matcher.chromaprint_extractor import ChromaprintExtractor
+    from app.services.config_service import get_config
+    from app.services.contribution_queue import ContributionQueue
+
+    cfg = await get_config()
+
+    # Resolve fpcalc path: prefer explicit config, fall back to auto-detection.
+    fpcalc_path = cfg.fpcalc_path
+    if not fpcalc_path:
+        detected = await asyncio.to_thread(detect_fpcalc)
+        fpcalc_path = detected.path if detected.found else None
+
+    if not fpcalc_path:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "fpcalc is not available. Install it (libchromaprint-tools / chromaprint) "
+                "and set its path in Engram settings, or ensure it is on PATH."
+            ),
+        )
+
+    extractor = ChromaprintExtractor(fpcalc_path=fpcalc_path)
+    queue = ContributionQueue()
+    pseudonym = cfg.contribution_pseudonym or ""
+
+    queued = 0
+    failed = 0
+
+    for item in req.items:
+        try:
+            result = await extractor.extract(item.file)
+            await queue.enqueue(
+                session=session,
+                title_id=None,
+                chromaprint_blob=result.to_blob(),
+                tmdb_id=item.tmdb_id,
+                season=item.season,
+                episode=item.episode,
+                match_confidence=1.0,
+                match_source="bootstrap",
+                disc_content_hash=None,
+                pseudonym=pseudonym,
+                contributions_enabled=cfg.enable_fingerprint_contributions,
+            )
+            queued += 1
+        except Exception as exc:
+            logger.warning(
+                f"bootstrap_accept: fingerprint extraction failed for {item.file!r}: {exc}",
+                exc_info=True,
+            )
+            failed += 1
+
+    await session.commit()
+    return {"queued": queued, "failed": failed}
+
+
 # --- Simulation Endpoints (debug mode only) ---
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1614,6 +1614,17 @@ class BootstrapAcceptRequest(BaseModel):
     items: list[BootstrapAcceptItem]
 
 
+class BootstrapAcceptResponse(BaseModel):
+    """Response body for /fingerprint/bootstrap/accept.
+
+    ``queued`` counts episodes confirmed in the local contribution queue —
+    including items already queued by a prior call (idempotent re-runs).
+    """
+
+    queued: int
+    failed: int
+
+
 @router.post(
     "/fingerprint/bootstrap/scan",
     dependencies=[Depends(require_localhost)],
@@ -1641,7 +1652,11 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
     from app.matcher.tmdb_client import fetch_show_details, fetch_show_id
     from app.scripts.bootstrap_library import parse_episode_filename, walk_library
 
-    root = Path(req.path)
+    # Canonicalize the user-supplied root so the symlink-containment check
+    # below has a stable base. The endpoint is localhost-only and the path is
+    # the user's own library, but rglob/exists follow symlinks, so confine
+    # every hit to the resolved tree.
+    root = Path(req.path).resolve()
     if not root.exists() or not root.is_dir():
         raise HTTPException(
             status_code=400, detail=f"Path does not exist or is not a directory: {req.path}"
@@ -1653,6 +1668,13 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
     all_media: set[Path] = set()
     for ext in _MEDIA_EXTENSIONS:
         for p in root.rglob(f"*{ext}"):
+            # rglob follows symlinks; skip any hit whose real path escapes the
+            # scanned tree so a crafted symlink can't surface outside files.
+            try:
+                if not p.resolve().is_relative_to(root):
+                    continue
+            except (OSError, ValueError):
+                continue
             if "Extras" not in p.parts:
                 all_media.add(p)
 
@@ -1685,7 +1707,14 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
 
     async def _resolve_show(show_name: str) -> str | None:
         if show_name not in tmdb_id_cache:
-            raw = await asyncio.to_thread(fetch_show_id, show_name)
+            # fetch_show_id hits TMDB; a network timeout / 429 must not bubble
+            # up as an unhandled 500 — treat it as a miss (symmetric with
+            # _get_details below and the CLI's _default_search).
+            try:
+                raw = await asyncio.to_thread(fetch_show_id, show_name)
+            except Exception:
+                logger.warning(f"TMDB show lookup failed for {show_name!r}", exc_info=True)
+                raw = None
             tmdb_id_cache[show_name] = raw
         return tmdb_id_cache[show_name]
 
@@ -1697,6 +1726,7 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
             try:
                 details = await asyncio.to_thread(fetch_show_details, int(tmdb_id_str))
             except Exception:
+                logger.warning(f"TMDB details fetch failed for id {tmdb_id_str}", exc_info=True)
                 details = None
             tmdb_details_cache[tmdb_id_str] = details
         return tmdb_details_cache[tmdb_id_str]
@@ -1716,6 +1746,7 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
                 tmdb_id = int(raw_id)
                 resolved = True
             except (TypeError, ValueError):
+                # Non-numeric id from TMDB (shouldn't happen); leave unresolved.
                 pass
 
         if tmdb_id is not None:
@@ -1727,6 +1758,7 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
                     try:
                         tmdb_year = int(first_air[:4])
                     except ValueError:
+                        # Malformed first_air_date prefix; year stays None.
                         pass
 
         episode_items = [
@@ -1761,11 +1793,15 @@ async def bootstrap_scan(req: BootstrapScanRequest) -> BootstrapScanResponse:
     )
 
 
-@router.post("/fingerprint/bootstrap/accept", dependencies=[Depends(require_localhost)])
+@router.post(
+    "/fingerprint/bootstrap/accept",
+    dependencies=[Depends(require_localhost)],
+    response_model=BootstrapAcceptResponse,
+)
 async def bootstrap_accept(
     req: BootstrapAcceptRequest,
     session: AsyncSession = Depends(get_session),
-) -> dict:
+) -> BootstrapAcceptResponse:
     """Fingerprint a confirmed set of library files and enqueue contributions.
 
     The UI calls this after the user reviews the scan results and confirms
@@ -1784,6 +1820,7 @@ async def bootstrap_accept(
     """
     from app.api.validation import detect_fpcalc
     from app.matcher.chromaprint_extractor import ChromaprintExtractor
+    from app.models.fingerprint import FingerprintContribution
     from app.services.config_service import get_config
     from app.services.contribution_queue import ContributionQueue
 
@@ -1808,10 +1845,39 @@ async def bootstrap_accept(
     queue = ContributionQueue()
     pseudonym = cfg.contribution_pseudonym or ""
 
+    # Idempotency guard: bootstrap is re-runnable and the UI submits in batches,
+    # so a double-click — or a batch retried after it actually succeeded
+    # server-side — must not insert the same episode twice (the uploader would
+    # then push duplicate rows to the network). Skip any (tmdb_id, season,
+    # episode) already present as a bootstrap row, plus duplicates within this
+    # request. Keyed off episode identity since the filename was ground truth.
+    EpisodeKey = tuple[int, int | None, int | None]
+    request_tmdb_ids = {item.tmdb_id for item in req.items}
+    existing_keys: set[EpisodeKey] = set()
+    if request_tmdb_ids:
+        existing_rows = await session.execute(
+            select(
+                FingerprintContribution.tmdb_id,
+                FingerprintContribution.season,
+                FingerprintContribution.episode,
+            ).where(
+                FingerprintContribution.match_source == "bootstrap",
+                FingerprintContribution.tmdb_id.in_(request_tmdb_ids),
+            )
+        )
+        existing_keys = {(r[0], r[1], r[2]) for r in existing_rows.all()}
+
     queued = 0
     failed = 0
+    seen: set[EpisodeKey] = set()
 
     for item in req.items:
+        key: EpisodeKey = (item.tmdb_id, item.season, item.episode)
+        if key in existing_keys or key in seen:
+            # Already queued by a prior call or earlier in this batch — count it
+            # as queued (the episode is in the queue) but don't duplicate it.
+            queued += 1
+            continue
         try:
             result = await extractor.extract(item.file)
             await queue.enqueue(
@@ -1827,6 +1893,7 @@ async def bootstrap_accept(
                 pseudonym=pseudonym,
                 contributions_enabled=cfg.enable_fingerprint_contributions,
             )
+            seen.add(key)
             queued += 1
         except Exception as exc:
             logger.warning(
@@ -1836,7 +1903,7 @@ async def bootstrap_accept(
             failed += 1
 
     await session.commit()
-    return {"queued": queued, "failed": failed}
+    return BootstrapAcceptResponse(queued=queued, failed=failed)
 
 
 # --- Simulation Endpoints (debug mode only) ---

--- a/backend/app/scripts/bootstrap_library.py
+++ b/backend/app/scripts/bootstrap_library.py
@@ -44,8 +44,20 @@ def parse_episode_filename(name: str) -> tuple[str, int, int] | None:
 
 
 def walk_library(root: Path) -> Iterable[tuple[Path, tuple[str, int, int]]]:
-    """Yield (file_path, (show, season, episode)) for every labeled MKV under root, skipping Extras."""
+    """Yield (file_path, (show, season, episode)) for every labeled MKV under root, skipping Extras.
+
+    ``root`` is canonicalized so the symlink-containment check has a stable
+    base. ``rglob`` follows symlinks, so any hit whose real path escapes the
+    resolved tree is skipped — a crafted symlink inside the library can't pull
+    in files from outside it (path traversal).
+    """
+    root = root.resolve()
     for mkv in sorted(root.rglob("*.mkv")):
+        try:
+            if not mkv.resolve().is_relative_to(root):
+                continue
+        except (OSError, ValueError):
+            continue
         if "Extras" in mkv.parts:
             continue
         label = parse_episode_filename(mkv.name)

--- a/backend/tests/integration/test_bootstrap_api.py
+++ b/backend/tests/integration/test_bootstrap_api.py
@@ -23,12 +23,22 @@ from app.main import app
 
 @pytest.fixture(autouse=True)
 async def setup_db():
-    """Initialize DB and scrub bootstrap rows between tests."""
+    """Initialize DB and scrub bootstrap rows before AND after each test.
+
+    The post-test teardown matters here specifically: leftover
+    ``fingerprint_contributions`` rows are exactly what ``ContributionUploader``
+    drains, so a test row surviving in a real DB could be uploaded to the live
+    network. Clean both sides so no ``bootstrap`` rows ever outlive the suite.
+    """
     await init_db()
     async with async_session() as session:
         await session.execute(text("DELETE FROM fingerprint_contributions"))
         await session.execute(text("DELETE FROM disc_titles"))
         await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+    yield
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM fingerprint_contributions"))
         await session.commit()
 
 

--- a/backend/tests/integration/test_bootstrap_api.py
+++ b/backend/tests/integration/test_bootstrap_api.py
@@ -1,0 +1,367 @@
+"""Integration tests for /api/fingerprint/bootstrap/scan and /accept.
+
+Heavy external dependencies (TMDB, fpcalc, filesystem walks) are monkeypatched
+so tests run without a real TV library, real TMDB credentials, or fpcalc binary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.api.routes import require_localhost
+from app.database import async_session, init_db
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    """Initialize DB and scrub bootstrap rows between tests."""
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM fingerprint_contributions"))
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+@pytest.fixture
+async def client():
+    """Async HTTP client backed by the FastAPI app. Bypasses localhost guard."""
+    app.dependency_overrides[require_localhost] = lambda: None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(require_localhost, None)
+
+
+# ---------------------------------------------------------------------------
+# /api/fingerprint/bootstrap/scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_groups_parseable_files_by_show(client, tmp_path):
+    """walk_library results are grouped by show; resolved show has tmdb_id set."""
+    # Create labeled MKV files for "Severance"
+    (tmp_path / "Severance - S01E01.mkv").touch()
+    (tmp_path / "Severance - S01E02.mkv").touch()
+    # Unparseable file (no Show - SnnEnn pattern)
+    (tmp_path / "Random Clip.mkv").touch()
+
+    def fake_fetch_show_id(show_name: str) -> str | None:
+        if "Severance" in show_name:
+            return "95396"
+        return None
+
+    fake_details = {
+        "name": "Severance",
+        "original_name": "Severance",
+        "first_air_date": "2022-02-18",
+    }
+
+    with (
+        patch("app.api.routes.asyncio.to_thread") as mock_to_thread,
+    ):
+        # to_thread is called for fetch_show_id and fetch_show_details; dispatch by callable.
+        async def side_effect(fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "") or getattr(fn, "__qualname__", "")
+            if "fetch_show_id" in fn_name:
+                return fake_fetch_show_id(*args)
+            if "fetch_show_details" in fn_name:
+                return fake_details
+            return fn(*args, **kwargs)
+
+        mock_to_thread.side_effect = side_effect
+
+        resp = await client.post("/api/fingerprint/bootstrap/scan", json={"path": str(tmp_path)})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    shows = data["shows"]
+    assert len(shows) == 1
+    show = shows[0]
+    assert show["folder_name"] == "Severance"
+    assert show["tmdb_id"] == 95396
+    assert show["tmdb_name"] == "Severance"
+    assert show["tmdb_year"] == 2022
+    assert show["resolved"] is True
+    assert show["episode_count"] == 2
+    assert len(show["episodes"]) == 2
+
+    unparseable = data["unparseable"]
+    unparseable_files = [u["file"] for u in unparseable]
+    assert any("Random Clip.mkv" in f for f in unparseable_files)
+
+    summary = data["summary"]
+    assert summary["parsed"] == 2
+    assert summary["unparseable"] == 1
+    assert summary["shows"] == 1
+    assert summary["total_files"] == 3
+
+
+@pytest.mark.asyncio
+async def test_scan_unresolved_show_has_null_tmdb(client, tmp_path):
+    """A show whose name doesn't match TMDB gets resolved=false and null tmdb_id."""
+    (tmp_path / "UnknownShow - S01E01.mkv").touch()
+
+    with patch("app.api.routes.asyncio.to_thread") as mock_to_thread:
+
+        async def side_effect(fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "") or getattr(fn, "__qualname__", "")
+            if "fetch_show_id" in fn_name:
+                return None  # unresolved
+            return fn(*args, **kwargs)
+
+        mock_to_thread.side_effect = side_effect
+
+        resp = await client.post("/api/fingerprint/bootstrap/scan", json={"path": str(tmp_path)})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    shows = data["shows"]
+    assert len(shows) == 1
+    show = shows[0]
+    assert show["resolved"] is False
+    assert show["tmdb_id"] is None
+    assert show["tmdb_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_scan_nonexistent_path_returns_400(client):
+    """A path that does not exist on disk returns HTTP 400."""
+    resp = await client.post(
+        "/api/fingerprint/bootstrap/scan",
+        json={"path": "/nonexistent/path/that/does/not/exist"},
+    )
+    assert resp.status_code == 400
+    assert (
+        "does not exist" in resp.json()["detail"].lower()
+        or "directory" in resp.json()["detail"].lower()
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_file_path_returns_400(client, tmp_path):
+    """Passing a file path (not a directory) returns HTTP 400."""
+    f = tmp_path / "not_a_dir.mkv"
+    f.touch()
+    resp = await client.post(
+        "/api/fingerprint/bootstrap/scan",
+        json={"path": str(f)},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_extras_directory(client, tmp_path):
+    """Files inside an Extras/ sub-directory are treated as unparseable (not grouped)."""
+    extras_dir = tmp_path / "Extras"
+    extras_dir.mkdir()
+    (extras_dir / "Severance - S01E01.mkv").touch()
+    # A parseable file outside Extras
+    (tmp_path / "Severance - S01E02.mkv").touch()
+
+    with patch("app.api.routes.asyncio.to_thread") as mock_to_thread:
+
+        async def side_effect(fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "") or getattr(fn, "__qualname__", "")
+            if "fetch_show_id" in fn_name:
+                return "95396"
+            if "fetch_show_details" in fn_name:
+                return {"name": "Severance", "first_air_date": "2022-02-18"}
+            return fn(*args, **kwargs)
+
+        mock_to_thread.side_effect = side_effect
+
+        resp = await client.post("/api/fingerprint/bootstrap/scan", json={"path": str(tmp_path)})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # Only the file outside Extras should be parsed
+    assert data["summary"]["parsed"] == 1
+    show = data["shows"][0]
+    assert show["episode_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /api/fingerprint/bootstrap/accept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_enqueues_contributions(client, tmp_path):
+    """Two items with a mocked extractor produce queued=2, failed=0 and DB rows."""
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    fake_result = ChromaprintResult(
+        hashes=[1, 2, 3, 4],
+        duration_seconds=42.0,
+        fpcalc_version="fpcalc version 1.5.1",
+    )
+
+    items = [
+        {"file": str(tmp_path / "ep1.mkv"), "tmdb_id": 95396, "season": 1, "episode": 1},
+        {"file": str(tmp_path / "ep2.mkv"), "tmdb_id": 95396, "season": 1, "episode": 2},
+    ]
+
+    # ChromaprintExtractor is imported lazily inside the endpoint body, so we
+    # patch it at its source module rather than on app.api.routes.
+    with (
+        patch("app.api.routes.asyncio.to_thread") as mock_to_thread,
+        patch("app.matcher.chromaprint_extractor.ChromaprintExtractor") as MockExtractor,
+    ):
+        # detect_fpcalc runs in to_thread; return a found result
+        from app.api.validation import ToolDetectionResult
+
+        mock_to_thread.return_value = ToolDetectionResult(found=True, path="/usr/bin/fpcalc")
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract = AsyncMock(return_value=fake_result)
+        MockExtractor.return_value = mock_extractor_instance
+
+        # Seed a pseudonym and contributions_enabled so the queue actually inserts
+        from app.services.config_service import update_config as update_db_config
+
+        await update_db_config(
+            contribution_pseudonym="test-pseudonym-bootstrap",
+            enable_fingerprint_contributions=True,
+            fpcalc_path=None,  # force auto-detect path via to_thread
+        )
+
+        resp = await client.post("/api/fingerprint/bootstrap/accept", json={"items": items})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["queued"] == 2
+    assert data["failed"] == 0
+
+    # Verify rows were written to the DB
+    async with async_session() as session:
+        from sqlmodel import select as sqlmodel_select
+
+        from app.models.fingerprint import FingerprintContribution
+
+        rows = (
+            (
+                await session.execute(
+                    sqlmodel_select(FingerprintContribution).where(
+                        FingerprintContribution.match_source == "bootstrap"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        for row in rows:
+            assert row.match_source == "bootstrap"
+            assert row.match_confidence == 1.0
+            assert row.tmdb_id == 95396
+
+
+@pytest.mark.asyncio
+async def test_accept_partial_failure_does_not_abort_batch(client, tmp_path):
+    """A failed extraction on one item is counted as failed without stopping others."""
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    fake_result = ChromaprintResult(
+        hashes=[10, 20],
+        duration_seconds=30.0,
+        fpcalc_version="fpcalc version 1.5.1",
+    )
+
+    items = [
+        {"file": str(tmp_path / "good.mkv"), "tmdb_id": 12345, "season": 1, "episode": 1},
+        {"file": str(tmp_path / "bad.mkv"), "tmdb_id": 12345, "season": 1, "episode": 2},
+    ]
+
+    call_count = 0
+
+    async def extract_side_effect(path: str) -> ChromaprintResult:
+        nonlocal call_count
+        call_count += 1
+        if "bad.mkv" in path:
+            raise RuntimeError("Simulated fpcalc failure")
+        return fake_result
+
+    with (
+        patch("app.api.routes.asyncio.to_thread") as mock_to_thread,
+        patch("app.matcher.chromaprint_extractor.ChromaprintExtractor") as MockExtractor,
+    ):
+        from app.api.validation import ToolDetectionResult
+
+        mock_to_thread.return_value = ToolDetectionResult(found=True, path="/usr/bin/fpcalc")
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract = AsyncMock(side_effect=extract_side_effect)
+        MockExtractor.return_value = mock_extractor_instance
+
+        from app.services.config_service import update_config as update_db_config
+
+        await update_db_config(
+            contribution_pseudonym="test-pseudonym-partial",
+            enable_fingerprint_contributions=True,
+            fpcalc_path=None,
+        )
+
+        resp = await client.post("/api/fingerprint/bootstrap/accept", json={"items": items})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["queued"] == 1
+    assert data["failed"] == 1
+
+    # Only 1 DB row should exist
+    async with async_session() as session:
+        from sqlmodel import select as sqlmodel_select
+
+        from app.models.fingerprint import FingerprintContribution
+
+        rows = (
+            (
+                await session.execute(
+                    sqlmodel_select(FingerprintContribution).where(
+                        FingerprintContribution.match_source == "bootstrap"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_no_fpcalc_returns_400(client, tmp_path):
+    """When fpcalc cannot be found, the endpoint returns 400 with a clear message."""
+    items = [
+        {"file": str(tmp_path / "ep1.mkv"), "tmdb_id": 99, "season": 1, "episode": 1},
+    ]
+
+    with (
+        patch("app.api.routes.asyncio.to_thread") as mock_to_thread,
+    ):
+        from app.api.validation import ToolDetectionResult
+
+        mock_to_thread.return_value = ToolDetectionResult(found=False, path=None, error="not found")
+
+        from app.services.config_service import update_config as update_db_config
+
+        await update_db_config(
+            contribution_pseudonym="test-pseudonym-nofpcalc",
+            enable_fingerprint_contributions=True,
+            fpcalc_path=None,  # no explicit config path either
+        )
+
+        resp = await client.post("/api/fingerprint/bootstrap/accept", json={"items": items})
+
+    assert resp.status_code == 400
+    assert "fpcalc" in resp.json()["detail"].lower()

--- a/backend/tests/integration/test_bootstrap_api.py
+++ b/backend/tests/integration/test_bootstrap_api.py
@@ -350,6 +350,122 @@ async def test_accept_partial_failure_does_not_abort_batch(client, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_accept_is_idempotent_on_duplicate_submit(client, tmp_path):
+    """Re-submitting the same items does not insert duplicate bootstrap rows.
+
+    Guards the double-click / retried-batch race: a second accept of an already
+    queued (tmdb_id, season, episode) counts as queued but writes no new row.
+    """
+    from app.matcher.chromaprint_extractor import ChromaprintResult
+
+    fake_result = ChromaprintResult(
+        hashes=[1, 2, 3, 4],
+        duration_seconds=42.0,
+        fpcalc_version="fpcalc version 1.5.1",
+    )
+
+    items = [
+        {"file": str(tmp_path / "ep1.mkv"), "tmdb_id": 95396, "season": 1, "episode": 1},
+        {"file": str(tmp_path / "ep2.mkv"), "tmdb_id": 95396, "season": 1, "episode": 2},
+    ]
+
+    with (
+        patch("app.api.routes.asyncio.to_thread") as mock_to_thread,
+        patch("app.matcher.chromaprint_extractor.ChromaprintExtractor") as MockExtractor,
+    ):
+        from app.api.validation import ToolDetectionResult
+
+        mock_to_thread.return_value = ToolDetectionResult(found=True, path="/usr/bin/fpcalc")
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract = AsyncMock(return_value=fake_result)
+        MockExtractor.return_value = mock_extractor_instance
+
+        from app.services.config_service import update_config as update_db_config
+
+        await update_db_config(
+            contribution_pseudonym="test-pseudonym-idempotent",
+            enable_fingerprint_contributions=True,
+            fpcalc_path=None,
+        )
+
+        first = await client.post("/api/fingerprint/bootstrap/accept", json={"items": items})
+        second = await client.post("/api/fingerprint/bootstrap/accept", json={"items": items})
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    # Both calls report the episodes as queued...
+    assert first.json()["queued"] == 2
+    assert second.json()["queued"] == 2
+    # ...but the second call inserts nothing new.
+    assert mock_extractor_instance.extract.await_count == 2
+
+    async with async_session() as session:
+        from sqlmodel import select as sqlmodel_select
+
+        from app.models.fingerprint import FingerprintContribution
+
+        rows = (
+            (
+                await session.execute(
+                    sqlmodel_select(FingerprintContribution).where(
+                        FingerprintContribution.match_source == "bootstrap"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2  # no duplicates despite two submits
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_symlink_escaping_root(client, tmp_path):
+    """A symlink inside the library pointing outside the root is not surfaced."""
+    library = tmp_path / "library"
+    library.mkdir()
+    (library / "Severance - S01E01.mkv").touch()
+
+    # A file living outside the scanned root.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "Secret - S09E09.mkv"
+    secret.touch()
+
+    # A symlink inside the library whose target escapes the root.
+    link = library / "Linked - S01E02.mkv"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+
+    with patch("app.api.routes.asyncio.to_thread") as mock_to_thread:
+
+        async def side_effect(fn, *args, **kwargs):
+            fn_name = getattr(fn, "__name__", "") or getattr(fn, "__qualname__", "")
+            if "fetch_show_id" in fn_name:
+                return "95396" if args and "Severance" in args[0] else None
+            if "fetch_show_details" in fn_name:
+                return {"name": "Severance", "first_air_date": "2022-02-18"}
+            return fn(*args, **kwargs)
+
+        mock_to_thread.side_effect = side_effect
+
+        resp = await client.post("/api/fingerprint/bootstrap/scan", json={"path": str(library)})
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    all_files = [e["file"] for s in data["shows"] for e in s["episodes"]] + [
+        u["file"] for u in data["unparseable"]
+    ]
+    # The escaping symlink (and its outside target) must not appear anywhere.
+    assert not any("Secret - S09E09" in f for f in all_files)
+    assert not any("Linked - S01E02" in f for f in all_files)
+    # The legitimate in-tree file is still surfaced.
+    assert any("Severance - S01E01" in f for f in all_files)
+
+
+@pytest.mark.asyncio
 async def test_accept_no_fpcalc_returns_400(client, tmp_path):
     """When fpcalc cannot be found, the endpoint returns 400 with a clear message."""
     items = [

--- a/docs/design_handoff_synapse/explorations/bootstrap-cards.html
+++ b/docs/design_handoff_synapse/explorations/bootstrap-cards.html
@@ -1,0 +1,923 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Bootstrap Library · Direction C · Grouped Cards</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+  --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+  --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;
+  --magenta:#ff3d7f;--magentaHi:#ff7aa5;--magentaDim:#d63171;
+  --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;
+  --red:#ff5555;--purple:#a78bfa;
+  --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+  --mono:"JetBrains Mono",ui-monospace,monospace;
+  --display:"Chakra Petch",ui-sans-serif,sans-serif;
+}
+html,body{height:100%;width:2560px}
+body{
+  background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;
+  line-height:1.5;-webkit-font-smoothing:antialiased;min-height:100vh;
+  background-image:
+    radial-gradient(circle,rgba(94,234,212,.15) 1px,transparent 1px),
+    repeating-linear-gradient(0deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px),
+    repeating-linear-gradient(90deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px);
+  background-size:20px 20px,100% 80px,80px 100%;
+}
+body::before{
+  content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px);
+}
+body::after{
+  content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background:
+    radial-gradient(1600px 900px at 20% 0%,rgba(94,234,212,.06),transparent 60%),
+    radial-gradient(1000px 600px at 80% 100%,rgba(255,61,127,.05),transparent 60%);
+}
+
+/* ── Layout ── */
+.page{
+  position:relative;z-index:1;display:flex;flex-direction:column;
+  min-height:100vh;width:2560px;
+}
+
+/* ── Topbar ── */
+.topbar{
+  height:48px;background:rgba(5,7,12,.94);border-bottom:1px solid var(--line);
+  display:flex;align-items:center;padding:0 40px;gap:24px;flex-shrink:0;position:sticky;top:0;z-index:50;
+}
+.logo{
+  font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:.22em;
+  color:var(--cyanHi);text-shadow:0 0 12px rgba(94,234,212,.45);text-transform:uppercase;
+}
+.topbar-sep{width:1px;height:20px;background:var(--line)}
+.nav-item{font-size:11px;letter-spacing:.16em;color:var(--inkDim);text-transform:uppercase;cursor:pointer}
+.nav-item.active{color:var(--cyan)}
+.topbar-grow{flex:1}
+.topbar-tag{
+  font-size:10px;letter-spacing:.18em;color:var(--magenta);text-transform:uppercase;
+  border:1px solid rgba(255,61,127,.3);padding:4px 10px;
+}
+
+/* ── Sticky top section ── */
+.sticky-top{
+  position:sticky;top:48px;z-index:40;
+  background:rgba(5,7,12,.95);backdrop-filter:blur(8px);
+  border-bottom:1px solid var(--lineMid);
+}
+
+/* ── Page header ── */
+.page-header{
+  padding:28px 40px 0;display:flex;align-items:flex-end;gap:32px;flex-wrap:wrap;
+}
+.page-title-group{flex:0 0 auto}
+.page-eyebrow{font-size:10px;letter-spacing:.22em;color:var(--magenta);text-transform:uppercase;margin-bottom:6px}
+.page-title{
+  font-family:var(--display);font-size:26px;font-weight:700;letter-spacing:.04em;
+  color:var(--cyanHi);text-shadow:0 0 18px rgba(94,234,212,.28);
+}
+
+/* ── Directory + scan strip (in sticky) ── */
+.dir-scan{
+  display:flex;align-items:center;gap:12px;padding:14px 40px;
+  border-top:1px solid var(--line);
+}
+.dir-label{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint);white-space:nowrap}
+.dir-input{
+  width:420px;background:var(--bg0);border:1px solid var(--lineMid);color:var(--ink);
+  font-family:var(--mono);font-size:12px;padding:8px 12px;outline:none;
+}
+.dir-input:focus{border-color:var(--cyan)}
+.btn{
+  font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+  padding:9px 16px;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;
+  background:transparent;transition:.14s;white-space:nowrap;
+}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.primary{background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600;box-shadow:0 0 10px rgba(94,234,212,.3)}
+.btn.green-sm{border-color:rgba(134,239,172,.45);color:var(--green);font-size:9px;padding:7px 12px}
+.btn.sm{padding:6px 11px;font-size:9px}
+
+/* ── Overall progress bar ── */
+.overall-bar{
+  padding:10px 40px 14px;display:flex;align-items:center;gap:16px;
+}
+.prog-track{flex:1;height:6px;background:var(--inkGhost);position:relative}
+.prog-fill{height:100%;background:linear-gradient(90deg,var(--cyanDim),var(--cyan));position:absolute;left:0;top:0}
+.prog-fill.with-review{
+  background:linear-gradient(90deg,var(--green) 0%,var(--green) 57%,var(--yellow) 57%,var(--yellow) 70%,var(--inkGhost) 70%);
+  width:100% !important;
+}
+.prog-legend{display:flex;gap:14px}
+.leg-item{display:flex;align-items:center;gap:5px;font-size:10px;letter-spacing:.12em;color:var(--inkFaint)}
+.leg-dot{width:6px;height:6px;border-radius:50%;background:currentColor}
+.leg-item .val{color:var(--ink);font-weight:600;margin-left:3px}
+
+/* ── Content layout: sidebar + main ── */
+.content-area{display:flex;gap:0;padding:28px 40px;align-items:flex-start}
+
+/* ── Left sidebar: show nav ── */
+.show-nav{
+  width:260px;flex-shrink:0;display:flex;flex-direction:column;gap:2px;
+  position:sticky;top:180px;max-height:calc(100vh - 220px);overflow-y:auto;
+  scrollbar-width:thin;scrollbar-color:rgba(94,234,212,.3) transparent;
+  margin-right:28px;
+}
+.show-nav::-webkit-scrollbar{width:3px}
+.show-nav::-webkit-scrollbar-thumb{background:rgba(94,234,212,.3)}
+.nav-show-item{
+  padding:10px 14px;border:1px solid var(--line);background:var(--bg1);
+  cursor:pointer;transition:.12s;display:flex;align-items:center;gap:10px;
+}
+.nav-show-item:hover{border-color:var(--lineMid);background:rgba(94,234,212,.04)}
+.nav-show-item.active{border-color:var(--lineHi);background:rgba(94,234,212,.07);border-left:2px solid var(--cyan)}
+.nav-show-name{font-size:11px;color:var(--ink);font-weight:500;flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.nav-show-ep-count{font-size:10px;color:var(--inkFaint);white-space:nowrap}
+.nav-prog{height:2px;background:var(--inkGhost);margin-top:4px;position:relative;flex:1}
+.nav-prog-fill{height:100%;position:absolute;left:0;top:0}
+.nav-prog-fill.full{background:var(--green)}
+.nav-prog-fill.partial{background:var(--yellow)}
+.nav-prog-fill.none{background:var(--inkFaint)}
+
+.nav-section-lbl{
+  font-size:9px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkFaint);
+  padding:12px 14px 6px;
+}
+
+/* ── Main area: show cards ── */
+.show-cards{flex:1;display:flex;flex-direction:column;gap:24px;min-width:0}
+
+/* ── Show card ── */
+.show-card{
+  background:linear-gradient(180deg,var(--bg2),var(--bg1));
+  border:1px solid var(--line);position:relative;
+}
+.show-card::before,.show-card::after{
+  content:"";position:absolute;width:10px;height:10px;
+  border:1px solid var(--cyan);pointer-events:none;z-index:2;
+}
+.show-card::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.show-card::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.show-card.complete::before,.show-card.complete::after{border-color:var(--green)}
+.show-card.complete{border-color:rgba(134,239,172,.25)}
+
+/* Card header */
+.card-header{
+  display:flex;align-items:stretch;gap:0;border-bottom:1px solid var(--line);
+}
+.card-poster{
+  width:72px;flex-shrink:0;background:var(--bg3);position:relative;overflow:hidden;
+  display:flex;align-items:center;justify-content:center;border-right:1px solid var(--line);
+}
+.poster-placeholder{
+  width:100%;height:100%;display:flex;flex-direction:column;align-items:center;
+  justify-content:center;gap:4px;background:linear-gradient(135deg,var(--bg3),var(--bg2));
+}
+.poster-icon{font-size:22px;opacity:.25}
+.poster-initials{
+  font-family:var(--display);font-size:10px;font-weight:700;letter-spacing:.12em;
+  color:var(--inkFaint);text-transform:uppercase;text-align:center;line-height:1.2;
+  padding:0 4px;
+}
+/* Fake poster color strip for visual variety */
+.show-card:nth-child(1) .card-poster{background:linear-gradient(180deg,#0d1a2a,#071019)}
+.show-card:nth-child(2) .card-poster{background:linear-gradient(180deg,#1a0d1a,#0f0710)}
+.show-card:nth-child(3) .card-poster{background:linear-gradient(180deg,#0d1a10,#071009)}
+.show-card:nth-child(4) .card-poster{background:linear-gradient(180deg,#1a1a0d,#0f0f07)}
+
+.card-meta{flex:1;padding:16px 20px;display:flex;flex-direction:column;justify-content:center;gap:4px}
+.card-show-name{
+  font-family:var(--display);font-size:16px;font-weight:600;letter-spacing:.06em;
+  color:var(--ink);
+}
+.card-show-sub{font-size:11px;color:var(--inkFaint);letter-spacing:.12em;margin-top:2px}
+
+/* Mini progress within header */
+.card-mini-prog{display:flex;align-items:center;gap:10px;margin-top:8px}
+.card-prog-track{flex:1;max-width:280px;height:3px;background:var(--inkGhost);position:relative}
+.card-prog-fill{height:100%;position:absolute;left:0;top:0}
+.card-prog-fill.green{background:var(--green)}
+.card-prog-fill.yellow{background:var(--yellow)}
+.card-prog-fill.zero{width:0}
+.card-prog-lbl{font-size:10px;color:var(--inkDim);white-space:nowrap}
+
+.card-header-actions{
+  padding:16px 20px;display:flex;flex-direction:column;align-items:flex-end;
+  justify-content:center;gap:8px;border-left:1px solid var(--line);min-width:220px;
+}
+
+/* Episode stats row */
+.ep-stats{display:flex;gap:12px}
+.ep-stat{display:flex;flex-direction:column;align-items:center;gap:1px}
+.ep-stat-val{font-size:18px;font-weight:700;font-family:var(--display);line-height:1;color:var(--ink)}
+.ep-stat-val.green{color:var(--green)}
+.ep-stat-val.yellow{color:var(--yellow)}
+.ep-stat-val.magenta{color:var(--magenta)}
+.ep-stat-lbl{font-size:8px;letter-spacing:.16em;text-transform:uppercase;color:var(--inkFaint)}
+
+/* Accept all button */
+.accept-all-btn{
+  font-family:var(--mono);font-size:9px;letter-spacing:.15em;text-transform:uppercase;
+  padding:7px 12px;border:1px solid rgba(134,239,172,.45);color:var(--green);
+  cursor:pointer;background:rgba(134,239,172,.05);transition:.14s;white-space:nowrap;
+}
+.accept-all-btn:hover{background:rgba(134,239,172,.12);border-color:var(--green)}
+.accept-all-btn.done{
+  border-color:var(--green);color:var(--green);background:rgba(134,239,172,.12);
+  pointer-events:none;
+}
+
+/* Toggle expand */
+.toggle-btn{
+  font-family:var(--mono);font-size:9px;letter-spacing:.14em;text-transform:uppercase;
+  padding:5px 10px;border:1px solid var(--line);color:var(--inkFaint);cursor:pointer;
+  background:transparent;transition:.12s;
+}
+.toggle-btn:hover{border-color:var(--lineMid);color:var(--inkDim)}
+
+/* ── Episode list (expanded) ── */
+.ep-list{border-top:1px solid var(--line)}
+.ep-col-header{
+  display:grid;
+  grid-template-columns:48px 1fr 180px 110px 90px 160px;
+  gap:0;padding:8px 16px;
+  background:rgba(94,234,212,.04);border-bottom:1px solid var(--line);
+}
+.col-lbl{font-size:9px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint)}
+
+.ep-row{
+  display:grid;
+  grid-template-columns:48px 1fr 180px 110px 90px 160px;
+  gap:0;align-items:center;min-height:46px;border-bottom:1px solid var(--line);transition:background .1s;
+}
+.ep-row:last-child{border-bottom:0}
+.ep-row:hover{background:rgba(94,234,212,.03)}
+.ep-row.accepted{background:rgba(134,239,172,.03)}
+.ep-row.skipped{opacity:.38}
+.ep-row.flagged{background:rgba(253,224,71,.03)}
+
+.ep-cell{padding:7px 16px;display:flex;align-items:center;gap:8px;min-width:0}
+.ep-num{
+  font-size:10px;color:var(--inkFaint);font-family:var(--mono);
+  letter-spacing:.06em;text-align:center;
+}
+.ep-file{
+  font-size:11px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.ep-path{font-size:10px;color:var(--inkFaint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.ep-code{font-size:12px;color:var(--cyan);font-weight:600;letter-spacing:.05em;font-family:var(--mono)}
+.ep-code.yellow{color:var(--yellow)}
+.ep-code.faint{color:var(--inkFaint)}
+
+.conf-cell{display:flex;align-items:center;gap:7px}
+.conf-track{width:50px;height:3px;background:var(--inkGhost);position:relative;flex-shrink:0}
+.conf-fill{height:100%;position:absolute;left:0;top:0}
+.conf-fill.hi{background:var(--green)}
+.conf-fill.mid{background:var(--yellow)}
+.conf-fill.lo{background:var(--magenta)}
+.conf-pct{font-size:11px;color:var(--inkDim);font-variant-numeric:tabular-nums}
+
+.badge{
+  display:inline-flex;align-items:center;gap:4px;font-size:9px;letter-spacing:.13em;
+  text-transform:uppercase;padding:3px 7px;border:1px solid var(--line);
+}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.4);background:rgba(134,239,172,.06)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.4);background:rgba(253,224,71,.06)}
+.badge.magenta{color:var(--magentaHi);border-color:rgba(255,61,127,.4);background:rgba(255,61,127,.06)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.4);background:rgba(94,234,212,.06)}
+.badge.ghost{color:var(--inkFaint);border-color:var(--line)}
+.dot{width:5px;height:5px;border-radius:50%;background:currentColor;box-shadow:0 0 4px currentColor;flex-shrink:0}
+
+.ep-actions{display:flex;gap:5px;align-items:center;padding:7px 16px}
+.act-btn{
+  font-family:var(--mono);font-size:9px;letter-spacing:.11em;text-transform:uppercase;
+  padding:4px 8px;border:1px solid var(--line);color:var(--inkDim);cursor:pointer;
+  background:transparent;transition:.12s;
+}
+.act-btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.act-btn.accept{border-color:rgba(134,239,172,.45);color:var(--green)}
+.act-btn.accept:hover{background:rgba(134,239,172,.08)}
+.act-btn.accept.done{background:rgba(134,239,172,.09);border-color:var(--green);pointer-events:none}
+.act-btn.edit{border-color:rgba(253,224,71,.35);color:var(--yellow)}
+.act-btn.skip{border-color:rgba(255,85,85,.3);color:var(--red);opacity:.65}
+.act-btn.skip:hover{opacity:1;background:rgba(255,85,85,.06)}
+
+/* Collapsed summary strip */
+.card-collapsed-strip{
+  padding:12px 20px;display:flex;align-items:center;gap:16px;flex-wrap:wrap;
+  border-top:1px solid var(--line);background:rgba(94,234,212,.02);
+}
+.collapsed-ep-chips{display:flex;gap:6px;flex-wrap:wrap;flex:1}
+.ep-chip{
+  font-size:9px;letter-spacing:.08em;font-family:var(--mono);
+  padding:3px 7px;border:1px solid var(--line);color:var(--inkDim);
+}
+.ep-chip.green{border-color:rgba(134,239,172,.35);color:var(--greenDim)}
+.ep-chip.cyan{border-color:rgba(94,234,212,.3);color:var(--cyanDim)}
+.ep-chip.yellow{border-color:rgba(253,224,71,.35);color:var(--yellow)}
+.ep-chip.ghost{color:var(--inkFaint)}
+.collapsed-more{font-size:10px;color:var(--inkFaint);letter-spacing:.12em;align-self:center}
+
+/* ── Queue footer ── */
+.queue-bar{
+  position:sticky;bottom:0;z-index:40;
+  margin:0 40px;
+  background:rgba(10,14,24,.97);backdrop-filter:blur(6px);
+  border:1px solid var(--lineHi);border-top:2px solid var(--cyan);
+  display:flex;align-items:center;gap:16px;padding:14px 20px;
+  box-shadow:0 -4px 24px rgba(94,234,212,.1);
+}
+.queue-stat{font-size:11px;letter-spacing:.13em;color:var(--inkDim)}
+.queue-stat b{color:var(--ink)}
+.queue-stat.cyan b{color:var(--cyan)}
+.queue-stat.green b{color:var(--green)}
+.queue-stat.yellow b{color:var(--yellow)}
+.queue-sep{width:1px;height:18px;background:var(--lineMid)}
+.queue-grow{flex:1}
+.fp-label{font-size:10px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase}
+.fp-val{font-size:14px;font-weight:700;color:var(--cyanHi);font-family:var(--display);letter-spacing:.1em;margin-left:8px}
+</style>
+<script>
+function toggleExpand(id) {
+  var el = document.getElementById(id);
+  var btn = document.getElementById('toggle-' + id);
+  if (el.style.display === 'none') {
+    el.style.display = 'block';
+    btn.textContent = '▲ Collapse';
+  } else {
+    el.style.display = 'none';
+    btn.textContent = '▼ Expand';
+  }
+}
+</script>
+</head>
+<body>
+
+<div class="page">
+
+  <!-- Topbar -->
+  <div class="topbar">
+    <div class="logo">ENGRAM</div>
+    <div class="topbar-sep"></div>
+    <div class="nav-item">Dashboard</div>
+    <div class="nav-item">Review</div>
+    <div class="nav-item">History</div>
+    <div class="nav-item active">Library Bootstrap</div>
+    <div class="topbar-grow"></div>
+    <div class="topbar-tag">Beta Feature</div>
+  </div>
+
+  <!-- Sticky top -->
+  <div class="sticky-top">
+    <!-- Page header -->
+    <div class="page-header">
+      <div class="page-title-group">
+        <div class="page-eyebrow">Fingerprint Network · Seed Catalog</div>
+        <div class="page-title">Bootstrap from Library</div>
+      </div>
+      <div style="flex:1"></div>
+      <div style="display:flex;gap:10px;padding-bottom:2px">
+        <button class="btn" style="border-color:rgba(255,61,127,.4);color:var(--magenta)">Discard Session</button>
+        <button class="btn primary">Queue All Accepted →</button>
+      </div>
+    </div>
+
+    <!-- Dir + scan -->
+    <div class="dir-scan">
+      <div class="dir-label">Source</div>
+      <input class="dir-input" type="text" value="D:\TV" />
+      <button class="btn">Browse…</button>
+      <button class="btn primary">▶ Re-Scan</button>
+      <div style="width:1px;height:18px;background:var(--line);margin:0 4px"></div>
+      <div style="font-size:10px;color:var(--inkFaint)">Scan complete · 6 shows · <span style="color:var(--ink)">187</span> files</div>
+      <div style="flex:1"></div>
+      <button class="btn green-sm">✓ Accept All High Confidence (142)</button>
+    </div>
+
+    <!-- Overall progress -->
+    <div class="overall-bar">
+      <div style="font-size:10px;letter-spacing:.14em;color:var(--inkFaint);white-space:nowrap;text-transform:uppercase">Overall</div>
+      <div class="prog-track">
+        <div class="prog-fill with-review"></div>
+      </div>
+      <div class="prog-legend">
+        <div class="leg-item" style="color:var(--green)"><div class="leg-dot"></div>Accepted <span class="val">107</span></div>
+        <div class="leg-item" style="color:var(--yellow)"><div class="leg-dot"></div>Review <span class="val">32</span></div>
+        <div class="leg-item" style="color:var(--inkFaint)"><div class="leg-dot"></div>Pending <span class="val">48</span></div>
+      </div>
+    </div>
+  </div><!-- /sticky-top -->
+
+  <!-- Content area -->
+  <div class="content-area">
+
+    <!-- Left nav -->
+    <div class="show-nav">
+      <div class="nav-section-lbl">Shows (6)</div>
+
+      <div class="nav-show-item active">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">Severance</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill full" style="width:100%"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count" style="color:var(--green)">18/18</div>
+      </div>
+
+      <div class="nav-show-item">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">Arrested Development</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill partial" style="width:44%"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count" style="color:var(--yellow)">36/82</div>
+      </div>
+
+      <div class="nav-show-item">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">The Bear</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill partial" style="width:72%"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count" style="color:var(--yellow)">19/26</div>
+      </div>
+
+      <div class="nav-show-item">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">Succession</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill none" style="width:0"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count">0/39</div>
+      </div>
+
+      <div class="nav-show-item">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">The Wire</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill none" style="width:0"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count">0/60</div>
+      </div>
+
+      <div class="nav-show-item">
+        <div style="display:flex;flex-direction:column;flex:1;gap:3px;min-width:0">
+          <div class="nav-show-name">Parks &amp; Recreation</div>
+          <div style="display:flex;align-items:center;gap:6px">
+            <div class="nav-prog" style="width:100%"><div class="nav-prog-fill full" style="width:100%"></div></div>
+          </div>
+        </div>
+        <div class="nav-show-ep-count" style="color:var(--green)">125/125</div>
+      </div>
+
+    </div><!-- /show-nav -->
+
+    <!-- Show cards -->
+    <div class="show-cards">
+
+      <!-- ───────────────── CARD 1: Severance ───────────────── -->
+      <div class="show-card complete">
+        <div class="card-header">
+          <div class="card-poster">
+            <div class="poster-placeholder">
+              <div class="poster-icon">📺</div>
+              <div class="poster-initials">SVR</div>
+            </div>
+          </div>
+          <div class="card-meta">
+            <div class="card-show-name">Severance</div>
+            <div class="card-show-sub">2 Seasons · 18 files found · Apple TV+</div>
+            <div class="card-mini-prog">
+              <div class="card-prog-track">
+                <div class="card-prog-fill green" style="width:100%"></div>
+              </div>
+              <div class="card-prog-lbl" style="color:var(--green)">18 / 18 accepted</div>
+            </div>
+          </div>
+          <div class="card-header-actions">
+            <div class="ep-stats">
+              <div class="ep-stat">
+                <div class="ep-stat-val green">18</div>
+                <div class="ep-stat-lbl">Accepted</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val">0</div>
+                <div class="ep-stat-lbl">Review</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val">0</div>
+                <div class="ep-stat-lbl">Unmatched</div>
+              </div>
+            </div>
+            <button class="accept-all-btn done">✓ All Accepted</button>
+            <button class="toggle-btn" id="toggle-sev" onclick="toggleExpand('sev')">▼ Expand</button>
+          </div>
+        </div>
+
+        <!-- Collapsed strip showing episode chips -->
+        <div class="card-collapsed-strip" id="sev-strip">
+          <div class="collapsed-ep-chips">
+            <span class="ep-chip green">S01E01</span><span class="ep-chip green">S01E02</span>
+            <span class="ep-chip green">S01E03</span><span class="ep-chip green">S01E04</span>
+            <span class="ep-chip green">S01E05</span><span class="ep-chip green">S01E06</span>
+            <span class="ep-chip green">S01E07</span><span class="ep-chip green">S01E08</span>
+            <span class="ep-chip green">S01E09</span><span class="ep-chip green">S02E01</span>
+            <span class="ep-chip green">S02E02</span><span class="ep-chip green">S02E03</span>
+          </div>
+          <div class="collapsed-more">+6 more</div>
+        </div>
+
+        <!-- Expanded episode list (hidden by default) -->
+        <div class="ep-list" id="sev" style="display:none">
+          <div class="ep-col-header">
+            <div class="col-lbl">#</div>
+            <div class="col-lbl">File</div>
+            <div class="col-lbl">Episode</div>
+            <div class="col-lbl">TMDB Conf.</div>
+            <div class="col-lbl">Status</div>
+            <div class="col-lbl">Actions</div>
+          </div>
+          <div class="ep-row accepted">
+            <div class="ep-cell"><span class="ep-num">S01E01</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Severance.S01E01.Good.News.About.Hell.mkv</span>
+              <span class="ep-path">D:\TV\Severance\Season 1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E01</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:94%"></div></div><span class="conf-pct">94%</span></div></div>
+            <div class="ep-cell"><span class="badge green"><span class="dot"></span>Accepted</span></div>
+            <div class="ep-actions"><button class="act-btn accept done">✓ Done</button></div>
+          </div>
+          <div class="ep-row accepted">
+            <div class="ep-cell"><span class="ep-num">S01E07</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Severance_S01E07_Defiant_Jazz.mkv</span>
+              <span class="ep-path">D:\TV\Severance\Season 1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E07</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:88%"></div></div><span class="conf-pct">88%</span></div></div>
+            <div class="ep-cell"><span class="badge green"><span class="dot"></span>Accepted</span></div>
+            <div class="ep-actions"><button class="act-btn accept done">✓ Done</button></div>
+          </div>
+        </div>
+      </div><!-- /show-card severance -->
+
+
+      <!-- ───────────────── CARD 2: Arrested Development ───────────────── -->
+      <div class="show-card">
+        <div class="card-header">
+          <div class="card-poster">
+            <div class="poster-placeholder">
+              <div class="poster-icon">📺</div>
+              <div class="poster-initials">AD</div>
+            </div>
+          </div>
+          <div class="card-meta">
+            <div class="card-show-name">Arrested Development</div>
+            <div class="card-show-sub">5 Seasons · 82 files found · Netflix / Fox</div>
+            <div class="card-mini-prog">
+              <div class="card-prog-track">
+                <div class="card-prog-fill yellow" style="width:44%"></div>
+              </div>
+              <div class="card-prog-lbl" style="color:var(--yellow)">36 / 82 accepted</div>
+            </div>
+          </div>
+          <div class="card-header-actions">
+            <div class="ep-stats">
+              <div class="ep-stat">
+                <div class="ep-stat-val green">36</div>
+                <div class="ep-stat-lbl">Accepted</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val yellow">14</div>
+                <div class="ep-stat-lbl">Review</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val magenta">3</div>
+                <div class="ep-stat-lbl">Unmatched</div>
+              </div>
+            </div>
+            <button class="accept-all-btn">✓ Accept All High Conf. (36)</button>
+            <button class="toggle-btn" id="toggle-ad" onclick="toggleExpand('ad')">▼ Expand</button>
+          </div>
+        </div>
+
+        <!-- Collapsed -->
+        <div class="card-collapsed-strip">
+          <div class="collapsed-ep-chips">
+            <span class="ep-chip green">S01E01</span>
+            <span class="ep-chip yellow">S01E02</span>
+            <span class="ep-chip green">S01E03</span>
+            <span class="ep-chip green">S01E04</span>
+            <span class="ep-chip cyan">S01E05</span>
+            <span class="ep-chip green">S01E06</span>
+            <span class="ep-chip yellow">S01E07</span>
+            <span class="ep-chip ghost">S01E08 ?</span>
+            <span class="ep-chip green">S02E01</span>
+            <span class="ep-chip green">S02E02</span>
+            <span class="ep-chip yellow">S02E03</span>
+            <span class="ep-chip cyan">S02E04</span>
+          </div>
+          <div class="collapsed-more">+70 more</div>
+        </div>
+
+        <!-- Expanded episode list -->
+        <div class="ep-list" id="ad">
+          <div class="ep-col-header">
+            <div class="col-lbl">#</div>
+            <div class="col-lbl">File</div>
+            <div class="col-lbl">Episode</div>
+            <div class="col-lbl">TMDB Conf.</div>
+            <div class="col-lbl">Status</div>
+            <div class="col-lbl">Actions</div>
+          </div>
+
+          <div class="ep-row accepted">
+            <div class="ep-cell"><span class="ep-num">S01E01</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Arrested.Development.1x01.mp4</span>
+              <span class="ep-path">D:\TV\AD\S1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E01</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:91%"></div></div><span class="conf-pct">91%</span></div></div>
+            <div class="ep-cell"><span class="badge green"><span class="dot"></span>Accepted</span></div>
+            <div class="ep-actions"><button class="act-btn accept done">✓ Done</button></div>
+          </div>
+
+          <div class="ep-row flagged">
+            <div class="ep-cell"><span class="ep-num">S01E02</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">AD_S01E02_Pilot.mkv</span>
+              <span class="ep-path">D:\TV\AD\S1\</span>
+            </div>
+            <div class="ep-cell">
+              <span class="ep-code yellow">S01E02</span>
+              <span class="badge yellow" style="font-size:8px;padding:2px 5px;margin-left:6px">conflict</span>
+            </div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill mid" style="width:47%"></div></div><span class="conf-pct">47%</span></div></div>
+            <div class="ep-cell"><span class="badge yellow"><span class="dot"></span>Review</span></div>
+            <div class="ep-actions">
+              <button class="act-btn accept">✓ Accept</button>
+              <button class="act-btn edit">✎</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+
+          <div class="ep-row">
+            <div class="ep-cell"><span class="ep-num">S01E03</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Arrested.Development.S01E03.Bringing.Up.Buster.mkv</span>
+              <span class="ep-path">D:\TV\AD\S1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E03</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:89%"></div></div><span class="conf-pct">89%</span></div></div>
+            <div class="ep-cell"><span class="badge cyan"><span class="dot"></span>High Conf.</span></div>
+            <div class="ep-actions">
+              <button class="act-btn accept">✓ Accept</button>
+              <button class="act-btn edit">✎</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+
+          <div class="ep-row">
+            <div class="ep-cell"><span class="ep-num">—</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">UNKNOWN_EPISODE_HDR.mkv</span>
+              <span class="ep-path">D:\TV\AD\misc\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code faint">—</span></div>
+            <div class="ep-cell"><span class="badge magenta"><span class="dot"></span>No match</span></div>
+            <div class="ep-cell"><span class="badge magenta"><span class="dot"></span>Unmatched</span></div>
+            <div class="ep-actions">
+              <button class="act-btn edit">✎ Assign</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+
+          <div class="ep-row skipped">
+            <div class="ep-cell"><span class="ep-num">—</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Featurette_MakingOf.mkv</span>
+              <span class="ep-path">D:\TV\AD\Extras\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code faint">—</span></div>
+            <div class="ep-cell"><span style="color:var(--inkFaint);font-size:11px">—</span></div>
+            <div class="ep-cell"><span class="badge ghost">Skipped</span></div>
+            <div class="ep-actions"><button class="act-btn" style="font-size:9px">↩ Restore</button></div>
+          </div>
+
+        </div>
+      </div><!-- /show-card AD -->
+
+
+      <!-- ───────────────── CARD 3: The Bear ───────────────── -->
+      <div class="show-card">
+        <div class="card-header">
+          <div class="card-poster">
+            <div class="poster-placeholder">
+              <div class="poster-icon">📺</div>
+              <div class="poster-initials">TB</div>
+            </div>
+          </div>
+          <div class="card-meta">
+            <div class="card-show-name">The Bear</div>
+            <div class="card-show-sub">3 Seasons · 26 files found · FX / Hulu</div>
+            <div class="card-mini-prog">
+              <div class="card-prog-track">
+                <div class="card-prog-fill yellow" style="width:72%"></div>
+              </div>
+              <div class="card-prog-lbl" style="color:var(--yellow)">19 / 26 accepted</div>
+            </div>
+          </div>
+          <div class="card-header-actions">
+            <div class="ep-stats">
+              <div class="ep-stat">
+                <div class="ep-stat-val green">19</div>
+                <div class="ep-stat-lbl">Accepted</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val yellow">6</div>
+                <div class="ep-stat-lbl">Review</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val">1</div>
+                <div class="ep-stat-lbl">Unmatched</div>
+              </div>
+            </div>
+            <button class="accept-all-btn">✓ Accept All High Conf. (19)</button>
+            <button class="toggle-btn" id="toggle-bear" onclick="toggleExpand('bear')">▲ Collapse</button>
+          </div>
+        </div>
+
+        <!-- Expanded by default for demo -->
+        <div class="ep-list" id="bear">
+          <div class="ep-col-header">
+            <div class="col-lbl">#</div>
+            <div class="col-lbl">File</div>
+            <div class="col-lbl">Episode</div>
+            <div class="col-lbl">TMDB Conf.</div>
+            <div class="col-lbl">Status</div>
+            <div class="col-lbl">Actions</div>
+          </div>
+
+          <div class="ep-row accepted">
+            <div class="ep-cell"><span class="ep-num">S01E01</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">TheBear.S01E01.SystemError.mkv</span>
+              <span class="ep-path">D:\TV\The Bear\Season 1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E01</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:97%"></div></div><span class="conf-pct">97%</span></div></div>
+            <div class="ep-cell"><span class="badge green"><span class="dot"></span>Accepted</span></div>
+            <div class="ep-actions"><button class="act-btn accept done">✓ Done</button></div>
+          </div>
+
+          <div class="ep-row">
+            <div class="ep-cell"><span class="ep-num">S02E06</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">The.Bear.S02E06.Fishes.mkv</span>
+              <span class="ep-path">D:\TV\The Bear\S2\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S02E06</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:98%"></div></div><span class="conf-pct">98%</span></div></div>
+            <div class="ep-cell"><span class="badge cyan"><span class="dot"></span>High Conf.</span></div>
+            <div class="ep-actions">
+              <button class="act-btn accept">✓ Accept</button>
+              <button class="act-btn edit">✎</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+
+          <div class="ep-row">
+            <div class="ep-cell"><span class="ep-num">S03E01</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">The.Bear.S03E01.Tomorrow.mkv</span>
+              <span class="ep-path">D:\TV\The Bear\Season 3\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S03E01</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:95%"></div></div><span class="conf-pct">95%</span></div></div>
+            <div class="ep-cell"><span class="badge cyan"><span class="dot"></span>High Conf.</span></div>
+            <div class="ep-actions">
+              <button class="act-btn accept">✓ Accept</button>
+              <button class="act-btn edit">✎</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+
+        </div>
+      </div><!-- /show-card The Bear -->
+
+
+      <!-- ───────────────── CARD 4: Succession (collapsed, 0 accepted) ───────────────── -->
+      <div class="show-card">
+        <div class="card-header">
+          <div class="card-poster">
+            <div class="poster-placeholder">
+              <div class="poster-icon">📺</div>
+              <div class="poster-initials">SUC</div>
+            </div>
+          </div>
+          <div class="card-meta">
+            <div class="card-show-name">Succession</div>
+            <div class="card-show-sub">4 Seasons · 39 files found · HBO</div>
+            <div class="card-mini-prog">
+              <div class="card-prog-track">
+                <div class="card-prog-fill green" style="width:0"></div>
+              </div>
+              <div class="card-prog-lbl" style="color:var(--inkDim)">0 / 39 accepted</div>
+            </div>
+          </div>
+          <div class="card-header-actions">
+            <div class="ep-stats">
+              <div class="ep-stat">
+                <div class="ep-stat-val">0</div>
+                <div class="ep-stat-lbl">Accepted</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val cyan">39</div>
+                <div class="ep-stat-lbl">High Conf.</div>
+              </div>
+              <div class="ep-stat">
+                <div class="ep-stat-val">0</div>
+                <div class="ep-stat-lbl">Unmatched</div>
+              </div>
+            </div>
+            <button class="accept-all-btn">✓ Accept All High Conf. (39)</button>
+            <button class="toggle-btn" id="toggle-suc" onclick="toggleExpand('suc')">▼ Expand</button>
+          </div>
+        </div>
+        <div class="card-collapsed-strip">
+          <div class="collapsed-ep-chips">
+            <span class="ep-chip cyan">S01E01</span><span class="ep-chip cyan">S01E02</span>
+            <span class="ep-chip cyan">S01E03</span><span class="ep-chip cyan">S01E04</span>
+            <span class="ep-chip cyan">S01E05</span><span class="ep-chip cyan">S02E01</span>
+            <span class="ep-chip cyan">S02E02</span><span class="ep-chip cyan">S02E03</span>
+          </div>
+          <div class="collapsed-more">+31 more · all high confidence</div>
+        </div>
+        <div class="ep-list" id="suc" style="display:none">
+          <div class="ep-col-header">
+            <div class="col-lbl">#</div><div class="col-lbl">File</div>
+            <div class="col-lbl">Episode</div><div class="col-lbl">TMDB Conf.</div>
+            <div class="col-lbl">Status</div><div class="col-lbl">Actions</div>
+          </div>
+          <div class="ep-row">
+            <div class="ep-cell"><span class="ep-num">S01E01</span></div>
+            <div class="ep-cell" style="flex-direction:column;align-items:flex-start;gap:1px">
+              <span class="ep-file">Succession.S01E01.Celebration.mkv</span>
+              <span class="ep-path">D:\TV\Succession\Season 1\</span>
+            </div>
+            <div class="ep-cell"><span class="ep-code">S01E01</span></div>
+            <div class="ep-cell"><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:96%"></div></div><span class="conf-pct">96%</span></div></div>
+            <div class="ep-cell"><span class="badge cyan"><span class="dot"></span>High Conf.</span></div>
+            <div class="ep-actions">
+              <button class="act-btn accept">✓ Accept</button>
+              <button class="act-btn edit">✎</button>
+              <button class="act-btn skip">Skip</button>
+            </div>
+          </div>
+        </div>
+      </div><!-- /succession -->
+
+      <div style="height:80px"></div>
+
+    </div><!-- /show-cards -->
+  </div><!-- /content-area -->
+
+  <!-- Queue footer -->
+  <div class="queue-bar">
+    <div class="queue-stat cyan">6 shows · <b>187</b> files</div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat green">Accepted: <b>55</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat yellow">Needs Review: <b>20</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat" style="color:var(--inkDim)">Pending: <b>108</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat" style="color:var(--magentaHi)">Unmatched: <b>4</b></div>
+    <div class="queue-grow"></div>
+    <div class="fp-label">Queue for fingerprinting:</div>
+    <div class="fp-val">55 files</div>
+    <div style="width:1px;height:24px;background:var(--lineMid);margin:0 8px"></div>
+    <button class="btn" style="border-color:rgba(134,239,172,.45);color:var(--green);padding:10px 18px">
+      Accept All High Confidence (142)
+    </button>
+    <button class="btn primary" style="padding:11px 22px;font-size:11px">
+      Queue 55 Accepted for Fingerprinting →
+    </button>
+  </div>
+
+</div><!-- /page -->
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/bootstrap-table.html
+++ b/docs/design_handoff_synapse/explorations/bootstrap-table.html
@@ -1,0 +1,697 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Bootstrap Library · Direction B · Dense Table</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+  --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+  --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;
+  --magenta:#ff3d7f;--magentaHi:#ff7aa5;--magentaDim:#d63171;
+  --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;
+  --red:#ff5555;--purple:#a78bfa;
+  --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+  --mono:"JetBrains Mono",ui-monospace,monospace;
+  --display:"Chakra Petch",ui-sans-serif,sans-serif;
+}
+html,body{height:100%;width:2560px}
+body{
+  background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;
+  line-height:1.5;-webkit-font-smoothing:antialiased;min-height:100vh;
+  background-image:
+    radial-gradient(circle,rgba(94,234,212,.15) 1px,transparent 1px),
+    repeating-linear-gradient(0deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px),
+    repeating-linear-gradient(90deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px);
+  background-size:20px 20px,100% 80px,80px 100%;
+}
+body::before{
+  content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px);
+}
+/* Subtle radial glow corners */
+body::after{
+  content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background:
+    radial-gradient(1600px 800px at 0% 0%,rgba(94,234,212,.07),transparent 60%),
+    radial-gradient(1200px 700px at 100% 100%,rgba(255,61,127,.05),transparent 60%);
+}
+
+/* ── Layout ── */
+.page{
+  position:relative;z-index:1;display:flex;flex-direction:column;
+  min-height:100vh;width:2560px;
+}
+
+/* ── Topbar ── */
+.topbar{
+  height:48px;background:rgba(5,7,12,.94);border-bottom:1px solid var(--line);
+  display:flex;align-items:center;padding:0 40px;gap:24px;flex-shrink:0;position:sticky;top:0;z-index:50;
+}
+.logo{
+  font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:.22em;
+  color:var(--cyanHi);text-shadow:0 0 12px rgba(94,234,212,.45);text-transform:uppercase;
+}
+.topbar-sep{width:1px;height:20px;background:var(--line)}
+.nav-item{font-size:11px;letter-spacing:.16em;color:var(--inkDim);text-transform:uppercase;cursor:pointer}
+.nav-item.active{color:var(--cyan)}
+.topbar-grow{flex:1}
+.topbar-tag{
+  font-size:10px;letter-spacing:.18em;color:var(--magenta);text-transform:uppercase;
+  border:1px solid rgba(255,61,127,.3);padding:4px 10px;
+}
+
+/* ── Page header ── */
+.page-header{
+  padding:36px 40px 0;display:flex;align-items:flex-end;justify-content:space-between;
+}
+.page-title-group{}
+.page-eyebrow{
+  font-size:10px;letter-spacing:.22em;color:var(--magenta);text-transform:uppercase;margin-bottom:8px;
+}
+.page-title{
+  font-family:var(--display);font-size:28px;font-weight:700;letter-spacing:.04em;
+  color:var(--cyanHi);text-shadow:0 0 20px rgba(94,234,212,.3);
+}
+.page-sub{font-size:12px;letter-spacing:.13em;color:var(--inkDim);text-transform:uppercase;margin-top:6px}
+.page-actions{display:flex;gap:10px;align-items:center}
+
+/* ── Directory picker bar ── */
+.dir-bar{
+  margin:28px 40px 0;display:flex;align-items:center;gap:12px;
+  padding:14px 18px;
+  background:linear-gradient(180deg,var(--bg2),var(--bg1));
+  border:1px solid var(--lineHi);
+  position:relative;
+}
+.dir-bar::before,.dir-bar::after{
+  content:"";position:absolute;width:9px;height:9px;border:1px solid var(--cyan);pointer-events:none;
+}
+.dir-bar::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.dir-bar::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+.dir-label{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint);white-space:nowrap}
+.dir-input{
+  flex:1;background:var(--bg0);border:1px solid var(--lineMid);color:var(--ink);
+  font-family:var(--mono);font-size:12px;padding:8px 12px;outline:none;
+}
+.dir-input:focus{border-color:var(--cyan)}
+.btn{
+  font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+  padding:9px 16px;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;
+  background:transparent;transition:.14s;white-space:nowrap;
+}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.primary{
+  background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600;
+  box-shadow:0 0 10px rgba(94,234,212,.3);
+}
+.btn.primary:hover{box-shadow:0 0 18px rgba(94,234,212,.45)}
+.btn.green-outline{border-color:rgba(134,239,172,.5);color:var(--green)}
+.btn.green-outline:hover{background:rgba(134,239,172,.08)}
+.btn.magenta-outline{border-color:rgba(255,61,127,.45);color:var(--magenta)}
+.btn.sm{padding:6px 11px;font-size:9px}
+
+/* ── Scan progress strip ── */
+.scan-strip{
+  margin:12px 40px 0;padding:10px 16px;
+  background:rgba(94,234,212,.04);border:1px solid var(--line);
+  display:flex;align-items:center;gap:16px;
+}
+.scan-strip-label{font-size:10px;letter-spacing:.16em;color:var(--cyanDim);text-transform:uppercase}
+.scan-bar-wrap{flex:1;height:3px;background:var(--inkGhost);position:relative}
+.scan-bar-fill{height:100%;background:var(--cyanDim);position:absolute;left:0;top:0;width:93%}
+.scan-count{font-size:11px;color:var(--ink);white-space:nowrap;font-weight:600}
+.scan-sub{font-size:10px;color:var(--inkFaint)}
+
+/* ── Bulk action bar (sticky) ── */
+.bulk-bar{
+  position:sticky;top:48px;z-index:40;
+  margin:0 40px;
+  background:rgba(10,14,24,.96);backdrop-filter:blur(6px);
+  border:1px solid var(--lineHi);border-top:0;
+  display:flex;align-items:center;gap:12px;padding:10px 18px;
+  box-shadow:0 4px 20px rgba(0,0,0,.5);
+}
+.bulk-selected{
+  font-size:11px;font-weight:600;color:var(--cyan);letter-spacing:.12em;
+  display:flex;align-items:center;gap:8px;
+}
+.bulk-dot{width:6px;height:6px;border-radius:50%;background:var(--cyan);box-shadow:0 0 6px var(--cyan)}
+.bulk-sep{width:1px;height:18px;background:var(--lineMid)}
+.bulk-grow{flex:1}
+.bulk-note{font-size:10px;color:var(--inkFaint);letter-spacing:.12em}
+
+/* ── Filter row ── */
+.filter-row{
+  margin:16px 40px 0;display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+}
+.filter-tabs{display:flex;gap:0}
+.ftab{
+  font-size:9px;letter-spacing:.18em;text-transform:uppercase;padding:7px 14px;
+  border:1px solid var(--line);color:var(--inkDim);cursor:pointer;background:transparent;
+  border-right:0;transition:.12s;
+}
+.ftab:last-child{border-right:1px solid var(--line)}
+.ftab:hover{color:var(--ink);border-color:var(--lineMid)}
+.ftab.active{background:rgba(94,234,212,.08);border-color:var(--lineHi);color:var(--cyan)}
+.filter-grow{flex:1}
+.filter-search{
+  background:var(--bg1);border:1px solid var(--lineMid);color:var(--ink);
+  font-family:var(--mono);font-size:11px;padding:7px 12px;outline:none;width:280px;
+}
+.filter-search:focus{border-color:var(--cyan)}
+.filter-search::placeholder{color:var(--inkFaint)}
+.sort-lbl{font-size:10px;letter-spacing:.14em;color:var(--inkFaint);text-transform:uppercase}
+.sort-sel{
+  background:var(--bg1);border:1px solid var(--lineMid);color:var(--inkDim);
+  font-family:var(--mono);font-size:10px;padding:6px 10px;cursor:pointer;
+}
+
+/* ── Table ── */
+.tbl-wrap{margin:12px 40px 0;position:relative}
+.tbl-panel{
+  background:linear-gradient(180deg,var(--bg2),var(--bg1));
+  border:1px solid var(--line);position:relative;
+}
+.tbl-panel::before,.tbl-panel::after{
+  content:"";position:absolute;width:10px;height:10px;border:1px solid var(--cyan);pointer-events:none;z-index:2;
+}
+.tbl-panel::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.tbl-panel::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+
+.tbl{width:100%;border-collapse:collapse}
+.tbl th{
+  font-size:9px;letter-spacing:.2em;text-transform:uppercase;color:var(--inkFaint);
+  padding:11px 14px;border-bottom:1px solid var(--lineMid);text-align:left;
+  background:rgba(94,234,212,.04);font-weight:600;white-space:nowrap;
+}
+.tbl th.sortable{cursor:pointer;user-select:none}
+.tbl th.sortable:hover{color:var(--inkDim)}
+.tbl th.sorted{color:var(--cyan)}
+.sort-arrow{margin-left:4px;opacity:.6}
+
+.tbl td{
+  padding:9px 14px;border-bottom:1px solid var(--line);vertical-align:middle;
+  font-size:12px;
+}
+.tbl tr:last-child td{border-bottom:0}
+.tbl tr:hover td{background:rgba(94,234,212,.03)}
+.tbl tr.row-accepted td{background:rgba(134,239,172,.03)}
+.tbl tr.row-skipped td{opacity:.38}
+.tbl tr.row-flagged td{background:rgba(253,224,71,.03)}
+.tbl tr.row-selected td{background:rgba(94,234,212,.06)}
+.tbl tr.row-selected td:first-child{border-left:2px solid var(--cyan)}
+
+/* Checkbox */
+.chk{
+  width:15px;height:15px;border:1px solid var(--lineMid);background:transparent;
+  display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0;
+}
+.chk.checked{border-color:var(--cyan);background:rgba(94,234,212,.12)}
+.chk.checked::after{content:"✓";font-size:9px;color:var(--cyan)}
+
+/* File cell */
+.td-file{}
+.f-name{color:var(--ink);font-size:12px;font-weight:500;white-space:nowrap}
+.f-path{font-size:10px;color:var(--inkFaint);margin-top:1px;white-space:nowrap}
+
+/* Show cell */
+.td-show{white-space:nowrap;color:var(--ink)}
+
+/* Episode cell */
+.ep-code{
+  font-family:var(--mono);font-size:12px;font-weight:600;letter-spacing:.05em;
+  color:var(--cyan);white-space:nowrap;
+}
+.ep-code.yellow{color:var(--yellow)}
+.ep-code.faint{color:var(--inkFaint)}
+.ep-title{font-size:10px;color:var(--inkDim);margin-top:1px;white-space:nowrap;max-width:200px;overflow:hidden;text-overflow:ellipsis}
+
+/* Confidence cell */
+.conf-cell{display:flex;align-items:center;gap:8px;white-space:nowrap}
+.conf-track{width:60px;height:3px;background:var(--inkGhost);position:relative;flex-shrink:0}
+.conf-fill{height:100%;position:absolute;left:0;top:0}
+.conf-fill.hi{background:var(--green)}
+.conf-fill.mid{background:var(--yellow)}
+.conf-fill.lo{background:var(--magenta)}
+.conf-pct{font-size:11px;color:var(--inkDim);font-variant-numeric:tabular-nums}
+
+/* Status / badge */
+.badge{
+  display:inline-flex;align-items:center;gap:4px;font-size:9px;letter-spacing:.14em;
+  text-transform:uppercase;padding:3px 7px;border:1px solid var(--line);
+}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.4);background:rgba(134,239,172,.06)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.4);background:rgba(253,224,71,.06)}
+.badge.magenta{color:var(--magentaHi);border-color:rgba(255,61,127,.4);background:rgba(255,61,127,.06)}
+.badge.ghost{color:var(--inkFaint);border-color:var(--line);background:rgba(255,255,255,.02)}
+.badge.cyan{color:var(--cyan);border-color:rgba(94,234,212,.4);background:rgba(94,234,212,.06)}
+.dot{width:5px;height:5px;border-radius:50%;background:currentColor;box-shadow:0 0 5px currentColor;flex-shrink:0}
+
+/* Action cell */
+.td-actions{white-space:nowrap}
+.act-row{display:flex;gap:5px;align-items:center}
+.act-btn{
+  font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;
+  padding:5px 8px;border:1px solid var(--line);color:var(--inkDim);cursor:pointer;
+  background:transparent;transition:.12s;white-space:nowrap;
+}
+.act-btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.act-btn.accept{border-color:rgba(134,239,172,.45);color:var(--green)}
+.act-btn.accept:hover{background:rgba(134,239,172,.09)}
+.act-btn.accept.done{
+  background:rgba(134,239,172,.1);border-color:var(--green);color:var(--green);
+  pointer-events:none;
+}
+.act-btn.edit{border-color:rgba(253,224,71,.35);color:var(--yellow)}
+.act-btn.skip{border-color:rgba(255,85,85,.3);color:var(--red);opacity:.7}
+.act-btn.skip:hover{opacity:1;background:rgba(255,85,85,.07)}
+
+/* ── Footer / queue bar ── */
+.queue-bar{
+  position:sticky;bottom:0;z-index:40;
+  margin:0 40px;
+  background:rgba(10,14,24,.97);backdrop-filter:blur(6px);
+  border:1px solid var(--lineHi);border-top:2px solid var(--cyan);
+  display:flex;align-items:center;gap:16px;padding:14px 20px;
+  box-shadow:0 -4px 24px rgba(94,234,212,.1);
+}
+.queue-stat{font-size:11px;letter-spacing:.13em;color:var(--inkDim)}
+.queue-stat b{color:var(--ink)}
+.queue-stat.cyan b{color:var(--cyan)}
+.queue-stat.green b{color:var(--green)}
+.queue-stat.yellow b{color:var(--yellow)}
+.queue-sep{width:1px;height:18px;background:var(--lineMid)}
+.queue-grow{flex:1}
+.queue-fp-label{
+  font-size:10px;letter-spacing:.16em;color:var(--inkDim);text-transform:uppercase;
+}
+.queue-fp-val{
+  font-size:14px;font-weight:700;color:var(--cyanHi);
+  font-family:var(--display);letter-spacing:.1em;margin-left:8px;
+}
+</style>
+</head>
+<body>
+
+<div class="page">
+
+  <!-- Topbar -->
+  <div class="topbar">
+    <div class="logo">ENGRAM</div>
+    <div class="topbar-sep"></div>
+    <div class="nav-item">Dashboard</div>
+    <div class="nav-item">Review</div>
+    <div class="nav-item">History</div>
+    <div class="nav-item active">Library Bootstrap</div>
+    <div class="topbar-grow"></div>
+    <div class="topbar-tag">Beta Feature</div>
+  </div>
+
+  <!-- Page header -->
+  <div class="page-header">
+    <div class="page-title-group">
+      <div class="page-eyebrow">Fingerprint Network · Seed Catalog</div>
+      <div class="page-title">Bootstrap from Library</div>
+      <div class="page-sub">Scan existing TV files · Propose episode labels · Queue for fingerprinting</div>
+    </div>
+    <div class="page-actions">
+      <button class="btn magenta-outline">Discard Session</button>
+    </div>
+  </div>
+
+  <!-- Directory picker -->
+  <div class="dir-bar">
+    <div class="dir-label">Source Directory</div>
+    <input class="dir-input" type="text" value="D:\TV" />
+    <button class="btn">Browse…</button>
+    <button class="btn primary">▶ Re-Scan</button>
+    <div style="width:1px;height:20px;background:var(--line)"></div>
+    <div style="font-size:10px;color:var(--inkFaint);letter-spacing:.12em">Scanned <span style="color:var(--ink)">187</span> files · Completed</div>
+  </div>
+
+  <!-- Scan progress strip -->
+  <div class="scan-strip">
+    <div class="scan-strip-label">Scan Complete</div>
+    <div class="scan-bar-wrap"><div class="scan-bar-fill"></div></div>
+    <div class="scan-count">174 / 187 parsed</div>
+    <div style="width:1px;height:14px;background:var(--line)"></div>
+    <div class="scan-sub"><span style="color:var(--green)">142</span> high-conf · <span style="color:var(--yellow)">32</span> review · <span style="color:var(--magenta)">13</span> unmatched</div>
+  </div>
+
+  <!-- Bulk action bar -->
+  <div class="bulk-bar">
+    <div class="bulk-selected">
+      <div class="bulk-dot"></div>
+      47 selected
+    </div>
+    <div class="bulk-sep"></div>
+    <button class="btn sm green-outline">✓ Accept 47 Selected</button>
+    <button class="btn sm" style="border-color:rgba(255,85,85,.3);color:var(--red);font-size:9px;padding:6px 11px;">Skip 47 Selected</button>
+    <div class="bulk-grow"></div>
+    <div class="bulk-note">Shift-click to range-select · Ctrl-click individual rows</div>
+  </div>
+
+  <!-- Filter row -->
+  <div class="filter-row">
+    <div class="filter-tabs">
+      <button class="ftab active">All (187)</button>
+      <button class="ftab">Accepted (4)</button>
+      <button class="ftab">Needs Review (32)</button>
+      <button class="ftab">Unmatched (13)</button>
+      <button class="ftab">Skipped (1)</button>
+    </div>
+    <div class="filter-grow"></div>
+    <input class="filter-search" type="text" placeholder="Filter by file name, show, or episode…" />
+    <div class="sort-lbl">Sort by</div>
+    <select class="sort-sel">
+      <option>Show · Season · Episode</option>
+      <option>Confidence ↓</option>
+      <option>File Name</option>
+      <option>Status</option>
+    </select>
+  </div>
+
+  <!-- Table -->
+  <div class="tbl-wrap">
+  <div class="tbl-panel">
+  <table class="tbl">
+    <thead>
+      <tr>
+        <th style="width:32px"><div class="chk checked"></div></th>
+        <th class="sortable">File <span class="sort-arrow">↕</span></th>
+        <th class="sortable sorted">Show <span class="sort-arrow">↑</span></th>
+        <th class="sortable">Season / Episode <span class="sort-arrow">↕</span></th>
+        <th class="sortable">Episode Title <span class="sort-arrow">↕</span></th>
+        <th class="sortable">TMDB Conf. <span class="sort-arrow">↕</span></th>
+        <th>Status</th>
+        <th style="width:190px">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+
+      <!-- Accepted rows -->
+      <tr class="row-accepted row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">Severance.S01E01.Good.News.About.Hell.mkv</div>
+          <div class="f-path">D:\TV\Severance\Season 1\</div>
+        </td>
+        <td class="td-show">Severance</td>
+        <td><span class="ep-code">S01E01</span></td>
+        <td><div class="ep-title">Good News About Hell</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:94%"></div></div>
+            <span class="conf-pct">94%</span>
+          </div>
+        </td>
+        <td><span class="badge green"><span class="dot"></span>Accepted</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept done">✓ Accepted</button>
+          </div>
+        </td>
+      </tr>
+
+      <tr class="row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">Severance.1x02.BlueField.mkv</div>
+          <div class="f-path">D:\TV\Severance\Season 1\</div>
+        </td>
+        <td class="td-show">Severance</td>
+        <td><span class="ep-code yellow">S01E02</span></td>
+        <td><div class="ep-title">Half Loop</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill mid" style="width:61%"></div></div>
+            <span class="conf-pct">61%</span>
+          </div>
+        </td>
+        <td><span class="badge yellow"><span class="dot"></span>Review</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <tr class="row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">Severance_S01E07_Defiant_Jazz.mkv</div>
+          <div class="f-path">D:\TV\Severance\Season 1\</div>
+        </td>
+        <td class="td-show">Severance</td>
+        <td><span class="ep-code">S01E07</span></td>
+        <td><div class="ep-title">Defiant Jazz</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:88%"></div></div>
+            <span class="conf-pct">88%</span>
+          </div>
+        </td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <!-- Arrested Development -->
+      <tr class="row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">Arrested.Development.1x01.mp4</div>
+          <div class="f-path">D:\TV\AD\S1\</div>
+        </td>
+        <td class="td-show">Arrested Development</td>
+        <td><span class="ep-code">S01E01</span></td>
+        <td><div class="ep-title">Pilot</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:91%"></div></div>
+            <span class="conf-pct">91%</span>
+          </div>
+        </td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <tr class="row-flagged row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">AD_S01E02_Pilot.mkv</div>
+          <div class="f-path">D:\TV\AD\S1\</div>
+        </td>
+        <td class="td-show">Arrested Development</td>
+        <td>
+          <span class="ep-code yellow">S01E02</span>
+          <span class="badge yellow" style="font-size:8px;padding:2px 5px;margin-left:4px">conflict</span>
+        </td>
+        <td><div class="ep-title" style="color:var(--yellow)">Possible: Top Banana</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill mid" style="width:47%"></div></div>
+            <span class="conf-pct">47%</span>
+          </div>
+        </td>
+        <td><span class="badge yellow"><span class="dot"></span>Review</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <!-- The Bear -->
+      <tr class="row-accepted row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">TheBear.S01E01.SystemError.mkv</div>
+          <div class="f-path">D:\TV\The Bear\Season 1\</div>
+        </td>
+        <td class="td-show">The Bear</td>
+        <td><span class="ep-code">S01E01</span></td>
+        <td><div class="ep-title">System</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:97%"></div></div>
+            <span class="conf-pct">97%</span>
+          </div>
+        </td>
+        <td><span class="badge green"><span class="dot"></span>Accepted</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept done">✓ Accepted</button>
+          </div>
+        </td>
+      </tr>
+
+      <tr class="row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">The.Bear.S02E06.Fishes.mkv</div>
+          <div class="f-path">D:\TV\The Bear\S2\</div>
+        </td>
+        <td class="td-show">The Bear</td>
+        <td><span class="ep-code">S02E06</span></td>
+        <td><div class="ep-title">Fishes</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:98%"></div></div>
+            <span class="conf-pct">98%</span>
+          </div>
+        </td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <tr class="row-selected">
+        <td><div class="chk checked"></div></td>
+        <td class="td-file">
+          <div class="f-name">The.Bear.S03E01.Tomorrow.mkv</div>
+          <div class="f-path">D:\TV\The Bear\Season 3\</div>
+        </td>
+        <td class="td-show">The Bear</td>
+        <td><span class="ep-code">S03E01</span></td>
+        <td><div class="ep-title">Tomorrow</div></td>
+        <td>
+          <div class="conf-cell">
+            <div class="conf-track"><div class="conf-fill hi" style="width:95%"></div></div>
+            <span class="conf-pct">95%</span>
+          </div>
+        </td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <!-- Unmatched -->
+      <tr>
+        <td><div class="chk"></div></td>
+        <td class="td-file">
+          <div class="f-name">UNKNOWN_EPISODE_HDR.mkv</div>
+          <div class="f-path">D:\TV\Misc\</div>
+        </td>
+        <td class="td-show" style="color:var(--inkFaint);font-style:italic">No match</td>
+        <td><span class="ep-code faint">—</span></td>
+        <td><div class="ep-title" style="color:var(--inkFaint)">—</div></td>
+        <td><span class="badge magenta"><span class="dot"></span>Unmatched</span></td>
+        <td><span class="badge magenta"><span class="dot"></span>Unmatched</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn edit">✎ Assign</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </td>
+      </tr>
+
+      <!-- Skipped -->
+      <tr class="row-skipped">
+        <td><div class="chk"></div></td>
+        <td class="td-file">
+          <div class="f-name">Featurette_BehindScenes.mkv</div>
+          <div class="f-path">D:\TV\The Bear\Extras\</div>
+        </td>
+        <td class="td-show" style="color:var(--inkFaint)">—</td>
+        <td><span class="ep-code faint">—</span></td>
+        <td><div class="ep-title" style="color:var(--inkFaint)">—</div></td>
+        <td><span style="color:var(--inkFaint);font-size:11px">—</span></td>
+        <td><span class="badge ghost">Skipped</span></td>
+        <td class="td-actions">
+          <div class="act-row">
+            <button class="act-btn" style="font-size:9px">↩ Restore</button>
+          </div>
+        </td>
+      </tr>
+
+      <!-- More rows (faded hint) -->
+      <tr style="opacity:.4">
+        <td><div class="chk"></div></td>
+        <td class="td-file"><div class="f-name">Severance.S01E09.The.We_We_Are.mkv</div><div class="f-path">D:\TV\Severance\Season 1\</div></td>
+        <td>Severance</td>
+        <td><span class="ep-code">S01E09</span></td>
+        <td><div class="ep-title">The We We Are</div></td>
+        <td><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:96%"></div></div><span class="conf-pct">96%</span></div></td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions"><div class="act-row"><button class="act-btn accept">✓ Accept</button><button class="act-btn edit">✎</button><button class="act-btn skip">Skip</button></div></td>
+      </tr>
+
+      <tr style="opacity:.22">
+        <td><div class="chk"></div></td>
+        <td class="td-file"><div class="f-name">Arrested.Development.S02E04.Good.Grief.mkv</div><div class="f-path">D:\TV\AD\S2\</div></td>
+        <td>Arrested Development</td>
+        <td><span class="ep-code">S02E04</span></td>
+        <td><div class="ep-title">Good Grief</div></td>
+        <td><div class="conf-cell"><div class="conf-track"><div class="conf-fill hi" style="width:93%"></div></div><span class="conf-pct">93%</span></div></td>
+        <td><span class="badge cyan"><span class="dot"></span>High Conf.</span></td>
+        <td class="td-actions"><div class="act-row"><button class="act-btn accept">✓ Accept</button><button class="act-btn edit">✎</button><button class="act-btn skip">Skip</button></div></td>
+      </tr>
+
+    </tbody>
+  </table>
+  </div>
+  </div>
+
+  <div style="padding:12px 40px;font-size:10px;color:var(--inkFaint);letter-spacing:.12em">
+    Showing 12 of 187 files · <span style="color:var(--cyan);cursor:pointer">Load all</span>
+  </div>
+  <div style="height:80px"></div>
+
+  <!-- Queue footer bar -->
+  <div class="queue-bar">
+    <div class="queue-stat cyan">Total files: <b>187</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat green">Accepted: <b>4</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat yellow">Pending review: <b>32</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat" style="color:var(--inkDim)">Skipped: <b>1</b></div>
+    <div class="queue-sep"></div>
+    <div class="queue-stat" style="color:var(--magentaHi)">Unmatched: <b>13</b></div>
+    <div class="queue-grow"></div>
+    <div class="queue-fp-label">Queue for fingerprinting:</div>
+    <div class="queue-fp-val">4 files</div>
+    <div style="width:1px;height:24px;background:var(--lineMid);margin:0 8px"></div>
+    <button class="btn" style="border-color:rgba(134,239,172,.4);color:var(--green);padding:10px 20px;font-size:10px">
+      Accept All High Confidence (142)
+    </button>
+    <button class="btn primary" style="padding:11px 22px;font-size:11px">
+      Queue 4 Accepted for Fingerprinting →
+    </button>
+  </div>
+
+</div><!-- /page -->
+</body>
+</html>

--- a/docs/design_handoff_synapse/explorations/bootstrap-wizard.html
+++ b/docs/design_handoff_synapse/explorations/bootstrap-wizard.html
@@ -1,0 +1,593 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Bootstrap Library · Direction A · Wizard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg0:#05070c;--bg1:#0a0e18;--bg2:#121827;--bg3:#1a2234;
+  --ink:#e6ecf5;--inkDim:#8893a8;--inkFaint:#4a5369;--inkGhost:#2a3147;
+  --cyan:#5eead4;--cyanHi:#9ff8e8;--cyanDim:#2dd4bf;
+  --magenta:#ff3d7f;--magentaHi:#ff7aa5;--magentaDim:#d63171;
+  --yellow:#fde047;--amber:#fcd34d;--green:#86efac;--greenDim:#4ade80;
+  --red:#ff5555;--purple:#a78bfa;
+  --line:rgba(94,234,212,.14);--lineMid:rgba(94,234,212,.24);--lineHi:rgba(94,234,212,.42);
+  --mono:"JetBrains Mono",ui-monospace,monospace;
+  --display:"Chakra Petch",ui-sans-serif,sans-serif;
+}
+html,body{height:100%;width:100%}
+body{
+  background:var(--bg0);color:var(--ink);font-family:var(--mono);font-size:13px;
+  line-height:1.5;-webkit-font-smoothing:antialiased;
+  min-height:100vh;width:2560px;
+  background-image:
+    radial-gradient(circle,rgba(94,234,212,.15) 1px,transparent 1px),
+    repeating-linear-gradient(0deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px),
+    repeating-linear-gradient(90deg,transparent,transparent 79px,rgba(94,234,212,.06) 79px,rgba(94,234,212,.06) 80px);
+  background-size:20px 20px,100% 80px,80px 100%;
+}
+body::before{
+  content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background:repeating-linear-gradient(0deg,rgba(255,255,255,.013) 0 1px,transparent 1px 3px);
+}
+
+/* ── App shell ── */
+.app-shell{
+  position:relative;z-index:1;display:flex;flex-direction:column;
+  min-height:100vh;width:2560px;
+}
+.topbar{
+  height:48px;background:rgba(5,7,12,.92);border-bottom:1px solid var(--line);
+  display:flex;align-items:center;padding:0 32px;gap:20px;flex-shrink:0;
+}
+.topbar-logo{
+  font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:.22em;
+  color:var(--cyanHi);text-shadow:0 0 12px rgba(94,234,212,.5);text-transform:uppercase;
+}
+.topbar-sep{width:1px;height:20px;background:var(--line)}
+.topbar-nav{font-size:11px;letter-spacing:.16em;color:var(--inkDim);text-transform:uppercase;cursor:pointer}
+.topbar-nav.active{color:var(--cyan)}
+
+/* ── Backdrop overlay ── */
+.overlay{
+  position:fixed;inset:0;background:rgba(0,0,0,.82);backdrop-filter:blur(4px);
+  display:flex;align-items:center;justify-content:center;z-index:100;
+  padding:40px;
+}
+
+/* ── Wizard modal ── */
+.wizard{
+  width:1040px;max-height:calc(100vh - 80px);display:flex;flex-direction:column;
+  background:linear-gradient(180deg,rgba(18,24,39,.96),rgba(10,14,24,.99));
+  border:1px solid var(--lineHi);
+  box-shadow:0 0 40px rgba(94,234,212,.12),0 0 80px rgba(94,234,212,.06);
+  position:relative;overflow:hidden;
+}
+/* Corner ticks */
+.wizard::before,.wizard::after{
+  content:"";position:absolute;width:12px;height:12px;border:1px solid var(--cyan);
+  pointer-events:none;z-index:10;opacity:.8;
+}
+.wizard::before{top:-1px;left:-1px;border-right:0;border-bottom:0}
+.wizard::after{bottom:-1px;right:-1px;border-left:0;border-top:0}
+/* Scanline overlay */
+.wizard-scanlines{
+  position:absolute;inset:0;pointer-events:none;z-index:1;
+  background:repeating-linear-gradient(0deg,rgba(255,255,255,.009) 0 1px,transparent 1px 4px);
+}
+
+/* ── Wizard header ── */
+.wizard-header{
+  padding:22px 32px 20px;background:rgba(94,234,212,.03);
+  border-bottom:1px solid var(--line);position:relative;z-index:2;flex-shrink:0;
+  display:flex;align-items:flex-start;justify-content:space-between;
+}
+.wizard-title{
+  font-family:var(--display);font-size:18px;font-weight:700;letter-spacing:.22em;
+  color:var(--cyanHi);text-transform:uppercase;text-shadow:0 0 14px rgba(94,234,212,.45);
+}
+.wizard-subtitle{
+  font-size:11px;letter-spacing:.14em;color:var(--inkDim);text-transform:uppercase;
+  margin-top:4px;
+}
+.wizard-close{
+  background:transparent;border:1px solid rgba(255,61,127,.4);color:var(--magenta);
+  width:30px;height:30px;display:flex;align-items:center;justify-content:center;
+  cursor:pointer;font-size:16px;font-family:Arial,sans-serif;flex-shrink:0;
+}
+
+/* ── Step indicator ── */
+.steps-bar{
+  padding:18px 32px;border-bottom:1px solid var(--line);
+  display:flex;align-items:center;gap:0;flex-shrink:0;position:relative;z-index:2;
+  background:rgba(5,7,12,.3);
+}
+.step-item{display:flex;align-items:center;gap:0;flex:1}
+.step-item:last-child{flex:0 0 auto}
+.step-pip{
+  width:28px;height:28px;border:1px solid var(--line);
+  display:flex;align-items:center;justify-content:center;
+  font-size:10px;font-weight:600;letter-spacing:.1em;color:var(--inkFaint);
+  flex-shrink:0;position:relative;
+}
+.step-pip.done{border-color:var(--cyanDim);color:var(--cyanDim);background:rgba(94,234,212,.07)}
+.step-pip.active{border-color:var(--cyan);color:var(--bg0);background:var(--cyan);box-shadow:0 0 10px rgba(94,234,212,.4)}
+.step-label{
+  font-size:9px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint);
+  margin-left:8px;white-space:nowrap;
+}
+.step-label.done{color:var(--cyanDim)}
+.step-label.active{color:var(--ink)}
+.step-connector{flex:1;height:1px;background:var(--line);margin:0 12px}
+.step-connector.done{background:var(--cyanDim)}
+
+/* ── Wizard body ── */
+.wizard-body{
+  flex:1;overflow-y:auto;position:relative;z-index:2;
+  scrollbar-width:thin;scrollbar-color:rgba(94,234,212,.35) transparent;
+}
+.wizard-body::-webkit-scrollbar{width:4px}
+.wizard-body::-webkit-scrollbar-thumb{background:rgba(94,234,212,.35)}
+
+/* ── Step 3: Review list ── */
+.step-content{padding:28px 32px}
+
+/* Filter / stats bar */
+.review-stats-bar{
+  display:flex;align-items:center;gap:16px;margin-bottom:20px;
+  padding:12px 16px;background:rgba(94,234,212,.03);border:1px solid var(--line);
+  flex-wrap:wrap;
+}
+.stat-chip{
+  font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--inkDim);
+  display:flex;align-items:center;gap:6px;
+}
+.stat-val{color:var(--ink);font-weight:600}
+.stat-val.cyan{color:var(--cyan)}
+.stat-val.yellow{color:var(--yellow)}
+.stat-val.green{color:var(--green)}
+.stat-val.magenta{color:var(--magenta)}
+.stats-sep{width:1px;height:14px;background:var(--line)}
+.stats-spacer{flex:1}
+.filter-tabs{display:flex;gap:4px}
+.filter-tab{
+  font-size:9px;letter-spacing:.16em;text-transform:uppercase;padding:5px 10px;
+  border:1px solid var(--line);color:var(--inkDim);cursor:pointer;background:transparent;
+}
+.filter-tab.active{border-color:var(--lineHi);color:var(--cyan);background:rgba(94,234,212,.06)}
+
+/* Column header */
+.review-col-header{
+  display:grid;
+  grid-template-columns:1fr 220px 120px 110px 130px;
+  gap:0;padding:8px 14px;
+  border:1px solid var(--line);border-bottom:0;
+  background:rgba(94,234,212,.04);
+}
+.col-lbl{font-size:9px;letter-spacing:.18em;text-transform:uppercase;color:var(--inkFaint)}
+
+/* Row */
+.review-rows{border:1px solid var(--line)}
+.review-row{
+  display:grid;
+  grid-template-columns:1fr 220px 120px 110px 130px;
+  gap:0;align-items:center;
+  border-bottom:1px solid var(--line);min-height:52px;
+  transition:background .1s;
+}
+.review-row:last-child{border-bottom:0}
+.review-row:hover{background:rgba(94,234,212,.035)}
+.review-row.accepted{background:rgba(134,239,172,.04)}
+.review-row.skipped{opacity:.45}
+.review-row.editing{background:rgba(253,224,71,.04);outline:1px solid rgba(253,224,71,.2)}
+
+.row-cell{padding:8px 14px;display:flex;align-items:center;gap:8px;min-width:0}
+.row-cell.filename{flex-direction:column;align-items:flex-start;gap:2px}
+.file-name{
+  font-size:12px;color:var(--ink);white-space:nowrap;overflow:hidden;
+  text-overflow:ellipsis;max-width:100%;
+}
+.file-path{font-size:10px;color:var(--inkFaint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%}
+
+.show-name{font-size:12px;color:var(--ink);font-weight:500}
+.ep-code{
+  font-size:12px;color:var(--cyan);font-weight:600;letter-spacing:.05em;font-family:var(--mono);
+}
+.ep-code.editing{
+  background:transparent;border-bottom:1px solid var(--yellow);color:var(--yellow);
+  outline:none;width:80px;font-family:var(--mono);font-size:12px;
+  padding:2px 4px;
+}
+.conf-bar{display:flex;align-items:center;gap:8px}
+.conf-track{width:54px;height:4px;background:var(--inkGhost);position:relative}
+.conf-fill{height:100%;position:absolute;left:0;top:0}
+.conf-fill.hi{background:var(--green)}
+.conf-fill.mid{background:var(--yellow)}
+.conf-fill.lo{background:var(--magenta)}
+.conf-pct{font-size:10px;color:var(--inkDim)}
+
+.row-actions{display:flex;gap:6px;align-items:center;padding:8px 14px}
+.act-btn{
+  font-family:var(--mono);font-size:9px;letter-spacing:.14em;text-transform:uppercase;
+  padding:5px 9px;border:1px solid var(--line);color:var(--inkDim);cursor:pointer;
+  background:transparent;white-space:nowrap;transition:.12s;
+}
+.act-btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.act-btn.accept{border-color:rgba(134,239,172,.5);color:var(--green)}
+.act-btn.accept:hover{background:rgba(134,239,172,.1)}
+.act-btn.accept.done{background:rgba(134,239,172,.12);border-color:var(--green)}
+.act-btn.edit{border-color:rgba(253,224,71,.4);color:var(--yellow)}
+.act-btn.skip{border-color:rgba(255,85,85,.35);color:var(--red);opacity:.7}
+
+/* Badge */
+.badge{
+  display:inline-flex;align-items:center;gap:5px;font-size:9px;letter-spacing:.14em;
+  text-transform:uppercase;padding:3px 7px;border:1px solid var(--line);color:var(--inkDim);
+}
+.badge.green{color:var(--green);border-color:rgba(134,239,172,.4);background:rgba(134,239,172,.06)}
+.badge.yellow{color:var(--yellow);border-color:rgba(253,224,71,.4);background:rgba(253,224,71,.06)}
+.badge.magenta{color:var(--magentaHi);border-color:rgba(255,61,127,.4);background:rgba(255,61,127,.06)}
+.badge.ghost{color:var(--inkFaint);border-color:var(--line)}
+.dot{width:5px;height:5px;border-radius:50%;background:currentColor;box-shadow:0 0 5px currentColor;flex-shrink:0}
+
+/* ── Wizard footer ── */
+.wizard-footer{
+  padding:18px 32px;border-top:1px solid var(--line);
+  display:flex;align-items:center;gap:12px;flex-shrink:0;
+  background:rgba(5,7,12,.5);position:relative;z-index:2;
+}
+.footer-note{font-size:10px;letter-spacing:.12em;color:var(--inkFaint)}
+.footer-note b{color:var(--inkDim)}
+.footer-spacer{flex:1}
+.btn{
+  font-family:var(--mono);font-size:10px;letter-spacing:.18em;text-transform:uppercase;
+  padding:10px 18px;border:1px solid var(--lineMid);color:var(--inkDim);cursor:pointer;
+  background:transparent;transition:.14s;
+}
+.btn:hover{border-color:var(--lineHi);color:var(--ink)}
+.btn.primary{
+  background:var(--cyan);color:var(--bg0);border-color:var(--cyan);font-weight:600;
+  box-shadow:0 0 12px rgba(94,234,212,.3);
+}
+.btn.primary:hover{box-shadow:0 0 18px rgba(94,234,212,.45)}
+.btn.magenta{
+  background:transparent;border-color:rgba(255,61,127,.5);color:var(--magenta);
+}
+.bulk-accept{
+  font-size:10px;letter-spacing:.14em;color:var(--inkDim);
+  border:1px solid rgba(134,239,172,.4);color:var(--green);
+  padding:8px 14px;cursor:pointer;background:rgba(134,239,172,.04);
+}
+
+/* ── Background app (dimmed) ── */
+.bg-app{
+  min-height:100vh;display:flex;flex-direction:column;filter:blur(1px);
+  opacity:.35;pointer-events:none;user-select:none;
+}
+.disc-card{
+  padding:20px 24px;background:var(--bg2);border:1px solid var(--line);margin-bottom:8px;
+  display:flex;align-items:center;gap:20px;
+}
+</style>
+</head>
+<body>
+
+<!-- Dimmed background app -->
+<div class="app-shell">
+  <div class="topbar">
+    <div class="topbar-logo">ENGRAM</div>
+    <div class="topbar-sep"></div>
+    <div class="topbar-nav active">Dashboard</div>
+    <div class="topbar-nav">Review</div>
+    <div class="topbar-nav">History</div>
+    <div class="topbar-nav">Library</div>
+  </div>
+  <div style="padding:32px 40px;display:flex;flex-direction:column;gap:8px">
+    <div class="disc-card">
+      <div style="width:8px;height:8px;border-radius:50%;background:var(--greenDim);box-shadow:0 0 6px var(--greenDim)"></div>
+      <div style="flex:1">
+        <div style="font-size:12px;font-weight:600;color:var(--ink)">Severance — Season 2</div>
+        <div style="font-size:10px;color:var(--inkFaint);margin-top:2px">COMPLETED · 10 episodes · Organized to TV/Severance/Season 02/</div>
+      </div>
+      <div style="font-size:9px;color:var(--inkFaint);letter-spacing:.12em">2 days ago</div>
+    </div>
+    <div class="disc-card">
+      <div style="width:8px;height:8px;border-radius:50%;background:var(--amber);box-shadow:0 0 6px var(--amber)"></div>
+      <div style="flex:1">
+        <div style="font-size:12px;font-weight:600;color:var(--ink)">The Bear — Season 3</div>
+        <div style="font-size:10px;color:var(--inkFaint);margin-top:2px">MATCHING · 6 / 10 titles matched</div>
+      </div>
+      <div style="width:160px;height:4px;background:var(--inkGhost)"><div style="width:60%;height:100%;background:var(--amber)"></div></div>
+    </div>
+  </div>
+</div>
+
+<!-- Modal overlay -->
+<div class="overlay" style="position:fixed;top:0;left:0;right:0;bottom:0">
+<div class="wizard">
+  <div class="wizard-scanlines"></div>
+
+  <!-- Header -->
+  <div class="wizard-header">
+    <div>
+      <div class="wizard-title">Bootstrap Library</div>
+      <div class="wizard-subtitle">Seed fingerprint network from existing media files · TV shows only</div>
+    </div>
+    <button class="wizard-close">✕</button>
+  </div>
+
+  <!-- Step indicator -->
+  <div class="steps-bar">
+    <div class="step-item">
+      <div class="step-pip done">✓</div>
+      <div class="step-label done">Directory</div>
+      <div class="step-connector done"></div>
+    </div>
+    <div class="step-item">
+      <div class="step-pip done">✓</div>
+      <div class="step-label done">Scanning</div>
+      <div class="step-connector done"></div>
+    </div>
+    <div class="step-item">
+      <div class="step-pip active">3</div>
+      <div class="step-label active">Review</div>
+      <div class="step-connector"></div>
+    </div>
+    <div class="step-item">
+      <div class="step-pip">4</div>
+      <div class="step-label">Fingerprint</div>
+    </div>
+  </div>
+
+  <!-- Body: Step 3 — Review -->
+  <div class="wizard-body">
+    <div class="step-content">
+
+      <!-- Stats / filter bar -->
+      <div class="review-stats-bar">
+        <div class="stat-chip">Files found <span class="stat-val">187</span></div>
+        <div class="stats-sep"></div>
+        <div class="stat-chip">Parsed <span class="stat-val cyan">174</span></div>
+        <div class="stats-sep"></div>
+        <div class="stat-chip">High confidence <span class="stat-val green">142</span></div>
+        <div class="stats-sep"></div>
+        <div class="stat-chip">Needs review <span class="stat-val yellow">32</span></div>
+        <div class="stats-sep"></div>
+        <div class="stat-chip">Unmatched <span class="stat-val magenta">13</span></div>
+        <div class="stats-spacer"></div>
+        <div class="filter-tabs">
+          <button class="filter-tab">All</button>
+          <button class="filter-tab active">Needs Review</button>
+          <button class="filter-tab">High Conf.</button>
+          <button class="filter-tab">Unmatched</button>
+        </div>
+        <button class="bulk-accept">Accept All High Confidence (142)</button>
+      </div>
+
+      <!-- Column headers -->
+      <div class="review-col-header">
+        <div class="col-lbl">File</div>
+        <div class="col-lbl">Show</div>
+        <div class="col-lbl">Episode</div>
+        <div class="col-lbl">TMDB Conf.</div>
+        <div class="col-lbl">Action</div>
+      </div>
+
+      <!-- Rows: Needs Review -->
+      <div class="review-rows">
+
+        <!-- Row 1: accepted -->
+        <div class="review-row accepted">
+          <div class="row-cell filename">
+            <span class="file-name">Severance.S01E01.Good.News.About.Hell.mkv</span>
+            <span class="file-path">D:\TV\Severance\Season 1\</span>
+          </div>
+          <div class="row-cell"><span class="show-name">Severance</span></div>
+          <div class="row-cell"><span class="ep-code">S01E01</span></div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill hi" style="width:94%"></div></div>
+              <span class="conf-pct">94%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept done">✓ Accepted</button>
+          </div>
+        </div>
+
+        <!-- Row 2: editing -->
+        <div class="review-row editing">
+          <div class="row-cell filename">
+            <span class="file-name">Severance.1x02.BlueField.mkv</span>
+            <span class="file-path">D:\TV\Severance\Season 1\</span>
+          </div>
+          <div class="row-cell"><span class="show-name">Severance</span></div>
+          <div class="row-cell">
+            <input class="ep-code editing" type="text" value="S01E02" />
+          </div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill mid" style="width:61%"></div></div>
+              <span class="conf-pct">61%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept">✓ Save</button>
+            <button class="act-btn skip">✕</button>
+          </div>
+        </div>
+
+        <!-- Row 3: unmatched / ambiguous -->
+        <div class="review-row">
+          <div class="row-cell filename">
+            <span class="file-name">Arrested.Development.1x01.mp4</span>
+            <span class="file-path">D:\TV\AD\S1\</span>
+          </div>
+          <div class="row-cell">
+            <span class="show-name" style="color:var(--inkDim)">Arrested Development</span>
+          </div>
+          <div class="row-cell"><span class="ep-code">S01E01</span></div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill hi" style="width:91%"></div></div>
+              <span class="conf-pct">91%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </div>
+
+        <!-- Row 4 -->
+        <div class="review-row">
+          <div class="row-cell filename">
+            <span class="file-name">The.Bear.S02E06.Fishes.mkv</span>
+            <span class="file-path">D:\TV\The Bear\S2\</span>
+          </div>
+          <div class="row-cell"><span class="show-name">The Bear</span></div>
+          <div class="row-cell"><span class="ep-code">S02E06</span></div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill hi" style="width:98%"></div></div>
+              <span class="conf-pct">98%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </div>
+
+        <!-- Row 5: low confidence -->
+        <div class="review-row">
+          <div class="row-cell filename">
+            <span class="file-name">AD_S01E02_Pilot.mkv</span>
+            <span class="file-path">D:\TV\AD\S1\</span>
+          </div>
+          <div class="row-cell">
+            <span class="show-name">Arrested Development</span>
+          </div>
+          <div class="row-cell">
+            <span class="ep-code" style="color:var(--yellow)">S01E02</span>
+            <span class="badge yellow" style="font-size:8px;padding:2px 5px">conflict</span>
+          </div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill mid" style="width:47%"></div></div>
+              <span class="conf-pct">47%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </div>
+
+        <!-- Row 6: no match -->
+        <div class="review-row">
+          <div class="row-cell filename">
+            <span class="file-name">UNKNOWN_EPISODE_HDR.mkv</span>
+            <span class="file-path">D:\TV\Misc\</span>
+          </div>
+          <div class="row-cell">
+            <span class="show-name" style="color:var(--inkFaint);font-style:italic">No match found</span>
+          </div>
+          <div class="row-cell">
+            <span class="ep-code" style="color:var(--inkFaint)">—</span>
+          </div>
+          <div class="row-cell">
+            <span class="badge magenta"><span class="dot"></span>Unmatched</span>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </div>
+
+        <!-- Row 7: accepted -->
+        <div class="review-row accepted">
+          <div class="row-cell filename">
+            <span class="file-name">TheBear.S01E01.SystemError.mkv</span>
+            <span class="file-path">D:\TV\The Bear\Season 1\</span>
+          </div>
+          <div class="row-cell"><span class="show-name">The Bear</span></div>
+          <div class="row-cell"><span class="ep-code">S01E01</span></div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill hi" style="width:97%"></div></div>
+              <span class="conf-pct">97%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept done">✓ Accepted</button>
+          </div>
+        </div>
+
+        <!-- Row 8 -->
+        <div class="review-row">
+          <div class="row-cell filename">
+            <span class="file-name">Severance_S01E07_Defiant_Jazz.mkv</span>
+            <span class="file-path">D:\TV\Severance\Season 1\</span>
+          </div>
+          <div class="row-cell"><span class="show-name">Severance</span></div>
+          <div class="row-cell"><span class="ep-code">S01E07</span></div>
+          <div class="row-cell">
+            <div class="conf-bar">
+              <div class="conf-track"><div class="conf-fill hi" style="width:88%"></div></div>
+              <span class="conf-pct">88%</span>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button class="act-btn accept">✓ Accept</button>
+            <button class="act-btn edit">✎ Edit</button>
+            <button class="act-btn skip">Skip</button>
+          </div>
+        </div>
+
+        <!-- Row 9: skipped -->
+        <div class="review-row skipped">
+          <div class="row-cell filename">
+            <span class="file-name">Featurette_BehindScenes.mkv</span>
+            <span class="file-path">D:\TV\The Bear\Extras\</span>
+          </div>
+          <div class="row-cell"><span class="show-name" style="color:var(--inkFaint)">—</span></div>
+          <div class="row-cell"><span class="ep-code" style="color:var(--inkFaint)">—</span></div>
+          <div class="row-cell"><span class="badge ghost">Skipped</span></div>
+          <div class="row-actions">
+            <button class="act-btn" style="font-size:9px">↩ Restore</button>
+          </div>
+        </div>
+
+      </div><!-- /review-rows -->
+
+      <div style="height:12px"></div>
+      <div style="font-size:10px;color:var(--inkFaint);letter-spacing:.12em">
+        Showing 32 files needing review · 13 unmatched hidden ·
+        <span style="color:var(--cyan);cursor:pointer">Show all 187 files</span>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <div class="wizard-footer">
+    <div class="footer-note">Step 3 of 4 · <b>4 accepted</b> · 1 editing · 27 pending</div>
+    <div class="footer-spacer"></div>
+    <button class="btn">← Back</button>
+    <button class="btn" style="border-color:rgba(134,239,172,.4);color:var(--green)">Accept All Visible</button>
+    <button class="btn primary">Continue → Fingerprint (4 files)</button>
+  </div>
+</div>
+</div>
+
+</body>
+</html>

--- a/frontend/e2e/bootstrap-library.spec.ts
+++ b/frontend/e2e/bootstrap-library.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * E2E for the Bootstrap-Library wizard (BootstrapLibraryFlow).
+ *
+ * The wizard seeds the fingerprint network from an existing TV library. Its two
+ * backend endpoints are localhost-gated and require a real on-disk library to
+ * scan, which isn't available in CI — so we route-mock both:
+ *
+ *   POST /api/fingerprint/bootstrap/scan   → a deterministic 3-show scan result
+ *   POST /api/fingerprint/bootstrap/accept → echoes back queued counts
+ *
+ * Everything else (config load, WebSocket) hits the real E2E backend. The test
+ * drives the full scan → review → accept flow and asserts the single accept
+ * batch the frontend submits, then captures screenshots at each step.
+ */
+
+const SCREENSHOT_DIR = 'e2e-screenshots/bootstrap-library';
+
+// Deterministic scan payload: two resolved shows (accepted by default) + one
+// unresolved show (needs a TMDB ID) + one unparseable file.
+//   resolved episodes:   2 (Breaking Bad) + 3 (Arrested Development) = 5
+//   unresolved episodes: 2 (Mystery Show) — counted only after a TMDB ID is entered
+const SCAN_RESULT = {
+    shows: [
+        {
+            folder_name: 'Breaking Bad',
+            tmdb_id: 1396,
+            tmdb_name: 'Breaking Bad',
+            tmdb_year: 2008,
+            resolved: true,
+            episode_count: 2,
+            episodes: [
+                { file: 'Breaking Bad/Season 01/Breaking Bad - S01E01.mkv', season: 1, episode: 1 },
+                { file: 'Breaking Bad/Season 01/Breaking Bad - S01E02.mkv', season: 1, episode: 2 },
+            ],
+        },
+        {
+            folder_name: 'Arrested Development',
+            tmdb_id: 4589,
+            tmdb_name: 'Arrested Development',
+            tmdb_year: 2003,
+            resolved: true,
+            episode_count: 3,
+            episodes: [
+                { file: 'Arrested Development/Season 01/Arrested Development - S01E01.mkv', season: 1, episode: 1 },
+                { file: 'Arrested Development/Season 01/Arrested Development - S01E02.mkv', season: 1, episode: 2 },
+                { file: 'Arrested Development/Season 01/Arrested Development - S01E03.mkv', season: 1, episode: 3 },
+            ],
+        },
+        {
+            folder_name: 'Mystery Show',
+            tmdb_id: null,
+            tmdb_name: null,
+            tmdb_year: null,
+            resolved: false,
+            episode_count: 2,
+            episodes: [
+                { file: 'Mystery Show/Season 01/Mystery Show - S01E01.mkv', season: 1, episode: 1 },
+                { file: 'Mystery Show/Season 01/Mystery Show - S01E02.mkv', season: 1, episode: 2 },
+            ],
+        },
+    ],
+    unparseable: [{ file: 'home_videos/birthday_2019.mkv' }],
+    summary: { total_files: 8, parsed: 7, shows: 3, unparseable: 1 },
+};
+
+const MYSTERY_TMDB_ID = 603; // entered by the user for the unresolved show
+
+interface AcceptBody {
+    items: Array<{ file: string; tmdb_id: number; season: number; episode: number }>;
+}
+
+/** Open the Settings modal and land on the Preferences tab (step 4). */
+async function openSettingsPreferences(page: Page) {
+    await page.locator('[data-testid="sv-settings-btn"]').click();
+    await expect(page.getByText('Preferences')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: /Step 4: Preferences/i }).click();
+    await expect(page.getByText('Configure additional options for your workflow')).toBeVisible({ timeout: 3000 });
+}
+
+test.describe('Bootstrap library wizard', () => {
+    test('scan → review → accept queues the selected episodes', async ({ page }) => {
+        // Project-convention capture size.
+        await page.setViewportSize({ width: 2560, height: 1440 });
+
+        const acceptBodies: AcceptBody[] = [];
+
+        // Mock only the two bootstrap endpoints; everything else hits the real backend.
+        await page.route('**/api/fingerprint/bootstrap/scan', async (route) => {
+            expect(route.request().method()).toBe('POST');
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(SCAN_RESULT),
+            });
+        });
+        await page.route('**/api/fingerprint/bootstrap/accept', async (route) => {
+            const body = route.request().postDataJSON() as AcceptBody;
+            acceptBodies.push(body);
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ queued: body.items.length, failed: 0 }),
+            });
+        });
+
+        await page.goto('/');
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+
+        // ── Open the wizard from Preferences ─────────────────────────────────
+        await openSettingsPreferences(page);
+
+        // Contributions are opt-in (checked by default); the bootstrap button is
+        // gated behind it. Ensure it's on, then open the wizard.
+        const contributeToggle = page.getByRole('checkbox', { name: /Contribute audio fingerprints/i });
+        await expect(contributeToggle).toBeVisible();
+        if (!(await contributeToggle.isChecked())) {
+            await contributeToggle.check();
+        }
+
+        await page.getByRole('button', { name: /Contribute from existing library/i }).click();
+
+        const wizard = page.getByRole('dialog', { name: /Bootstrap library fingerprints/i });
+        await expect(wizard).toBeVisible();
+        await expect(wizard.getByText('Library Directory')).toBeVisible();
+        await page.screenshot({ path: `${SCREENSHOT_DIR}/01-directory.png`, fullPage: true, animations: 'disabled' });
+
+        // ── Scan ─────────────────────────────────────────────────────────────
+        await page.getByLabel(/TV Library Path/i).fill('D:\\TV Shows');
+        await page.getByRole('button', { name: 'Scan Directory' }).click();
+
+        // ── Review ───────────────────────────────────────────────────────────
+        // Resolved shows render and are accepted by default.
+        await expect(wizard.getByText('Breaking Bad', { exact: true })).toBeVisible({ timeout: 5000 });
+        await expect(wizard.getByText('Arrested Development', { exact: true })).toBeVisible();
+        await expect(wizard.getByText(/2 resolved shows/i)).toBeVisible();
+        // The unresolved show needs a TMDB ID.
+        await expect(wizard.getByText('Mystery Show', { exact: true })).toBeVisible();
+        await expect(wizard.getByText(/need TMDB IDs/i)).toBeVisible();
+        // Summary stats.
+        await expect(wizard.getByText('Files found')).toBeVisible();
+
+        // Footer reflects the two auto-accepted resolved shows (5 episodes).
+        await expect(wizard.getByText(/2 shows accepted/i)).toBeVisible();
+        await expect(wizard.getByText(/5 episodes to queue/i)).toBeVisible();
+        await page.screenshot({ path: `${SCREENSHOT_DIR}/02-review.png`, fullPage: true, animations: 'disabled' });
+
+        // Entering a valid TMDB ID for the unresolved show auto-accepts it,
+        // adding its 2 episodes → 3 shows / 7 episodes.
+        await page.getByRole('textbox', { name: /TMDB ID for Mystery Show/i }).fill(String(MYSTERY_TMDB_ID));
+        await expect(wizard.getByText(/3 shows accepted/i)).toBeVisible();
+        await expect(wizard.getByText(/7 episodes to queue/i)).toBeVisible();
+
+        // ── Accept / Queue ───────────────────────────────────────────────────
+        await page.getByRole('button', { name: /Confirm/i }).click();
+
+        await expect(wizard.getByText('Episodes queued')).toBeVisible({ timeout: 5000 });
+        await expect(wizard.getByText('7', { exact: true })).toBeVisible();
+        // Scope to the wizard — the dashboard's "DONE [0]" filter also matches "Done".
+        await expect(wizard.getByRole('button', { name: 'Done' })).toBeVisible();
+        await page.screenshot({ path: `${SCREENSHOT_DIR}/03-fingerprint-complete.png`, fullPage: true, animations: 'disabled' });
+
+        // ── Assert the single accept batch the frontend submitted ────────────
+        expect(acceptBodies).toHaveLength(1);
+        const items = acceptBodies[0].items;
+        expect(items).toHaveLength(7);
+        // Resolved show items carry the scan's TMDB ID...
+        expect(items).toContainEqual({
+            file: 'Breaking Bad/Season 01/Breaking Bad - S01E01.mkv',
+            tmdb_id: 1396,
+            season: 1,
+            episode: 1,
+        });
+        // ...and the unresolved show carries the user-entered ID.
+        expect(items).toContainEqual({
+            file: 'Mystery Show/Season 01/Mystery Show - S01E01.mkv',
+            tmdb_id: MYSTERY_TMDB_ID,
+            season: 1,
+            episode: 1,
+        });
+
+        // Done closes the wizard.
+        await wizard.getByRole('button', { name: 'Done' }).click();
+        await expect(wizard).not.toBeVisible();
+    });
+});

--- a/frontend/src/components/BootstrapLibraryFlow.tsx
+++ b/frontend/src/components/BootstrapLibraryFlow.tsx
@@ -11,7 +11,7 @@
  * review surface is per-SHOW TMDB resolution. No per-episode confidence UI.
  */
 
-import { useState, useCallback, type CSSProperties } from 'react';
+import { useState, useCallback, useMemo, type CSSProperties } from 'react';
 import { sv } from '../app/components/synapse/tokens';
 import { SvPanel } from '../app/components/synapse/SvPanel';
 import { SvCorners } from '../app/components/synapse/SvCorners';
@@ -458,8 +458,13 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
         }));
     }, []);
 
-    /** Build the full list of AcceptItems from the current showStates. */
-    const buildAcceptItems = useCallback((): AcceptItem[] => {
+    /**
+     * Full list of AcceptItems derived from the current showStates.
+     * Memoized so it only recomputes when the scan result or per-show
+     * acceptance state changes — not on every render (e.g. a keystroke in
+     * any unrelated input would otherwise re-walk every show/episode).
+     */
+    const acceptItems = useMemo<AcceptItem[]>(() => {
         if (!scanResult) return [];
         const items: AcceptItem[] = [];
         for (const show of scanResult.shows) {
@@ -479,7 +484,7 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
     }, [scanResult, showStates]);
 
     const handleFingerprint = useCallback(async () => {
-        const items = buildAcceptItems();
+        const items = acceptItems;
         if (items.length === 0) {
             setStep('fingerprint');
             setFinalResult({ queued: 0, failed: 0 });
@@ -523,7 +528,7 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
         }
 
         setFinalResult({ queued: totalQueued, failed: totalFailed });
-    }, [buildAcceptItems]);
+    }, [acceptItems]);
 
     // ─── Computed values for review step ─────────────────────────────────────
 
@@ -532,7 +537,6 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
     const acceptedCount = Object.values(showStates).filter((s) => s.accepted).length;
 
     // Count episodes that will be submitted (only shows with valid TMDB IDs)
-    const acceptItems = buildAcceptItems();
     const acceptEpisodeCount = acceptItems.length;
 
     // ─── Step renderers ───────────────────────────────────────────────────────
@@ -624,10 +628,9 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
                     border: `2px solid ${sv.line}`,
                     borderTopColor: sv.cyan,
                     borderRadius: '50%',
-                    animation: 'spin 0.8s linear infinite',
+                    animation: 'svSpin 0.8s linear infinite',
                 }}
             />
-            <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
             <p style={{ ...mono, fontSize: 12, color: sv.inkDim, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
                 Scanning directory&hellip;
             </p>
@@ -914,7 +917,7 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
                                 border: `2px solid ${sv.line}`,
                                 borderTopColor: sv.cyan,
                                 borderRadius: '50%',
-                                animation: 'spin 0.8s linear infinite',
+                                animation: 'svSpin 0.8s linear infinite',
                                 flexShrink: 0,
                             }}
                         />

--- a/frontend/src/components/BootstrapLibraryFlow.tsx
+++ b/frontend/src/components/BootstrapLibraryFlow.tsx
@@ -11,7 +11,7 @@
  * review surface is per-SHOW TMDB resolution. No per-episode confidence UI.
  */
 
-import { useState, useCallback, useMemo, type CSSProperties } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect, type CSSProperties } from 'react';
 import { sv } from '../app/components/synapse/tokens';
 import { SvPanel } from '../app/components/synapse/SvPanel';
 import { SvCorners } from '../app/components/synapse/SvCorners';
@@ -413,10 +413,19 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
     const [finalResult, setFinalResult] = useState<AcceptResult | null>(null);
     const [fingerprintError, setFingerprintError] = useState<string | null>(null);
 
+    // Abort in-flight scan/accept fetches when the user navigates away (Back /
+    // Cancel) or the modal unmounts, so a late response can't write state onto
+    // an abandoned step or fire on an unmounted component.
+    const abortRef = useRef<AbortController | null>(null);
+    useEffect(() => () => abortRef.current?.abort(), []);
+
     // ─── Handlers ────────────────────────────────────────────────────────────
 
     const handleScan = useCallback(async () => {
         if (!path.trim()) return;
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
         setScanError(null);
         setStep('scanning');
 
@@ -425,6 +434,7 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path: path.trim() }),
+                signal: controller.signal,
             });
             if (!res.ok) {
                 const body = await res.text().catch(() => '');
@@ -446,6 +456,8 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
             setShowStates(initial);
             setStep('review');
         } catch (err) {
+            // A user-triggered abort (Back/unmount) is not an error to surface.
+            if (err instanceof DOMException && err.name === 'AbortError') return;
             setScanError(err instanceof Error ? err.message : String(err));
             setStep('directory');
         }
@@ -491,6 +503,10 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
             return;
         }
 
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
         setStep('fingerprint');
         setFingerprintError(null);
 
@@ -511,6 +527,7 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ items: batches[i] }),
+                    signal: controller.signal,
                 });
                 if (!res.ok) {
                     const body = await res.text().catch(() => '');
@@ -521,12 +538,15 @@ export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
                 totalFailed += result.failed;
                 setBatchProgress({ done: i + 1, total: batches.length });
             } catch (err) {
+                // Aborted (modal closed / new run started) — stop without writing state.
+                if (err instanceof DOMException && err.name === 'AbortError') return;
                 setFingerprintError(err instanceof Error ? err.message : String(err));
                 setBatchProgress({ done: i + 1, total: batches.length });
                 // Continue remaining batches even on partial failure
             }
         }
 
+        if (controller.signal.aborted) return;
         setFinalResult({ queued: totalQueued, failed: totalFailed });
     }, [acceptItems]);
 

--- a/frontend/src/components/BootstrapLibraryFlow.tsx
+++ b/frontend/src/components/BootstrapLibraryFlow.tsx
@@ -1,0 +1,1178 @@
+/**
+ * BootstrapLibraryFlow — Seed the fingerprint network from an existing TV library.
+ *
+ * 4-step wizard:
+ *   1. Directory  — text input for library path + Scan button
+ *   2. Scanning   — loading state while the scan POST is in flight
+ *   3. Review     — per-show resolution: accept/skip resolved shows, enter TMDB IDs for unresolved
+ *   4. Fingerprint — POST to /accept in batches, show progress + final result
+ *
+ * Data model: Bootstrap TRUSTS the filename's season/episode numbers. The ONLY
+ * review surface is per-SHOW TMDB resolution. No per-episode confidence UI.
+ */
+
+import { useState, useCallback, type CSSProperties } from 'react';
+import { sv } from '../app/components/synapse/tokens';
+import { SvPanel } from '../app/components/synapse/SvPanel';
+import { SvCorners } from '../app/components/synapse/SvCorners';
+import { SvActionButton } from '../app/components/synapse/SvActionButton';
+import { SvNotice } from '../app/components/synapse/SvNotice';
+
+// ─── API types ──────────────────────────────────────────────────────────────
+
+interface ScanEpisode {
+    file: string;
+    season: number;
+    episode: number;
+}
+
+interface ScanShow {
+    folder_name: string;
+    tmdb_id: number | null;
+    tmdb_name: string | null;
+    tmdb_year: number | null;
+    resolved: boolean;
+    episode_count: number;
+    episodes: ScanEpisode[];
+}
+
+interface ScanSummary {
+    total_files: number;
+    parsed: number;
+    shows: number;
+    unparseable: number;
+}
+
+interface UnparseableFile {
+    file: string;
+}
+
+interface ScanResult {
+    shows: ScanShow[];
+    unparseable: UnparseableFile[];
+    summary: ScanSummary;
+}
+
+interface AcceptItem {
+    file: string;
+    tmdb_id: number;
+    season: number;
+    episode: number;
+}
+
+interface AcceptResult {
+    queued: number;
+    failed: number;
+}
+
+// ─── Internal state per show ─────────────────────────────────────────────────
+
+interface ShowState {
+    /** Included in the accept batch when true */
+    accepted: boolean;
+    /** User-entered TMDB ID for unresolved shows (overrides scan result) */
+    manualTmdbId: string;
+}
+
+// ─── Wizard steps ────────────────────────────────────────────────────────────
+
+type WizardStep = 'directory' | 'scanning' | 'review' | 'fingerprint';
+
+const STEP_ORDER: WizardStep[] = ['directory', 'scanning', 'review', 'fingerprint'];
+const STEP_LABELS: Record<WizardStep, string> = {
+    directory: 'Directory',
+    scanning: 'Scanning',
+    review: 'Review',
+    fingerprint: 'Fingerprint',
+};
+
+// ─── Shared style helpers ─────────────────────────────────────────────────────
+
+const mono: CSSProperties = {
+    fontFamily: sv.mono,
+};
+
+const labelStyle: CSSProperties = {
+    ...mono,
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: '0.18em',
+    textTransform: 'uppercase',
+    color: sv.inkDim,
+    display: 'block',
+    marginBottom: 6,
+};
+
+const inputStyle: CSSProperties = {
+    ...mono,
+    width: '100%',
+    padding: '8px 12px',
+    background: 'rgba(94, 234, 212, 0.04)',
+    border: `1px solid ${sv.lineMid}`,
+    color: sv.ink,
+    fontSize: 13,
+    outline: 'none',
+};
+
+const hintStyle: CSSProperties = {
+    ...mono,
+    fontSize: 10,
+    color: sv.inkFaint,
+    letterSpacing: '0.10em',
+    marginTop: 6,
+    lineHeight: 1.5,
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+/** Horizontal step indicator */
+function StepBar({ current }: { current: WizardStep }) {
+    const currentIdx = STEP_ORDER.indexOf(current);
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '14px 24px',
+                borderBottom: `1px solid ${sv.line}`,
+                background: 'rgba(5, 7, 12, 0.3)',
+                gap: 0,
+            }}
+        >
+            {STEP_ORDER.map((step, idx) => {
+                const isDone = idx < currentIdx;
+                const isActive = idx === currentIdx;
+                return (
+                    <div key={step} style={{ display: 'flex', alignItems: 'center', flex: idx < STEP_ORDER.length - 1 ? 1 : undefined }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                            <div
+                                style={{
+                                    width: 26,
+                                    height: 26,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    border: `1px solid ${isDone ? sv.cyanDim : isActive ? sv.cyan : sv.line}`,
+                                    background: isDone
+                                        ? 'rgba(94, 234, 212, 0.07)'
+                                        : isActive
+                                            ? sv.cyan
+                                            : 'transparent',
+                                    color: isDone
+                                        ? sv.cyanDim
+                                        : isActive
+                                            ? sv.bg0
+                                            : sv.inkFaint,
+                                    fontFamily: sv.mono,
+                                    fontSize: 10,
+                                    fontWeight: 700,
+                                    letterSpacing: '0.10em',
+                                    boxShadow: isActive ? `0 0 10px ${sv.cyan}66` : undefined,
+                                    flexShrink: 0,
+                                }}
+                            >
+                                {isDone ? '✓' : idx + 1}
+                            </div>
+                            <span
+                                style={{
+                                    fontFamily: sv.mono,
+                                    fontSize: 9,
+                                    letterSpacing: '0.18em',
+                                    textTransform: 'uppercase',
+                                    color: isDone ? sv.cyanDim : isActive ? sv.ink : sv.inkFaint,
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {STEP_LABELS[step]}
+                            </span>
+                        </div>
+                        {idx < STEP_ORDER.length - 1 && (
+                            <div
+                                style={{
+                                    flex: 1,
+                                    height: 1,
+                                    background: isDone ? sv.cyanDim : sv.line,
+                                    margin: '0 12px',
+                                }}
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+/** Single resolved-show row */
+function ResolvedShowRow({
+    show,
+    state,
+    onToggleAccepted,
+    onChangeManualId,
+}: {
+    show: ScanShow;
+    state: ShowState;
+    onToggleAccepted: () => void;
+    onChangeManualId: (v: string) => void;
+}) {
+    const [showChange, setShowChange] = useState(false);
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '10px 14px',
+                borderBottom: `1px solid ${sv.line}`,
+                background: state.accepted ? 'rgba(134, 239, 172, 0.03)' : undefined,
+                opacity: state.accepted ? 1 : 0.5,
+            }}
+        >
+            {/* Checkbox */}
+            <input
+                type="checkbox"
+                checked={state.accepted}
+                onChange={onToggleAccepted}
+                style={{ width: 14, height: 14, cursor: 'pointer', accentColor: sv.cyan, flexShrink: 0 }}
+                aria-label={`Accept ${show.folder_name}`}
+            />
+
+            {/* Show info */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ ...mono, fontSize: 12, color: sv.ink, fontWeight: 500 }}>
+                    {show.folder_name}
+                </span>
+                <span style={{ ...mono, fontSize: 11, color: sv.inkDim, marginLeft: 8 }}>
+                    → {show.tmdb_name} ({show.tmdb_year})
+                </span>
+            </div>
+
+            {/* Episode count */}
+            <span style={{ ...mono, fontSize: 10, color: sv.inkFaint, letterSpacing: '0.10em', flexShrink: 0 }}>
+                {show.episode_count} eps
+            </span>
+
+            {/* Change affordance */}
+            <button
+                type="button"
+                onClick={() => setShowChange(!showChange)}
+                style={{
+                    ...mono,
+                    fontSize: 9,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: sv.inkFaint,
+                    background: 'transparent',
+                    border: `1px solid ${sv.line}`,
+                    padding: '3px 8px',
+                    cursor: 'pointer',
+                    flexShrink: 0,
+                    transition: 'color 120ms, border-color 120ms',
+                }}
+                onMouseEnter={(e) => {
+                    e.currentTarget.style.color = sv.inkDim;
+                    e.currentTarget.style.borderColor = sv.lineMid;
+                }}
+                onMouseLeave={(e) => {
+                    e.currentTarget.style.color = sv.inkFaint;
+                    e.currentTarget.style.borderColor = sv.line;
+                }}
+            >
+                Change
+            </button>
+
+            {/* Inline TMDB ID override when Change is open */}
+            {showChange && (
+                <input
+                    type="text"
+                    value={state.manualTmdbId}
+                    onChange={(e) => onChangeManualId(e.target.value)}
+                    placeholder="TMDB ID override"
+                    style={{
+                        ...inputStyle,
+                        width: 140,
+                        fontSize: 11,
+                        padding: '4px 8px',
+                    }}
+                    onFocus={(e) => { e.currentTarget.style.borderColor = sv.cyan; }}
+                    onBlur={(e) => { e.currentTarget.style.borderColor = sv.lineMid; }}
+                />
+            )}
+        </div>
+    );
+}
+
+/** Single unresolved-show row — requires a TMDB ID or explicit skip */
+function UnresolvedShowRow({
+    show,
+    state,
+    onChangeManualId,
+    onToggleAccepted,
+}: {
+    show: ScanShow;
+    state: ShowState;
+    onChangeManualId: (v: string) => void;
+    onToggleAccepted: () => void;
+}) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                padding: '10px 14px',
+                borderBottom: `1px solid ${sv.line}`,
+                background: state.accepted ? 'rgba(255, 61, 127, 0.04)' : undefined,
+                outline: `1px solid rgba(255, 61, 127, 0.15)`,
+            }}
+        >
+            {/* Magenta dot */}
+            <div
+                style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    background: sv.magenta,
+                    boxShadow: `0 0 5px ${sv.magenta}`,
+                    flexShrink: 0,
+                }}
+            />
+
+            {/* Show info */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ ...mono, fontSize: 12, color: sv.magentaHi, fontWeight: 600 }}>
+                    {show.folder_name}
+                </span>
+                <span style={{ ...mono, fontSize: 10, color: sv.inkFaint, marginLeft: 8, letterSpacing: '0.10em' }}>
+                    unresolved · {show.episode_count} eps
+                </span>
+            </div>
+
+            {/* TMDB ID input */}
+            <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ ...mono, fontSize: 10, color: sv.inkDim, letterSpacing: '0.12em' }}>TMDB ID</span>
+                <input
+                    type="text"
+                    value={state.manualTmdbId}
+                    onChange={(e) => onChangeManualId(e.target.value)}
+                    placeholder="e.g. 1396"
+                    style={{
+                        ...inputStyle,
+                        width: 110,
+                        fontSize: 12,
+                        padding: '5px 8px',
+                    }}
+                    onFocus={(e) => { e.currentTarget.style.borderColor = sv.cyan; }}
+                    onBlur={(e) => { e.currentTarget.style.borderColor = sv.lineMid; }}
+                    aria-label={`TMDB ID for ${show.folder_name}`}
+                />
+            </div>
+
+            {/* Skip toggle */}
+            <button
+                type="button"
+                onClick={onToggleAccepted}
+                style={{
+                    ...mono,
+                    fontSize: 9,
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    color: state.accepted ? sv.red : sv.inkFaint,
+                    background: 'transparent',
+                    border: `1px solid ${state.accepted ? `${sv.red}55` : sv.line}`,
+                    padding: '3px 8px',
+                    cursor: 'pointer',
+                    flexShrink: 0,
+                    transition: 'color 120ms, border-color 120ms',
+                }}
+            >
+                {state.accepted ? 'Unskip' : 'Skip'}
+            </button>
+        </div>
+    );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface BootstrapLibraryFlowProps {
+    onClose: () => void;
+}
+
+export function BootstrapLibraryFlow({ onClose }: BootstrapLibraryFlowProps) {
+    // Wizard state
+    const [step, setStep] = useState<WizardStep>('directory');
+    const [path, setPath] = useState('');
+    const [scanResult, setScanResult] = useState<ScanResult | null>(null);
+    const [scanError, setScanError] = useState<string | null>(null);
+    const [showStates, setShowStates] = useState<Record<string, ShowState>>({});
+    const [showUnparseable, setShowUnparseable] = useState(false);
+
+    // Fingerprint step
+    const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
+    const [finalResult, setFinalResult] = useState<AcceptResult | null>(null);
+    const [fingerprintError, setFingerprintError] = useState<string | null>(null);
+
+    // ─── Handlers ────────────────────────────────────────────────────────────
+
+    const handleScan = useCallback(async () => {
+        if (!path.trim()) return;
+        setScanError(null);
+        setStep('scanning');
+
+        try {
+            const res = await fetch('/api/fingerprint/bootstrap/scan', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path: path.trim() }),
+            });
+            if (!res.ok) {
+                const body = await res.text().catch(() => '');
+                throw new Error(`Scan failed (${res.status}): ${body || res.statusText}`);
+            }
+            const data: ScanResult = await res.json();
+            setScanResult(data);
+
+            // Initialize per-show state
+            const initial: Record<string, ShowState> = {};
+            for (const show of data.shows) {
+                // Resolved shows: checked by default.
+                // Unresolved shows: NOT accepted until user provides a TMDB ID.
+                initial[show.folder_name] = {
+                    accepted: show.resolved,
+                    manualTmdbId: show.tmdb_id != null ? String(show.tmdb_id) : '',
+                };
+            }
+            setShowStates(initial);
+            setStep('review');
+        } catch (err) {
+            setScanError(err instanceof Error ? err.message : String(err));
+            setStep('directory');
+        }
+    }, [path]);
+
+    const updateShowState = useCallback((folderName: string, patch: Partial<ShowState>) => {
+        setShowStates((prev) => ({
+            ...prev,
+            [folderName]: { ...prev[folderName], ...patch },
+        }));
+    }, []);
+
+    /** Build the full list of AcceptItems from the current showStates. */
+    const buildAcceptItems = useCallback((): AcceptItem[] => {
+        if (!scanResult) return [];
+        const items: AcceptItem[] = [];
+        for (const show of scanResult.shows) {
+            const state = showStates[show.folder_name];
+            if (!state?.accepted) continue;
+
+            // Effective TMDB ID: manual override if entered, otherwise from scan
+            const rawId = state.manualTmdbId.trim() || (show.tmdb_id != null ? String(show.tmdb_id) : '');
+            const tmdbId = parseInt(rawId, 10);
+            if (isNaN(tmdbId) || tmdbId <= 0) continue; // no valid TMDB ID → skip
+
+            for (const ep of show.episodes) {
+                items.push({ file: ep.file, tmdb_id: tmdbId, season: ep.season, episode: ep.episode });
+            }
+        }
+        return items;
+    }, [scanResult, showStates]);
+
+    const handleFingerprint = useCallback(async () => {
+        const items = buildAcceptItems();
+        if (items.length === 0) {
+            setStep('fingerprint');
+            setFinalResult({ queued: 0, failed: 0 });
+            return;
+        }
+
+        setStep('fingerprint');
+        setFingerprintError(null);
+
+        const BATCH_SIZE = 50;
+        const batches: AcceptItem[][] = [];
+        for (let i = 0; i < items.length; i += BATCH_SIZE) {
+            batches.push(items.slice(i, i + BATCH_SIZE));
+        }
+
+        setBatchProgress({ done: 0, total: batches.length });
+
+        let totalQueued = 0;
+        let totalFailed = 0;
+
+        for (let i = 0; i < batches.length; i++) {
+            try {
+                const res = await fetch('/api/fingerprint/bootstrap/accept', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ items: batches[i] }),
+                });
+                if (!res.ok) {
+                    const body = await res.text().catch(() => '');
+                    throw new Error(`Batch ${i + 1} failed (${res.status}): ${body || res.statusText}`);
+                }
+                const result: AcceptResult = await res.json();
+                totalQueued += result.queued;
+                totalFailed += result.failed;
+                setBatchProgress({ done: i + 1, total: batches.length });
+            } catch (err) {
+                setFingerprintError(err instanceof Error ? err.message : String(err));
+                setBatchProgress({ done: i + 1, total: batches.length });
+                // Continue remaining batches even on partial failure
+            }
+        }
+
+        setFinalResult({ queued: totalQueued, failed: totalFailed });
+    }, [buildAcceptItems]);
+
+    // ─── Computed values for review step ─────────────────────────────────────
+
+    const resolvedShows = scanResult?.shows.filter((s) => s.resolved) ?? [];
+    const unresolvedShows = scanResult?.shows.filter((s) => !s.resolved) ?? [];
+    const acceptedCount = Object.values(showStates).filter((s) => s.accepted).length;
+
+    // Count episodes that will be submitted (only shows with valid TMDB IDs)
+    const acceptItems = buildAcceptItems();
+    const acceptEpisodeCount = acceptItems.length;
+
+    // ─── Step renderers ───────────────────────────────────────────────────────
+
+    const renderDirectory = () => (
+        <div style={{ padding: 28 }}>
+            <h3
+                style={{
+                    fontFamily: sv.sans,
+                    fontSize: 15,
+                    fontWeight: 700,
+                    letterSpacing: '0.16em',
+                    textTransform: 'uppercase',
+                    color: sv.cyanHi,
+                    marginBottom: 8,
+                    textShadow: `0 0 14px ${sv.cyan}66`,
+                }}
+            >
+                Library Directory
+            </h3>
+            <p style={{ ...hintStyle, fontSize: 12, color: sv.inkDim, marginBottom: 20, letterSpacing: '0.06em' }}>
+                Point Engram at your existing TV library. We read your filenames,
+                identify shows and episodes, and seed the fingerprint network.
+            </p>
+
+            <div style={{ marginBottom: 20 }}>
+                <label htmlFor="bootstrap-path" style={labelStyle}>
+                    TV Library Path
+                </label>
+                <div style={{ display: 'flex', gap: 10 }}>
+                    <input
+                        id="bootstrap-path"
+                        type="text"
+                        value={path}
+                        onChange={(e) => setPath(e.target.value)}
+                        placeholder="e.g. D:\TV Shows or /mnt/media/tv"
+                        style={{ ...inputStyle, flex: 1 }}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleScan(); }}
+                        onFocus={(e) => { e.currentTarget.style.borderColor = sv.cyan; e.currentTarget.style.boxShadow = `0 0 8px ${sv.cyan}33`; }}
+                        onBlur={(e) => { e.currentTarget.style.borderColor = sv.lineMid; e.currentTarget.style.boxShadow = 'none'; }}
+                        autoFocus
+                    />
+                    <SvActionButton tone="cyan" size="md" onClick={handleScan} disabled={!path.trim()}>
+                        Scan
+                    </SvActionButton>
+                </div>
+                <p style={hintStyle}>TV shows only. We parse &ldquo;Show - SxxEyy&rdquo; filename patterns.</p>
+            </div>
+
+            {scanError && (
+                <SvNotice tone="error" style={{ marginTop: 16 }}>
+                    {scanError}
+                </SvNotice>
+            )}
+
+            <div
+                style={{
+                    marginTop: 24,
+                    padding: '12px 16px',
+                    background: 'rgba(94, 234, 212, 0.03)',
+                    border: `1px solid ${sv.line}`,
+                }}
+            >
+                <p style={{ ...hintStyle, marginTop: 0 }}>
+                    <span style={{ color: sv.cyan }}>Privacy:</span> No filenames or paths are uploaded &mdash;
+                    only audio fingerprints extracted from the actual MKV files
+                    (queued locally, submitted when you rip future discs).
+                </p>
+            </div>
+        </div>
+    );
+
+    const renderScanning = () => (
+        <div
+            style={{
+                padding: 48,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 20,
+                minHeight: 260,
+                justifyContent: 'center',
+            }}
+        >
+            <div
+                style={{
+                    width: 40,
+                    height: 40,
+                    border: `2px solid ${sv.line}`,
+                    borderTopColor: sv.cyan,
+                    borderRadius: '50%',
+                    animation: 'spin 0.8s linear infinite',
+                }}
+            />
+            <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+            <p style={{ ...mono, fontSize: 12, color: sv.inkDim, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+                Scanning directory&hellip;
+            </p>
+            <p style={{ ...mono, fontSize: 11, color: sv.inkFaint, letterSpacing: '0.10em' }}>
+                {path}
+            </p>
+        </div>
+    );
+
+    const renderReview = () => {
+        if (!scanResult) return null;
+        const { summary } = scanResult;
+
+        return (
+            <div style={{ padding: 24 }}>
+                {/* Summary stats bar */}
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 16,
+                        flexWrap: 'wrap',
+                        padding: '10px 14px',
+                        background: 'rgba(94, 234, 212, 0.03)',
+                        border: `1px solid ${sv.line}`,
+                        marginBottom: 20,
+                    }}
+                >
+                    {[
+                        { label: 'Files found', value: summary.total_files, color: sv.ink },
+                        { label: 'Parsed', value: summary.parsed, color: sv.cyan },
+                        { label: 'Shows', value: summary.shows, color: sv.ink },
+                        { label: 'Unresolved', value: unresolvedShows.length, color: unresolvedShows.length > 0 ? sv.magenta : sv.inkFaint },
+                        { label: 'Unparseable', value: summary.unparseable, color: summary.unparseable > 0 ? sv.yellow : sv.inkFaint },
+                    ].map(({ label, value, color }, i, arr) => (
+                        <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                <span style={{ ...mono, fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: sv.inkDim }}>
+                                    {label}
+                                </span>
+                                <span style={{ ...mono, fontSize: 11, fontWeight: 700, color }}>{value}</span>
+                            </div>
+                            {i < arr.length - 1 && (
+                                <div style={{ width: 1, height: 14, background: sv.line }} />
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                {/* Unresolved shows — need TMDB IDs */}
+                {unresolvedShows.length > 0 && (
+                    <div style={{ marginBottom: 16 }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 8,
+                                padding: '6px 14px',
+                                background: 'rgba(255, 61, 127, 0.06)',
+                                border: `1px solid rgba(255, 61, 127, 0.3)`,
+                                borderBottom: 0,
+                            }}
+                        >
+                            <div style={{ width: 5, height: 5, borderRadius: '50%', background: sv.magenta, boxShadow: `0 0 5px ${sv.magenta}` }} />
+                            <span style={{ ...mono, fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: sv.magenta }}>
+                                {unresolvedShows.length} show{unresolvedShows.length !== 1 ? 's' : ''} need TMDB IDs
+                            </span>
+                        </div>
+                        <div style={{ border: `1px solid rgba(255, 61, 127, 0.3)` }}>
+                            {unresolvedShows.map((show) => (
+                                <UnresolvedShowRow
+                                    key={show.folder_name}
+                                    show={show}
+                                    state={showStates[show.folder_name] ?? { accepted: false, manualTmdbId: '' }}
+                                    onChangeManualId={(v) => {
+                                        const id = v.trim();
+                                        const num = parseInt(id, 10);
+                                        const validId = !isNaN(num) && num > 0;
+                                        updateShowState(show.folder_name, {
+                                            manualTmdbId: v,
+                                            // Auto-accept when a valid ID is entered
+                                            accepted: validId,
+                                        });
+                                    }}
+                                    onToggleAccepted={() => updateShowState(show.folder_name, { accepted: !showStates[show.folder_name]?.accepted })}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Resolved shows */}
+                {resolvedShows.length > 0 && (
+                    <div style={{ marginBottom: 16 }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                padding: '6px 14px',
+                                background: 'rgba(94, 234, 212, 0.04)',
+                                border: `1px solid ${sv.line}`,
+                                borderBottom: 0,
+                            }}
+                        >
+                            <span style={{ ...mono, fontSize: 9, letterSpacing: '0.18em', textTransform: 'uppercase', color: sv.cyanDim }}>
+                                {resolvedShows.length} resolved show{resolvedShows.length !== 1 ? 's' : ''} &mdash; accepted by default
+                            </span>
+                            <div style={{ display: 'flex', gap: 8 }}>
+                                <button
+                                    type="button"
+                                    onClick={() => resolvedShows.forEach((s) => updateShowState(s.folder_name, { accepted: true }))}
+                                    style={{
+                                        ...mono,
+                                        fontSize: 9,
+                                        letterSpacing: '0.14em',
+                                        textTransform: 'uppercase',
+                                        color: sv.green,
+                                        background: 'transparent',
+                                        border: `1px solid rgba(134, 239, 172, 0.4)`,
+                                        padding: '3px 8px',
+                                        cursor: 'pointer',
+                                    }}
+                                >
+                                    Accept All
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => resolvedShows.forEach((s) => updateShowState(s.folder_name, { accepted: false }))}
+                                    style={{
+                                        ...mono,
+                                        fontSize: 9,
+                                        letterSpacing: '0.14em',
+                                        textTransform: 'uppercase',
+                                        color: sv.inkFaint,
+                                        background: 'transparent',
+                                        border: `1px solid ${sv.line}`,
+                                        padding: '3px 8px',
+                                        cursor: 'pointer',
+                                    }}
+                                >
+                                    Deselect All
+                                </button>
+                            </div>
+                        </div>
+                        <div style={{ border: `1px solid ${sv.line}` }}>
+                            {resolvedShows.map((show) => (
+                                <ResolvedShowRow
+                                    key={show.folder_name}
+                                    show={show}
+                                    state={showStates[show.folder_name] ?? { accepted: true, manualTmdbId: String(show.tmdb_id ?? '') }}
+                                    onToggleAccepted={() => updateShowState(show.folder_name, { accepted: !showStates[show.folder_name]?.accepted })}
+                                    onChangeManualId={(v) => updateShowState(show.folder_name, { manualTmdbId: v })}
+                                />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Unparseable files section */}
+                {scanResult.unparseable.length > 0 && (
+                    <div>
+                        <button
+                            type="button"
+                            onClick={() => setShowUnparseable(!showUnparseable)}
+                            style={{
+                                ...mono,
+                                width: '100%',
+                                textAlign: 'left',
+                                fontSize: 10,
+                                letterSpacing: '0.12em',
+                                color: sv.inkFaint,
+                                background: 'transparent',
+                                border: `1px solid ${sv.line}`,
+                                padding: '8px 14px',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                            }}
+                        >
+                            <span>
+                                {scanResult.unparseable.length} file{scanResult.unparseable.length !== 1 ? 's' : ''} couldn&apos;t be matched to Show &mdash; SxxEyy and will be skipped
+                            </span>
+                            <span style={{ letterSpacing: '0.06em' }}>{showUnparseable ? '▲' : '▼'}</span>
+                        </button>
+                        {showUnparseable && (
+                            <div
+                                style={{
+                                    border: `1px solid ${sv.line}`,
+                                    borderTop: 0,
+                                    maxHeight: 160,
+                                    overflowY: 'auto',
+                                    scrollbarWidth: 'thin',
+                                }}
+                            >
+                                {scanResult.unparseable.map((u, i) => (
+                                    <div
+                                        key={i}
+                                        style={{
+                                            padding: '6px 14px',
+                                            borderBottom: i < scanResult.unparseable.length - 1 ? `1px solid ${sv.line}` : undefined,
+                                        }}
+                                    >
+                                        <span style={{ ...mono, fontSize: 11, color: sv.inkFaint }}>{u.file}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {/* Nothing selected warning */}
+                {acceptedCount === 0 && (
+                    <SvNotice tone="warn" style={{ marginTop: 16 }}>
+                        No shows selected. At least one show must be accepted to proceed.
+                    </SvNotice>
+                )}
+            </div>
+        );
+    };
+
+    const renderFingerprint = () => {
+        const totalBatches = batchProgress?.total ?? 0;
+        const doneBatches = batchProgress?.done ?? 0;
+        const progressPct = totalBatches > 0 ? Math.round((doneBatches / totalBatches) * 100) : 0;
+        const isComplete = finalResult != null;
+
+        return (
+            <div style={{ padding: 28 }}>
+                <h3
+                    style={{
+                        fontFamily: sv.sans,
+                        fontSize: 15,
+                        fontWeight: 700,
+                        letterSpacing: '0.16em',
+                        textTransform: 'uppercase',
+                        color: sv.cyanHi,
+                        marginBottom: 16,
+                        textShadow: `0 0 14px ${sv.cyan}66`,
+                    }}
+                >
+                    Queuing Fingerprints
+                </h3>
+
+                {/* Progress bar */}
+                {!isComplete && batchProgress && (
+                    <div style={{ marginBottom: 24 }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                            <span style={{ ...mono, fontSize: 10, color: sv.inkDim, letterSpacing: '0.12em', textTransform: 'uppercase' }}>
+                                Batch {doneBatches} / {totalBatches}
+                            </span>
+                            <span style={{ ...mono, fontSize: 10, color: sv.cyan, fontWeight: 700 }}>
+                                {progressPct}%
+                            </span>
+                        </div>
+                        <div style={{ height: 4, background: sv.inkGhost, position: 'relative' }}>
+                            <div
+                                style={{
+                                    position: 'absolute',
+                                    left: 0,
+                                    top: 0,
+                                    height: '100%',
+                                    width: `${progressPct}%`,
+                                    background: sv.cyan,
+                                    boxShadow: `0 0 8px ${sv.cyan}66`,
+                                    transition: 'width 300ms ease-out',
+                                }}
+                            />
+                        </div>
+                        <p style={{ ...hintStyle, marginTop: 8 }}>
+                            Submitting in batches of 50 episodes&hellip;
+                        </p>
+                    </div>
+                )}
+
+                {/* Waiting state (before first batch progress) */}
+                {!isComplete && !batchProgress && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 24 }}>
+                        <div
+                            style={{
+                                width: 24,
+                                height: 24,
+                                border: `2px solid ${sv.line}`,
+                                borderTopColor: sv.cyan,
+                                borderRadius: '50%',
+                                animation: 'spin 0.8s linear infinite',
+                                flexShrink: 0,
+                            }}
+                        />
+                        <span style={{ ...mono, fontSize: 12, color: sv.inkDim, letterSpacing: '0.12em' }}>
+                            Preparing batches&hellip;
+                        </span>
+                    </div>
+                )}
+
+                {/* Error notice */}
+                {fingerprintError && (
+                    <SvNotice tone="error" style={{ marginBottom: 16 }}>
+                        {fingerprintError}
+                    </SvNotice>
+                )}
+
+                {/* Final result */}
+                {isComplete && finalResult && (
+                    <div>
+                        <SvPanel
+                            glow={finalResult.queued > 0}
+                            style={{ marginBottom: 16 }}
+                            accent={finalResult.queued > 0 ? `${sv.cyan}55` : sv.line}
+                        >
+                            <div style={{ display: 'flex', gap: 32, flexWrap: 'wrap' }}>
+                                <div>
+                                    <div style={{ ...mono, fontSize: 28, fontWeight: 700, color: finalResult.queued > 0 ? sv.cyan : sv.inkDim }}>
+                                        {finalResult.queued}
+                                    </div>
+                                    <div style={{ ...mono, fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: sv.inkDim, marginTop: 4 }}>
+                                        Episodes queued
+                                    </div>
+                                </div>
+                                {finalResult.failed > 0 && (
+                                    <div>
+                                        <div style={{ ...mono, fontSize: 28, fontWeight: 700, color: sv.red }}>
+                                            {finalResult.failed}
+                                        </div>
+                                        <div style={{ ...mono, fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: sv.inkDim, marginTop: 4 }}>
+                                            Failed
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </SvPanel>
+
+                        <p style={{ ...hintStyle, fontSize: 12, color: sv.inkDim, letterSpacing: '0.06em' }}>
+                            {finalResult.queued > 0
+                                ? 'Fingerprints are queued locally. They will be submitted to the community catalog when Engram processes future discs.'
+                                : 'No episodes were queued. Select at least one show with a valid TMDB ID and try again.'}
+                        </p>
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    // ─── Footer actions ───────────────────────────────────────────────────────
+
+    const renderFooter = () => {
+        switch (step) {
+            case 'directory':
+                return (
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+                        <SvActionButton tone="neutral" size="md" onClick={onClose}>
+                            Cancel
+                        </SvActionButton>
+                        <SvActionButton tone="cyan" size="md" onClick={handleScan} disabled={!path.trim()}>
+                            Scan Directory
+                        </SvActionButton>
+                    </div>
+                );
+            case 'scanning':
+                return (
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+                        <SvActionButton tone="neutral" size="md" onClick={() => setStep('directory')}>
+                            Cancel
+                        </SvActionButton>
+                    </div>
+                );
+            case 'review':
+                return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                        <span style={{ ...mono, fontSize: 10, color: sv.inkFaint, letterSpacing: '0.10em', flex: 1 }}>
+                            {acceptedCount} show{acceptedCount !== 1 ? 's' : ''} accepted &middot; {acceptEpisodeCount} episode{acceptEpisodeCount !== 1 ? 's' : ''} to queue
+                        </span>
+                        <SvActionButton tone="neutral" size="md" onClick={() => setStep('directory')}>
+                            ← Back
+                        </SvActionButton>
+                        <SvActionButton
+                            tone="cyan"
+                            size="md"
+                            onClick={handleFingerprint}
+                            disabled={acceptEpisodeCount === 0}
+                        >
+                            Confirm &rarr; Queue {acceptEpisodeCount > 0 ? `(${acceptEpisodeCount})` : ''}
+                        </SvActionButton>
+                    </div>
+                );
+            case 'fingerprint':
+                return (
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
+                        {finalResult ? (
+                            <SvActionButton tone="cyan" size="md" onClick={onClose}>
+                                Done
+                            </SvActionButton>
+                        ) : (
+                            <SvActionButton tone="neutral" size="md" disabled>
+                                Processing&hellip;
+                            </SvActionButton>
+                        )}
+                    </div>
+                );
+        }
+    };
+
+    // ─── Render ───────────────────────────────────────────────────────────────
+
+    return (
+        /* Backdrop overlay */
+        <div
+            style={{
+                position: 'fixed',
+                inset: 0,
+                background: 'rgba(0, 0, 0, 0.85)',
+                backdropFilter: 'blur(4px)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                zIndex: 1100,
+                padding: '1rem',
+            }}
+            onClick={onClose}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Bootstrap library fingerprints"
+        >
+            {/* Modal */}
+            <div
+                onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: '100%',
+                    maxWidth: 760,
+                    maxHeight: '88vh',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    background: 'linear-gradient(180deg, rgba(18,24,39,0.96), rgba(10,14,24,0.99))',
+                    border: `1px solid ${sv.lineHi}`,
+                    boxShadow: `0 0 40px ${sv.cyan}1e, 0 0 80px ${sv.cyan}0f`,
+                    position: 'relative',
+                    overflow: 'hidden',
+                }}
+            >
+                {/* Corner ticks */}
+                <SvCorners />
+
+                {/* Header */}
+                <div
+                    style={{
+                        padding: '18px 24px 16px',
+                        background: 'rgba(94, 234, 212, 0.03)',
+                        borderBottom: `1px solid ${sv.line}`,
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        justifyContent: 'space-between',
+                        flexShrink: 0,
+                    }}
+                >
+                    <div>
+                        <div
+                            style={{
+                                fontFamily: sv.sans,
+                                fontSize: 15,
+                                fontWeight: 700,
+                                letterSpacing: '0.22em',
+                                textTransform: 'uppercase',
+                                color: sv.cyanHi,
+                                textShadow: `0 0 14px ${sv.cyan}77`,
+                            }}
+                        >
+                            Bootstrap Library
+                        </div>
+                        <div
+                            style={{
+                                ...mono,
+                                fontSize: 10,
+                                letterSpacing: '0.14em',
+                                textTransform: 'uppercase',
+                                color: sv.inkDim,
+                                marginTop: 3,
+                            }}
+                        >
+                            Seed fingerprint network from existing media files &middot; TV shows only
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close bootstrap wizard"
+                        style={{
+                            background: 'transparent',
+                            border: `1px solid rgba(255, 61, 127, 0.4)`,
+                            color: sv.magenta,
+                            width: 30,
+                            height: 30,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            cursor: 'pointer',
+                            fontSize: 16,
+                            fontFamily: 'Arial, sans-serif',
+                            flexShrink: 0,
+                        }}
+                        onMouseEnter={(e) => {
+                            e.currentTarget.style.background = 'rgba(255, 61, 127, 0.10)';
+                            e.currentTarget.style.boxShadow = `0 0 12px rgba(255, 61, 127, 0.45)`;
+                        }}
+                        onMouseLeave={(e) => {
+                            e.currentTarget.style.background = 'transparent';
+                            e.currentTarget.style.boxShadow = 'none';
+                        }}
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                {/* Step bar */}
+                <StepBar current={step} />
+
+                {/* Body */}
+                <div
+                    style={{
+                        flex: 1,
+                        overflowY: 'auto',
+                        scrollbarWidth: 'thin',
+                        scrollbarColor: `rgba(94, 234, 212, 0.35) transparent`,
+                    }}
+                >
+                    {step === 'directory' && renderDirectory()}
+                    {step === 'scanning' && renderScanning()}
+                    {step === 'review' && renderReview()}
+                    {step === 'fingerprint' && renderFingerprint()}
+                </div>
+
+                {/* Footer */}
+                <div
+                    style={{
+                        padding: '14px 24px',
+                        borderTop: `1px solid ${sv.line}`,
+                        background: 'rgba(5, 7, 12, 0.5)',
+                        flexShrink: 0,
+                    }}
+                >
+                    {renderFooter()}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default BootstrapLibraryFlow;

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { QRCodeSVG } from 'qrcode.react';
 import { FEATURES } from '../config/constants';
 import { EngramSelect } from './ui/EngramSelect';
+import { BootstrapLibraryFlow } from './BootstrapLibraryFlow';
 import './ConfigWizard.css';
 
 interface ConfigWizardProps {
@@ -165,6 +166,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [showFfmpegOverride, setShowFfmpegOverride] = useState(false);
     const [savedKeys, setSavedKeys] = useState<{makemkv: boolean, tmdb: boolean, opensubtitles: boolean}>({makemkv: false, tmdb: false, opensubtitles: false});
     const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid', error?: string}>({status: 'idle'});
+    const [showBootstrapFlow, setShowBootstrapFlow] = useState(false);
 
     const totalSteps = 4;
 
@@ -870,6 +872,22 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             </>
                         )}
 
+                        {config.enableFingerprintContributions && (
+                            <div className="form-group" style={{ marginTop: '0.75rem' }}>
+                                <button
+                                    type="button"
+                                    className="btn-secondary"
+                                    style={{ padding: '0.45rem 1rem', fontSize: '0.85rem' }}
+                                    onClick={() => setShowBootstrapFlow(true)}
+                                >
+                                    Contribute from existing library&hellip;
+                                </button>
+                                <span className="form-hint" style={{ display: 'block', marginTop: '0.4rem' }}>
+                                    Seed the fingerprint network from your existing TV library (reads filenames only — no files are uploaded).
+                                </span>
+                            </div>
+                        )}
+
                         <div className="form-group checkbox-group">
                             <label className="checkbox-label">
                                 <input
@@ -1316,6 +1334,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     };
 
     return (
+        <>
         <div className="wizard-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="wizard-title">
             <div className="wizard-modal" onClick={(e) => e.stopPropagation()}>
                 <div className="modal-header">
@@ -1381,6 +1400,11 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                 </div>
             </div>
         </div>
+
+        {showBootstrapFlow && (
+            <BootstrapLibraryFlow onClose={() => setShowBootstrapFlow(false)} />
+        )}
+    </>
     );
 }
 


### PR DESCRIPTION
## Summary

A **Bootstrap from existing library** flow (Phase 3, Track B): point Engram at a directory of your already-labeled TV library, it resolves each show to TMDB, and accepted episodes are fingerprinted and queued as `bootstrap` contributions to seed the fingerprint network. Independent of the identification cascade ([#252](https://github.com/Jsakkos/engram/pull/252)) — builds only on Phase 1/2 (already on `main`).

## Design decision (with the user)
The mockups initially showed per-episode confidence/conflict, but bootstrap **trusts the filename's season/episode** — it never *identifies* at bootstrap time. So the only genuine uncertainty is **show-name → TMDB resolution**, and the review surface is **per-show, not per-episode**. A single mislabeled file is harmless: it enters as one `bootstrap` CANDIDATE and the network's ≥3-independent-contributor consensus + anti-poison filters it. This makes the wizard low-friction — most shows auto-resolve and the user only touches the ambiguous ones.

## What's included
- **API** (`backend/app/api/routes.py`, localhost-gated):
  - `POST /api/fingerprint/bootstrap/scan {path}` → groups files by show, resolves each via TMDB, returns per-show resolution + unparseable files + summary. Reuses `walk_library`/`fetch_show_id`/`fetch_show_details`.
  - `POST /api/fingerprint/bootstrap/accept {items}` → fingerprints each accepted episode (`ChromaprintExtractor`) and enqueues a `bootstrap` contribution; per-file failures are isolated.
- **UI** (`frontend/src/components/BootstrapLibraryFlow.tsx`): a 4-step Synapse v2 wizard (Directory → Scan → Review shows → Fingerprint), wired into ConfigWizard. Resolved shows accepted by default; unresolved shows get a manual TMDB-id input or skip; unparseable files shown informationally. Accept POSTs in batches of 50 with a progress bar.
- **Direction mockups** under `docs/design_handoff_synapse/explorations/` (wizard/table/cards — wizard was chosen).

## Testing
- Backend: 8 integration tests (scan grouping/resolution/path-validation/Extras; accept happy/partial-failure/no-fpcalc). The test fixture scrubs `fingerprint_contributions` **after** each test so test rows can never reach the uploader.
- Frontend: `npm run build` (TS check + vite) green; ESLint clean. A Playwright e2e (`bootstrap-library.spec.ts`) is a noted follow-up.
- No new npm dependencies; `package-lock.json` is unchanged.

## Notes
- TV-only (matches the existing bootstrap CLI).
- Minor follow-up polish noted in review: `useMemo` for the accept-items count; move the spin keyframe out of render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)