### PR TITLE
fix(matcher): rank+margin chunk-vote gate fixes ASR episode-match scale mismatch

### DIFF
--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -273,6 +273,54 @@ MAX_VOTE_BOOST = 0.30
 HIGH_VOTE_RATIO = 3.0
 MIN_CONSENSUS_FOR_RATIO = 0.50
 
+# Rank+margin chunk-vote gate. A 30s ASR chunk (~30-120 words) compared against a
+# full-episode TF-IDF vector (~3-5k words) yields a structurally low absolute
+# cosine even for a perfect match (~0.08-0.22): both vectors are L2-normalized, so
+# the short, sparse chunk can only overlap a small fraction of the episode's mass.
+# An absolute gate (the historical `cosine > 0.15`) therefore rejected most
+# correct chunks, returning episode=None. The *ranking* is reliable instead -- the
+# correct episode leads the runner-up by ~1.8-5.6x -- so a chunk votes for its top
+# episode when that lead is clear. See select_chunk_vote and the empirical scale
+# measurement in docs/superpowers/reviews/2026-05-29-asr-chunk-vote-scale-mismatch.md.
+CHUNK_VOTE_FLOOR = 0.06  # below this top-1 cosine, treat the chunk as noise
+CHUNK_VOTE_MARGIN_RATIO = 1.8  # top-1 must lead the runner-up by this ratio to vote
+
+
+def select_chunk_vote(
+    tfidf_results: list[tuple[str, float]],
+    floor: float = CHUNK_VOTE_FLOOR,
+    ratio: float = CHUNK_VOTE_MARGIN_RATIO,
+) -> tuple[str, float] | None:
+    """Pick the single episode a transcribed chunk votes for, or None.
+
+    Replaces the miscalibrated absolute cosine gate with a rank+margin rule that
+    survives the chunk-vs-full-episode scale mismatch (see CHUNK_VOTE_FLOOR notes).
+    A chunk votes for its top-ranked episode iff that episode (a) clears ``floor``
+    (guards pure-noise/near-silent chunks) and (b) leads the runner-up by
+    ``ratio``x (so recap or shared-dialogue chunks, where two episodes score
+    similarly, abstain instead of casting a confident-but-wrong vote).
+
+    Args:
+        tfidf_results: ``(reference, cosine)`` pairs sorted by cosine descending,
+            as returned by ``TfidfMatcher.match()``.
+        floor: minimum top-1 cosine required to consider voting.
+        ratio: required ``top1 / runner_up`` lead. A lone candidate (no runner-up)
+            only needs to clear the floor.
+
+    Returns:
+        ``(reference, cosine)`` for the winning episode, or None when no episode
+        clearly leads.
+    """
+    if not tfidf_results:
+        return None
+    top_ref, top_score = tfidf_results[0]
+    if top_score < floor:
+        return None
+    runner_up_score = tfidf_results[1][1] if len(tfidf_results) > 1 else 0.0
+    if top_score < ratio * runner_up_score:
+        return None
+    return top_ref, top_score
+
 
 def _clamp01(value: float) -> float:
     return max(0.0, min(1.0, value))
@@ -724,6 +772,9 @@ class EpisodeMatcher:
         # Ranked voting parameters
         self.min_vote_count = min_vote_count
         self.match_threshold = match_threshold
+        # Rank+margin chunk-vote gate parameters (see select_chunk_vote).
+        self.chunk_vote_floor = CHUNK_VOTE_FLOOR
+        self.chunk_vote_margin_ratio = CHUNK_VOTE_MARGIN_RATIO
         # Enable/disable ranked voting (default: True for improved confidence scores)
         self.use_ranked_voting = use_ranked_voting
 
@@ -1224,30 +1275,36 @@ class EpisodeMatcher:
                         f"Chunk {i}/{len(scan_points)} @ {start_time}s: transcribed {len(text)} chars, matching via TF-IDF..."
                     )
 
-                    # TF-IDF cosine similarity against full episode texts
+                    # TF-IDF cosine similarity against full episode texts. The
+                    # chunk-vs-full-episode cosine is structurally low even for a
+                    # perfect match, so vote on rank+margin rather than an absolute
+                    # cosine gate (see select_chunk_vote). One vote per chunk: its
+                    # clearly-leading top episode, or none.
                     tfidf_results = self.tfidf_matcher.match(text)
