### PR TITLE
fix(import): detect season folders at show-folder depth + match flat imports across all seasons

### DIFF
--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -39,6 +39,7 @@ class EpisodeCurator:
         self._initialized = False
         self._cache_dir: Path | None = None
         self._current_show: str | None = None
+        self._current_show_id: str | None = None
 
     def _ensure_initialized(self, show_name: str) -> bool:
         """Lazily initialize the matcher library for a specific show."""
@@ -62,6 +63,7 @@ class EpisodeCurator:
                 # We need to run async TMDB calls in a sync context here or use sync versions?
                 # tmdb_client functions are synchronous (requests based)
                 tmdb_id = fetch_show_id(show_name)
+                self._current_show_id = str(tmdb_id) if tmdb_id else None
                 if tmdb_id:
                     details = fetch_show_details(tmdb_id)
                     if details and "name" in details:
@@ -122,6 +124,109 @@ class EpisodeCurator:
             needs_review=True,
             match_details=match_details,
         )
+
+    def _candidate_seasons(self, series_name: str | None) -> list[int]:
+        """Seasons worth searching when the season is unknown.
+
+        Prefers seasons that already have reference data (precomputed cloud cache
+        or downloaded subtitles) so we don't run Whisper against seasons we cannot
+        match. Falls back to 1..N from TMDB when nothing is cached yet.
+        """
+        show = (self._matcher.show_name if self._matcher else None) or series_name
+        if not show:
+            return []
+
+        seasons: set[int] = set()
+
+        # 1. Precomputed cloud cache — the manifest lists which seasons it covers.
+        if self._cache_dir:
+            try:
+                from app.matcher.episode_identification import load_precomputed_manifest
+
+                manifest = load_precomputed_manifest(self._cache_dir)
+                entry = (manifest or {}).get("shows", {}).get(show)
+                if entry:
+                    seasons.update(int(s) for s in entry.get("seasons", []))
+            except Exception as e:  # noqa: BLE001 — best-effort enumeration
+                logger.debug(f"Precomputed manifest unavailable for '{show}': {e}")
+
+        # 2. Subtitles already downloaded to disk (cache_dir/data/<show>/*.srt).
+        if self._cache_dir:
+            try:
+                from app.matcher.subtitle_utils import (
+                    parse_season_episode_numbers,
+                    sanitize_filename,
+                )
+
+                data_dir = self._cache_dir / "data" / sanitize_filename(show)
+                if data_dir.is_dir():
+                    for srt in list(data_dir.glob("*.srt")) + list(data_dir.glob("*.SRT")):
+                        parsed = parse_season_episode_numbers(srt.name)
+                        if parsed:
+                            seasons.add(parsed[0])
+            except Exception as e:  # noqa: BLE001 — best-effort enumeration
+                logger.debug(f"Could not enumerate downloaded subtitles for '{show}': {e}")
+
+        if seasons:
+            return sorted(seasons)
+
+        # 3. Nothing cached yet — fall back to the show's full season count.
+        try:
+            from app.matcher.tmdb_client import fetch_show_id, get_number_of_seasons
+
+            show_id = self._current_show_id or fetch_show_id(show)
+            if show_id:
+                count = get_number_of_seasons(show_id)
+                if count and count > 0:
+                    return list(range(1, count + 1))
+        except Exception as e:  # noqa: BLE001 — best-effort enumeration
+            logger.debug(f"Could not resolve season count for '{show}': {e}")
+
+        return []
+
+    async def _match_across_seasons(
+        self,
+        file_path: Path,
+        series_name: str | None,
+        progress_callback: Callable[..., None] | None = None,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+    ) -> MatchResult:
+        """Match a file when the season is unknown by searching every candidate season.
+
+        Runs the normal single-season matcher once per candidate season and keeps the
+        most confident episode match. Returns early on a confident (no-review) match to
+        bound the per-season Whisper cost. Falls back to filename parsing when no season
+        produces a match or none have references available.
+        """
+        seasons = self._candidate_seasons(series_name)
+        if not seasons:
+            logger.warning(
+                f"No candidate seasons with references for '{series_name}'; "
+                f"cannot audio-match {file_path.name} without a season"
+            )
+            return self._fallback_result(file_path)
+
+        logger.info(
+            f"Season unknown for {file_path.name}; searching seasons {seasons} of '{series_name}'"
+        )
+
+        best: MatchResult | None = None
+        for s in seasons:
+            result = await self.match_single_file(
+                file_path, series_name, s, progress_callback, num_points, min_vote_count
+            )
+            if not result.episode_code:
+                continue
+            if best is None or result.confidence > best.confidence:
+                best = result
+            if not result.needs_review:
+                # A confident match is definitive; stop burning Whisper on other seasons.
+                break
+
+        if best is None:
+            return self._fallback_result(file_path)
+        return best
 
     async def match_files(
         self,
@@ -201,9 +306,16 @@ class EpisodeCurator:
                 f"Matcher initialized={initialized}, matcher={'available' if self._matcher else 'None'}"
             )
 
