### PR TITLE
docs(claude): document parallel-session isolation + scoped server cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Engram is a disc ripping and media organization tool with a reactive web dashboa
 ## Important Rules
 
 - **NEVER delete `backend/engram.db`** unless the user explicitly asks. It contains API keys and credentials that must be re-entered manually.
-- **Always terminate backend processes after testing.** Kill all `uvicorn`, `python` (uvicorn workers), and `makemkvcon` processes when done. Orphaned processes cause duplicate jobs and MakeMKV drive conflicts. Never use `--reload` — it spawns a child process with its own drive sentinel, creating duplicate disc events.
+- **Always terminate this session's servers when work is done — and before opening a PR.** Kill the `uvicorn`/`python` (uvicorn workers) and `makemkvcon` processes you started; orphans cause duplicate jobs and MakeMKV drive conflicts. If you're the only running session, killing them all is fine; if other sessions are live, scope the kill to **your own ports** so you don't take down a sibling (see "Parallel sessions / worktree isolation"). Never use `--reload` — it spawns a child process with its own drive sentinel, creating duplicate disc events.
 
 ## Repository Organization
 
@@ -45,6 +45,52 @@ npm run test:e2e     # Run Playwright E2E tests
 npm run test:e2e:ui  # Run E2E tests with interactive UI
 npm run brand:export # Regenerate favicons + .ico/.icns from SVG sources
 ```
+
+### Parallel sessions / worktree isolation
+
+Running two Claude/dev sessions at once (e.g. two `.claude/worktrees/*`) collides on the
+default **ports** (backend `8000`, Vite `5173`) and on any **shared database**. Give each
+session its own ports + DB:
+
+| Knob | Env var | Default | Notes |
+|------|---------|---------|-------|
+| Backend DB | `DATABASE_URL` | `sqlite+aiosqlite:///./engram.db` | Read at import (`database.py`). Each worktree's relative `./engram.db` is already distinct — only override if you pointed it at a **shared/real** DB. Never let two live sessions share one DB file. |
+| Backend port | uvicorn `--port` flag | `8000` | **`PORT`/`HOST` env vars are ignored** by `uvicorn app.main:app` (only honored by `python -m app.main`). Use the CLI flag. |
+| Frontend port | `VITE_PORT` | `5173` | Vite dev server. |
+| Proxy target | `VITE_BACKEND_PORT` | `8000` | **Must equal the backend `--port`** or `/api` + `/ws` 502. |
+
+Second stack (PowerShell), backend from `backend/`, frontend from `frontend/`:
+
+```powershell
+# backend  (distinct DB + port)
+$env:DATABASE_URL = "sqlite+aiosqlite:///./engram-b.db"
+uv run uvicorn app.main:app --port 8100
+
+# frontend (distinct port; proxy points at the backend above)
+$env:VITE_PORT = "5273"; $env:VITE_BACKEND_PORT = "8100"; npm run dev
+```
+
+bash equivalent: `DATABASE_URL=sqlite+aiosqlite:///./engram-b.db uv run uvicorn app.main:app --port 8100`
+and `VITE_PORT=5273 VITE_BACKEND_PORT=8100 npm run dev`.
+
+**Drive sentinel is per-backend and unconditional** (`job_manager.start()` → `_drive_monitor.start()`):
+every backend polls the physical optical drive. Two live backends → duplicate disc events +
+`makemkvcon` conflicts. For parallel work use **simulation** (`DEBUG=true` + `/api/simulate/*`),
+never two backends against a real inserted disc. Real-disc testing = exactly one backend.
+
+**Clean up before the PR.** When the work is done, stop the servers this session started —
+scoped by port so a sibling session keeps running:
+
+```powershell
+# Stop THIS session's backend + frontend by port (use the ports you launched on)
+Get-NetTCPConnection -LocalPort 8100,5273 -State Listen -ErrorAction SilentlyContinue |
+  Select-Object -ExpandProperty OwningProcess -Unique |
+  ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+If you're the only session (e.g. single real-disc backend), the global kill from **Important
+Rules** — all `uvicorn`/`python`/`makemkvcon` — is equivalent and also sweeps orphaned
+`makemkvcon` children.
 
 ### Simulation (requires backend running with DEBUG=true)
 


### PR DESCRIPTION
## What

Documents how to run **parallel Claude/dev sessions** (e.g. two `.claude/worktrees/*`) without colliding, and how each session should clean up its servers before opening a PR. **Docs only — no code changes.**

### `CLAUDE.md` additions

1. **New "Parallel sessions / worktree isolation" subsection** under `## Commands`. A knob table maps each collision surface to its real control:
   - **DB** → `DATABASE_URL` (each worktree's relative `./engram.db` is already distinct; only override when pointed at a shared/real DB).
   - **Backend port** → uvicorn `--port` flag. Calls out the footgun that **`PORT`/`HOST` env vars are silently ignored** by `uvicorn app.main:app` — they're only honored by the `python -m app.main` (`__main__`) path.
   - **Frontend** → `VITE_PORT` + `VITE_BACKEND_PORT` (the latter must equal the backend `--port` or `/api`+`/ws` 502).
   - Copy-paste PowerShell and bash for a full second stack.
   - Notes the **drive sentinel is per-backend and unconditional** (`job_manager.start()` → `_drive_monitor.start()`), so parallel work must use simulation, never two backends against a real disc.

2. **Server cleanup before the PR.** Updated the `## Important Rules` line so cleanup is mandatory and tied to a concrete trigger ("before opening a PR"), and reconciled it with the parallel-session world: the old blanket "kill all `uvicorn`/`python`" would take down sibling sessions, so cleanup is now **scoped by port** (`Get-NetTCPConnection -LocalPort … | Stop-Process`) when other sessions are live, reserving the global kill for the single real-disc backend (where it also sweeps orphaned `makemkvcon` children).

## Why

The isolation knobs already existed in the code (`config.py`, `vite.config.ts`) but were undocumented, and one (`PORT`) is an active footgun that silently does nothing on the documented launch path. Nothing told a session to scope its cleanup, so following the existing "kill all" rule under parallelism would kill a sibling's backend.

## Reviewer notes

- All claims were verified against source: `config.py:51-56`, `vite.config.ts:29-36`, `main.py:293-310` (`PORT` only honored in `__main__`), `database.py:24-25` (`DATABASE_URL` read at import), `job_manager.py:125-136` (unconditional drive monitor).
- The example ports (`8100`/`5273`) are illustrative; the doc tells readers to substitute the ports they launched on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
