### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-30
+
+_Highlights: a wider setup wizard with a dedicated Data Sharing tab and guided TMDB onboarding; the Import Watch Folder now handles libraries pointed straight at a show and flat folders with no season; and an ASR matcher fix that restores episode matches the new fingerprint-vector scale had started rejecting._
+
+### Added
+
+- **Data Sharing settings tab** — a dedicated tab in the setup/settings wizard now groups everything that sends data off your machine (the fingerprint network, AI assistance, and the gated TheDiscDB integration) in one place, separate from local Preferences. (#263)
+- **Guided TMDB onboarding** — the TMDB token field shows instructional text instead of a token-shaped placeholder, validates automatically when you leave the field (with inline ✓/✗ feedback), and first-run setup no longer advances past the TMDB step until you've entered a valid token or explicitly chosen to continue without one. (#243, #263)
+
+### Changed
+
+- **Wider, collapsible config wizard** — the setup/settings modal is wider (800 → 1040px) and Preferences plus the new Data Sharing tab are grouped into collapsible sections, so the page starts compact and you expand only what you need. Inline action buttons that previously rendered as bare text ("Forget me", "Contribute from existing library") are fixed. (#263)
+
+### Fixed
+
+- **Import Watch Folder missed shows it was pointed at directly** — pointing the watch folder straight at a single show's folder broke ingestion: `Season NN` subfolders sat one nesting level too shallow to be detected (jobs were mislabeled with no show or season), and flat folders with no season matched nothing because the matcher requires a season. Engram now recognizes `Season N` / `Season 01` folders when the watch root *is* the show, and searches every candidate season for flat imports so they match across all seasons. (#264)
+- **ASR episode matching rejected correct matches on known seasons** — a 30-second speech-recognition chunk scores a structurally low similarity against a full-episode reference vector, and the recent precomputed-vector migration lowered that scale further, so the old fixed similarity threshold rejected most correct chunks and returned no episode. Matching now uses a rank-and-margin vote (the top candidate must clear a low floor *and* lead the runner-up by a wide margin) and falls through to a full-file comparison when no chunk votes, restoring matches while still abstaining on out-of-corpus content. (#269)
+
 ## [0.11.0] - 2026-05-29
 
 ### Added

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.11.0"
+version = "0.12.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.11.0"
+version = "0.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.11.0",
+    "version": "0.12.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Cuts **v0.12.0**. On squash-merge, `tag-release.yml` matches the `chore: release v` title, re-reads the version from `backend/pyproject.toml`, pushes the `v0.12.0` tag, and dispatches `release.yml` (binaries + release notes extracted from `CHANGELOG.md`) and `docker.yml` (GHCR image).

## Version bump (6 files, lockstep)
- `backend/pyproject.toml` → `0.12.0`
- `backend/app/__init__.py` `__version__` → `0.12.0`
- `backend/uv.lock` (`engram-backend`) → `0.12.0`
- `frontend/package.json` → `0.12.0`
- `frontend/package-lock.json` (both self-version fields) → `0.12.0`
- `CHANGELOG.md` — new `## [0.12.0] - 2026-05-30` section

## Release notes (extracted verbatim by `release.yml`)

_Highlights: a wider setup wizard with a dedicated Data Sharing tab and guided TMDB onboarding; the Import Watch Folder now handles libraries pointed straight at a show and flat folders with no season; and an ASR matcher fix that restores episode matches the new fingerprint-vector scale had started rejecting._

### Added
- **Data Sharing settings tab** — groups everything that sends data off your machine (fingerprint network, AI assistance, gated TheDiscDB) into one wizard tab, separate from local Preferences. (#263)
- **Guided TMDB onboarding** — instructional placeholder, on-blur token validation with inline check/cross, and a first-run gate that won't advance past the TMDB step without a valid token or an explicit opt-out. (#243, #263)

### Changed
- **Wider, collapsible config wizard** (800 to 1040px), collapsible sections, and fixes for inline action buttons that rendered as bare text. (#263)

### Fixed
- **Import Watch Folder missed shows pointed at directly** — recognizes `Season N`/`Season 01` when the watch root *is* the show, and searches every candidate season for flat imports. (#264)
- **ASR episode matching rejected correct matches on known seasons** — replaces the fixed similarity threshold with a rank-and-margin chunk vote plus a full-file fallback. (#269)

## Excluded from the user-facing changelog (internal only)
- #267 — e2e flakiness fix (decouple SQL echo from DEBUG; isolate basic-ui spec)
- #268 — release-notes-from-CHANGELOG plumbing (the tooling that publishes *this* release's notes)

## Verification
- `extract_changelog.py --version 0.12.0 --check` -> ok
- All 6 version strings confirmed at `0.12.0`; pre-commit hooks (ruff/format/toml) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)