### PR TITLE
feat(release): generate release notes from curated CHANGELOG.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,23 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  changelog-version-check:
+    name: Changelog Version Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # The GitHub release body is generated from the matching CHANGELOG.md
+      # section (see release.yml), so a `chore: release vX.Y.Z` PR must ship its
+      # changelog entry. This fails such a PR fast — before the ~20-min binary
+      # build — when the section is missing. Normal PRs pass trivially (pyproject
+      # is still the last released version, whose section already exists).
+      - name: CHANGELOG has a section for the pyproject version
+        run: |
+          VERSION=$(grep '^version = ' backend/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "pyproject version: $VERSION"
+          python3 backend/scripts/extract_changelog.py \
+            --version "$VERSION" --changelog CHANGELOG.md --check
+
   backend-lint:
     name: Backend Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,11 @@ jobs:
     needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need CHANGELOG.md for the release body and full tag history so the
+          # "Full Changelog" compare link can resolve the previous tag.
+          fetch-depth: 0
       - uses: actions/download-artifact@v8
         with:
           name: engram-windows-x64
@@ -334,6 +339,20 @@ jobs:
         run: |
           sha256sum engram-windows-x64.zip engram-linux-x64.tar.gz engram-macos-arm64.tar.gz > sha256sums.txt
           cat sha256sums.txt
+      - name: Generate release notes from CHANGELOG
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          python3 backend/scripts/extract_changelog.py \
+            --version "$VERSION" --changelog CHANGELOG.md > release-notes.md
+          # Append a compare link to the previous tag (omitted for the first release).
+          PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+          if [ -n "$PREV" ]; then
+            printf '\n\n---\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "${{ github.repository }}" "$PREV" "$TAG" >> release-notes.md
+          fi
+          echo "----- release-notes.md -----"
+          cat release-notes.md
       - uses: softprops/action-gh-release@v3
         with:
           # A manual workflow_dispatch can request a draft (hidden from the public
@@ -341,7 +360,11 @@ jobs:
           # polls) for testing a build. Tag-push releases leave inputs unset, so
           # this resolves to false and they publish normally.
           draft: ${{ inputs.draft || false }}
-          generate_release_notes: true
+          # Release body is the curated CHANGELOG section (built in the step above)
+          # plus a compare-link footer — not GitHub's flat auto-generated PR list.
+          generate_release_notes: false
+          body_path: release-notes.md
+          name: ${{ inputs.tag || github.ref_name }}
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             engram-windows-x64.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,3 +404,13 @@ For development without physical discs:
 - SQLite database stored at `backend/engram.db`
 - Subtitle cache stored at `~/.engram/cache/`
 - Logs written to `~/.engram/engram.log`
+
+## Release and Changelog
+
+**The GitHub release page is generated from `CHANGELOG.md`, not from GitHub's auto-generated PR list.** At release time, `release.yml` runs `backend/scripts/extract_changelog.py` to pull the section for the version being tagged and uses it as the release body, then appends a `**Full Changelog**` compare link. So the curated changelog *is* the release notes — keep it good.
+
+- **Before cutting a release, `CHANGELOG.md` MUST contain a curated `## [X.Y.Z] - YYYY-MM-DD` section whose version matches `backend/pyproject.toml`.** CI enforces this: the `changelog-version-check` job (`ci.yml`) runs the extractor in `--check` mode against the pyproject version and fails the PR if the section is missing — so a release PR can't merge without its changelog entry.
+- **Section format** (Keep a Changelog): open with a one-line italic `_Highlights: …_` summary (this leads the release notes), then `### Added` / `### Changed` / `### Fixed` / `### Removed` as needed. Reference PRs as `(#NNN)`. Write user-facing prose, not commit subjects.
+- **`[Unreleased]`** holds entries accumulated between releases; move its content into the new `## [X.Y.Z]` section as part of the release PR. Extraction targets a concrete version and never returns `[Unreleased]`.
+- **Release flow**: a `chore: release vX.Y.Z` PR (bump the version files + write the CHANGELOG section) → squash-merge → `tag-release.yml` tags from `main` → `release.yml` builds binaries and publishes the release with the extracted notes.
+- **Preview locally**: `python3 backend/scripts/extract_changelog.py --version X.Y.Z` (or `uv run python …` on Windows) prints exactly what the release body will contain.

--- a/backend/scripts/extract_changelog.py
+++ b/backend/scripts/extract_changelog.py
@@ -1,0 +1,114 @@
+"""Extract a single version's section from the repo-root ``CHANGELOG.md``.
+
+The release workflow (``.github/workflows/release.yml``) uses this to turn the
+curated changelog into the GitHub release body, replacing GitHub's flat
+auto-generated PR list. The CI guard in ``.github/workflows/ci.yml`` runs it in
+``--check`` mode so a ``chore: release`` PR fails fast if its CHANGELOG section
+is missing — before the ~20-minute binary build, not after.
+
+Pure stdlib so it runs under plain ``python3`` in CI (the create-release job
+has no ``uv``)::
+
+    python3 scripts/extract_changelog.py --version 0.10.0    # print the section body
+    python3 scripts/extract_changelog.py --version 0.10.0 --check   # validate only
+
+The matched section excludes its own ``## [version]`` header line (the release
+page already shows the title) and stops at the next ``##`` heading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _normalize_version(version: str) -> str:
+    """Drop a single leading ``v`` from a tag-style version (``v0.10.0`` → ``0.10.0``)."""
+    if version[:1] == "v" and version[1:2].isdigit():
+        return version[1:]
+    return version
+
+
+def extract_section(changelog_text: str, version: str) -> str | None:
+    """Return the body of the ``## [version]`` section, or ``None`` if absent.
+
+    The header line itself is excluded; the body runs up to (not including) the
+    next level-2 ``##`` heading and is stripped of surrounding whitespace.
+    """
+    version = _normalize_version(version)
+    header_re = re.compile(r"^##\s+\[" + re.escape(version) + r"\]")
+    next_section_re = re.compile(r"^##\s")
+
+    lines = changelog_text.splitlines()
+    start = next((i for i, line in enumerate(lines) if header_re.match(line)), None)
+    if start is None:
+        return None
+
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if next_section_re.match(line):
+            break
+        body.append(line)
+    return "\n".join(body).strip()
+
+
+def _default_changelog() -> Path:
+    """Repo-root ``CHANGELOG.md`` — scripts/ -> backend/ -> repo root."""
+    return Path(__file__).resolve().parent.parent.parent / "CHANGELOG.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Extract a version's section from CHANGELOG.md.")
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="version to extract, e.g. 0.10.0 (a leading 'v' is tolerated)",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=_default_changelog(),
+        help="path to CHANGELOG.md (default: repo-root CHANGELOG.md)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the section exists; print a status line and emit no body",
+    )
+    args = parser.parse_args(argv)
+
+    # The changelog contains non-Latin-1 characters (em dashes, arrows). Pin
+    # stdout to UTF-8 so `print(section)` doesn't crash when the platform's
+    # default encoding is cp1252 (Windows) or a non-UTF-8 CI locale. Guarded
+    # because capture streams (pytest) don't always support reconfigure.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
+    try:
+        text = args.changelog.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read changelog {args.changelog}: {exc}", file=sys.stderr)
+        return 1
+
+    section = extract_section(text, args.version)
+    if section is None:
+        print(
+            f"error: no CHANGELOG section found for version {args.version!r} in {args.changelog}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.check:
+        print(f"ok: CHANGELOG has a section for {args.version}")
+        return 0
+
+    print(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/extract_changelog.py
+++ b/backend/scripts/extract_changelog.py
@@ -97,9 +97,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     section = extract_section(text, args.version)
-    if section is None:
+    # `not section` catches both a missing header (None) and a header with an
+    # empty body (""), e.g. a stub `## [X.Y.Z]` added before the entry is
+    # written — an empty release body is as broken as a missing one.
+    if not section:
         print(
-            f"error: no CHANGELOG section found for version {args.version!r} in {args.changelog}",
+            f"error: no non-empty CHANGELOG section for version {args.version!r} "
+            f"in {args.changelog}",
             file=sys.stderr,
         )
         return 1

--- a/backend/scripts/extract_changelog.py
+++ b/backend/scripts/extract_changelog.py
@@ -86,6 +86,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         sys.stdout.reconfigure(encoding="utf-8")
     except (AttributeError, ValueError):
+        # A capture/replacement stream (e.g. pytest) may lack reconfigure or
+        # reject an encoding change mid-stream; fall back to default stdout.
         pass
 
     try:

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -58,6 +58,12 @@ def bsc():
     return _load_script_module("build_subtitle_cache")
 
 
+@pytest.fixture(scope="session")
+def ecl():
+    """The extract_changelog.py module, loaded once per pytest session."""
+    return _load_script_module("extract_changelog")
+
+
 _unit_engine = create_async_engine(
     "sqlite+aiosqlite:///:memory:",
     connect_args={"check_same_thread": False},

--- a/backend/tests/unit/test_extract_changelog.py
+++ b/backend/tests/unit/test_extract_changelog.py
@@ -99,12 +99,13 @@ def test_unknown_version_returns_none(ecl):
     assert ecl.extract_section(_SAMPLE, "9.9.9") is None
 
 
-def test_unreleased_is_not_matched_by_a_version_query(ecl):
-    # Extraction targets a concrete version; the [Unreleased] placeholder
-    # should never be returned for a numeric version query.
-    assert ecl.extract_section(_SAMPLE, "Unreleased") is not None  # explicit only
-    section = ecl.extract_section(_SAMPLE, "0.10.0")
-    assert "[Unreleased]" not in section
+def test_unreleased_placeholder_is_empty_and_not_leaked(ecl):
+    # The [Unreleased] header exists but has no body, so it extracts to ""
+    # (falsy) — not None, and not the next version's content. main() rejects
+    # this empty result (see test_empty_section_rejected_by_check).
+    assert ecl.extract_section(_SAMPLE, "Unreleased") == ""
+    # A concrete-version query must never bleed into the [Unreleased] block.
+    assert "[Unreleased]" not in ecl.extract_section(_SAMPLE, "0.10.0")
 
 
 def test_main_default_prints_body(ecl, tmp_path, capsys):
@@ -132,6 +133,30 @@ def test_main_missing_version_reports_error(ecl, tmp_path, capsys):
     assert rc != 0
     err = capsys.readouterr().err
     assert "9.9.9" in err
+
+
+# A header that exists but carries no body — e.g. a stub `## [X.Y.Z]` added
+# before the entry is written. This must be treated as "no usable section",
+# not silently accepted (which would publish a blank release body).
+_EMPTY_SECTION = "## [1.0.0]\n\n## [0.9.0]\n\n### Fixed\n\n- a real entry\n"
+
+
+def test_empty_section_body_returns_falsy(ecl):
+    assert not ecl.extract_section(_EMPTY_SECTION, "1.0.0")
+
+
+def test_empty_section_rejected_by_check(ecl, tmp_path):
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(_EMPTY_SECTION, encoding="utf-8")
+    assert ecl.main(["--version", "1.0.0", "--changelog", str(path), "--check"]) != 0
+
+
+def test_empty_section_rejected_in_print_mode(ecl, tmp_path, capsys):
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(_EMPTY_SECTION, encoding="utf-8")
+    rc = ecl.main(["--version", "1.0.0", "--changelog", str(path)])
+    assert rc != 0
+    assert capsys.readouterr().out.strip() == ""
 
 
 @pytest.mark.skipif(

--- a/backend/tests/unit/test_extract_changelog.py
+++ b/backend/tests/unit/test_extract_changelog.py
@@ -1,0 +1,145 @@
+"""Unit tests for scripts/extract_changelog.py.
+
+The script pulls a single version's section out of the repo-root CHANGELOG.md
+so the release workflow can use the curated changelog as the GitHub release
+body (instead of GitHub's flat auto-generated PR list). These tests pin the
+parser against a synthetic changelog plus one smoke check against the real
+CHANGELOG.md.
+
+The `ecl` fixture (loaded once per pytest session) lives in conftest.py.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+# Repo layout: backend/tests/unit/<this file>.
+#   parents[2] == backend/, parents[3] == repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REAL_CHANGELOG = _REPO_ROOT / "CHANGELOG.md"
+_PYPROJECT = _REPO_ROOT / "backend" / "pyproject.toml"
+
+_SAMPLE = """\
+# Changelog
+
+All notable changes to Engram will be documented in this file.
+
+## [Unreleased]
+
+## [0.10.0] - 2026-05-28
+
+_Highlights: bundled fpcalc and bulk review actions._
+
+### Added
+
+- **Bulk actions in the review queue** — select multiple titles. (#249)
+
+### Fixed
+
+- **/review page rendered black** — nav linked a bare route. (#247)
+
+## [0.9.1] - 2026-05-27
+
+### Fixed
+
+- **Episodic TV never auto-organizing** — vote-ratio path. (#239)
+
+## [0.9.0-no-date]
+
+### Added
+
+- A section whose header carries no date suffix.
+"""
+
+
+def _write_sample(tmp_path: Path) -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(_SAMPLE, encoding="utf-8")
+    return path
+
+
+def test_extracts_section_body(ecl):
+    section = ecl.extract_section(_SAMPLE, "0.10.0")
+    assert section is not None
+    # Body content is present...
+    assert "_Highlights: bundled fpcalc and bulk review actions._" in section
+    assert "### Added" in section
+    assert "Bulk actions in the review queue" in section
+    assert "### Fixed" in section
+
+
+def test_excludes_version_header_line(ecl):
+    # The release page already shows the title, so the body must not begin
+    # with the "## [0.10.0]" header line.
+    section = ecl.extract_section(_SAMPLE, "0.10.0")
+    assert "## [0.10.0]" not in section
+    assert section.lstrip().startswith("_Highlights")
+
+
+def test_stops_at_next_version(ecl):
+    # Must not bleed into the following 0.9.1 section.
+    section = ecl.extract_section(_SAMPLE, "0.10.0")
+    assert "0.9.1" not in section
+    assert "vote-ratio path" not in section
+    assert "Episodic TV never auto-organizing" not in section
+
+
+def test_header_without_date_parses(ecl):
+    section = ecl.extract_section(_SAMPLE, "0.9.0-no-date")
+    assert section is not None
+    assert "A section whose header carries no date suffix." in section
+
+
+def test_leading_v_is_tolerated(ecl):
+    assert ecl.extract_section(_SAMPLE, "v0.10.0") == ecl.extract_section(_SAMPLE, "0.10.0")
+
+
+def test_unknown_version_returns_none(ecl):
+    assert ecl.extract_section(_SAMPLE, "9.9.9") is None
+
+
+def test_unreleased_is_not_matched_by_a_version_query(ecl):
+    # Extraction targets a concrete version; the [Unreleased] placeholder
+    # should never be returned for a numeric version query.
+    assert ecl.extract_section(_SAMPLE, "Unreleased") is not None  # explicit only
+    section = ecl.extract_section(_SAMPLE, "0.10.0")
+    assert "[Unreleased]" not in section
+
+
+def test_main_default_prints_body(ecl, tmp_path, capsys):
+    path = _write_sample(tmp_path)
+    rc = ecl.main(["--version", "0.10.0", "--changelog", str(path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Bulk actions in the review queue" in out
+    assert "## [0.10.0]" not in out
+
+
+def test_main_check_present_returns_zero(ecl, tmp_path):
+    path = _write_sample(tmp_path)
+    assert ecl.main(["--version", "0.10.0", "--changelog", str(path), "--check"]) == 0
+
+
+def test_main_check_absent_returns_nonzero(ecl, tmp_path):
+    path = _write_sample(tmp_path)
+    assert ecl.main(["--version", "9.9.9", "--changelog", str(path), "--check"]) != 0
+
+
+def test_main_missing_version_reports_error(ecl, tmp_path, capsys):
+    path = _write_sample(tmp_path)
+    rc = ecl.main(["--version", "9.9.9", "--changelog", str(path)])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "9.9.9" in err
+
+
+@pytest.mark.skipif(
+    not _REAL_CHANGELOG.exists() or not _PYPROJECT.exists(),
+    reason="real CHANGELOG.md / pyproject.toml not present",
+)
+def test_real_changelog_has_section_for_current_version(ecl):
+    version = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["version"]
+    section = ecl.extract_section(_REAL_CHANGELOG.read_text(encoding="utf-8"), version)
+    assert section is not None, f"CHANGELOG.md has no section for current version {version}"
+    assert "###" in section


### PR DESCRIPTION
## Why

The GitHub release page (e.g. [v0.10.0](https://github.com/Jsakkos/engram/releases/tag/v0.10.0)) is built by `softprops/action-gh-release` with `generate_release_notes: true`, which produces a **flat, ungrouped dump of merged PRs** — no structure, no grouping. Meanwhile the repo already maintains a curated, well-structured `CHANGELOG.md` (Keep a Changelog: `### Added` / `### Changed` / `### Fixed` / `### Removed`) whose content never reached the release page.

This makes `CHANGELOG.md` the **source of truth** for the release body.

## What changed

- **`backend/scripts/extract_changelog.py`** (new) — pure-stdlib script that extracts a version's section from `CHANGELOG.md`. Excludes the header line, stops at the next version, tolerates a leading `v`, and has a `--check` mode for CI. Pins stdout to UTF-8 so non-Latin-1 characters (arrows, em dashes) don't crash on a non-UTF-8 locale.
- **`.github/workflows/release.yml`** — the `create-release` job now checks out the repo (`fetch-depth: 0`), extracts the tagged version's section, appends a `**Full Changelog**` compare link, and publishes with `body_path` + `generate_release_notes: false` + an explicit `name`.
- **`.github/workflows/ci.yml`** — new `changelog-version-check` job: runs the extractor in `--check` mode against the `pyproject.toml` version, so a `chore: release vX.Y.Z` PR **fails fast** if its CHANGELOG section is missing (before the ~20-min binary build). Normal PRs pass trivially.
- **`CLAUDE.md`** — documents the release/changelog contract, including the `_Highlights:_` one-line summary convention that now leads each release.
- **Tests** — `backend/tests/unit/test_extract_changelog.py` (12 tests, written test-first) + a shared `ecl` fixture in `conftest.py`.

## Result

The release body becomes the curated, grouped `### Added`/`### Fixed` content followed by a single `**Full Changelog**: …compare/<prev>...<tag>` link — instead of the flat PR list.

## Verification

- New extractor tests pass; full backend unit suite **1401 passed**.
- `ruff check` + `ruff format --check` clean; both workflow YAMLs parse.
- Previewed against the real `CHANGELOG.md` — `v0.10.0` renders the expected grouped notes + compare footer.
- A Windows-locale `UnicodeEncodeError` (the `→` char in cp1252 stdout) was caught during verification and fixed by pinning stdout to UTF-8.

## Reviewer note (manual follow-up)

To make `changelog-version-check` actually **block** a release PR, mark it as a required status check in branch protection — that's a GitHub setting, not in the repo. It still runs and reports red/green without this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