-                    chunk_matches = 0
-                    for rf_str, score in tfidf_results:
-                        if score > 0.15:  # TF-IDF cosine threshold (range ~0.05-0.5)
-                            coverages[rf_str].add_match(start_time, chunk_len, score)
-                            chunk_matches += 1
-                            logger.debug(
-                                f"  {Path(rf_str).stem}: MATCH @ video={start_time}s "
-                                f"(cosine={score:.3f})"
-                            )
-                        elif score > 0.08:  # Log near-misses
-                            logger.debug(
-                                f"  {Path(rf_str).stem}: near-miss @ video={start_time}s "
-                                f"(cosine={score:.3f})"
-                            )
+                    vote = select_chunk_vote(
+                        tfidf_results,
+                        floor=self.chunk_vote_floor,
+                        ratio=self.chunk_vote_margin_ratio,
+                    )
 
-                    if chunk_matches > 0:
+                    if vote is not None:
+                        rf_str, score = vote
+                        coverages[rf_str].add_match(start_time, chunk_len, score)
                         matches_found_count += 1
-                    else:
                         logger.debug(
-                            f"Chunk {i}/{len(scan_points)} @ {start_time}s: no matches found (best cosine < 0.15)"
+                            f"  {Path(rf_str).stem}: VOTE @ video={start_time}s "
+                            f"(cosine={score:.3f}, clear margin over runner-up)"
                         )
+                    else:
                         matches_rejected_count += 1
+                        if tfidf_results:
+                            top_ref, top_score = tfidf_results[0]
+                            runner = tfidf_results[1][1] if len(tfidf_results) > 1 else 0.0
+                            logger.debug(
+                                f"Chunk {i}/{len(scan_points)} @ {start_time}s: no clear vote "
+                                f"(top {Path(top_ref).stem}={top_score:.3f}, "
+                                f"runner-up={runner:.3f})"
+                            )
 
                 except Exception as e:
                     logger.warning(
@@ -1328,85 +1385,88 @@ class EpisodeMatcher:
                 "total_chunks": len(scan_points),
             }
 
-            if not best_match:
-                logger.warning(f"No episode matches found for {video_file}")
-                return {
-                    "season": season_number,
-                    "episode": None,
-                    "confidence": 0.0,
-                    "score": 0.0,
-                    "match_details": match_stats,
-                    "runner_ups": [],
-                }
+            if best_match:
+                # Merge stats into match_details before calibration so the helper
+                # operates on the full per-winner detail dict.
+                best_match["match_details"].update(match_stats)
 
-            # Merge stats into match_details before calibration so the helper
-            # operates on the full per-winner detail dict.
-            best_match["match_details"].update(match_stats)
+                # Sort candidates so the calibrator sees top1/top2 in order, then
+                # translate the raw signals into a 0-1 reviewer-facing confidence
+                # and build the runner-up leaderboard. This sets
+                # best_match["confidence"] (calibrated, -> DiscTitle.match_confidence)
+                # while leaving best_match["score"] raw for the accept-gate and
+                # conflict resolution. All candidates (incl. the winner) appear in
+                # runner_ups so the UI can show the full leaderboard. See
+                # calibrate_confidence for rationale.
+                results_summary.sort(key=lambda x: x["score"], reverse=True)
+                _attach_calibrated_confidence(best_match, results_summary, video_duration)
 
-            # Sort candidates so the calibrator sees top1/top2 in order, then
-            # translate the raw signals into a 0-1 reviewer-facing confidence and
-            # build the runner-up leaderboard. This sets best_match["confidence"]
-            # (calibrated, -> DiscTitle.match_confidence) while leaving
-            # best_match["score"] raw for the accept-gate and conflict resolution.
-            # All candidates (incl. the winner) appear in runner_ups so the UI can
-            # show the full leaderboard. See calibrate_confidence for rationale.
-            results_summary.sort(key=lambda x: x["score"], reverse=True)
-            _attach_calibrated_confidence(best_match, results_summary, video_duration)
+                score_gap = best_match["match_details"].get("score_gap", 0.0)
 
