### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-29
+
+### Added
+
+- **Bootstrap Library (bulk fingerprint upload)** — a one-pass tool that walks your existing organized TV library, extracts a Chromaprint acoustic fingerprint from every episode, and contributes them to the shared fingerprint network in bulk. Previously the network only grew as you ripped new discs; now shows you already own can seed matching immediately. Respects the same privacy model and opt-out as the per-rip contribution flow. (#253)
+- **Bundled `fpcalc`** — the Chromaprint `fpcalc` binary is now shipped inside the Windows, Linux, and macOS builds, so audio fingerprinting works out of the box with no manual Chromaprint install. Development builds fetch it on demand. (#260)
+- **Broadcast vs. DVD/streaming episode reordering** — episode organization now reconciles aired order with DVD/streaming order using TMDB episode groups, so shows that shipped in a different order than they aired land in the correct files. (#200, #254)
+- **Global episode-ordering default in the Config UI** — pick DVD or aired ordering as the library-wide default directly from Settings, instead of per-show only. (#255, #259)
+
+### Fixed
+
+- **Startup crash `no such column: app_config.episode_ordering_preference`** — the pre-init LAN-address read queried `app_config` before the schema reconcilers ran, so a freshly migrated database crashed on launch. The read now tolerates schema drift. (#261)
+- **Bulk fingerprint upload silently skipped episodes with certain codecs** — the bundled Chromaprint 1.5.1 `fpcalc` can't decode DTS, TrueHD, FLAC, or E-AC-3 audio, so ~128 library episodes failed fingerprinting with no warning. Engram now falls back to an `ffmpeg` pre-decode so every track can be fingerprinted. (#261)
+- **"Queued contribution for title None" in the logs** — the show title is now persisted and logged, so bulk-upload progress is attributable per show. (#261)
+- **Dashboard not refreshing after an in-app update, and incorrect frozen-build detection** — the UI now reloads after applying an update and correctly identifies packaged builds. (#258)
+- **Long filenames and paths truncated in job history** — they now wrap instead of being cut off. (#256)
+- **Cramped MANUAL row in the review inspector** — split into two rows so the manual-assignment controls are readable. (#257)
+
 ## [0.10.0] - 2026-05-28
 
 ### Added

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.10.0"
+version = "0.11.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.10.0"
+version = "0.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.10.0",
+    "version": "0.11.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Cuts the **v0.11.0** release so the bulk fingerprint-upload (Bootstrap Library) fixes can be tested on a real install. The current draft `.exe` still logs `Starting engram 0.10.0` because the version was never bumped — this bumps it everywhere.

## Why now

[#261](https://github.com/Jsakkos/engram/pull/261) (merged) fixes three bugs found while testing the draft v0.11.0 exe's Bootstrap Library / bulk fingerprint-upload feature:

1. **Startup crash** `no such column: app_config.episode_ordering_preference` — schema drift in the pre-init LAN read.
2. **fpcalc codec gap** — the bundled Chromaprint 1.5.1 `fpcalc` can't decode DTS/TrueHD/FLAC/E-AC-3, so ~128 library episodes silently failed; it now falls back to an `ffmpeg` pre-decode.
3. **"Queued contribution for title None"** — the show name is now persisted and logged.

Bulk fingerprint upload is a new feature, so this is a minor bump (`0.10.0` → `0.11.0`).

## Version bump (0.10.0 -> 0.11.0)

- `backend/pyproject.toml`
- `backend/app/__init__.py` (surfaced as the outbound User-Agent)
- `backend/uv.lock` (`engram-backend` self-version)
- `frontend/package.json`
- `frontend/package-lock.json` — both `.version` and `.packages[""].version` (historically missed)
- `CHANGELOG.md` — new `## [0.11.0]` section

## Release mechanics

Squash-merging this PR (title kept as `chore: release v0.11.0`) triggers `.github/workflows/tag-release.yml`, which pushes the `v0.11.0` tag and dispatches `release.yml`. That builds the Windows/Linux/macOS PyInstaller bundles, smoke-tests each, and publishes them as a **draft** GitHub Release (`draft: true`) for testing — plus the GHCR image via `docker.yml`.

> **Do not merge until ready to test** — merging is what produces the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)