### PR TITLE
feat(fingerprint): bundle fpcalc in builds so end users skip manual install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         description: "Tag to release (e.g. v0.7.3)"
         required: true
         type: string
+      draft:
+        description: "Create as a draft release (hidden from users; for testing builds)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -331,7 +336,11 @@ jobs:
           cat sha256sums.txt
       - uses: softprops/action-gh-release@v3
         with:
-          draft: false
+          # A manual workflow_dispatch can request a draft (hidden from the public
+          # releases page and from the /releases/latest endpoint the auto-updater
+          # polls) for testing a build. Tag-push releases leave inputs unset, so
+          # this resolves to false and they publish normally.
+          draft: ${{ inputs.draft || false }}
           generate_release_notes: true
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           uv sync --no-install-project
           uv pip install pyinstaller
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
       - name: Build executable
         working-directory: backend
         run: uv run pyinstaller engram.spec
@@ -87,6 +91,10 @@ jobs:
             $count = (Get-Process engram -ErrorAction SilentlyContinue | Measure-Object).Count
             Write-Host "engram process count: $count"
             if ($count -gt 2) { throw "too many engram processes ($count) - possible multiprocessing fork-bomb" }
+            # fpcalc must be bundled and detected — the whole point of shipping it.
+            $tools = Invoke-RestMethod -Uri "http://127.0.0.1:8765/api/detect-tools" -TimeoutSec 5
+            if (-not $tools.fpcalc.found) { throw "bundled fpcalc was not detected: $($tools.fpcalc.error)" }
+            Write-Host "fpcalc detected: $($tools.fpcalc.path)"
             Write-Host "smoke test passed"
           } finally {
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
@@ -136,6 +144,10 @@ jobs:
         run: |
           uv sync --no-install-project
           uv pip install pyinstaller
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
       - name: Build executable
         working-directory: backend
         run: uv run pyinstaller engram.spec
@@ -176,6 +188,14 @@ jobs:
           echo "engram process count: $count"
           if [ "$count" -gt 2 ]; then
             echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
+            exit 1
+          fi
+          # fpcalc must be bundled and detected — the whole point of shipping it.
+          fpcalc_found=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/detect-tools \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['fpcalc']['found'])")
+          echo "fpcalc detected: $fpcalc_found"
+          if [ "$fpcalc_found" != "True" ]; then
+            echo "bundled fpcalc was not detected"
             exit 1
           fi
           echo "smoke test passed"
@@ -228,6 +248,10 @@ jobs:
         run: |
           uv sync --no-install-project
           uv pip install pyinstaller
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
       - name: Build executable
         working-directory: backend
         run: uv run pyinstaller engram.spec
@@ -268,6 +292,14 @@ jobs:
           echo "engram process count: $count"
           if [ "$count" -gt 2 ]; then
             echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
+            exit 1
+          fi
+          # fpcalc must be bundled and detected — the whole point of shipping it.
+          fpcalc_found=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/detect-tools \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['fpcalc']['found'])")
+          echo "fpcalc detected: $fpcalc_found"
+          if [ "$fpcalc_found" != "True" ]; then
+            echo "bundled fpcalc was not detected"
             exit 1
           fi
           echo "smoke test passed"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ frontend/dist/
 # Bundled frontend served from backend (PyInstaller build output)
 backend/app/static/
 
+# Bundled fpcalc binary (fetched by scripts/fetch_fpcalc.py, never committed)
+backend/app/bin/
+
 # Subtitle-cache build outputs (local artifacts of build_subtitle_cache.py;
 # published via gh release upload, not committed).
 backend/engram-subtitle-cache.tar.gz

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,18 @@
+# Third-Party Licenses
+
+Engram's distributable builds bundle the following third-party binaries.
+
+## Chromaprint (`fpcalc`)
+
+- **Component:** `fpcalc`, the command-line audio fingerprinter from Chromaprint.
+- **Version:** 1.5.1 (pinned in `backend/scripts/fetch_fpcalc.py`).
+- **License:** GNU Lesser General Public License, version 2.1 or later (LGPL-2.1+).
+- **Copyright:** © Lukáš Lalinský and the Chromaprint contributors.
+- **Source:** https://github.com/acoustid/chromaprint (release `v1.5.1`).
+- **Modifications:** None. The official release binary is redistributed unmodified.
+
+The binary is fetched at build time from the official GitHub release and verified
+against a pinned SHA256 (see `backend/scripts/fetch_fpcalc.py`); it is not stored
+in this repository. Engram invokes `fpcalc` as a separate executable (it does not
+link against libchromaprint), so no relinking is required to satisfy the LGPL. The
+complete corresponding source for the bundled version is available at the URL above.

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -262,9 +262,14 @@ def _bundled_fpcalc_path() -> str | None:
     roots: list[Path] = []
     meipass = getattr(sys, "_MEIPASS", None)
     if meipass:
+        # Frozen build: the spec bundles fpcalc to <_MEIPASS>/bin. (In a frozen
+        # build __file__ also lives under _MEIPASS, so the app/bin probe below
+        # would resolve to a path that never exists — skip it.)
         roots.append(Path(meipass) / "bin")
-    # app/ is the parent of this module's package dir (app/api/ -> app/).
-    roots.append(Path(__file__).resolve().parent.parent / "bin")
+    else:
+        # Source checkout: app/bin/ (app/ is the parent of this module's package
+        # dir, app/api/ -> app/), populated by scripts/fetch_fpcalc.py.
+        roots.append(Path(__file__).resolve().parent.parent / "bin")
     for root in roots:
         candidate = root / name
         if candidate.is_file():

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -249,16 +249,48 @@ FPCALC_COMMON_PATHS = [
 _DEV_FPCALC_ENV = "ENGRAM_FPCALC_PATH"
 
 
+def _bundled_fpcalc_path() -> str | None:
+    """Return the path to the fpcalc binary shipped with Engram, if present.
+
+    Frozen PyInstaller builds carry it at ``<sys._MEIPASS>/bin/fpcalc[.exe]``;
+    source checkouts get it at ``app/bin/fpcalc[.exe]`` once
+    ``scripts/fetch_fpcalc.py`` has populated that directory. Returns the first
+    existing candidate, or None when no bundled copy is available — so the
+    detector cleanly falls through to PATH / common locations.
+    """
+    name = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+    roots: list[Path] = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        roots.append(Path(meipass) / "bin")
+    # app/ is the parent of this module's package dir (app/api/ -> app/).
+    roots.append(Path(__file__).resolve().parent.parent / "bin")
+    for root in roots:
+        candidate = root / name
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
 def detect_fpcalc() -> ToolDetectionResult:
     """Auto-detect a usable fpcalc binary.
 
-    Order: explicit `ENGRAM_FPCALC_PATH` env var, then PATH, then common
-    platform locations. Returns the first result that validates successfully.
+    Order: explicit ``ENGRAM_FPCALC_PATH`` env var, then Engram's bundled copy
+    (``<_MEIPASS>/bin`` when frozen, ``app/bin`` in a checkout), then PATH, then
+    common platform locations. Returns the first result that validates
+    successfully.
     """
     candidates: list[str] = []
     env_override = os.environ.get(_DEV_FPCALC_ENV)
     if env_override:
         candidates.append(env_override)
+    # Engram's own bundled copy beats whatever is on PATH so users get the
+    # known-good shipped version by default — but an explicit env override still
+    # wins, and a bundled binary that fails validation (e.g. wrong arch) falls
+    # through to PATH / common locations below.
+    bundled = _bundled_fpcalc_path()
+    if bundled:
+        candidates.append(bundled)
     via_path = shutil.which("fpcalc")
     if via_path:
         candidates.append(via_path)

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -87,10 +87,27 @@ if os.path.isdir(static_dir):
 datas += collect_data_files("faster_whisper")
 datas += collect_data_files("ctranslate2")
 
+# Ship the third-party license notice (covers the bundled fpcalc) alongside the
+# binary it describes, satisfying Chromaprint's LGPL redistribution terms.
+_licenses = os.path.join("..", "THIRD_PARTY_LICENSES.md")
+if os.path.isfile(_licenses):
+    datas.append((_licenses, "."))
+
+# Bundle fpcalc (fetched by scripts/fetch_fpcalc.py before the build) so end
+# users get audio fingerprinting without installing Chromaprint themselves. It
+# lands at <bundle>/bin/fpcalc[.exe], which detect_fpcalc() resolves via
+# sys._MEIPASS. If absent (script not run), it simply isn't bundled and the app
+# falls back to auto-detecting a system/PATH fpcalc.
+binaries = []
+_fpcalc_name = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+_fpcalc_path = os.path.join("app", "bin", _fpcalc_name)
+if os.path.isfile(_fpcalc_path):
+    binaries.append((_fpcalc_path, "bin"))
+
 a = Analysis(
     ["run.py"],
     pathex=[],
-    binaries=[],
+    binaries=binaries,
     datas=datas,
     hiddenimports=all_hidden,
     hookspath=[],

--- a/backend/scripts/fetch_fpcalc.py
+++ b/backend/scripts/fetch_fpcalc.py
@@ -27,6 +27,7 @@ import os
 import platform
 import tarfile
 import tempfile
+import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -115,8 +116,13 @@ def main() -> int:
     asset, expected_sha = _ASSETS[system]
     url = f"{_BASE}/{asset}"
     print(f"downloading {url}")
-    with urllib.request.urlopen(url) as resp:  # noqa: S310 - pinned https GitHub release URL
-        data = resp.read()
+    try:
+        with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 - pinned https URL
+            data = resp.read()
+    except urllib.error.HTTPError as exc:  # HTTPError is a URLError subclass — catch first
+        raise SystemExit(f"error: HTTP {exc.code} fetching {url}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"error: network failure fetching {url}: {exc.reason}") from exc
 
     actual_sha = _sha256(data)
     if actual_sha != expected_sha:

--- a/backend/scripts/fetch_fpcalc.py
+++ b/backend/scripts/fetch_fpcalc.py
@@ -1,0 +1,138 @@
+"""Fetch the bundled ``fpcalc`` binary for the current platform.
+
+Downloads the pinned Chromaprint release asset, verifies its SHA256 against the
+hardcoded table below, extracts the ``fpcalc`` executable, and installs it to
+``backend/app/bin/fpcalc[.exe]`` — the location :func:`app.api.validation.detect_fpcalc`
+checks before PATH, and the one ``engram.spec`` bundles into frozen builds.
+
+Run by CI before ``pyinstaller engram.spec`` so end users get a working fpcalc
+out of the box, and usable by developers who want a locally-detected fpcalc
+without a system-wide install::
+
+    uv run python scripts/fetch_fpcalc.py            # current platform
+    uv run python scripts/fetch_fpcalc.py --force    # re-download even if present
+
+``app/bin/`` is gitignored: the binary is fetched, never committed (the same
+way the frontend is built into ``app/static`` rather than checked in).
+
+Chromaprint is licensed under the LGPL-2.1+; the binary is redistributed
+unmodified. See ``THIRD_PARTY_LICENSES`` at the repo root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import platform
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+CHROMAPRINT_VERSION = "1.5.1"
+_BASE = f"https://github.com/acoustid/chromaprint/releases/download/v{CHROMAPRINT_VERSION}"
+
+# Per-platform release asset + its SHA256. Hashes were computed from the
+# official v1.5.1 GitHub release assets. Bump all three together on a version
+# change. macOS uses the native arm64 build, matching the arm64-only release
+# matrix in .github/workflows/release.yml.
+_ASSETS: dict[str, tuple[str, str]] = {
+    "windows": (
+        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-windows-x86_64.zip",
+        "36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc",
+    ),
+    "linux": (
+        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-linux-x86_64.tar.gz",
+        "4d7433a7f778e5946d7225230681cbcd634e153316ecac87c538c33ac32387a5",
+    ),
+    "darwin": (
+        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-macos-arm64.tar.gz",
+        "9c5d9565d2396dbcf0e1d797e1ffdf1e19242f3bed88ac3200e144286b57ede6",
+    ),
+}
+
+
+def _target_path() -> Path:
+    """``backend/app/bin/fpcalc[.exe]`` — resolved relative to this script."""
+    exe = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+    # scripts/ -> backend/, so backend/app/bin/
+    return Path(__file__).resolve().parent.parent / "app" / "bin" / exe
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_fpcalc(archive: Path, dest: Path) -> None:
+    """Pull the single ``fpcalc[.exe]`` member out of the archive into ``dest``.
+
+    The release archives wrap the binary in a versioned top-level folder, so we
+    locate it by basename rather than assuming a fixed path.
+    """
+    want = dest.name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as zf:
+            member = next((m for m in zf.namelist() if Path(m).name == want), None)
+            if member is None:
+                raise SystemExit(f"error: {want} not found inside {archive.name}")
+            with zf.open(member) as src, open(dest, "wb") as out:
+                out.write(src.read())
+    else:  # .tar.gz
+        with tarfile.open(archive, "r:gz") as tf:
+            member = next((m for m in tf.getmembers() if Path(m.name).name == want), None)
+            if member is None:
+                raise SystemExit(f"error: {want} not found inside {archive.name}")
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                raise SystemExit(f"error: {want} is not a regular file in {archive.name}")
+            with extracted as src, open(dest, "wb") as out:
+                out.write(src.read())
+
+    if os.name != "nt":
+        dest.chmod(0o755)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch the bundled fpcalc binary.")
+    parser.add_argument(
+        "--force", action="store_true", help="re-download even if the binary already exists"
+    )
+    args = parser.parse_args()
+
+    system = platform.system().lower()
+    if system not in _ASSETS:
+        raise SystemExit(f"error: no pinned fpcalc asset for platform {system!r}")
+
+    dest = _target_path()
+    if dest.is_file() and not args.force:
+        print(f"fpcalc already present at {dest} (use --force to re-download)")
+        return 0
+
+    asset, expected_sha = _ASSETS[system]
+    url = f"{_BASE}/{asset}"
+    print(f"downloading {url}")
+    with urllib.request.urlopen(url) as resp:  # noqa: S310 - pinned https GitHub release URL
+        data = resp.read()
+
+    actual_sha = _sha256(data)
+    if actual_sha != expected_sha:
+        raise SystemExit(
+            f"error: SHA256 mismatch for {asset}\n  expected {expected_sha}\n  got      {actual_sha}"
+        )
+    print(f"sha256 ok ({actual_sha})")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        archive = Path(tmp) / asset
+        archive.write_bytes(data)
+        _extract_fpcalc(archive, dest)
+
+    print(f"installed fpcalc -> {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_fpcalc_validation.py
+++ b/backend/tests/unit/test_fpcalc_validation.py
@@ -1,5 +1,6 @@
 """Tests for fpcalc binary validation."""
 
+import os
 from unittest.mock import patch
 
 from app.api.validation import _validate_fpcalc_binary
@@ -39,6 +40,11 @@ def test_detect_fpcalc_uses_path_search(monkeypatch):
     """detect_fpcalc consults shutil.which before falling back to common paths."""
     from app.api import validation as v
 
+    # Isolate the PATH-vs-common-locations behavior under test from the higher
+    # precedence tiers: no env override and no bundled binary present.
+    monkeypatch.delenv(v._DEV_FPCALC_ENV, raising=False)
+    monkeypatch.setattr(v, "_bundled_fpcalc_path", lambda: None)
+
     def fake_which(name):
         return "/usr/local/bin/fpcalc" if name == "fpcalc" else None
 
@@ -51,3 +57,72 @@ def test_detect_fpcalc_uses_path_search(monkeypatch):
     result = v.detect_fpcalc()
     assert result.found is True
     assert result.path == "/usr/local/bin/fpcalc"
+
+
+def test_bundled_fpcalc_path_frozen(monkeypatch, tmp_path):
+    """In a frozen build, the bundled binary resolves under <_MEIPASS>/bin/."""
+    from app.api import validation as v
+
+    name = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / name).write_bytes(b"\x00")
+    monkeypatch.setattr(v.sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert v._bundled_fpcalc_path() == str(bin_dir / name)
+
+
+def test_detect_fpcalc_prefers_bundled_over_path(monkeypatch, tmp_path):
+    """A valid bundled binary wins over one merely found on PATH.
+
+    End users get the known-good shipped fpcalc by default rather than whatever
+    happens to be on PATH.
+    """
+    from app.api import validation as v
+
+    name = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = bin_dir / name
+    bundled.write_bytes(b"\x00")
+    monkeypatch.setattr(v.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.delenv(v._DEV_FPCALC_ENV, raising=False)
+    monkeypatch.setattr(v.shutil, "which", lambda n: "/usr/bin/fpcalc")
+    monkeypatch.setattr(
+        v,
+        "_validate_fpcalc_binary",
+        lambda p: v.ToolDetectionResult(found=True, path=p, version="fpcalc version 1.5.1"),
+    )
+
+    result = v.detect_fpcalc()
+    assert result.found is True
+    assert result.path == str(bundled)
+
+
+def test_detect_fpcalc_invalid_bundled_falls_through_to_path(monkeypatch, tmp_path):
+    """A bundled binary that fails validation (e.g. wrong arch) falls through to PATH.
+
+    This is the macOS-arm64 safety net: a bundled x86_64 fpcalc that won't run
+    without Rosetta must not shadow a native fpcalc the user has on PATH.
+    """
+    from app.api import validation as v
+
+    name = "fpcalc.exe" if os.name == "nt" else "fpcalc"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    bundled = bin_dir / name
+    bundled.write_bytes(b"\x00")
+    monkeypatch.setattr(v.sys, "_MEIPASS", str(tmp_path), raising=False)
+    monkeypatch.delenv(v._DEV_FPCALC_ENV, raising=False)
+    monkeypatch.setattr(v.shutil, "which", lambda n: "/usr/bin/fpcalc")
+
+    def validate(p):
+        if p == str(bundled):
+            return v.ToolDetectionResult(found=False, path=p, error="cannot execute")
+        return v.ToolDetectionResult(found=True, path=p, version="fpcalc version 1.5.1")
+
+    monkeypatch.setattr(v, "_validate_fpcalc_binary", validate)
+
+    result = v.detect_fpcalc()
+    assert result.found is True
+    assert result.path == "/usr/bin/fpcalc"


### PR DESCRIPTION
## What

Ships a version-pinned `fpcalc` (Chromaprint 1.5.1) inside every release build so end users — and dev machines — get audio fingerprinting / library bootstrap **without installing Chromaprint by hand**. The build previously bundled no external tools (`binaries=[]`), so anyone using fingerprinting had to install fpcalc themselves (like MakeMKV/ffmpeg).

## Why

A user hit `400: fpcalc is not available` partway through a UI bootstrap run. Root cause: nothing durable pointed the backend at fpcalc — not PATH, not common locations, not DB config — so availability hinged on a transient `ENGRAM_FPCALC_PATH` env var that a mid-run backend restart silently dropped (batches 1–20 worked, batch 21 onward 400'd). Bundling fpcalc removes the manual install entirely.

## How

- **`backend/scripts/fetch_fpcalc.py`** — downloads the official Chromaprint 1.5.1 asset for the current platform (Windows x64 / Linux x64 / **native** macOS arm64), verifies a pinned SHA256, extracts `fpcalc[.exe]` into `backend/app/bin/` (gitignored — fetched, never committed, mirroring how the frontend builds into `app/static`). Idempotent.
- **`detect_fpcalc()`** (`backend/app/api/validation.py`) — new precedence: `ENGRAM_FPCALC_PATH` override → **bundled** (`<_MEIPASS>/bin` when frozen, `app/bin` in a checkout) → PATH → common locations. Every candidate is still validated, so a bundled binary that cannot run falls through to PATH (arch safety net).
- **`backend/engram.spec`** — bundles `app/bin/fpcalc[.exe]` → `<bundle>/bin/` and ships `THIRD_PARTY_LICENSES.md`.
- **`.github/workflows/release.yml`** — `Fetch fpcalc` step before PyInstaller in all three build jobs; the smoke test now asserts `/api/detect-tools` reports `fpcalc.found`.
- **`THIRD_PARTY_LICENSES.md`** — Chromaprint LGPL-2.1+ notice (redistributed unmodified; invoked as a separate executable, not linked).

## Also in this PR — draft test builds

`release.yml`'s `workflow_dispatch` gains a `draft` boolean input. Running `gh workflow run release.yml --ref main --field tag=v0.11.0-rc1 --field draft=true` produces a **draft** GitHub release (all three platform artifacts attached) instead of a public one — hidden from the public releases page and from the `/releases/latest` endpoint the auto-updater polls, so a real bundled build can be tested before users ever see it. Tag-push releases leave inputs unset and publish normally. This is how we will verify the fpcalc bundle end-to-end after merge.

## Tests

TDD on the detection logic: bundled-beats-PATH, invalid-bundled-falls-through-to-PATH, and frozen `_MEIPASS/bin` resolution. Full unit suite green (**1377 passed**); ruff clean; spec syntax + workflow YAML validated; fetch→checksum→extract→detect verified locally on Windows.

## Reviewer notes

- The true end-to-end proof (PyInstaller actually bundling the binary on each OS + the frozen `_MEIPASS/bin` lookup at runtime) only runs in the Release workflow. After merge, do a `workflow_dispatch` Release with `draft=true` to verify; the new smoke-test assertion fails the build if the bundle is broken.
- To bump fpcalc later: edit the pinned version + three SHA256s in `fetch_fpcalc.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)