-            score_gap = best_match["match_details"].get("score_gap", 0.0)
-
-            # Log top candidates with voting + calibration analysis
-            voting_method = "ranked voting" if self.use_ranked_voting else "weighted score"
-            logger.info(f"{voting_method.capitalize()} results for {video_file.name}:")
-            logger.info(
-                f"  Calibrated confidence: {best_match['confidence']:.3f} "
-                f"(raw score={best_match['score']:.3f}, "
-                f"score_gap={score_gap:.4f} "
-                f"{'decisive' if score_gap > 0.01 else 'LOW-uncertain'})"
-            )
-
-            for i, result in enumerate(results_summary[:5], 1):
+                # Log top candidates with voting + calibration analysis
+                voting_method = "ranked voting" if self.use_ranked_voting else "weighted score"
+                logger.info(f"{voting_method.capitalize()} results for {video_file.name}:")
                 logger.info(
-                    f"  {i}. {result['episode']}: "
-                    f"score={result['score']:.3f}, "
-                    f"votes={result['vote_count']}, "
-                    f"avg_conf={result['avg_conf']:.3f}, "
-                    f"coverage={result['file_cov']:.1%}, "
-                    f"total_weight={result['total_weight']:.4f}"
+                    f"  Calibrated confidence: {best_match['confidence']:.3f} "
+                    f"(raw score={best_match['score']:.3f}, "
+                    f"score_gap={score_gap:.4f} "
+                    f"{'decisive' if score_gap > 0.01 else 'LOW-uncertain'})"
                 )
 
-            effective_min_votes = (
-                min_vote_count if min_vote_count is not None else self.min_vote_count
-            )
-
-            if best_match and best_match["score"] > self.match_threshold:
-                vote_count = best_match["match_details"]["vote_count"]
-
-                logger.info(
-                    f"Best match evaluation: "
-                    f"score {best_match['score']:.3f} vs threshold {self.match_threshold}, "
-                    f"votes {vote_count} vs minimum {effective_min_votes}"
-                )
-
-                if vote_count < effective_min_votes:
-                    logger.warning(
-                        f"⚠ Match rejected: insufficient evidence. "
-                        f"Episode: {best_match['match_details']['episode']}, "
-                        f"score: {best_match['score']:.3f}, "
-                        f"votes: {vote_count}/{effective_min_votes}, "
-                        f"coverage: {best_match['match_details']['file_cov']:.1%}, "
-                        f"matched_at: {best_match['matched_at']}s"
-                    )
-                    # Fall through to fallback
-                else:
+                for i, result in enumerate(results_summary[:5], 1):
                     logger.info(
-                        f"Ranked voting match: S{best_match['season']:02d}E{best_match['episode']:02d} "
-                        f"(score: {best_match['score']:.3f}, votes: {vote_count})"
+                        f"  {i}. {result['episode']}: "
+                        f"score={result['score']:.3f}, "
+                        f"votes={result['vote_count']}, "
+                        f"avg_conf={result['avg_conf']:.3f}, "
+                        f"coverage={result['file_cov']:.1%}, "
+                        f"total_weight={result['total_weight']:.4f}"
                     )
-                    return best_match
+
+                effective_min_votes = (
+                    min_vote_count if min_vote_count is not None else self.min_vote_count
+                )
+
+                if best_match["score"] > self.match_threshold:
+                    vote_count = best_match["match_details"]["vote_count"]
+
+                    logger.info(
+                        f"Best match evaluation: "
+                        f"score {best_match['score']:.3f} vs threshold {self.match_threshold}, "
+                        f"votes {vote_count} vs minimum {effective_min_votes}"
+                    )
+
+                    if vote_count < effective_min_votes:
+                        logger.warning(
+                            f"⚠ Match rejected: insufficient evidence. "
+                            f"Episode: {best_match['match_details']['episode']}, "
+                            f"score: {best_match['score']:.3f}, "
+                            f"votes: {vote_count}/{effective_min_votes}, "
+                            f"coverage: {best_match['match_details']['file_cov']:.1%}, "
+                            f"matched_at: {best_match['matched_at']}s"
+                        )
+                        # Fall through to fallback
+                    else:
+                        logger.info(
+                            f"Ranked voting match: S{best_match['season']:02d}E{best_match['episode']:02d} "
+                            f"(score: {best_match['score']:.3f}, votes: {vote_count})"
+                        )
+                        return best_match
+            else:
+                # Zero chunks cleared the rank+margin vote gate. Crucially, do NOT
+                # early-return episode=None here: the chunk cosine scale is
+                # structurally low, while the full-file fallback compares
+                # whole-vs-whole on a higher, properly-calibrated scale. Falling
+                # through reaches it. (Historically the early return made that
+                # fallback dead code in exactly the total-miss case it exists for.)
+                logger.warning(
+                    f"No chunks cleared the vote gate for {video_file}; "
+                    f"attempting full-file fallback"
+                )
 
             # --- FALLBACK ---