-        if not self._matcher or not season:
-            # Fall back to filename parsing if matcher unavailable or no season
+        if not self._matcher:
+            # Fall back to filename parsing if the matcher is unavailable
             return self._fallback_result(file_path)
+
+        if not season:
+            # Season unknown (e.g. a flat import folder with no Season NN dir):
+            # search across every candidate season and keep the best match.
+            return await self._match_across_seasons(
+                file_path, series_name, progress_callback, num_points, min_vote_count
+            )
 
         # Phase 3 cascade: chromaprint first (no-op when the flag is off → identical to legacy ASR path).
         # The guard above already guarantees `season` is truthy, so only `series_name` needs checking.

--- a/backend/app/core/staging_watcher.py
+++ b/backend/app/core/staging_watcher.py
@@ -255,6 +255,28 @@ class StagingWatcher:
                     units.extend(season_units)
                     continue
 
+                # Pattern B': the watch root IS the show — subdir itself is a Season
+                # folder (root/Season NN/*.mkv). Derive the show name from the root.
+                season_match = _SEASON_RE.match(entry.name)
+                if season_match:
+                    mkv_count, total_size = self._count_mkvs(subdir)
+                    if mkv_count > 0:
+                        units.append(
+                            (
+                                subdir,
+                                mkv_count,
+                                total_size,
+                                {
+                                    "structure": "show_organised",
+                                    "show_name": root.name,
+                                    "season": int(season_match.group(1)),
+                                    "destination_mode": self._import_destination_mode,
+                                    "source": "import",
+                                },
+                            )
+                        )
+                    continue
+
                 # Pattern A: subdir directly contains MKVs
                 mkv_count, total_size = self._count_mkvs(subdir)
                 if mkv_count > 0:

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -46,6 +46,7 @@ class IdentificationCoordinator:
         self._get_discdb_mappings: callable = None
         self._set_discdb_mappings: callable = None
         self._start_subtitle_download: callable = None
+        self._start_subtitle_download_all_seasons: callable = None
         self._restart_subtitle_download: callable = None
         self._try_discdb_assignment: callable = None
         self._match_single_file: callable = None
@@ -62,6 +63,7 @@ class IdentificationCoordinator:
         start_subtitle_download,
         restart_subtitle_download,
         try_discdb_assignment,
+        start_subtitle_download_all_seasons=None,
         match_single_file,
         on_match_task_done,
         check_job_completion,
@@ -72,6 +74,7 @@ class IdentificationCoordinator:
         self._get_discdb_mappings = get_discdb_mappings
         self._set_discdb_mappings = set_discdb_mappings
         self._start_subtitle_download = start_subtitle_download
+        self._start_subtitle_download_all_seasons = start_subtitle_download_all_seasons
         self._restart_subtitle_download = restart_subtitle_download
         self._try_discdb_assignment = try_discdb_assignment
         self._match_single_file = match_single_file
@@ -384,6 +387,25 @@ class IdentificationCoordinator:
                 logger.exception(f"Error identifying disc for job {job_id}")
                 await self._state_machine.transition_to_failed(job, session, str(e))
 
+    async def _resolve_all_season_numbers(self, title: str) -> list[int]:
+        """Resolve 1..N season numbers for a show via TMDB (unknown-season import).
+
+        Returns an empty list when the show can't be resolved; callers then rely on
+        the precomputed cache / already-downloaded references during matching.
+        """
+        try:
+            from app.matcher.tmdb_client import fetch_show_id, get_number_of_seasons
+
+            show_id = await asyncio.to_thread(fetch_show_id, title)
+            if not show_id:
+                return []
+            count = await asyncio.to_thread(get_number_of_seasons, show_id)
+            if count and count > 0:
+                return list(range(1, count + 1))
+        except Exception as e:  # noqa: BLE001 — best-effort; fall back to cache at match time
+            logger.debug(f"Could not resolve season count for '{title}': {e}")
+        return []
+
     async def identify_from_staging(self, job_id: int) -> None:
         """Identify and process pre-ripped MKV files from staging."""
         from app.core.analyst import TitleInfo
