### PR TITLE
fix(e2e): decouple SQL echo from DEBUG + isolate basic-ui spec to fix flaky timeouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ No client messages currently supported (WebSocket is server-push only).
 ### Configuration Sources (Priority Order)
 
 1. **Database** (`app_config` table) — Runtime configuration, editable via API
-2. **Environment variables** (or optional `.env` file) — Server-level settings (DEBUG, HOST, PORT, DATABASE_URL)
+2. **Environment variables** (or optional `.env` file) — Server-level settings (DEBUG, HOST, PORT, DATABASE_URL, DB_ECHO). `DB_ECHO=true` enables verbose SQLAlchemy SQL tracing (default off; decoupled from DEBUG so the E2E backend can run with DEBUG=true without flooding logs)
 3. **Defaults** — Hardcoded in `AppConfig` model
 
 ### Configuration Flow

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,13 +50,10 @@ class Settings(BaseSettings):
     # Database
     database_url: str = _default_database_url()
 
-    # SQLAlchemy engine echo — logs every emitted SQL statement. Off by default.
-    # Deliberately decoupled from `debug`: the E2E backend must run with
-    # DEBUG=true (the /api/simulate/* endpoints are gated behind require_debug),
-    # but echoing every statement during a simulated rip (a session.get+commit
-    # and two broadcasts every 0.1s per title) floods stdout and stalls the
-    # single-worker event loop, which surfaced as flaky Playwright timeouts.
-    # Set DB_ECHO=true to restore SQL logging for local debugging.
+    # SQLAlchemy engine echo. Deliberately decoupled from `debug`: the E2E
+    # backend runs DEBUG=true (for /api/simulate/*) but must not echo SQL, which
+    # floods stdout and stalls the event loop under simulation load (flaky test
+    # timeouts; see PR #267). Off by default; set DB_ECHO=true for local SQL tracing.
     db_echo: bool = False
 
     # Server

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,6 +50,15 @@ class Settings(BaseSettings):
     # Database
     database_url: str = _default_database_url()
 
+    # SQLAlchemy engine echo — logs every emitted SQL statement. Off by default.
+    # Deliberately decoupled from `debug`: the E2E backend must run with
+    # DEBUG=true (the /api/simulate/* endpoints are gated behind require_debug),
+    # but echoing every statement during a simulated rip (a session.get+commit
+    # and two broadcasts every 0.1s per title) floods stdout and stalls the
+    # single-worker event loop, which surfaced as flaky Playwright timeouts.
+    # Set DB_ECHO=true to restore SQL logging for local debugging.
+    db_echo: bool = False
+
     # Server
     host: str = "127.0.0.1"
     port: int = 8000

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,10 +20,8 @@ logger = logging.getLogger(__name__)
 # Path to Alembic config (relative to backend/)
 _ALEMBIC_INI = Path(__file__).parent.parent / "alembic.ini"
 