-            # Standard full file fallback if no good match
+            # Full-file fallback when chunk voting produced no acceptable match
+            # (no votes at all, score below threshold, or too few votes).
             logger.info(
                 f"Ranked voting matching failed "
                 f"(best score: {best_score:.3f} < {self.match_threshold} threshold "
@@ -1430,7 +1490,18 @@ class EpisodeMatcher:
                 }
                 return match
 
-            return None
+            # Nothing matched, even via the fallback. Return the no-episode result
+            # with scan stats preserved (not a bare None) so the UI/diagnostics
+            # show what was attempted.
+            logger.warning(f"No episode matches found for {video_file}")
+            return {
+                "season": season_number,
+                "episode": None,
+                "confidence": 0.0,
+                "score": 0.0,
+                "match_details": match_stats,
+                "runner_ups": [],
+            }
 
         except Exception as e:
             logger.error(

--- a/backend/tests/real_data/test_chunk_vote_real_cache.py
+++ b/backend/tests/real_data/test_chunk_vote_real_cache.py
@@ -1,0 +1,115 @@
+"""Real-cache fidelity test for the rank+margin chunk-vote gate.
+
+Uses the shipped precomputed subtitle-vector cache (~/.engram/cache) and the
+real downloaded SRTs to reproduce the production bug: feeding a known episode's
+own subtitle text (sliced into the matcher's 30s windows = best-case "perfect
+transcription") must accumulate enough votes for the CORRECT episode under the
+rank+margin gate, while the old absolute 0.15 gate accepted too few to match.
+
+Skipped when the cache/SRTs aren't present (CI and most dev machines).
+Run locally with:  uv run pytest tests/real_data/ -v -m real_data
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+CACHE = Path.home() / ".engram" / "cache"
+SHOW = "The Expanse"
+PRE = CACHE / "precomputed" / SHOW
+DATA = CACHE / "data" / SHOW
+SRT = DATA / "The Expanse - S01E01.srt"
+
+pytestmark = pytest.mark.real_data
+
+_missing = (
+    not (PRE / "S01.npz").exists()
+    or not SRT.exists()
+    or not (CACHE / "precomputed" / "idf.npy").exists()
+)
+
+
+@pytest.mark.skipif(_missing, reason="Real Expanse precomputed cache / SRTs not present")
+class TestChunkVoteRealCache:
+    def _load_season(self, season):
+        from scipy.sparse import load_npz
+
+        from app.matcher.vectorizer_config import apply_tfidf
+
+        idf = np.load(CACHE / "precomputed" / "idf.npy")
+        refs = apply_tfidf(load_npz(PRE / f"S{season:02d}.npz"), idf)
+        codes = json.loads((PRE / f"S{season:02d}.index.json").read_text(encoding="utf-8"))
+        return refs, codes, idf
+
+    def _perfect_chunks(self, idf):
+        """Real S01E01 subtitle text sliced into the matcher's evenly-spaced 30s
+        windows, projected through the real runtime query path."""
+        from app.matcher.episode_identification import SubtitleReader, _clean_subtitle_text
+        from app.matcher.vectorizer_config import transform_query
+
+        content = SubtitleReader.read_srt_file(str(SRT))
+        last_end = 0.0
+        for block in content.strip().split("\n\n"):
+            lines = block.split("\n")
+            if len(lines) >= 3 and "-->" in lines[1]:
+                try:
+                    last_end = max(
+                        last_end, SubtitleReader.parse_timestamp(lines[1].split(" --> ")[1].strip())
+                    )
+                except Exception:
+                    pass
+        skip_initial, skip_final, chunk_len, n = 300, 120, 30, 10
+        interval = (last_end - skip_initial - skip_final) / (n - 1)
+        queries = []
+        for i in range(n):
+            start = int(skip_initial + i * interval)
+            txt = _clean_subtitle_text(
+                " ".join(SubtitleReader.extract_subtitle_chunk(content, start, start + chunk_len))
+            )
+            if txt:
+                queries.append(transform_query(txt, idf))
+        return queries
+
+    def _votes(self, refs, codes, queries):
+        from collections import defaultdict
+
+        from sklearn.metrics.pairwise import cosine_similarity
+
+        from app.matcher.episode_identification import select_chunk_vote
+
+        tally = defaultdict(int)
+        for q in queries:
+            sims = cosine_similarity(q, refs)[0]
+            results = sorted(
+                zip(codes, sims.tolist(), strict=False), key=lambda x: x[1], reverse=True
+            )
+            vote = select_chunk_vote(results)
+            if vote is not None:
+                tally[vote[0]] += 1
+        return tally
+
+    def test_correct_episode_accumulates_min_votes(self):
+        refs, codes, idf = self._load_season(1)
+        queries = self._perfect_chunks(idf)
+        assert queries, "no perfect chunks extracted"
+
+        tally = self._votes(refs, codes, queries)
+
+        # The correct episode wins, with enough votes to clear min_vote_count (2),
+        # and no wrong episode out-votes it.
+        assert tally.get("S01E01", 0) >= 2, f"S01E01 under-voted: {dict(tally)}"
+        assert max(tally, key=tally.get) == "S01E01", f"wrong winner: {dict(tally)}"
+
+    def test_wrong_season_does_not_confidently_match(self):
+        # Negative control: S01E01 chunks vs S02 vectors must not manufacture a
+        # confident (>= min_vote_count) match for any S02 episode.
+        _, _, idf = self._load_season(1)
+        refs2, codes2, _ = self._load_season(2)
+        queries = self._perfect_chunks(idf)
+
+        tally = self._votes(refs2, codes2, queries)
+
+        top = max(tally.values(), default=0)
+        assert top < 2, f"wrong-season false match: {dict(tally)}"

--- a/backend/tests/real_data/test_chunk_vote_real_cache.py
+++ b/backend/tests/real_data/test_chunk_vote_real_cache.py
@@ -58,8 +58,10 @@ class TestChunkVoteRealCache:
                     last_end = max(
                         last_end, SubtitleReader.parse_timestamp(lines[1].split(" --> ")[1].strip())
                     )
-                except Exception:
-                    pass
+                except (ValueError, IndexError):
+                    # Malformed timestamp/block: skip it when scanning for the
+                    # last subtitle end time (matches extract_subtitle_chunk).
+                    continue
         skip_initial, skip_final, chunk_len, n = 300, 120, 30, 10
         interval = (last_end - skip_initial - skip_final) / (n - 1)
         queries = []

--- a/backend/tests/unit/test_chunk_vote_gate.py
+++ b/backend/tests/unit/test_chunk_vote_gate.py
@@ -1,0 +1,129 @@
+"""Unit tests for the rank+margin chunk-vote gate and full-file fallback reach.
+
+Root cause these guard against: a 30s ASR chunk compared against a full-episode
+TF-IDF vector scores a structurally low absolute cosine (~0.08-0.22) even for a
+perfect match, because both vectors are L2-normalized and the chunk is far
+sparser. The old absolute `score > 0.15` gate therefore rejected most correct
+chunks, returning episode=None. The ranking, however, is reliable (correct
+episode leads the runner-up by ~1.8-5.6x), so we vote on rank+margin instead.
+
+CI-safe: no MKV/audio/Whisper; the ffmpeg + faster-whisper paths are stubbed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from app.matcher import episode_identification as ei
+from app.matcher.episode_identification import EpisodeMatcher, select_chunk_vote
+from app.matcher.vectorizer_config import apply_tfidf, build_hashing_vectorizer
+
+
+@pytest.mark.unit
+class TestSelectChunkVote:
+    def test_low_absolute_but_clear_margin_votes(self):
+        # The regression: 0.10 is BELOW the old 0.15 absolute gate, but it leads
+        # the runner-up (0.04) by 2.5x — a confident chunk that must vote.
+        vote = select_chunk_vote([("S01E01", 0.10), ("S01E02", 0.04)], floor=0.06, ratio=1.8)
+        assert vote == ("S01E01", 0.10)
+
+    def test_ambiguous_top_two_no_vote(self):
+        # Two episodes nearly tied (0.12 vs 0.11): no clear winner -> abstain,
+        # even though both clear the floor. Prevents recap/shared-dialogue chunks
+        # from casting a confident-but-wrong vote.
+        assert select_chunk_vote([("a", 0.12), ("b", 0.11)], floor=0.06, ratio=1.8) is None
+
+    def test_below_floor_no_vote(self):
+        # Top candidate clears the ratio (0.05 vs 0.0) but is below the noise floor.
+        assert select_chunk_vote([("a", 0.05)], floor=0.06, ratio=1.8) is None
+
+    def test_empty_results_no_vote(self):
+        assert select_chunk_vote([], floor=0.06, ratio=1.8) is None
+
+    def test_single_candidate_votes_when_above_floor(self):
+        # Only one reference episode in the season: no runner-up to out-margin,
+        # so clearing the floor is sufficient.
+        assert select_chunk_vote([("only", 0.09)], floor=0.06, ratio=1.8) == ("only", 0.09)
+
+    def test_just_below_ratio_abstains(self):
+        # 0.17 vs 0.10 is a 1.7x lead, under the 1.8x bar -> not decisive enough.
+        assert select_chunk_vote([("a", 0.17), ("b", 0.10)], floor=0.06, ratio=1.8) is None
+
+    def test_clearly_above_ratio_votes(self):
+        # 0.20 vs 0.10 is a 2.0x lead, comfortably over the 1.8x bar.
+        assert select_chunk_vote([("a", 0.20), ("b", 0.10)], floor=0.06, ratio=1.8) == ("a", 0.20)
+
+
+@pytest.mark.unit
+class TestFallbackReachWhenNoVotes:
+    """When zero chunks clear the vote gate, identify_episode must still reach the
+    full-file fallback instead of returning episode=None (the early-return bug
+    that made the fallback dead code in the total-miss case)."""
+
+    def _refs_in_hashed_space(self, texts):
+        counts = build_hashing_vectorizer().transform(texts)
+        idf = np.ones(counts.shape[1], dtype=np.float32)
+        return apply_tfidf(counts, idf), idf
+
+    def test_no_votes_reaches_full_file_fallback(self, tmp_path):
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="Demo", device="cpu")
+
+        ref_matrix, idf = self._refs_in_hashed_space(["alpha beta", "gamma delta", "epsilon zeta"])
+        codes = ["S01E01", "S01E02", "S01E03"]
+
+        fallback_result = {
+            "season": 1,
+            "episode": 2,
+            "confidence": 0.83,
+            "reference_file": "S01E02",
+            "matched_at": 0,
+            "method": "full_transcription",
+        }
+
+        fake_model = MagicMock()
+        fake_model.transcribe.return_value = {"text": "this transcription wins no vote at all"}
+
+        with (
+            patch.object(
+                matcher, "_load_precomputed_season", return_value=(ref_matrix, codes, idf)
+            ),
+            patch.object(ei, "get_video_duration", return_value=1800.0),
+            patch.object(ei, "get_cached_model", return_value=fake_model),
+            patch.object(matcher, "extract_audio_chunk", return_value=str(tmp_path / "c.wav")),
+            # Force the total-miss condition deterministically (audio/ASR are
+            # unavoidable to stub; this isolates the control-flow fix).
+            patch.object(ei, "select_chunk_vote", return_value=None),
+            patch.object(matcher, "_match_full_file", return_value=dict(fallback_result)) as mff,
+        ):
+            result = matcher.identify_episode(tmp_path / "demo.mkv", tmp_path, season_number=1)
+
+        mff.assert_called_once()
+        assert result is not None
+        assert result["episode"] == 2
+        assert result["match_details"]["method"] == "full_transcription"
+
+    def test_total_miss_without_fallback_returns_stats_not_none(self, tmp_path):
+        # When even the fallback finds nothing, the result still carries scan
+        # stats (not a bare None) so the UI/diagnostics show what was attempted.
+        matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="Demo", device="cpu")
+        ref_matrix, idf = self._refs_in_hashed_space(["alpha beta", "gamma delta"])
+        codes = ["S01E01", "S01E02"]
+        fake_model = MagicMock()
+        fake_model.transcribe.return_value = {"text": "no vote here whatsoever friend"}
+
+        with (
+            patch.object(
+                matcher, "_load_precomputed_season", return_value=(ref_matrix, codes, idf)
+            ),
+            patch.object(ei, "get_video_duration", return_value=1800.0),
+            patch.object(ei, "get_cached_model", return_value=fake_model),
+            patch.object(matcher, "extract_audio_chunk", return_value=str(tmp_path / "c.wav")),
+            patch.object(ei, "select_chunk_vote", return_value=None),
+            patch.object(matcher, "_match_full_file", return_value=None),
+        ):
+            result = matcher.identify_episode(tmp_path / "demo.mkv", tmp_path, season_number=1)
+
+        assert result is not None
+        assert result["episode"] is None
+        assert "total_chunks" in result["match_details"]

