### PR TITLE
fix: refresh UI after update + correct frozen-build detection

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2366,6 +2366,7 @@ async def _collect_environment() -> dict:
     """
     from app import __version__
     from app.api.validation import detect_ffmpeg, detect_makemkv
+    from app.config import is_frozen
     from app.services.config_service import get_config
 
     config = await get_config()
@@ -2377,6 +2378,11 @@ async def _collect_environment() -> dict:
         "app_version": __version__,
         "python_version": sys.version.split()[0],
         "os": f"{platform.system()} {platform.release()}",
+        "runtime": {
+            "is_frozen": is_frozen(),
+            "sys_frozen": bool(getattr(sys, "frozen", False)),
+            "meipass": hasattr(sys, "_MEIPASS"),
+        },
         "makemkv_version": mk.version if mk.found else (mk.error or "not found"),
         "ffmpeg_version": ff.version if ff.found else (ff.error or "not found"),
         "config": {
@@ -2403,6 +2409,9 @@ def _build_markdown_summary(env: dict, job_summary: dict | None, recent_errors: 
         f"**Engram version**: {env['app_version']}",
         f"**OS**: {env['os']}",
         f"**Python**: {env['python_version']}",
+        f"**Build**: {'frozen' if env.get('runtime', {}).get('is_frozen') else 'dev'} "
+        f"(sys.frozen={env.get('runtime', {}).get('sys_frozen')}, "
+        f"_MEIPASS={env.get('runtime', {}).get('meipass')})",
         f"**MakeMKV**: {env['makemkv_version']}",
         f"**FFmpeg**: {env['ffmpeg_version']}",
         "",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,9 +14,21 @@ from pathlib import Path
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+def is_frozen() -> bool:
+    """True for packaged (PyInstaller) builds.
+
+    PyInstaller's bootloader sets both ``sys.frozen`` and ``sys._MEIPASS``, but
+    they can diverge in the wild — some builds reach the bundled frontend (served
+    off ``sys._MEIPASS`` in ``main.py``) yet report ``sys.frozen`` falsy, which
+    made the updater wrongly show "dev mode". Treat either signal as
+    authoritative so every "am I frozen?" decision agrees.
+    """
+    return bool(getattr(sys, "frozen", False)) or hasattr(sys, "_MEIPASS")
+
+
 def _default_database_url() -> str:
     """Return the default database URL, using ~/.engram/ for frozen (PyInstaller) builds."""
-    if getattr(sys, "frozen", False):
+    if is_frozen():
         # Frozen build: store DB in a stable, user-writable location
         db_dir = Path.home() / ".engram"
         db_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -22,6 +22,7 @@ import httpx
 from loguru import logger
 
 from app import __version__
+from app.config import is_frozen
 from app.core.errors import ConfigurationError, EngramError
 from app.database import async_session
 
@@ -63,7 +64,7 @@ class UpdateChecker:
         self.download_progress: float = 0.0
         self.staging_path: Path | None = None
         self.error: str | None = None
-        self._is_frozen: bool = getattr(sys, "frozen", False)
+        self._is_frozen: bool = is_frozen()
         self._current_version: str = __version__
         self._broadcaster = None  # injected by set_broadcaster()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -223,8 +223,19 @@ if os.path.isdir(_static_dir):
     from fastapi.responses import FileResponse
     from fastapi.staticfiles import StaticFiles
 
+    # Vite content-hashes everything under /assets (e.g. index-AbC123.js), so the
+    # filename changes whenever the bytes change — they can be cached forever.
+    # The opposite of index.html below, which must never be cached (see serve_spa).
+    class _ImmutableStatic(StaticFiles):
+        def file_response(self, *args, **kwargs):
+            resp = super().file_response(*args, **kwargs)
+            resp.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            return resp
+
     # Mount static assets (JS, CSS, images)
-    app.mount("/assets", StaticFiles(directory=os.path.join(_static_dir, "assets")), name="assets")
+    app.mount(
+        "/assets", _ImmutableStatic(directory=os.path.join(_static_dir, "assets")), name="assets"
+    )
 
     # Root-level static files emitted by the Vite build (favicon, SVGs, etc.).
     # Built once at server startup by listing the static dir — no manual
@@ -253,7 +264,11 @@ if os.path.isdir(_static_dir):
         # have been removed since; fall through to index.html, never a 500.
         if static_file is not None and os.path.isfile(static_file):
             return FileResponse(static_file)
-        return FileResponse(_INDEX_HTML)
+        # index.html keeps a stable name across builds, so without this header the
+        # browser heuristically caches it and keeps loading the OLD hashed bundles
+        # after an update. no-cache forces revalidation; FileResponse's ETag makes
+        # the revalidation a cheap 304 when unchanged.
+        return FileResponse(_INDEX_HTML, headers={"Cache-Control": "no-cache"})
 
 else:
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -227,9 +227,17 @@ if os.path.isdir(_static_dir):
     # filename changes whenever the bytes change — they can be cached forever.
     # The opposite of index.html below, which must never be cached (see serve_spa).
     class _ImmutableStatic(StaticFiles):
-        def file_response(self, *args, **kwargs):
-            resp = super().file_response(*args, **kwargs)
-            resp.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        # Stamp the header by overriding get_response (the stable async entry
+        # point), NOT file_response: in Starlette 0.50.0 file_response is a *sync*
+        # method that get_response calls without await, so an `async def
+        # file_response` override would make get_response return an un-awaited
+        # coroutine and 500 every /assets request — while a `def file_response`
+        # override is correct only as long as it stays sync. Overriding the async
+        # get_response is robust regardless of file_response's sync/async-ness.
+        async def get_response(self, *args, **kwargs):
+            resp = await super().get_response(*args, **kwargs)
+            if resp.status_code == 200:
+                resp.headers["Cache-Control"] = "public, max-age=31536000, immutable"
             return resp
 
     # Mount static assets (JS, CSS, images)

--- a/backend/run.py
+++ b/backend/run.py
@@ -43,13 +43,21 @@ def main() -> None:
         import webbrowser
 
         import uvicorn
+        from loguru import logger
 
+        from app import __version__
+        from app.config import is_frozen
         from app.core.network import ALL_INTERFACES, resolve_startup_host
         from app.main import app, settings
 
-        is_frozen = getattr(sys, "frozen", False)
+        frozen = is_frozen()
+        logger.info(
+            f"Starting engram {__version__} — is_frozen()={frozen} "
+            f"(sys.frozen={getattr(sys, 'frozen', False)!r}, "
+            f"_MEIPASS={'set' if hasattr(sys, '_MEIPASS') else 'unset'})"
+        )
         host = resolve_startup_host(settings.host)
-        port = _find_free_port(host, settings.port) if is_frozen else settings.port
+        port = _find_free_port(host, settings.port) if frozen else settings.port
 
         if port != settings.port:
             print(f"Port {settings.port} in use, using {port} instead")
@@ -58,7 +66,7 @@ def main() -> None:
         app.state.bound_host = host
         app.state.bound_port = port
 
-        if is_frozen:
+        if frozen:
             # Open browser after a short delay to let the server bind the port.
             # When bound to all interfaces, open localhost (http://0.0.0.0 is not
             # a valid client address); LAN clients use the address shown in the UI.
@@ -71,7 +79,7 @@ def main() -> None:
             host=host,
             port=port,
             # reload is incompatible with frozen PyInstaller bundles
-            reload=False if is_frozen else settings.debug,
+            reload=False if frozen else settings.debug,
             factory=False,
         )
     except KeyboardInterrupt:
@@ -83,7 +91,9 @@ def main() -> None:
         # (including module-level import errors) lands here so a frozen build
         # keeps the console open with a visible traceback instead of vanishing.
         traceback.print_exc()
-        if getattr(sys, "frozen", False):
+        # Inline the frozen check (not app.config.is_frozen) so the console still
+        # pauses even when the crash was app.config failing to import.
+        if getattr(sys, "frozen", False) or hasattr(sys, "_MEIPASS"):
             print(f"\nFatal error: {exc}")
             print("Check ~/.engram/engram.log for details")
             input("Press Enter to exit...")

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,36 @@
+"""Unit tests for app.config helpers."""
+
+import sys
+
+from app.config import is_frozen
+
+
+class TestIsFrozen:
+    """is_frozen() must treat EITHER sys.frozen or sys._MEIPASS as authoritative.
+
+    Regression guard for the false "dev mode" bug: a packaged build reached the
+    bundled frontend (served off sys._MEIPASS) yet reported sys.frozen falsy, so
+    the updater wrongly refused to self-update. Either signal now means frozen.
+    """
+
+    def test_false_when_neither_signal_present(self, monkeypatch):
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+        assert is_frozen() is False
+
+    def test_true_when_sys_frozen_set(self, monkeypatch):
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        assert is_frozen() is True
+
+    def test_true_when_meipass_set_but_frozen_unset(self, monkeypatch):
+        # The exact divergence the user hit: UI served (=> _MEIPASS) but
+        # sys.frozen falsy. Must still report frozen.
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEIxxxx", raising=False)
+        assert is_frozen() is True
+
+    def test_true_when_both_set(self, monkeypatch):
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEIxxxx", raising=False)
+        assert is_frozen() is True

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -28,6 +28,25 @@ const STATE_PRIORITY: Record<string, number> = {
 // Title states that indicate a title has finished processing.
 const TERMINAL_TITLE_STATES = ['matched', 'completed', 'review', 'failed'];
 
+/**
+ * A WebSocket reconnect often follows a backend restart — notably after the
+ * auto-updater applies a new build. If the backend now reports a different
+ * version than the one THIS bundle was compiled from (`__APP_VERSION__`), the
+ * open tab is stale, so hard-reload to pull the new UI. `index.html` is served
+ * `no-cache`, so the reload fetches the new content-hashed bundles; the new
+ * bundle's `__APP_VERSION__` then matches, so this fires exactly once.
+ */
+async function reloadIfVersionChanged(): Promise<void> {
+    try {
+        const status = await apiFetch<{ current_version?: string }>('/api/updates/status');
+        if (status.current_version && status.current_version !== __APP_VERSION__) {
+            window.location.reload();
+        }
+    } catch {
+        // Transient blip during reconnect — skip; we re-check on the next reconnect.
+    }
+}
+
 export function useJobManagement(devMode: boolean = false) {
     const [jobs, setJobs] = useState<Job[]>([]);
     const [titlesMap, setTitlesMap] = useState<Record<number, DiscTitle[]>>({});
@@ -136,6 +155,8 @@ export function useJobManagement(devMode: boolean = false) {
         if (import.meta.env.DEV) {
             console.log('🔌 WebSocket reconnected — resyncing jobs');
         }
+        // The reconnect may follow an update+restart — reload if the build changed.
+        void reloadIfVersionChanged();
         fetchRef.current?.();
     }, []);
 

--- a/frontend/src/hooks/__tests__/useJobManagement.test.ts
+++ b/frontend/src/hooks/__tests__/useJobManagement.test.ts
@@ -387,6 +387,79 @@ describe("useJobManagement hook integration", () => {
     // Sanity: the listener was registered so WS messages would be handled.
     expect(typeof capturedListener).toBe("function");
   });
+
+  it("hard-reloads on reconnect when the backend reports a different version", async () => {
+    // Swap window.location for a stub that records reload() (jsdom's real
+    // reload is unimplemented). delete-then-assign is the jsdom-safe override.
+    const realLocation = window.location;
+    const reloadMock = vi.fn();
+    // @ts-expect-error — overriding the non-writable location for the test.
+    delete window.location;
+    // @ts-expect-error — install a minimal stub the hook can read + call.
+    window.location = { protocol: "http:", host: "localhost:5173", reload: reloadMock };
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const urlStr = String(input);
+      if (urlStr.includes("/api/updates/status"))
+        return Promise.resolve(okJson({ current_version: `${__APP_VERSION__}-next` }));
+      return Promise.resolve(okJson([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useJobManagement(false));
+
+    // First onOpen = initial connect (skipped); second = reconnect (version check).
+    act(() => {
+      capturedOnOpen?.();
+    });
+    await act(async () => {
+      capturedOnOpen?.();
+    });
+
+    await waitFor(() => {
+      expect(reloadMock).toHaveBeenCalled();
+    });
+
+    // @ts-expect-error — restore the real location for other tests.
+    window.location = realLocation;
+  });
+
+  it("does NOT reload on reconnect when the version matches", async () => {
+    const realLocation = window.location;
+    const reloadMock = vi.fn();
+    // @ts-expect-error — overriding the non-writable location for the test.
+    delete window.location;
+    // @ts-expect-error — install a minimal stub the hook can read + call.
+    window.location = { protocol: "http:", host: "localhost:5173", reload: reloadMock };
+
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const urlStr = String(input);
+      if (urlStr.includes("/api/updates/status"))
+        return Promise.resolve(okJson({ current_version: __APP_VERSION__ }));
+      return Promise.resolve(okJson([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useJobManagement(false));
+
+    act(() => {
+      capturedOnOpen?.();
+    });
+    await act(async () => {
+      capturedOnOpen?.();
+    });
+
+    // Wait until the status check has actually run, then assert no reload.
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some((c) => String(c[0]).includes("/api/updates/status")),
+      ).toBe(true);
+    });
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    // @ts-expect-error — restore the real location for other tests.
+    window.location = realLocation;
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes two defects in the update / release experience of the frozen Windows `.exe`. One PR, two commits (one per issue).

## Issue 1 — Stale UI after an update

**Symptom:** after updating, the browser kept serving the cached old UI, so bug fixes didn't show up.

**Root cause:** Vite content-hashes JS/CSS (`index-AbC123.js`) so those are safe, but the stable-named `index.html` was served with **no `Cache-Control`**, so browsers heuristically cached it and kept loading the *old* hashed bundles.

**Fix:**
- Serve `index.html` with `Cache-Control: no-cache` (forces revalidation; `FileResponse`'s ETag makes it a cheap `304` when unchanged) and the content-hashed `/assets` as `public, max-age=31536000, immutable`.
- On a WebSocket **reconnect** (which follows an update+restart), compare the backend's `current_version` to the bundle's `__APP_VERSION__` and hard-reload **once** if they differ — so the already-open tab refreshes itself with no manual `Ctrl+Shift+R`.

## Issue 2 — `.exe` falsely reported "dev mode"

**Symptom:** updating via the UI showed "dev mode, manual download required" and hid the "Restart now" button, even on a real `.exe`.

**Root cause:** a split-brain frozen check. The bundled UI is served when `sys._MEIPASS` is set, but the updater decided dev-vs-frozen via `getattr(sys, "frozen", False)`. PyInstaller normally sets both, but they diverged in the affected build: the UI was reachable (so `_MEIPASS` was set) yet `sys.frozen` was falsy → stuck on the manual-download path.

**Fix:**
- New `is_frozen()` helper in `app/config.py` — either signal means frozen — used everywhere the build mode is decided (updater, `run.py` port/browser/error-pause, DB-location default). The `run.py` crash handler inlines the check so it survives an import failure.
- Build mode is now observable: a startup log line (`is_frozen()=… sys.frozen=… _MEIPASS=…`), a `runtime` block in the diagnostics bundle, and a `**Build:**` line in the bug-report markdown.

## Verification
- **Backend:** 33 tests pass — new `test_config.py` covers the exact `_MEIPASS`-set / `sys.frozen`-unset regression case, plus `test_updater`, `test_update_workflow`, `test_diagnostics`. `ruff check`/`format` clean.
- **Frontend:** 14 tests pass (12 existing + 2 new: reload-on-version-mismatch, no-reload-on-match). `npm run build` (tsc) + `npm run lint` clean.

**Caveats:** the cache-header behavior has no automated test (the static mount only registers when `app/static` exists, which it never does in the test/CI job). The real-`.exe` end-to-end (confirm `is_frozen()=true`, watch the tab self-refresh) needs a packaged build — the new startup log line is the confirmation hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
