### PR TITLE
feat(ordering): expose global DVD/aired episode-ordering default in Config UI (#255)

### DIFF
--- a/frontend/e2e/episode-ordering-config.spec.ts
+++ b/frontend/e2e/episode-ordering-config.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Global "Episode Ordering" default selector in ConfigWizard (#255).
+ *
+ * Distinct from the per-show selector in the Review Queue (episode-ordering.spec.ts):
+ * this is the *global* default on the Preferences tab (step 4). It interacts with the
+ * real Settings modal and round-trips through GET/PUT /api/config — no route mocking.
+ *
+ * Tests verify:
+ *   - The select renders on the Preferences tab and shows the aired default.
+ *   - Switching to "DVD Order" and saving persists across a page reload.
+ *   - Restores the aired default afterwards to leave global config clean.
+ */
+
+async function openSettingsPreferences(page: import('@playwright/test').Page) {
+    await page.locator('[data-testid="sv-settings-btn"]').click();
+    await expect(page.getByText('Preferences')).toBeVisible({ timeout: 5000 });
+    // In settings mode all tabs are clickable; jump straight to step 4.
+    await page.getByRole('button', { name: /Step 4: Preferences/i }).click();
+    await expect(page.getByText('Configure additional options for your workflow')).toBeVisible({
+        timeout: 3000,
+    });
+}
+
+async function selectEpisodeOrdering(page: import('@playwright/test').Page, optionName: RegExp) {
+    // EngramSelect is a Radix Select: click the trigger, then the option in the portal.
+    await page.locator('#episodeOrdering').click();
+    await page.getByRole('option', { name: optionName }).click();
+}
+
+async function saveChanges(page: import('@playwright/test').Page) {
+    await page.getByRole('button', { name: /Save Changes/i }).click();
+    // Modal closes on a successful save.
+    await expect(page.locator('[data-testid="sv-settings-btn"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Global episode ordering default', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        // Wait for the WebSocket connection indicator before interacting.
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('defaults to aired, persists DVD across reload, then restores aired', async ({ page }) => {
+        // --- Step 1: open settings and normalise to the aired default ---
+        await openSettingsPreferences(page);
+        const trigger = page.locator('#episodeOrdering');
+        await expect(trigger).toBeVisible();
+
+        await selectEpisodeOrdering(page, /Aired Order/);
+        await expect(trigger).toContainText('Aired Order');
+        await saveChanges(page);
+
+        // --- Step 2: switch to DVD Order and save ---
+        await openSettingsPreferences(page);
+        await selectEpisodeOrdering(page, /DVD Order/);
+        await expect(page.locator('#episodeOrdering')).toContainText('DVD Order');
+        await saveChanges(page);
+
+        // --- Step 3: reload and confirm DVD persisted via GET /api/config ---
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+        await openSettingsPreferences(page);
+        await expect(page.locator('#episodeOrdering')).toContainText('DVD Order');
+
+        // --- Cleanup: restore the aired default so other tests start clean ---
+        await selectEpisodeOrdering(page, /Aired Order/);
+        await expect(page.locator('#episodeOrdering')).toContainText('Aired Order');
+        await saveChanges(page);
+    });
+});

--- a/frontend/e2e/episode-ordering-config.spec.ts
+++ b/frontend/e2e/episode-ordering-config.spec.ts
@@ -13,6 +13,9 @@ import { test, expect } from '@playwright/test';
  *   - Restores the aired default afterwards to leave global config clean.
  */
 
+// The E2E backend always runs on port 8001 (see playwright.config.ts).
+const API = 'http://localhost:8001';
+
 async function openSettingsPreferences(page: import('@playwright/test').Page) {
     await page.locator('[data-testid="sv-settings-btn"]').click();
     await expect(page.getByText('Preferences')).toBeVisible({ timeout: 5000 });
@@ -42,7 +45,16 @@ test.describe('Global episode ordering default', () => {
         await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
     });
 
-    test('defaults to aired, persists DVD across reload, then restores aired', async ({ page }) => {
+    // Tests share one backend DB and run serially (workers: 1). Restore the aired
+    // default directly via the API after each test so a mid-test failure (which
+    // could leave "dvd" persisted) doesn't bleed into later specs.
+    test.afterEach(async ({ request }) => {
+        await request.put(`${API}/api/config`, {
+            data: { episode_ordering_preference: 'aired' },
+        });
+    });
+
+    test('defaults to aired and persists DVD across reload', async ({ page }) => {
         // --- Step 1: open settings and normalise to the aired default ---
         await openSettingsPreferences(page);
         const trigger = page.locator('#episodeOrdering');
@@ -63,10 +75,6 @@ test.describe('Global episode ordering default', () => {
         await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
         await openSettingsPreferences(page);
         await expect(page.locator('#episodeOrdering')).toContainText('DVD Order');
-
-        // --- Cleanup: restore the aired default so other tests start clean ---
-        await selectEpisodeOrdering(page, /Aired Order/);
-        await expect(page.locator('#episodeOrdering')).toContainText('Aired Order');
-        await saveChanges(page);
+        // The aired default is restored by afterEach via the API.
     });
 });

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -57,7 +57,7 @@ interface ConfigData {
     maxConcurrentMatches: number;
     ffmpegPath: string;
     conflictResolutionDefault: string;
-    episodeOrderingPreference: string;
+    episodeOrderingPreference: 'aired' | 'dvd';
     watchdogEnabled: boolean;
     timeoutIdentifyingSeconds: number;
     timeoutRippingSeconds: number;

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -57,6 +57,7 @@ interface ConfigData {
     maxConcurrentMatches: number;
     ffmpegPath: string;
     conflictResolutionDefault: string;
+    episodeOrderingPreference: string;
     watchdogEnabled: boolean;
     timeoutIdentifyingSeconds: number;
     timeoutRippingSeconds: number;
@@ -125,6 +126,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         maxConcurrentMatches: 2,
         ffmpegPath: '',
         conflictResolutionDefault: 'ask',
+        episodeOrderingPreference: 'aired',
         watchdogEnabled: true,
         timeoutIdentifyingSeconds: 600,
         timeoutRippingSeconds: 1200,
@@ -215,6 +217,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     maxConcurrentMatches: data.max_concurrent_matches ?? 2,
                     ffmpegPath: data.ffmpeg_path || '',
                     conflictResolutionDefault: data.conflict_resolution_default || 'ask',
+                    episodeOrderingPreference: data.episode_ordering_preference || 'aired',
                     watchdogEnabled: data.watchdog_enabled ?? true,
                     timeoutIdentifyingSeconds: data.timeout_identifying_seconds ?? 600,
                     timeoutRippingSeconds: data.timeout_ripping_seconds ?? 1200,
@@ -326,6 +329,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     max_concurrent_matches: config.maxConcurrentMatches,
                     ffmpeg_path: config.ffmpegPath,
                     conflict_resolution_default: config.conflictResolutionDefault,
+                    episode_ordering_preference: config.episodeOrderingPreference,
                     watchdog_enabled: config.watchdogEnabled,
                     timeout_identifying_seconds: config.timeoutIdentifyingSeconds,
                     timeout_ripping_seconds: config.timeoutRippingSeconds,
@@ -1044,6 +1048,26 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             />
                             <span className="form-hint">
                                 What should Engram do when a file already exists in your library?
+                            </span>
+                        </div>
+
+                        <div className="form-group">
+                            <label htmlFor="episodeOrdering">Episode Ordering</label>
+                            <EngramSelect
+                                id="episodeOrdering"
+                                value={config.episodeOrderingPreference}
+                                onValueChange={(v) => handleInputChange('episodeOrderingPreference', v)}
+                                options={[
+                                    { value: 'aired', label: 'Aired Order (Default)' },
+                                    { value: 'dvd', label: 'DVD Order' },
+                                ]}
+                            />
+                            <span className="form-hint">
+                                How TV episodes are numbered in filenames. DVD order uses the disc
+                                release's numbering (e.g. Firefly) when a show provides it, falling back
+                                to aired order otherwise. This only affects new rips' filenames — matching,
+                                history, and the fingerprint network always use canonical aired numbering.
+                                Individual shows can be overridden during review.
                             </span>
                         </div>
 


### PR DESCRIPTION
Resolves #255.

## Problem

[Issue #255](https://github.com/Jsakkos/engram/issues/255) (from discussion #166) asks for an option to **prefer DVD order instead of aired order** for TV episode numbering. The owner's steer: *"Add a setting for this in the config UI, but respect #200 and #254."*

## Context: the backend already exists

PR #254 (resolving #200) built the entire ordering backend — the global default field, per-show overrides, the resolver, the canonical→output projection engine, the organize seam, validation, a migration, and unit tests. The only missing piece was a **Config-UI control** to edit the global default.

## What this PR does (frontend only)

- Adds an **"Episode Ordering"** dropdown to the ConfigWizard **Preferences** tab, wired through the existing load/state/save pattern to `episode_ordering_preference` on `GET`/`PUT /api/config`.
- Offers only **Aired Order (Default)** and **DVD Order** — the two orderings users understand. The backend supports six, but `digital`/`production`/`story_arc`/`tv` are niche and sparsely populated; they remain available **contextually** in the per-show Review Queue selector (`OrderingSelector`), which only surfaces an ordering when that show actually diverges.

## Respecting the #200/#254 invariant

Canonical = TMDB **aired** order. Output ordering is a presentation-only projection applied filename-only inside `organize_tv_episode`. This PR only sets the existing global default string — it never touches `matched_episode`, job history, or the fingerprint payload. **No backend logic changed**, so the invariant holds by construction. The help text makes this explicit ("only affects new rips' filenames — matching, history, and the fingerprint network always use canonical aired numbering").

## Testing

- **Existing backend unit tests green**: `test_episode_ordering_api.py` + `test_episode_ordering_service.py` (16 passed) — already cover the config GET/PUT/validation contract (incl. `422` on `absolute`/unknown).
- **Frontend** `npm run build` + `npm run lint` clean.
- **New Playwright E2E** (`episode-ordering-config.spec.ts`): opens the Settings modal, sets DVD order on the Preferences tab, saves, reloads, and confirms it persisted via the real `GET`/`PUT /api/config` round-trip (1 passed).

## Out of scope

No per-show UI changes (handled by #254's `OrderingSelector`), no retroactive renaming of already-organized files (deferred per #254), and `absolute`/anime ordering remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)