--- a/docs/superpowers/reviews/2026-05-29-asr-chunk-vote-scale-mismatch.md
+++ b/docs/superpowers/reviews/2026-05-29-asr-chunk-vote-scale-mismatch.md
@@ -1,0 +1,72 @@
+# ASR/TF-IDF matcher: chunk-vs-episode cosine scale mismatch
+
+**Date:** 2026-05-29
+**Symptom:** Matching a known-season file (e.g. The Expanse S01E01, season hard-coded to 1)
+returns `episode=None` ("needs review", no candidate). The matcher transcribes accurately
+and *ranks* the correct episode first, but every 30s chunk scores ~0.08–0.12 cosine —
+under the absolute `0.15` gate — so 0 chunks vote and the result is a total miss.
+
+## Root cause
+
+The per-chunk accept gate compared a **~30s chunk (30–120 words)** against a
+**full-episode TF-IDF vector (~3,500 words)** with an absolute `cosine > 0.15` threshold.
+Both vectors are L2-normalized, so the cosine of a short, sparse query against a long,
+dense reference is **structurally bounded near √(words_chunk / words_episode) ≈ 0.1** even
+for a *perfect* match. The correct episode still wins on **rank** (it leads runners-up by
+1.8–5.6×), but its **absolute** cosine sits at/below the gate.
+
+Two defects compounded:
+
+1. **Miscalibrated gate.** `0.15` was tuned for the legacy scraped `TfidfVectorizer`
+   (per-season fit, 10k features). The precomputed `HashingVectorizer` + global-IDF
+   migration (`vectorizer_config.py`) lowered the cosine scale ~20–30%, tipping an
+   already-marginal threshold into outright failure. The threshold constant never moved
+   with the vectorizer.
+2. **Unreachable safety net.** The full-file fallback (`_match_full_file`) is explicitly
+   designed for this — it compares whole-vs-whole on a higher scale. But when *every* chunk
+   scored below `0.15`, `best_match` was `None` and `identify_episode` early-returned
+   `episode=None` **before** the fallback ran. The fallback was dead code in exactly the
+   total-miss case it exists for.
+
+## Evidence (read-only probes against the real `~/.engram/cache`)
+
+Perfect transcription = the reference subtitle text itself, sliced into the matcher's 30s windows.
+
+| Measurement | Result |
+|---|---|
+| Perfect 30s chunks where S01E01 is **top-ranked** | **9/10** |
+| Perfect 30s chunks **crossing 0.15** | **3/10** (mean cosine 0.125) |
+| Runner-up episodes per chunk | 0.02–0.06 (correct ep leads 1.8–5.6×) |
+| **Full-file** query (3,563 words vs 3,563) | **cosine = 1.000** → proves vectorizer spaces are identical |
+| Real observed ASR snippets | 0.07–0.10, **still rank #1** |
+| Scraped path on identical chunks | 5/9 cross 0.15 (vs precomputed 3/9) → migration lowered scale |
+
+Ruled out by the 1.000 full-file cosine: vectorizer/tokenization mismatch, IDF/normalization
+bug. Ruled out by perfect-text still failing: ASR quality, time-window misalignment.
+
+## Fix
+
+Replace the absolute gate with a **rank+margin vote** (`select_chunk_vote`): a chunk votes
+for its top episode iff cosine ≥ `CHUNK_VOTE_FLOOR` (0.06) **and** leads the runner-up by
+`CHUNK_VOTE_MARGIN_RATIO` (1.8×). Also let `identify_episode` fall through to the full-file
+fallback when no chunk votes (defense-in-depth), and preserve scan stats on total miss.
+
+### Validation (same probes, candidate gate)
+
+| Case | Absolute 0.15 gate | Rank+margin gate |
+|---|---|---|
+| S01E01 chunks vs **S01** vectors | 3 votes | **8 votes** |
+| S01E01 chunks vs **S02** vectors (wrong season) | 0 | **0** (no false match) |
+| End-to-end calibrated confidence | — | **0.85 → AUTO-ACCEPT** |
+
+The margin gate ~doubles true-positive sensitivity without manufacturing a wrong-season match.
+
+## Tests
+
+- `tests/unit/test_chunk_vote_gate.py` — gate logic (synthetic, CI) + fallback reachability
+  (red-green verified: the fallback test fails against the old early-return).
+- `tests/real_data/test_chunk_vote_real_cache.py` — real Expanse cache, positive + negative
+  control (skipped when the cache is absent).
+
+This is separate from PR #264 (import-watch-folder), which only makes import paths *attempt*
+matching; it does not change matcher scoring.