@@ -503,6 +525,18 @@ class IdentificationCoordinator:
                         self._start_subtitle_download(
                             job_id, job.detected_title, job.detected_season
                         )
+                    elif job.detected_title and self._start_subtitle_download_all_seasons:
+                        # Season unknown (flat import folder): prefetch references for
+                        # every season so the curator can match across all of them.
+                        all_seasons = await self._resolve_all_season_numbers(job.detected_title)
+                        if all_seasons:
+                            logger.info(
+                                f"Job {job_id}: season unknown for '{job.detected_title}'; "
+                                f"prefetching subtitles for seasons {all_seasons}"
+                            )
+                            self._start_subtitle_download_all_seasons(
+                                job_id, job.detected_title, all_seasons
+                            )
 
                     # Transition to MATCHING and kick off per-title matching
                     succeeded = await self._state_machine.transition(

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -91,6 +91,7 @@ class JobManager:
             get_discdb_mappings=self._matching.get_discdb_mappings,
             set_discdb_mappings=self._matching.set_discdb_mappings,
             start_subtitle_download=self._matching.start_subtitle_download,
+            start_subtitle_download_all_seasons=self._matching.start_subtitle_download_all_seasons,
             restart_subtitle_download=self._matching.restart_subtitle_download,
             try_discdb_assignment=self._matching.try_discdb_assignment,
             match_single_file=self._matching.match_single_file,

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -153,6 +153,15 @@ class MatchingCoordinator:
             self.download_subtitles(job_id, show_name, season)
         )
 