-# Create async engine.
-# echo is gated on the dedicated db_echo setting (NOT debug): the E2E backend
-# runs with DEBUG=true but must not echo SQL, which floods stdout and stalls the
-# event loop under simulation load. See Settings.db_echo for the full rationale.
+# Create async engine. echo is gated on the dedicated db_echo setting, NOT
+# debug — see Settings.db_echo for the rationale.
 engine = create_async_engine(
     settings.database_url,
     echo=settings.db_echo,

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -20,10 +20,13 @@ logger = logging.getLogger(__name__)
 # Path to Alembic config (relative to backend/)
 _ALEMBIC_INI = Path(__file__).parent.parent / "alembic.ini"
 
-# Create async engine
+# Create async engine.
+# echo is gated on the dedicated db_echo setting (NOT debug): the E2E backend
+# runs with DEBUG=true but must not echo SQL, which floods stdout and stalls the
+# event loop under simulation load. See Settings.db_echo for the full rationale.
 engine = create_async_engine(
     settings.database_url,
-    echo=settings.debug,
+    echo=settings.db_echo,
     future=True,
     connect_args={"check_same_thread": False},  # Needed for SQLite
 )

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from app.config import is_frozen
+from app.config import Settings, is_frozen
 
 
 class TestIsFrozen:
@@ -34,3 +34,31 @@ class TestIsFrozen:
         monkeypatch.setattr(sys, "frozen", True, raising=False)
         monkeypatch.setattr(sys, "_MEIPASS", "/tmp/_MEIxxxx", raising=False)
         assert is_frozen() is True
+
+
+class TestDbEcho:
+    """SQLAlchemy echo must be controlled by db_echo, NOT debug.
+
+    Regression guard for E2E flakiness: the E2E backend runs with DEBUG=true to
+    expose the /api/simulate/* endpoints, but echoing every SQL statement during
+    a simulated rip floods stdout and stalls the single-worker event loop,
+    causing visibility-assertion timeouts. db_echo is decoupled from debug and
+    defaults off. ``_env_file=None`` skips any local backend/.env so the test is
+    deterministic regardless of the developer's environment.
+    """
+
+    def test_db_echo_defaults_false(self, monkeypatch):
+        monkeypatch.delenv("DB_ECHO", raising=False)
+        assert Settings(_env_file=None).db_echo is False
+
+    def test_debug_true_does_not_enable_db_echo(self, monkeypatch):
+        # The exact E2E configuration: DEBUG on, DB_ECHO unset. Echo must stay off.
+        monkeypatch.setenv("DEBUG", "true")
+        monkeypatch.delenv("DB_ECHO", raising=False)
+        settings = Settings(_env_file=None)
+        assert settings.debug is True
+        assert settings.db_echo is False
+
+    def test_db_echo_env_opt_in(self, monkeypatch):
+        monkeypatch.setenv("DB_ECHO", "true")
+        assert Settings(_env_file=None).db_echo is True

--- a/frontend/e2e/basic-ui-verification.spec.ts
+++ b/frontend/e2e/basic-ui-verification.spec.ts
@@ -15,7 +15,13 @@ test.describe('Basic UI Verification - No Disc Simulation', () => {
     // suite executes before the Firefox/WebKit projects reach this spec — that
     // cross-spec contamination is exactly what made "Empty state displays when
     // no discs present" flake on Firefox.
-    await resetAllJobs().catch(() => {});
+    // Best-effort: don't block the test if the backend is momentarily
+    // unavailable, but surface a misconfiguration (e.g. DEBUG off -> 403,
+    // backend down -> network error) in the logs instead of failing later with
+    // a confusing assertion error.
+    await resetAllJobs().catch((e) =>
+      console.warn('[beforeEach] resetAllJobs failed (continuing):', e),
+    );
     await page.goto('/');
   });
 

--- a/frontend/e2e/basic-ui-verification.spec.ts
+++ b/frontend/e2e/basic-ui-verification.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { resetAllJobs } from './fixtures/api-helpers';
 import { SELECTORS } from './fixtures/selectors';
 
 /**
@@ -8,6 +9,13 @@ import { SELECTORS } from './fixtures/selectors';
 
 test.describe('Basic UI Verification - No Disc Simulation', () => {
   test.beforeEach(async ({ page }) => {
+    // Reset jobs first so the empty-state and footer-count assertions don't
+    // depend on leftover jobs from earlier specs. The E2E backend uses a single
+    // shared database for the whole run, and with workers:1 the full Chromium
+    // suite executes before the Firefox/WebKit projects reach this spec — that
+    // cross-spec contamination is exactly what made "Empty state displays when
+    // no discs present" flake on Firefox.
+    await resetAllJobs().catch(() => {});
     await page.goto('/');
   });
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -72,6 +72,13 @@ export default defineConfig({
             env: {
                 ...process.env,
                 DEBUG: 'true',
+                // DEBUG enables the /api/simulate/* endpoints, but we explicitly
+                // keep SQLAlchemy echo OFF: echoing every statement during a
+                // simulated rip floods stdout and stalls the single-worker event
+                // loop, which caused flaky visibility-assertion timeouts. This is
+                // already the default (Settings.db_echo=False) — set here too so
+                // the intent is obvious at the E2E backend launch site.
+                DB_ECHO: 'false',
                 DATABASE_URL: E2E_DATABASE_URL,
             },
         },


### PR DESCRIPTION
## Problem

Two E2E tests flake intermittently (pass on re-run), observed in CI for PR #261:

1. `error-recovery.spec.ts:13` "failed job shows ERROR badge" — the `stateFailed` (`text=/ERROR/i`) assertion timed out (10s).
2. `basic-ui-verification.spec.ts:57` [firefox] "Empty state displays when no discs present" — the `NO ACTIVE OPERATIONS` heading was "not found".

## Root cause

**Two independent mechanisms, both real:**

### 1. Backend overload from `DEBUG`-coupled SQL echo (the cancel→ERROR flake)
The E2E backend **must** run `DEBUG=true` — the `/api/simulate/*` endpoints are gated behind `require_debug`. But `DEBUG=true` also turned on SQLAlchemy `echo` (`database.py`, `echo=settings.debug`). During a simulated rip at `rip_speed_multiplier:1`, the backend does a `session.get`+`commit` and **two WebSocket broadcasts every 0.1s × ~20 steps × N titles**. With echo on, every one of those SQL statements is serialized to stdout through Loguru. On a single-worker uvicorn under the GIL, that pegs the event loop and delays WS broadcasts / HTTP responses — UI elements render late, and the 10s visibility assertions occasionally time out. (This is what made CI step logs "almost entirely SQLAlchemy echo.")

> The `read ECONNRESET` / `write EPIPE` lines in the CI `[WebServer]` output turned out to be **Vite's** `ws proxy` logging benign WebSocket teardown between tests — they share the `[WebServer]` prefix with the backend but are not the load source. The SQL echo flood was.

### 2. Shared-DB contamination (the Firefox empty-state flake)
`basic-ui-verification.spec.ts`'s `beforeEach` only did `page.goto('/')` — no job reset (unlike `error-recovery.spec.ts`). The empty-state heading renders **only** when `filteredDiscs.length === 0` (no loading gate). The E2E run shares **one** database across all browser projects, and with `workers:1` the **full Chromium suite runs before the Firefox/WebKit projects** reach this spec — so leftover non-terminal jobs made the ACTIVE filter non-empty and `NO ACTIVE OPERATIONS` never rendered. It's Firefox-specific because of run *order*, not a rendering quirk; flaky because whether leftover jobs are still "active" is timing-dependent.

## Fix

- **Decouple SQL echo from `DEBUG`** via a dedicated `db_echo` setting (default `false`; `DB_ECHO=true` to opt back in for local SQL debugging). The E2E backend keeps `DEBUG=true` but no longer floods SQL logs; `DB_ECHO=false` is also set explicitly at the E2E launch site in `playwright.config.ts` to document intent.
- **Isolate `basic-ui-verification`** by adding `resetAllJobs()` to the first describe's `beforeEach`, so empty-state/footer-count assertions don't depend on prior specs' leftover state.
- **Regression test** in `tests/unit/test_config.py` (`TestDbEcho`) locking in that `db_echo` defaults off and is independent of `debug`.

These are targeted fixes for the root causes, not blanket timeout bumps.

## Verification (local, Windows, retries:0)

- Full suite once + **3 focused reruns** of the two affected specs across chromium/firefox/webkit → both previously-flaky tests **pass every time** (36/36 per focused run; 138 passed in the full suite).
- `uv run pytest tests/unit/test_config.py` → 7 passed (incl. 3 new).
- Backend `ruff check`/`format` clean; frontend ESLint clean.

### Out of scope (pre-existing, not touched here)
- `visual-regression.spec.ts` screenshots fail on **win32** by design — the committed baselines are Linux-only (documented in the spec header). They pass on CI's Linux runner.
- An intermittent Playwright **worker-teardown hang** on Windows (`worker process did not exit within 300000ms, force-killed`) — tests still pass; appears unrelated to backend load. Flagging for separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