### PR DESCRIPTION
## Problem

The ASR/TF-IDF episode matcher returned `episode=None` (needs review, no candidate) even when the season was known and the audio transcribed accurately. It ranked the correct episode #1 but every 30s chunk scored only ~0.08–0.12 cosine — under the absolute `0.15` gate — so **0 chunks voted** and the result was a total miss.

## Root cause

A ~30s ASR chunk (30–120 words) is compared against a **full-episode** TF-IDF vector (~3,500 words). Both vectors are L2-normalized, so the cosine of a short, sparse query against a long, dense reference is **structurally bounded near √(words_chunk / words_episode) ≈ 0.1** even for a *perfect* match. The absolute `cosine > 0.15` gate therefore rejects most correct chunks.

Two defects compounded:
1. **Miscalibrated gate.** `0.15` was tuned for the legacy scraped `TfidfVectorizer`. The precomputed `HashingVectorizer` + global-IDF migration lowered the cosine scale ~20–30% (measured: 3/9 vs 5/9 perfect chunks crossing 0.15), tipping an already-marginal threshold into outright failure. The constant never moved with the vectorizer.
2. **Unreachable safety net.** The full-file fallback (designed for exactly this low-chunk-scale case) was short-circuited by an early `return episode=None` whenever *all* chunks missed — i.e. precisely when it was needed.