+    def start_subtitle_download_all_seasons(
+        self, job_id: int, show_name: str, seasons: list[int]
+    ) -> None:
+        """Start a background download spanning multiple seasons (unknown-season import)."""
+        self._subtitle_ready[job_id] = asyncio.Event()
+        self._subtitle_tasks[job_id] = asyncio.create_task(
+            self.download_subtitles_all_seasons(job_id, show_name, seasons)
+        )
+
     async def restart_subtitle_download(self, job_id: int, show_name: str, season: int) -> None:
         """Cancel any in-flight subtitle download and start a fresh one.
 
@@ -1232,6 +1241,92 @@ class MatchingCoordinator:
                     match_details=title.match_details,
                 )
             await self._check_job_completion(session, job_id)
+
+    async def download_subtitles_all_seasons(
+        self, job_id: int, show_name: str, seasons: list[int]
+    ) -> None:
+        """Download references for every candidate season (unknown-season import).
+
+        Seasons already covered by the precomputed cache or prior downloads are cheap
+        no-ops. Results aggregate into a single ``subtitle_status`` ("completed" if any
+        season yielded references, else "failed") and one ``_subtitle_ready`` event, so
+        the existing per-job matching gate works without change. Failure BLOCKS matching.
+        """
+        from sqlalchemy import update
+
+        try:
+            async with async_session() as session:
+                await session.execute(
+                    update(DiscJob)
+                    .where(DiscJob.id == job_id)
+                    .values(subtitle_status="downloading")
+                )
+                await session.commit()
+
+            logger.info(
+                f"Starting background subtitle download for {show_name} across "
+                f"seasons {seasons} (season unknown)"
+            )
+            await ws_manager.broadcast_subtitle_event(job_id, "downloading", downloaded=0, total=0)
+
+            from app.matcher.testing_service import download_subtitles
+
+            any_refs = False
+            canonical_name: str | None = None
+            for season in seasons:
+                try:
+                    result = await asyncio.to_thread(download_subtitles, show_name, season)
+                except Exception as e:  # noqa: BLE001 — one season failing must not abort the rest
+                    logger.warning(f"Subtitle download failed for {show_name} S{season}: {e}")
+                    continue
+
+                episodes = result.get("episodes") or []
+                if any(ep["status"] in ("downloaded", "cached", "precomputed") for ep in episodes):
+                    any_refs = True
+                if result.get("show_name"):
+                    canonical_name = result["show_name"]
+
+            status = "completed" if any_refs else "failed"
+            error_msg = None
+            if status == "failed":
+                error_msg = (
+                    f"No reference subtitles found for '{show_name}' in any season. Episode "
+                    "matching can't run without them — add an OpenSubtitles API key in Settings, "
+                    "drop .srt files into the show's cache folder, or assign episodes manually "
+                    "in Review."
+                )
+
+            async with async_session() as session:
+                update_values: dict = {
+                    "subtitle_status": status,
+                    "subtitle_error_message": error_msg,
+                }
+                if canonical_name and canonical_name != show_name:
+                    logger.info(f"Updating job {job_id} title to canonical: {canonical_name}")
+                    update_values["detected_title"] = canonical_name
+                await session.execute(
+                    update(DiscJob).where(DiscJob.id == job_id).values(**update_values)
+                )
+                await session.commit()
+
+            await ws_manager.broadcast_subtitle_event(job_id, status, downloaded=0, total=0)
+
+        except Exception as e:
+            logger.exception(
+                f"Unexpected error in all-season subtitle download for {show_name}: {e}"
+            )
+            async with async_session() as session:
+                await session.execute(
+                    update(DiscJob)
+                    .where(DiscJob.id == job_id)
+                    .values(subtitle_status="failed", error_message=f"Download error: {str(e)}")
+                )
+                await session.commit()
+            await ws_manager.broadcast_subtitle_event(job_id, "failed")
+
+        finally:
+            if job_id in self._subtitle_ready:
+                self._subtitle_ready[job_id].set()
 
     async def download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
         """Download subtitles in background. Failure BLOCKS matching."""

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1271,8 +1271,10 @@ class MatchingCoordinator:
 
             from app.matcher.testing_service import download_subtitles
 
-            any_refs = False
             canonical_name: str | None = None
+            downloaded_total = 0
+            failed_total = 0
+            episode_total = 0
             for season in seasons:
                 try:
                     result = await asyncio.to_thread(download_subtitles, show_name, season)
@@ -1281,12 +1283,24 @@ class MatchingCoordinator:
                     continue
 
                 episodes = result.get("episodes") or []
-                if any(ep["status"] in ("downloaded", "cached", "precomputed") for ep in episodes):
-                    any_refs = True
-                if result.get("show_name"):
+                downloaded_total += sum(
+                    1 for ep in episodes if ep["status"] in ("downloaded", "cached", "precomputed")
+                )
+                failed_total += sum(1 for ep in episodes if ep["status"] in ("not_found", "failed"))
+                episode_total += len(episodes)
+                # First non-None canonical name wins (deterministic across seasons).
+                if result.get("show_name") and canonical_name is None:
                     canonical_name = result["show_name"]
+                # Per-season progress so the UI isn't silent during a cold multi-season fetch.
+                await ws_manager.broadcast_subtitle_event(
+                    job_id,
+                    "downloading",
+                    downloaded=downloaded_total,
+                    total=episode_total,
+                    failed_count=failed_total,
+                )
 
-            status = "completed" if any_refs else "failed"
+            status = "completed" if downloaded_total > 0 else "failed"
             error_msg = None
             if status == "failed":
                 error_msg = (
@@ -1309,7 +1323,13 @@ class MatchingCoordinator:
                 )
                 await session.commit()
 
-            await ws_manager.broadcast_subtitle_event(job_id, status, downloaded=0, total=0)
+            await ws_manager.broadcast_subtitle_event(
+                job_id,
+                status,
+                downloaded=downloaded_total,
+                total=episode_total,
+                failed_count=failed_total,
+            )
 
         except Exception as e:
             logger.exception(
@@ -1319,7 +1339,10 @@ class MatchingCoordinator:
                 await session.execute(
                     update(DiscJob)
                     .where(DiscJob.id == job_id)
-                    .values(subtitle_status="failed", error_message=f"Download error: {str(e)}")
+                    .values(
+                        subtitle_status="failed",
+                        subtitle_error_message=f"Download error: {str(e)}",
+                    )
                 )
                 await session.commit()
             await ws_manager.broadcast_subtitle_event(job_id, "failed")

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -76,15 +76,18 @@ class TestMatchSingleFile:
         assert result.needs_review is True
         assert result.episode_code == "S01E04"  # recovered from filename
 
-    async def test_fallback_when_no_season(self, tmp_path, monkeypatch):
+    async def test_unknown_season_with_no_candidate_seasons_falls_back(self, tmp_path, monkeypatch):
+        # Season unknown + no seasons have references → filename fallback (needs review).
         curator = EpisodeCurator()
         curator._matcher = Mock()
         f = tmp_path / "Show.S01E04.mkv"
         f.write_text("")
         monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_candidate_seasons", lambda show: [])
 
         result = await curator.match_single_file(f, "Show", None)
         assert result.needs_review is True
+        assert result.episode_code == "S01E04"  # recovered from filename
 
     async def test_high_confidence_match(self, tmp_path, monkeypatch):
         curator = EpisodeCurator()
@@ -157,6 +160,123 @@ class TestMatchSingleFile:
         result = await curator.match_single_file(f, "Show", 3)
         assert result.needs_review is True
         assert result.episode_code == "S03E07"  # filename fallback
+
+
+@pytest.mark.unit
+class TestMatchAcrossSeasons:
+    """Unknown-season import: search every candidate season, keep the best match."""
+
+    async def test_dispatches_when_season_unknown(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._matcher = Mock()
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        sentinel = MatchResult(f, "S04E02", None, 0.8, False)
+
+        async def fake_across(fp, series, *a, **k):
+            return sentinel
+
+        monkeypatch.setattr(curator, "_match_across_seasons", fake_across)
+        result = await curator.match_single_file(f, "Show", None)
+        assert result is sentinel
+
+    async def test_known_season_does_not_dispatch(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        curator._matcher = Mock()
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+
+        async def boom(*a, **k):
+            raise AssertionError("should not search all seasons when season is known")
+
+        monkeypatch.setattr(curator, "_match_across_seasons", boom)
+
+        async def fake_prepass(**k):
+            return None
+
+        monkeypatch.setattr(curator, "_chromaprint_prepass", fake_prepass)
+        sentinel = MatchResult(f, "S02E01", None, 0.9, False)
+
+        async def fake_asr(*a, **k):
+            return sentinel
+
+        monkeypatch.setattr(curator, "_run_asr_identify", fake_asr)
+        result = await curator.match_single_file(f, "Show", 2)
+        assert result is sentinel
+
+    async def test_picks_highest_confidence_across_seasons(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._matcher = Mock()
+        f = tmp_path / "ep.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_candidate_seasons", lambda show: [1, 2, 3])
+
+        canned = {
+            1: MatchResult(f, None, None, 0.0, True),
+            2: MatchResult(f, "S02E05", None, 0.92, False),
+            3: MatchResult(f, "S03E01", None, 0.6, True),
+        }
+
+        async def fake_single(fp, series, season, *a, **k):
+            return canned[season]
+
+        monkeypatch.setattr(curator, "match_single_file", fake_single)
+        result = await curator._match_across_seasons(f, "Show")
+        assert result.episode_code == "S02E05"
+        assert result.confidence == 0.92
+
+    async def test_no_match_in_any_season_falls_back(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._matcher = Mock()
+        f = tmp_path / "Show.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_candidate_seasons", lambda show: [1, 2])
+
+        async def fake_single(fp, series, season, *a, **k):
+            return MatchResult(fp, None, None, 0.0, True)
+
+        monkeypatch.setattr(curator, "match_single_file", fake_single)
+        result = await curator._match_across_seasons(f, "Show")
+        assert result.episode_code is None
+        assert result.needs_review is True
+
+    async def test_no_candidate_seasons_falls_back(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._matcher = Mock()
+        f = tmp_path / "Show.S01E04.mkv"
+        f.write_text("")
+        monkeypatch.setattr(curator, "_candidate_seasons", lambda show: [])
+        result = await curator._match_across_seasons(f, "Show")
+        assert result.needs_review is True
+        assert result.episode_code == "S01E04"  # filename fallback
+
+
+@pytest.mark.unit
+class TestCandidateSeasons:
+    def test_enumerates_seasons_from_downloaded_srts(self, tmp_path):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path
+        curator._matcher = Mock()
+        curator._matcher.show_name = "The Expanse"
+        data_dir = tmp_path / "data" / "The Expanse"
+        data_dir.mkdir(parents=True)
+        (data_dir / "The Expanse - S01E01.srt").write_text("")
+        (data_dir / "The Expanse - S01E02.srt").write_text("")
+        (data_dir / "The Expanse - S03E05.srt").write_text("")
+
+        assert curator._candidate_seasons("The Expanse") == [1, 3]
+
+    def test_falls_back_to_tmdb_season_count(self, tmp_path, monkeypatch):
+        curator = EpisodeCurator()
+        curator._cache_dir = tmp_path  # empty: no manifest, no SRTs
+        curator._matcher = Mock()
+        curator._matcher.show_name = "The Expanse"
+        curator._current_show_id = "999"
+        monkeypatch.setattr("app.matcher.tmdb_client.get_number_of_seasons", lambda show_id: 6)
+        assert curator._candidate_seasons("The Expanse") == [1, 2, 3, 4, 5, 6]
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -321,6 +321,7 @@ class TestDownloadSubtitlesAllSeasons:
         async with _unit_session_factory() as session:
             job, _t = await _seed(session)
             job_id = job.id
+        coord._subtitle_ready[job_id] = asyncio.Event()
 
         await coord.download_subtitles_all_seasons(job_id, "The Expanse", [1, 2, 3])
 
@@ -328,6 +329,8 @@ class TestDownloadSubtitlesAllSeasons:
             refreshed = await session.get(DiscJob, job_id)
             assert refreshed.subtitle_status == "completed"
             assert refreshed.subtitle_error_message is None
+        # The ready event must be set so the matching gate unblocks.
+        assert coord._subtitle_ready[job_id].is_set()
 
     async def test_fails_when_no_season_has_references(self, monkeypatch):
         coord = _make_coord()
@@ -338,6 +341,7 @@ class TestDownloadSubtitlesAllSeasons:
         async with _unit_session_factory() as session:
             job, _t = await _seed(session)
             job_id = job.id
+        coord._subtitle_ready[job_id] = asyncio.Event()
 
         await coord.download_subtitles_all_seasons(job_id, "Obscure Show", [1, 2])
 
@@ -346,6 +350,8 @@ class TestDownloadSubtitlesAllSeasons:
             assert refreshed.subtitle_status == "failed"
             assert "Obscure Show" in (refreshed.subtitle_error_message or "")
             assert refreshed.error_message is None
+        # The ready event must be set so the matching gate unblocks.
+        assert coord._subtitle_ready[job_id].is_set()
 
     async def test_sets_subtitle_ready_event(self, monkeypatch):
         coord = _make_coord()

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -289,3 +289,72 @@ class TestDownloadSubtitlesMessaging:
             refreshed = await session.get(DiscJob, job_id)
             assert refreshed.subtitle_status == "partial"
             assert refreshed.subtitle_error_message is None
+
+
+@pytest.mark.unit
+class TestDownloadSubtitlesAllSeasons:
+    """Unknown-season import downloads references for every candidate season and
+    aggregates them into a single subtitle_status / ready event so the existing
+    matching gate works unchanged.
+    """
+
+    def _mock(self, monkeypatch, per_season):
+        async def _noop(*a, **k):
+            return None
+
+        monkeypatch.setattr(ws_manager, "broadcast_subtitle_event", _noop)
+        monkeypatch.setattr(
+            "app.matcher.testing_service.download_subtitles",
+            lambda show, season: {"episodes": per_season.get(season, []), "show_name": show},
+        )
+
+    async def test_completes_when_any_season_has_references(self, monkeypatch):
+        coord = _make_coord()
+        self._mock(
+            monkeypatch,
+            {
+                1: [{"status": "not_found"}],
+                2: [{"status": "downloaded"}, {"status": "cached"}],
+                3: [{"status": "precomputed"}],
+            },
+        )
+        async with _unit_session_factory() as session:
+            job, _t = await _seed(session)
+            job_id = job.id
+
+        await coord.download_subtitles_all_seasons(job_id, "The Expanse", [1, 2, 3])
+
+        async with _unit_session_factory() as session:
+            refreshed = await session.get(DiscJob, job_id)
+            assert refreshed.subtitle_status == "completed"
+            assert refreshed.subtitle_error_message is None
+
+    async def test_fails_when_no_season_has_references(self, monkeypatch):
+        coord = _make_coord()
+        self._mock(
+            monkeypatch,
+            {1: [{"status": "not_found"}], 2: [{"status": "failed"}]},
+        )
+        async with _unit_session_factory() as session:
+            job, _t = await _seed(session)
+            job_id = job.id
+
+        await coord.download_subtitles_all_seasons(job_id, "Obscure Show", [1, 2])
+
+        async with _unit_session_factory() as session:
+            refreshed = await session.get(DiscJob, job_id)
+            assert refreshed.subtitle_status == "failed"
+            assert "Obscure Show" in (refreshed.subtitle_error_message or "")
+            assert refreshed.error_message is None
+
+    async def test_sets_subtitle_ready_event(self, monkeypatch):
+        coord = _make_coord()
+        self._mock(monkeypatch, {1: [{"status": "downloaded"}]})
+        async with _unit_session_factory() as session:
+            job, _t = await _seed(session)
+            job_id = job.id
+        coord._subtitle_ready[job_id] = asyncio.Event()
+
+        await coord.download_subtitles_all_seasons(job_id, "Show", [1])
+
+        assert coord._subtitle_ready[job_id].is_set()

--- a/backend/tests/unit/test_staging_watcher.py
+++ b/backend/tests/unit/test_staging_watcher.py
@@ -375,6 +375,61 @@ class TestImportWatcherStructureDetection:
 
         assert units[0][3]["destination_mode"] == "in_place"
 
+    async def test_watch_root_is_show_with_season_subdirs(self, tmp_path):
+        """Watch root pointed directly at a show folder with Season NN subdirs.
+
+        User layout: import_watch_path = .../The Expanse, containing Season 01/, Season 02/.
+        Each season folder should yield a show_organised unit whose show_name is the
+        watch-root folder name and whose season is parsed from the folder name.
+        """
+        show_root = tmp_path / "The Expanse"
+        show_root.mkdir()
+        s1 = show_root / "Season 01"
+        s1.mkdir()
+        (s1 / "title_t00.mkv").write_bytes(b"\x00" * 1024)
+        s2 = show_root / "Season 02"
+        s2.mkdir()
+        (s2 / "title_t00.mkv").write_bytes(b"\x00" * 2048)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(show_root))
+        units = watcher._scan_import_dir(show_root)
+
+        assert len(units) == 2
+        seasons = {meta["season"]: (path, meta) for path, _, _, meta in units}
+        assert set(seasons) == {1, 2}
+        assert seasons[1][0] == s1
+        assert seasons[1][1]["show_name"] == "The Expanse"
+        assert seasons[1][1]["structure"] == "show_organised"
+        assert seasons[2][0] == s2
+        assert seasons[2][1]["show_name"] == "The Expanse"
+
+    @pytest.mark.parametrize(
+        "folder_name,expected_season",
+        [
+            ("Season 1", 1),
+            ("Season 01", 1),
+            ("Season1", 1),
+            ("season 2", 2),
+            ("Season 12", 12),
+        ],
+    )
+    async def test_season_folder_spelling_variants(self, tmp_path, folder_name, expected_season):
+        """Single-digit, double-digit, and zero-padded season spellings all parse."""
+        show_root = tmp_path / "The Expanse"
+        show_root.mkdir()
+        season_dir = show_root / folder_name
+        season_dir.mkdir()
+        (season_dir / "title_t00.mkv").write_bytes(b"\x00" * 512)
+
+        watcher = StagingWatcher("/tmp/staging", import_watch_path=str(show_root))
+        units = watcher._scan_import_dir(show_root)
+
+        assert len(units) == 1
+        _, _, _, meta = units[0]
+        assert meta["season"] == expected_season
+        assert meta["show_name"] == "The Expanse"
+        assert meta["structure"] == "show_organised"
+
 
 class TestImportWatcherPolling:
     """Tests for the full poll loop with import paths."""

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,26 @@ and files everything into your media library -- automatically.
 
 **Windows** has full automatic disc detection via kernel32 APIs. **Linux** has native optical-drive detection via `/sys/block` and `blkid`. On **macOS**, the backend and dashboard run fully, but disc insertion must be triggered via the staging import API. On all platforms, a **staging folder workflow** lets you drop pre-ripped MKV files into the staging directory for automatic classification, matching, and organization.
 
+### Importing pre-ripped files
+
+Set an **Import Watch Folder** in Settings and Engram will automatically pick up MKV files placed there (e.g. by AutomaticRippingMachine, or copied in by hand). Point the watch folder at the directory that holds your rips. Three layouts are supported:
+
+```
+Import Watch Folder/
+├── The Expanse/
+│   └── Season 01/            ← recommended: gives the best episode matching
+│       ├── episode.mkv
+│       └── episode.mkv
+├── Firefly/                  ← flat: episodes are matched across all seasons
+│   ├── episode.mkv
+│   └── episode.mkv
+└── THE_OFFICE_S1D1/          ← per-disc, ARM-style
+    ├── title_t00.mkv
+    └── title_t01.mkv
+```
+
+Season folders may be written `Season 1` or `Season 01`. When there's no season folder, matching searches every season of the show, which works but is slower.
+
 ---
 
 <div style="text-align: center;" markdown>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -529,10 +529,17 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
 
                         <div className="form-group" style={{ marginTop: '1.5rem' }}>
                             <label htmlFor="importWatchPath">Import Watch Folder</label>
-                            <span className="form-hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
-                                Automatically import MKV files ripped by AutomaticRippingMachine or similar tools.
-                                Engram detects per-disc subfolders, show-organised trees, and flat layouts.
-                            </span>
+                            <div className="form-hint" style={{ display: 'block', marginBottom: '0.5rem' }}>
+                                Automatically import MKV files ripped by AutomaticRippingMachine or copied in
+                                manually. Point it at the folder that holds your rips. Supported layouts:
+                                <ul style={{ margin: '0.4rem 0 0.4rem', paddingLeft: '1.1rem' }}>
+                                    <li><code>Show Name / Season 01 / episode.mkv</code> — recommended, best episode matching</li>
+                                    <li><code>Show Name / episode.mkv</code> — flat; episodes are matched across all seasons of the show</li>
+                                    <li><code>DISC_LABEL / title_t00.mkv</code> — per-disc, ARM-style</li>
+                                </ul>
+                                Season folders may be written <code>Season 1</code> or <code>Season 01</code>.
+                                Without a season folder, matching searches every season, which is slower.
+                            </div>
                             <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
                                 <input
                                     id="importWatchPath"


### PR DESCRIPTION
## Problem

The import watch folder (`StagingWatcher`) was built for AutomaticRippingMachine's layout `watch_root/Show/Season NN/`, and only extracted the show name + season at that exact nesting depth. When the watch folder is pointed **directly at a show folder** (e.g. `X:\media\rips\Tests\The Expanse`), both layouts broke:

- **Season folders** (`The Expanse/Season 01/*.mkv`) sat one level too shallow — `_try_pattern_b` searched for `Season NN` as a *grandchild* of the watch root, missed it, and the folder was mislabeled as a generic disc with no show/season → *"doesn't pick up the tracks properly."*
- **Flat folders** (`The Expanse/*.mkv`) had no season anywhere, and the matcher hard-gates on season (`curator.py`), so every title fell straight to needs-review → *"detects the show but matches nothing."*

## Changes

- **`staging_watcher.py`** — recognize a `Season NN` directory when the watch root *is* the show (derive `show_name = root.name`). Handles `Season 1`, `Season 01`, and `Season1`. ARM and per-disc layouts are unchanged.
- **`curator.py`** — when the season is unknown, `_match_across_seasons` searches every candidate season (precomputed manifest → downloaded SRTs → TMDB season count, via new `_candidate_seasons`) and keeps the best match, early-exiting on a confident hit to bound transcription cost.
- **`matching_coordinator.py` / `identification_coordinator.py` / `job_manager.py`** — `download_subtitles_all_seasons` prefetches references for all candidate seasons, aggregated into a single `subtitle_status` / ready event so the existing matching gate is unchanged.
- **`ConfigWizard.tsx` + `docs/index.md`** — document the three supported layouts and the `Season 1`/`Season 01` rule.

## Validation

- **1393 backend unit tests pass**; new tests added for the watcher season-folder detection (parametrized over spellings), the curator all-season search + candidate-season enumeration, and the multi-season subtitle download.
- **Frontend `npm run build` + `npm run lint` pass.**
- **On the real test folder** `X:\media\rips\Tests\The Expanse`: the watcher returns the correct `flat` unit, and `_candidate_seasons('The Expanse')` reads `[1,2,3,4,5,6]` from the real precomputed manifest, then loops `identify_episode` per season against the real precomputed vectors.

## Known limitation (separate, pre-existing — tracked separately)

These specific test files do **not** match end-to-end even with a **known** season: the ASR matcher ranks the correct episode as the top candidate but scores ~0.08–0.12 cosine, under the 0.15 gate (`season=1 → episode=None`). This is independent of this change (reproducible with a hard-coded season) and is being investigated separately. This PR makes the import paths *attempt* matching correctly; it does not change matcher scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)