### PR TITLE
fix(review): split cramped MANUAL row into two rows in inspector

### DIFF
--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -285,102 +285,108 @@ export function Inspector({
                 </div>
 
                 {/* manual override */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 14, paddingTop: 14, borderTop: `1px dashed ${sv.lineMid}` }}>
-                    <span style={{ ...monoFaint, fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase' }}>Manual</span>
-                    <select
-                        value={selection && /^S\d+E\d+$/i.test(selection) ? selection : ''}
-                        onChange={(e) => e.target.value && onAssign(e.target.value)}
-                        aria-label={`Manual episode for title ${title.title_index}`}
-                        style={{
-                            flex: 1,
-                            background: sv.bg0,
-                            border: `1px solid ${sv.lineMid}`,
-                            color: sv.ink,
-                            fontFamily: sv.mono,
-                            fontSize: 12,
-                            padding: '7px 9px',
-                            outline: 'none',
-                            cursor: 'pointer',
-                        }}
-                    >
-                        <option value="">Pick episode…</option>
-                        {episodes.length > 0
-                            ? episodes.map((ep) => (
-                                  <option key={ep.episode_code} value={ep.episode_code}>
-                                      {`E${String(ep.episode_number).padStart(2, '0')}`}
-                                      {ep.name ? ` — ${ep.name}` : ''}
-                                  </option>
-                              ))
-                            : generateEpisodeOptions(
-                                  job.detected_season || 1,
-                                  EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON,
-                              ).map((code) => (
-                                  <option key={code} value={code}>
-                                      {code}
-                                  </option>
-                              ))}
-                    </select>
-                    <SvActionButton
-                        tone={action === 'extra' ? 'cyan' : 'neutral'}
-                        size="sm"
-                        onClick={() => onAction('extra')}
-                        title="Keep as extra content"
-                    >
-                        Extra
-                    </SvActionButton>
-                    <SvActionButton
-                        tone={action === 'discard' ? 'red' : 'neutral'}
-                        size="sm"
-                        onClick={() => onAction('discard')}
-                        title="Discard this title"
-                        ariaLabel="Discard"
-                    >
-                        <Trash2 size={11} />
-                    </SvActionButton>
-                    <SvActionButton
-                        tone="neutral"
-                        size="sm"
-                        onClick={() => onAction('skip')}
-                        title="Skip for now"
-                        ariaLabel="Skip"
-                    >
-                        <SkipForward size={11} />
-                    </SvActionButton>
-                    {aiEpisodeMatchingEnabled && (
-                        <SvActionButton
-                            tone="cyan"
-                            size="sm"
-                            onClick={() => onTryLLMMatch(title.id)}
-                            title="Run AI episode matching"
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginTop: 14, paddingTop: 14, borderTop: `1px dashed ${sv.lineMid}` }}>
+                    {/* row 1: label + episode picker */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span style={{ ...monoFaint, fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase' }}>Manual</span>
+                        <select
+                            value={selection && /^S\d+E\d+$/i.test(selection) ? selection : ''}
+                            onChange={(e) => e.target.value && onAssign(e.target.value)}
+                            aria-label={`Manual episode for title ${title.title_index}`}
+                            style={{
+                                flex: 1,
+                                background: sv.bg0,
+                                border: `1px solid ${sv.lineMid}`,
+                                color: sv.ink,
+                                fontFamily: sv.mono,
+                                fontSize: 12,
+                                padding: '7px 9px',
+                                outline: 'none',
+                                cursor: 'pointer',
+                            }}
                         >
-                            Try AI match
+                            <option value="">Pick episode…</option>
+                            {episodes.length > 0
+                                ? episodes.map((ep) => (
+                                      <option key={ep.episode_code} value={ep.episode_code}>
+                                          {`E${String(ep.episode_number).padStart(2, '0')}`}
+                                          {ep.name ? ` — ${ep.name}` : ''}
+                                      </option>
+                                  ))
+                                : generateEpisodeOptions(
+                                      job.detected_season || 1,
+                                      EPISODE_CONFIG.DEFAULT_EPISODES_PER_SEASON,
+                                  ).map((code) => (
+                                      <option key={code} value={code}>
+                                          {code}
+                                      </option>
+                                  ))}
+                        </select>
+                    </div>
+                    {/* row 2: action buttons */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'flex-end' }}>
+                        <SvActionButton
+                            tone={action === 'extra' ? 'cyan' : 'neutral'}
+                            size="sm"
+                            onClick={() => onAction('extra')}
+                            title="Keep as extra content"
+                        >
+                            Extra
                         </SvActionButton>
-                    )}
-                    {/* Per-track deep re-match — re-run the matcher on just this title
-                        at strict depth/votes (distinct from the conflict banner, which
-                        re-matches every title claiming the contested episode). */}
-                    <SvActionButton
-                        tone="magenta"
-                        size="sm"
-                        onClick={() => onRematch(title.id, 'engram', true)}
-                        disabled={isRematching}
-                        title="Deep re-match this track (denser sampling + stricter votes)"
-                        ariaLabel="Deep re-match this track"
-                    >
-                        <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
-                        <span style={{ marginLeft: 6 }}>Re-match</span>
-                    </SvActionButton>
-                    {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
+                        <SvActionButton
+                            tone={action === 'discard' ? 'red' : 'neutral'}
+                            size="sm"
+                            onClick={() => onAction('discard')}
+                            title="Discard this title"
+                            ariaLabel="Discard"
+                        >
+                            <Trash2 size={11} />
+                        </SvActionButton>
+                        <SvActionButton
+                            tone="neutral"
+                            size="sm"
+                            onClick={() => onAction('skip')}
+                            title="Skip for now"
+                            ariaLabel="Skip"
+                        >
+                            <SkipForward size={11} />
+                        </SvActionButton>
+                        {aiEpisodeMatchingEnabled && (
+                            <SvActionButton
+                                tone="cyan"
+                                size="sm"
+                                onClick={() => onTryLLMMatch(title.id)}
+                                title="Run AI episode matching"
+                            >
+                                Try AI match
+                            </SvActionButton>
+                        )}
+                        {/* Per-track deep re-match — re-run the matcher on just this title
+                            at strict depth/votes (distinct from the conflict banner, which
+                            re-matches every title claiming the contested episode). */}
                         <SvActionButton
                             tone="magenta"
                             size="sm"
-                            onClick={() => onRematch(title.id, title.match_source === 'discdb' ? 'engram' : 'discdb')}
-                            title="Toggle match source"
-                            ariaLabel="Toggle match source"
+                            onClick={() => onRematch(title.id, 'engram', true)}
+                            disabled={isRematching}
+                            title="Deep re-match this track (denser sampling + stricter votes)"
+                            ariaLabel="Deep re-match this track"
                         >
                             <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                            Re-match
                         </SvActionButton>
-                    )}
+                        {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
+                            <SvActionButton
+                                tone="magenta"
+                                size="sm"
+                                onClick={() => onRematch(title.id, title.match_source === 'discdb' ? 'engram' : 'discdb')}
+                                title="Toggle match source"
+                                ariaLabel="Toggle match source"
+                            >
+                                <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                            </SvActionButton>
+                        )}
+                    </div>
                 </div>
             </div>
         </SvPanel>

--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -138,7 +138,7 @@ export function Inspector({
                             disabled={isRematching}
                         >
                             <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
-                            <span style={{ marginLeft: 6 }}>{isRematching ? 'Re-matching…' : 'Deep re-match'}</span>
+                            {isRematching ? 'Re-matching…' : 'Deep re-match'}
                         </SvActionButton>
                     </div>
                 )}
@@ -383,7 +383,7 @@ export function Inspector({
                                 title="Toggle match source"
                                 ariaLabel="Toggle match source"
                             >
-                                <IcoRetry size={11} className={isRematching ? 'animate-spin' : ''} />
+                                <IcoRetry size={11} />
                             </SvActionButton>
                         )}
                     </div>


### PR DESCRIPTION
## Summary

- The inspector's MANUAL section packed 6–8 controls (label, dropdown, Extra, Trash, Skip, optional AI-match, Re-match, optional DiscDB toggle) into a single \`display: flex\` row at \`gap: 8\`. At the inspector panel's ~320 px width, the episode dropdown was squeezed nearly to zero and the Re-match button was clipped against the right edge.
- Split the container into two stacked rows: **Row 1** = \`MANUAL\` label + episode dropdown (full width via \`flex: 1\`); **Row 2** = all action buttons, \`justifyContent: flex-end\`.
- Also removed a redundant \`marginLeft: 6\` from the Re-match button's text spans — \`SvActionButton\` already applies \`gap: 4\` between icon and label for \`size="sm"\`.
- Decoupled DiscDB-toggle spinner from \`isRematching\` — it's an instant state flip, not a long operation; the two adjacent magenta buttons were both spinning from a single Re-match click.

## Change

Single file: \`frontend/src/components/ReviewQueue/Inspector.tsx\` (layout restructure of the MANUAL section — no logic changes).

## Test plan

- [x] **Playwright MCP** — navigated to \`/review/1\` (job with one \`review\`-state title), screenshot confirmed two-row layout: dropdown full-width on Row 1, all buttons visible and unclipped on Row 2
- [ ] Navigate to a job in \`review_needed\` state in the real app
- [ ] Confirm MANUAL section renders in two rows: dropdown full-width on top, buttons below
- [ ] Confirm all buttons (Extra, Trash, Skip, Re-match) are fully visible and unclipped
- [ ] Confirm optional AI-match and DiscDB-toggle buttons still appear when their feature flags are active