Ruled out empirically (read-only probes vs. the real cache): vectorizer/IDF/normalization mismatch (a full-file query scores *exactly 1.000* against its own shipped vector), ASR quality (perfect transcription still fails the gate), and time-window misalignment.

## Fix

- **`select_chunk_vote`** — replace the absolute gate with a rank+margin rule: a chunk votes for its top episode iff cosine ≥ `CHUNK_VOTE_FLOOR` (0.06) **and** it leads the runner-up by `CHUNK_VOTE_MARGIN_RATIO` (1.8×). This converts the reliable *ranking* into votes and abstains on ambiguous recap/shared-dialogue chunks.
- **Reachable fallback** — `identify_episode` now falls through to the full-file fallback when no chunk votes, and preserves scan stats on total miss instead of returning a bare `None`.

## Validation (real data)

| Show | Result |
|---|---|
| Expanse S01E01 | votes **3 → 8**, **0** false on wrong season, calibrated confidence **0.85 → auto-accept** |
| Arrested Development S01 | cache sweep **22/22**, zero false positives; real ASR **6/6** correct via fast chunk path (incl. 4 scrambled-name files; S01E04 at raw 0.143 — the old gate would have rejected it) |
| Frasier S01 | cache sweep **24/24**; real disc correctly **abstained** — it's the 2023 revival (out of corpus), so the gate rightly refuses a false positive |

The Frasier disc surfaced a *separate* upstream issue (same-name shows: original Frasier TMDB 3452 vs. the 2023 revival → wrong subtitle corpus). That is **not** addressed here — it's a corpus/identification problem and the matcher abstaining is correct. It's been filed as a follow-up.

## Tests

- `tests/unit/test_chunk_vote_gate.py` — gate logic (synthetic, CI) + fallback reachability. The fallback test is **red-green verified**: it fails against the old early-return.
- `tests/real_data/test_chunk_vote_real_cache.py` — real Expanse cache, positive + negative control (skipped when the cache is absent).

Full unit suite green (1398 passed); ruff clean.

## Reviewer notes

- `select_chunk_vote` is a pure function with module-level defaults, also exposed as tunable `EpisodeMatcher` attributes.
- Voting is now **top-1 per chunk** (was: every episode > 0.15). With near-zero runner-up votes the calibrator's separation maxes, which is intended (unanimous chunk agreement = strong evidence).
- Root-cause write-up with the empirical scale measurement: `docs/superpowers/reviews/2026-05-29-asr-chunk-vote-scale-mismatch.md`.
- Independent of #264 (import-watch-folder), which only makes import paths *attempt* matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)