### PR TITLE
fix(discdb): release-level cover-image upload (release/ path + multipart)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2879,10 +2879,17 @@ async def export_contribution(
 ):
     """Manually trigger export for a specific job."""
     from app.core.discdb_exporter import generate_export, mark_exported
+    from app.core.discdb_submitter import ensure_release_group_id
     from app.services.config_service import get_config as get_db_config
 
     if job.state != JobState.COMPLETED:
         raise HTTPException(status_code=400, detail="Job is not completed")
+
+    if not job.release_group_id:
+        ensure_release_group_id(job)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
 
     config = await get_db_config()
     titles_result = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job.id))
@@ -3380,13 +3387,19 @@ async def submit_contribution(
     session: AsyncSession = Depends(get_session),
 ):
     """Submit a job's disc data to TheDiscDB API."""
-    from app.core.discdb_submitter import submit_job
+    from app.core.discdb_submitter import ensure_release_group_id, submit_job
     from app.services.config_service import get_config as get_db_config
 
     if job.state != JobState.COMPLETED:
         raise HTTPException(status_code=400, detail="Job is not completed")
     if not job.exported_at or job.exported_at.year == 1970:
         raise HTTPException(status_code=400, detail="Job must be exported before submission")
+
+    if not job.release_group_id:
+        ensure_release_group_id(job)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
 
     config = await get_db_config()
 

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -177,6 +178,18 @@ async def submit_release_image(
         return False
 
 
+def ensure_release_group_id(job: DiscJob) -> str:
+    """Mint a UUID4 release_group_id on the job if missing; return the value.
+
+    A single-disc movie is its own "release" — every contribution needs a
+    release_id so the contribute UI and image-upload endpoints have something
+    to attach to. The caller persists the change (e.g. via session.add(job)).
+    """
+    if not job.release_group_id:
+        job.release_group_id = str(uuid.uuid4())
+    return job.release_group_id
+
+
 def _find_release_image_files(export_dirs: Iterable[Path]) -> dict[str, Path | None]:
     """Find front/back cover images across the export dirs of a release group.
 
@@ -201,6 +214,22 @@ def _find_release_image_files(export_dirs: Iterable[Path]) -> dict[str, Path | N
         if found["front"] is not None and found["back"] is not None:
             break
     return found
+
+
+async def _upload_release_images(
+    release_id: str,
+    export_dirs: list[Path],
+    api_key: str,
+    base_url: str,
+) -> dict[str, bool]:
+    """Find and upload release-level cover images from the given export dirs."""
+    results: dict[str, bool] = {}
+    images = _find_release_image_files(export_dirs)
+    for kind, path in images.items():
+        if path is None:
+            continue
+        results[kind] = await submit_release_image(release_id, kind, path, api_key, base_url)
+    return results
 
 
 async def submit_job(
@@ -236,6 +265,15 @@ async def submit_job(
         config.discdb_api_key,
         config.discdb_api_url,
     )
+
+    # Upload release-level cover images (best-effort)
+    if job.release_group_id:
+        await _upload_release_images(
+            job.release_group_id,
+            [export_dir],
+            config.discdb_api_key,
+            config.discdb_api_url,
+        )
 
     logger.info(f"Job {job.id}: Submitted to TheDiscDB (submission_id={result.submission_id})")
     return result
@@ -312,18 +350,12 @@ async def submit_release_group(
 
         export_base = get_export_directory(config)
         export_dirs = [export_base / j.content_hash for j in jobs if j.content_hash]
-        images = _find_release_image_files(export_dirs)
-        for kind, path in images.items():
-            if path is None:
-                continue
-            ok = await submit_release_image(
-                release_group_id,
-                kind,
-                path,
-                config.discdb_api_key,
-                config.discdb_api_url,
-            )
-            result.images_uploaded[kind] = ok
+        result.images_uploaded = await _upload_release_images(
+            release_group_id,
+            export_dirs,
+            config.discdb_api_key,
+            config.discdb_api_url,
+        )
 
     await session.commit()
     return result

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import quote
 
 import httpx
 from sqlalchemy import select
@@ -134,6 +134,12 @@ _IMAGE_KINDS = ("front", "back")
 _FRONT_PATTERNS = ("cover.jpg", "cover.jpeg", "cover.png")
 _BACK_PATTERNS = ("cover_back.jpg", "cover_back.jpeg", "cover_back.png")
 
+# A TheDiscDB release_id is an engram-minted UUID4 (or a DiscDB slug). Constrain
+# it to safe URL-path characters before interpolating it into the request URL —
+# this is the barrier that closes the partial-SSRF path: a value containing
+# "/", ".." or a scheme can't redirect the upload to a different resource/host.
+_RELEASE_ID_RE = re.compile(r"[A-Za-z0-9._-]{1,64}")
+
 
 def _image_content_type(path: Path) -> str:
     suffix = path.suffix.lower()
@@ -160,14 +166,18 @@ async def submit_release_image(
     """
     if kind not in _IMAGE_KINDS:
         raise ValueError(f"kind must be one of {_IMAGE_KINDS}, got {kind!r}")
+    if not _RELEASE_ID_RE.fullmatch(release_id):
+        logger.warning(
+            f"Refusing image upload: invalid release_id {sanitize_log_value(release_id)}"
+        )
+        return False
     if not image_path.exists():
         logger.debug(f"No image at {image_path}, skipping {kind} upload")
         return False
 
-    # quote() neutralises any path-altering chars in release_id, then guard the
-    # fully-built URL (host comes from the user-configurable discdb_api_url) so a
-    # misconfigured base_url can't redirect the upload at an internal host (SSRF).
-    url = f"{base_url.rstrip('/')}/api/engram/release/{quote(release_id, safe='')}/images/{kind}"
+    # release_id is allowlist-validated above; also guard the fully-built URL so a
+    # misconfigured discdb_api_url can't point the upload at an internal host (SSRF).
+    url = f"{base_url.rstrip('/')}/api/engram/release/{release_id}/images/{kind}"
     if not is_safe_remote_url(url):
         logger.warning(f"Refusing {kind} image upload to unsafe URL for {sanitize_log_value(url)}")
         return False

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 import httpx
 from sqlalchemy import select
@@ -25,6 +26,7 @@ from app.core.discdb_exporter import (
     generate_export,
     get_makemkv_log_dir,
 )
+from app.core.security import is_safe_remote_url, sanitize_log_value
 from app.models.app_config import AppConfig
 from app.models.disc_job import DiscJob, DiscTitle, JobState
 
@@ -162,11 +164,17 @@ async def submit_release_image(
         logger.debug(f"No image at {image_path}, skipping {kind} upload")
         return False
 
-    url = f"{base_url.rstrip('/')}/api/engram/release/{release_id}/images/{kind}"
+    # quote() neutralises any path-altering chars in release_id, then guard the
+    # fully-built URL (host comes from the user-configurable discdb_api_url) so a
+    # misconfigured base_url can't redirect the upload at an internal host (SSRF).
+    url = f"{base_url.rstrip('/')}/api/engram/release/{quote(release_id, safe='')}/images/{kind}"
+    if not is_safe_remote_url(url):
+        logger.warning(f"Refusing {kind} image upload to unsafe URL for {sanitize_log_value(url)}")
+        return False
     content_type = _image_content_type(image_path)
-    body = image_path.read_bytes()
 
     try:
+        body = image_path.read_bytes()
         async with httpx.AsyncClient(timeout=SUBMIT_TIMEOUT) as client:
             resp = await client.post(
                 url,
@@ -175,8 +183,10 @@ async def submit_release_image(
             )
             resp.raise_for_status()
             return True
-    except httpx.HTTPError as e:
-        logger.warning(f"Release {kind} image upload failed for {release_id}: {e}")
+    except (httpx.HTTPError, OSError) as e:
+        logger.warning(
+            f"Release {kind} image upload failed for {sanitize_log_value(release_id)}: {e}"
+        )
         return False
 
 
@@ -289,7 +299,6 @@ class BatchSubmissionResult:
     failed: int = 0
     results: list[dict] = field(default_factory=list)
     contribute_url: str | None = None
-    images_uploaded: dict[str, bool] = field(default_factory=dict)
 
 
 async def submit_release_group(
@@ -347,17 +356,9 @@ async def submit_release_group(
         else:
             result.failed += 1
 
-    if result.submitted > 0:
-        from app.core.discdb_exporter import get_export_directory
-
-        export_base = get_export_directory(config)
-        export_dirs = [export_base / j.content_hash for j in jobs if j.content_hash]
-        result.images_uploaded = await _upload_release_images(
-            release_group_id,
-            export_dirs,
-            config.discdb_api_key,
-            config.discdb_api_url,
-        )
-
+    # NOTE: cover images are uploaded per-disc inside submit_job() above, which
+    # only runs after that disc's data submits successfully. No consolidated
+    # group-level upload here — it would double-POST disc 1's cover and could
+    # attach images for discs whose submission failed.
     await session.commit()
     return result

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -126,6 +127,82 @@ async def submit_scan_log(
         return False
 
 
+_IMAGE_KINDS = ("front", "back")
+_FRONT_PATTERNS = ("cover.jpg", "cover.jpeg", "cover.png")
+_BACK_PATTERNS = ("cover_back.jpg", "cover_back.jpeg", "cover_back.png")
+
+
+def _image_content_type(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        return "image/png"
+    return "image/jpeg"
+
+
+async def submit_release_image(
+    release_id: str,
+    kind: str,
+    image_path: Path,
+    api_key: str,
+    base_url: str,
+) -> bool:
+    """Upload a release-level cover image to TheDiscDB.
+
+    POST {base_url}/api/engram/{release_id}/images/{kind}
+    """
+    if kind not in _IMAGE_KINDS:
+        raise ValueError(f"kind must be one of {_IMAGE_KINDS}, got {kind!r}")
+    if not image_path.exists():
+        logger.debug(f"No image at {image_path}, skipping {kind} upload")
+        return False
+
+    url = f"{base_url.rstrip('/')}/api/engram/{release_id}/images/{kind}"
+    content_type = _image_content_type(image_path)
+    body = image_path.read_bytes()
+
+    try:
+        async with httpx.AsyncClient(timeout=SUBMIT_TIMEOUT) as client:
+            resp = await client.post(
+                url,
+                content=body,
+                headers={
+                    **_auth_headers(api_key),
+                    "Content-Type": content_type,
+                },
+            )
+            resp.raise_for_status()
+            return True
+    except httpx.HTTPError as e:
+        logger.warning(f"Release {kind} image upload failed for {release_id}: {e}")
+        return False
+
+
+def _find_release_image_files(export_dirs: Iterable[Path]) -> dict[str, Path | None]:
+    """Find front/back cover images across the export dirs of a release group.
+
+    Returns the first match in iteration order, or None for kinds not found.
+    """
+    found: dict[str, Path | None] = {"front": None, "back": None}
+    for export_dir in export_dirs:
+        if not export_dir.is_dir():
+            continue
+        if found["front"] is None:
+            for name in _FRONT_PATTERNS:
+                candidate = export_dir / name
+                if candidate.exists():
+                    found["front"] = candidate
+                    break
+        if found["back"] is None:
+            for name in _BACK_PATTERNS:
+                candidate = export_dir / name
+                if candidate.exists():
+                    found["back"] = candidate
+                    break
+        if found["front"] is not None and found["back"] is not None:
+            break
+    return found
+
+
 async def submit_job(
     job: DiscJob,
     titles: list[DiscTitle],
@@ -172,6 +249,7 @@ class BatchSubmissionResult:
     failed: int = 0
     results: list[dict] = field(default_factory=list)
     contribute_url: str | None = None
+    images_uploaded: dict[str, bool] = field(default_factory=dict)
 
 
 async def submit_release_group(
@@ -228,6 +306,24 @@ async def submit_release_group(
             session.add(job)
         else:
             result.failed += 1
+
+    if result.submitted > 0:
+        from app.core.discdb_exporter import get_export_directory
+
+        export_base = get_export_directory(config)
+        export_dirs = [export_base / j.content_hash for j in jobs if j.content_hash]
+        images = _find_release_image_files(export_dirs)
+        for kind, path in images.items():
+            if path is None:
+                continue
+            ok = await submit_release_image(
+                release_group_id,
+                kind,
+                path,
+                config.discdb_api_key,
+                config.discdb_api_url,
+            )
+            result.images_uploaded[kind] = ok
 
     await session.commit()
     return result

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -149,7 +149,12 @@ async def submit_release_image(
 ) -> bool:
     """Upload a release-level cover image to TheDiscDB.
 
-    POST {base_url}/api/engram/{release_id}/images/{kind}
+    POST {base_url}/api/engram/release/{release_id}/images/{kind}
+
+    Sent as multipart/form-data with a ``file`` field (ASP.NET ``IFormFile``),
+    matching the maintainer's working curl. The ``release/`` path segment and
+    the multipart body are both required — the disc-level path and raw-bytes
+    body return 404/415 respectively (verified against prod, discussion #111).
     """
     if kind not in _IMAGE_KINDS:
         raise ValueError(f"kind must be one of {_IMAGE_KINDS}, got {kind!r}")
@@ -157,7 +162,7 @@ async def submit_release_image(
         logger.debug(f"No image at {image_path}, skipping {kind} upload")
         return False
 
-    url = f"{base_url.rstrip('/')}/api/engram/{release_id}/images/{kind}"
+    url = f"{base_url.rstrip('/')}/api/engram/release/{release_id}/images/{kind}"
     content_type = _image_content_type(image_path)
     body = image_path.read_bytes()
 
@@ -165,11 +170,8 @@ async def submit_release_image(
         async with httpx.AsyncClient(timeout=SUBMIT_TIMEOUT) as client:
             resp = await client.post(
                 url,
-                content=body,
-                headers={
-                    **_auth_headers(api_key),
-                    "Content-Type": content_type,
-                },
+                files={"file": (image_path.name, body, content_type)},
+                headers=_auth_headers(api_key),
             )
             resp.raise_for_status()
             return True

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -7,8 +7,10 @@ import httpx
 import pytest
 
 from app.core.discdb_submitter import (
+    _find_release_image_files,
     submit_disc,
     submit_job,
+    submit_release_image,
     submit_scan_log,
 )
 from app.models.app_config import AppConfig
@@ -235,3 +237,131 @@ class TestSubmitJob:
         result = await submit_job(job, titles, config)
         assert result.success is False
         assert "No content hash" in result.error
+
+
+class TestSubmitReleaseImage:
+    @pytest.mark.anyio
+    async def test_uploads_front_image(self, api_key, base_url, tmp_path):
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(200)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("rel-uuid-1", "front", cover, api_key, base_url)
+
+        assert ok is True
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/rel-uuid-1/images/front"
+        assert call_kwargs.kwargs["headers"]["Content-Type"] == "image/jpeg"
+        assert call_kwargs.kwargs["headers"]["Authorization"] == f"ApiKey {api_key}"
+        assert call_kwargs.kwargs["content"] == cover.read_bytes()
+
+    @pytest.mark.anyio
+    async def test_uploads_back_image(self, api_key, base_url, tmp_path):
+        cover = tmp_path / "cover_back.jpg"
+        cover.write_bytes(b"back-bytes")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(200)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("rel-2", "back", cover, api_key, base_url)
+
+        assert ok is True
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/rel-2/images/back"
+
+    @pytest.mark.anyio
+    async def test_png_content_type(self, api_key, base_url, tmp_path):
+        cover = tmp_path / "cover.png"
+        cover.write_bytes(b"\x89PNGfake")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(200)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("rel-3", "front", cover, api_key, base_url)
+
+        assert ok is True
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs.kwargs["headers"]["Content-Type"] == "image/png"
+
+    @pytest.mark.anyio
+    async def test_missing_file_returns_false(self, api_key, base_url, tmp_path):
+        missing = tmp_path / "nope.jpg"
+        ok = await submit_release_image("rel-4", "front", missing, api_key, base_url)
+        assert ok is False
+
+    @pytest.mark.anyio
+    async def test_invalid_kind_raises(self, api_key, base_url, tmp_path):
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"x")
+        with pytest.raises(ValueError):
+            await submit_release_image("rel-5", "side", cover, api_key, base_url)
+
+    @pytest.mark.anyio
+    async def test_http_error_returns_false(self, api_key, base_url, tmp_path):
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"x")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(500)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("rel-6", "front", cover, api_key, base_url)
+
+        assert ok is False
+
+
+class TestFindReleaseImageFiles:
+    def test_finds_front_cover(self, tmp_path):
+        disc_a = tmp_path / "HASH_A"
+        disc_a.mkdir()
+        (disc_a / "cover.jpg").write_bytes(b"front")
+
+        result = _find_release_image_files([disc_a])
+        assert result["front"] == disc_a / "cover.jpg"
+        assert result["back"] is None
+
+    def test_finds_back_cover(self, tmp_path):
+        disc_a = tmp_path / "HASH_A"
+        disc_a.mkdir()
+        (disc_a / "cover_back.png").write_bytes(b"back")
+
+        result = _find_release_image_files([disc_a])
+        assert result["back"] == disc_a / "cover_back.png"
+        assert result["front"] is None
+
+    def test_first_disc_with_image_wins(self, tmp_path):
+        disc_a = tmp_path / "A"
+        disc_b = tmp_path / "B"
+        disc_a.mkdir()
+        disc_b.mkdir()
+        (disc_b / "cover.jpg").write_bytes(b"front-b")
+
+        result = _find_release_image_files([disc_a, disc_b])
+        assert result["front"] == disc_b / "cover.jpg"
+
+    def test_no_images_returns_none(self, tmp_path):
+        disc_a = tmp_path / "A"
+        disc_a.mkdir()
+        result = _find_release_image_files([disc_a])
+        assert result == {"front": None, "back": None}
+
+    def test_skips_missing_dirs(self, tmp_path):
+        result = _find_release_image_files([tmp_path / "does-not-exist"])
+        assert result == {"front": None, "back": None}

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -8,6 +8,8 @@ import pytest
 
 from app.core.discdb_submitter import (
     _find_release_image_files,
+    _upload_release_images,
+    ensure_release_group_id,
     submit_disc,
     submit_job,
     submit_release_image,
@@ -365,3 +367,92 @@ class TestFindReleaseImageFiles:
     def test_skips_missing_dirs(self, tmp_path):
         result = _find_release_image_files([tmp_path / "does-not-exist"])
         assert result == {"front": None, "back": None}
+
+
+class TestEnsureReleaseGroupId:
+    def test_returns_existing_id(self):
+        job = DiscJob(
+            id=1,
+            drive_id="E:",
+            volume_label="X",
+            state=JobState.COMPLETED,
+            release_group_id="existing-uuid",
+        )
+        assert ensure_release_group_id(job) == "existing-uuid"
+        assert job.release_group_id == "existing-uuid"
+
+    def test_mints_new_uuid_when_missing(self):
+        job = DiscJob(
+            id=1,
+            drive_id="E:",
+            volume_label="X",
+            state=JobState.COMPLETED,
+            release_group_id=None,
+        )
+        assigned = ensure_release_group_id(job)
+        assert assigned
+        assert job.release_group_id == assigned
+        # Standard UUID4 string format: 8-4-4-4-12
+        parts = assigned.split("-")
+        assert len(parts) == 5
+        assert [len(p) for p in parts] == [8, 4, 4, 4, 12]
+
+    def test_treats_empty_string_as_missing(self):
+        job = DiscJob(
+            id=1,
+            drive_id="E:",
+            volume_label="X",
+            state=JobState.COMPLETED,
+            release_group_id="",
+        )
+        assigned = ensure_release_group_id(job)
+        assert assigned != ""
+        assert job.release_group_id == assigned
+
+
+class TestUploadReleaseImages:
+    @pytest.mark.anyio
+    async def test_uploads_when_image_present(self, api_key, base_url, tmp_path):
+        export_dir = tmp_path / "HASH"
+        export_dir.mkdir()
+        (export_dir / "cover.jpg").write_bytes(b"front-bytes")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(200)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            results = await _upload_release_images("rel-x", [export_dir], api_key, base_url)
+
+        assert results == {"front": True}
+        assert mock_client.post.call_args.args[0] == (
+            "https://thediscdb.com/api/engram/rel-x/images/front"
+        )
+
+    @pytest.mark.anyio
+    async def test_skip_when_no_images(self, api_key, base_url, tmp_path):
+        export_dir = tmp_path / "HASH"
+        export_dir.mkdir()
+        results = await _upload_release_images("rel-x", [export_dir], api_key, base_url)
+        assert results == {}
+
+    @pytest.mark.anyio
+    async def test_uploads_front_and_back(self, api_key, base_url, tmp_path):
+        export_dir = tmp_path / "HASH"
+        export_dir.mkdir()
+        (export_dir / "cover.jpg").write_bytes(b"f")
+        (export_dir / "cover_back.png").write_bytes(b"b")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = _mock_response(200)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            results = await _upload_release_images("rel-y", [export_dir], api_key, base_url)
+
+        assert results == {"front": True, "back": True}
+        assert mock_client.post.call_count == 2

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -369,6 +369,25 @@ class TestSubmitReleaseImage:
             ok = await submit_release_image("rel-8", "front", not_a_file, api_key, base_url)
 
         assert ok is False
+
+    @pytest.mark.anyio
+    async def test_invalid_release_id_returns_false_without_request(
+        self, api_key, base_url, tmp_path
+    ):
+        """A release_id with path-altering chars is rejected before any request."""
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"x")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("../../etc/passwd", "front", cover, api_key, base_url)
+
+        assert ok is False
+        mock_client.post.assert_not_called()
         mock_client.post.assert_not_called()
 
 

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -258,10 +258,16 @@ class TestSubmitReleaseImage:
 
         assert ok is True
         call_kwargs = mock_client.post.call_args
-        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/rel-uuid-1/images/front"
-        assert call_kwargs.kwargs["headers"]["Content-Type"] == "image/jpeg"
+        assert (
+            call_kwargs.args[0]
+            == "https://thediscdb.com/api/engram/release/rel-uuid-1/images/front"
+        )
         assert call_kwargs.kwargs["headers"]["Authorization"] == f"ApiKey {api_key}"
-        assert call_kwargs.kwargs["content"] == cover.read_bytes()
+        # multipart/form-data with a `file` field: (filename, bytes, content-type)
+        file_field = call_kwargs.kwargs["files"]["file"]
+        assert file_field[0] == cover.name
+        assert file_field[1] == cover.read_bytes()
+        assert file_field[2] == "image/jpeg"
 
     @pytest.mark.anyio
     async def test_uploads_back_image(self, api_key, base_url, tmp_path):
@@ -279,7 +285,7 @@ class TestSubmitReleaseImage:
 
         assert ok is True
         call_kwargs = mock_client.post.call_args
-        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/rel-2/images/back"
+        assert call_kwargs.args[0] == "https://thediscdb.com/api/engram/release/rel-2/images/back"
 
     @pytest.mark.anyio
     async def test_png_content_type(self, api_key, base_url, tmp_path):
@@ -297,7 +303,7 @@ class TestSubmitReleaseImage:
 
         assert ok is True
         call_kwargs = mock_client.post.call_args
-        assert call_kwargs.kwargs["headers"]["Content-Type"] == "image/png"
+        assert call_kwargs.kwargs["files"]["file"][2] == "image/png"
 
     @pytest.mark.anyio
     async def test_missing_file_returns_false(self, api_key, base_url, tmp_path):
@@ -428,7 +434,7 @@ class TestUploadReleaseImages:
 
         assert results == {"front": True}
         assert mock_client.post.call_args.args[0] == (
-            "https://thediscdb.com/api/engram/rel-x/images/front"
+            "https://thediscdb.com/api/engram/release/rel-x/images/front"
         )
 
     @pytest.mark.anyio

--- a/backend/tests/unit/test_discdb_submitter.py
+++ b/backend/tests/unit/test_discdb_submitter.py
@@ -334,6 +334,43 @@ class TestSubmitReleaseImage:
 
         assert ok is False
 
+    @pytest.mark.anyio
+    async def test_unsafe_base_url_returns_false_without_request(self, api_key, tmp_path):
+        """SSRF guard: a base_url pointing at an internal host is refused, no POST."""
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"x")
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image(
+                "rel-7", "front", cover, api_key, "http://localhost:8080"
+            )
+
+        assert ok is False
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_read_error_returns_false(self, api_key, base_url, tmp_path):
+        """A read failure (e.g. path is a directory) is caught, not propagated."""
+        # A directory passes exists() but read_bytes() raises an OSError subclass.
+        not_a_file = tmp_path / "cover.jpg"
+        not_a_file.mkdir()
+
+        with patch("app.core.discdb_submitter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ok = await submit_release_image("rel-8", "front", not_a_file, api_key, base_url)
+
+        assert ok is False
+        mock_client.post.assert_not_called()
+
 
 class TestFindReleaseImageFiles:
     def test_finds_front_cover(self, tmp_path):

--- a/docs/superpowers/plans/2026-05-05-fetch-cover-silent-failure.md
+++ b/docs/superpowers/plans/2026-05-05-fetch-cover-silent-failure.md
@@ -1,0 +1,155 @@
+# Fix: fetch-cover silent failure breaks DiscDB image upload
+
+**Date:** 2026-05-05
+**Status:** Open — discovered during the For All Mankind S1 4-disc end-to-end test
+**Branch context:** `feat/discdb-release-image-upload` (image upload code is correct; the bug is upstream of it)
+
+## Symptom
+
+User completed the full TheDiscDB submission flow for a 4-disc release group. All 4 disc payloads + scan logs landed at TheDiscDB. The "Submit group" banner showed `4 submitted, 0 failed`. But the resulting contribution page on TheDiscDB rendered `Front cover —` and `Back cover —` empty.
+
+User had clicked "Fetch cover" in the EnhanceWizard for one of the discs and seen no error — they assumed it worked.
+
+## Root cause
+
+**No cover image ever made it to disk.** Verified by inspecting all four export dirs at `~/.engram/discdb-exports/{content_hash}/`: only `disc_data.json` and `makemkv_scan.log` present, no `cover.jpg`/`cover.png`. The image-upload code (`_find_release_image_files` + `_upload_release_images` in `app/core/discdb_submitter.py`) correctly looked for files, found none, and returned `{}` — working as designed.
+
+Two layered bugs caused the cover to never reach the export dir:
+
+### Bug 1: backend inconsistent path handling
+
+`backend/app/api/routes.py:1711-1713` (the `fetch-cover` route):
+
+```python
+config = await get_db_config()
+export_base = Path(config.discdb_export_path) if config.discdb_export_path else None
+if not export_base:
+    raise HTTPException(status_code=400, detail="No export path configured")
+```
+
+When `app_config.discdb_export_path` is empty string (the default), this returns `400`. **Inconsistent with the rest of the codebase** — every other call site uses `app.core.discdb_exporter.get_export_directory()`, which falls back to `~/.engram/discdb-exports/`. The fetch-cover route is the lone outlier.
+
+The user's config has `discdb_export_path=""`, so every "Fetch cover" click returned `400 No export path configured` server-side.
+
+### Bug 2: frontend silently swallows the error
+
+`frontend/src/components/EnhanceWizard.tsx:179-192`:
+
+```typescript
+const handleFetchCover = async () => {
+  if (!selectedImage) return;
+  setCoverSaving(true);
+  try {
+    const res = await fetch(`/api/contributions/${job.id}/fetch-cover`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ image_url: selectedImage }),
+    });
+    if (res.ok) setCoverSaved(true);
+    // ← no else clause, no error state, no toast
+  } finally {
+    setCoverSaving(false);
+  }
+};
+```
+
+A 400 response looked indistinguishable from success — the button stopped spinning, no UI changed, no error appeared. Compare to `handleUpcLookup` in the same file, which has a `setLookupError` path.
+
+### Bug 3 (instrumentation gap)
+
+`_upload_release_images` in `app/core/discdb_submitter.py` returns `{}` silently when no covers are found. There's no log line indicating "scanned dirs X, Y, Z; no front/back covers found." If we'd had that line, the silent fetch-cover failure would have been visible in logs immediately. Working as designed, but unhelpful for diagnosis.
+
+## Why my image-upload code didn't surface the issue
+
+It's strictly downstream. Given the inputs it received (no cover files anywhere), returning `{}` and uploading nothing was correct behavior — submitting without cover art is a legitimate use case. The bug is in the data-gathering step (fetch-cover), not the submission step.
+
+## Fixes
+
+### 1. Use `get_export_directory()` in fetch-cover
+
+`backend/app/api/routes.py:1697-1716` — replace inline path logic with the canonical helper:
+
+```python
+from app.core.discdb_exporter import get_export_directory
+
+# ...
+config = await get_db_config()
+export_dir = get_export_directory(config) / job.content_hash
+export_dir.mkdir(parents=True, exist_ok=True)
+```
+
+Drop the `400 No export path configured` HTTPException entirely — `get_export_directory` always returns a usable path.
+
+### 2. Surface errors in `handleFetchCover`
+
+`frontend/src/components/EnhanceWizard.tsx:179-192` — mirror the `handleUpcLookup` pattern. Add `coverError` state, render it inline near the Fetch cover button, and parse the error response body when `!res.ok`:
+
+```typescript
+const [coverError, setCoverError] = useState<string | null>(null);
+
+const handleFetchCover = async () => {
+  if (!selectedImage) return;
+  setCoverSaving(true);
+  setCoverError(null);
+  try {
+    const res = await fetch(`/api/contributions/${job.id}/fetch-cover`, { … });
+    if (res.ok) {
+      setCoverSaved(true);
+    } else {
+      const body = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
+      setCoverError(body.detail ?? "Cover fetch failed");
+    }
+  } catch (e) {
+    setCoverError(e instanceof Error ? e.message : "Cover fetch failed");
+  } finally {
+    setCoverSaving(false);
+  }
+};
+```
+
+### 3. Log skipped image uploads
+
+`backend/app/core/discdb_submitter.py` `_upload_release_images` — when the helper finds no images, log it once at INFO with the release_id and dirs scanned. This makes silent skips visible in `~/.engram/engram.log`.
+
+```python
+async def _upload_release_images(release_id, export_dirs, api_key, base_url):
+    images = _find_release_image_files(export_dirs)
+    if not any(images.values()):
+        logger.info(
+            f"No release cover images found for release {release_id} "
+            f"(searched {len(list(export_dirs))} dirs); skipping image upload"
+        )
+        return {}
+    # … existing upload loop
+```
+
+(Note: `export_dirs` is iterable; capture the count before the find call if iteration is destructive.)
+
+### 4. (Optional) Echo the saved path on success
+
+Have `fetch-cover` return `{"status": "saved", "filename": "cover.jpg", "path": str(filepath)}` and have `handleFetchCover` show "Saved to …/cover.jpg" as a positive confirmation. This makes success equally visible.
+
+## Validation plan
+
+After applying fixes 1+2:
+
+1. `uv run pytest backend/tests/unit/test_discdb_*` should still pass (no test changes expected, but rerun to confirm).
+2. With backend running and `DISCDB_ENABLED=True`, manually:
+   - In the contribute UI, Enhance any pending disc.
+   - Enter UPC, Lookup, pick a cover, click Fetch cover.
+   - **Expect:** toast/inline message "Saved", and a `cover.jpg` appearing under `~/.engram/discdb-exports/{content_hash}/`.
+   - **Expect on failure:** the inline error renders the backend's `detail` string (e.g., 400 / 502).
+3. Group + Submit Group → `_upload_release_images` posts to `/api/engram/{releaseId}/images/front` with the image bytes. Verify on TheDiscDB contribute page that the cover renders.
+
+## State of the For All Mankind submission
+
+- All 4 discs at TheDiscDB with shared release_group_id `a1e5fa90...` — disc data + scan logs intact.
+- No covers uploaded.
+- After the fixes ship, two ways to add the cover:
+  - Re-enhance one disc in the UI, then re-submit the group (TheDiscDB endpoint behavior on duplicate disc submit needs verification — may upsert or 409).
+  - Manually `POST /api/engram/{releaseGroupId}/images/front` with `Content-Type: image/jpeg` once the cover is on disk. lfoust did not put the image endpoints behind auth, so a curl call against the existing release_group_id should work.
+
+## Out of scope for this fix
+
+- The `discdb_export_path` config field could be dropped entirely if no users set it manually — the default is good. Consider for cleanup later, not in this fix.
+- Back-cover support: the UI only fetches a single front cover today. Adding `cover_back.jpg` flow is a separate feature.


### PR DESCRIPTION
## What

Rebases the release-image-upload feature onto current `main` (it was ~3 weeks / 125 commits behind) and fixes the upload endpoint that returned **404** in every prior test (discussion [#111](https://github.com/Jsakkos/engram/discussions/111)).

## Root cause — two bugs, both verified live against prod

Per @lfoust's [latest correction](https://github.com/Jsakkos/engram/discussions/111#discussioncomment-17117261), and confirmed by testing all four shapes against a real release (SNW S3, `release_id=bdd9ab36-…`, live in his DB):

| Variant | Result |
|---|---|
| `POST /api/engram/**release**/{id}/images/front` + **multipart** (`file` field) | **HTTP 200** ✅ |
| same path + raw bytes (`Content-Type: image/jpeg`) | 415 (route exists, wrong media type) |
| `POST /api/engram/{id}/images/front` (no `release/`) + raw bytes — *what the branch did* | 404 |

So `submit_release_image` was missing the `release/` path segment **and** was sending raw bytes instead of `multipart/form-data`.

## Changes

- `backend/app/core/discdb_submitter.py` — `submit_release_image` now posts to `/api/engram/release/{release_id}/images/{kind}` as multipart (`files={"file": (name, bytes, content_type)}`), dropping the manual `Content-Type` header.
- `backend/tests/unit/test_discdb_submitter.py` — assert the new URL and the multipart `files` payload.

## Verification

- `uv run pytest tests/unit/test_discdb_submitter.py` → 27 passed
- `uv run ruff check` → clean
- **Live smoke** calling the fixed `submit_release_image` against prod → `front: True, back: True` (HTTP 200)

## Scope

The DiscDB feature stays **gated off** (`DISCDB_ENABLED=False`, `FEATURES.DISCDB`) — this PR only fixes the upload path so it's ready when the gate is flipped. (The branch also carries a pre-existing `docs/` plan for the unrelated fetch-cover bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)