### PR TITLE
fix(discdb): surface fetch-cover errors + fall back on empty export path

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2969,6 +2969,7 @@ async def fetch_cover(
     session: AsyncSession = Depends(get_session),
 ):
     """Download a cover image and save it to the export directory."""
+    from app.core.discdb_exporter import get_export_directory
     from app.services.config_service import get_config as get_db_config
 
     # SSRF guard runs BEFORE the DB lookup so a disallowed URL fails fast
@@ -2985,12 +2986,11 @@ async def fetch_cover(
     if not job.content_hash:
         raise HTTPException(status_code=400, detail="No content hash")
 
+    # Use the canonical export-dir helper (falls back to ~/.engram/discdb-exports/)
+    # rather than 400-ing on an unset discdb_export_path — matches every other
+    # call site, and an empty path is the default.
     config = await get_db_config()
-    export_base = Path(config.discdb_export_path) if config.discdb_export_path else None
-    if not export_base:
-        raise HTTPException(status_code=400, detail="No export path configured")
-
-    export_dir = export_base / job.content_hash
+    export_dir = get_export_directory(config) / job.content_hash
     export_dir.mkdir(parents=True, exist_ok=True)
 
     max_size = 10 * 1024 * 1024  # 10 MB

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2969,6 +2969,10 @@ async def fetch_cover(
     session: AsyncSession = Depends(get_session),
 ):
     """Download a cover image and save it to the export directory."""
+    # Lazy import (matches get_db_config below). Keep it inline: the fetch-cover
+    # test patches app.core.discdb_exporter.get_export_directory — the binding
+    # this resolves at call time — so hoisting it to module scope would bypass
+    # the patch and silently break that test.
     from app.core.discdb_exporter import get_export_directory
     from app.services.config_service import get_config as get_db_config
 

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -247,7 +247,7 @@ async def _upload_release_images(
     """Find and upload release-level cover images from the given export dirs."""
     results: dict[str, bool] = {}
     images = _find_release_image_files(export_dirs)
-    if not any(images.values()):
+    if all(p is None for p in images.values()):
         # Surface the silent skip in logs — a missing cover here is usually an
         # upstream fetch-cover failure, not an intentional omission.
         logger.info(

--- a/backend/app/core/discdb_submitter.py
+++ b/backend/app/core/discdb_submitter.py
@@ -247,6 +247,14 @@ async def _upload_release_images(
     """Find and upload release-level cover images from the given export dirs."""
     results: dict[str, bool] = {}
     images = _find_release_image_files(export_dirs)
+    if not any(images.values()):
+        # Surface the silent skip in logs — a missing cover here is usually an
+        # upstream fetch-cover failure, not an intentional omission.
+        logger.info(
+            f"No release cover images found for release {sanitize_log_value(release_id)} "
+            f"(searched {len(export_dirs)} export dir(s)); skipping image upload"
+        )
+        return {}
     for kind, path in images.items():
         if path is None:
             continue

--- a/backend/tests/unit/test_fetch_cover_security.py
+++ b/backend/tests/unit/test_fetch_cover_security.py
@@ -103,6 +103,8 @@ class TestFetchCoverExportPath:
             job_id = job.id
 
         # Redirect the fallback dir to tmp so the test never writes to ~/.engram.
+        # Patch the source-module attribute: fetch_cover imports get_export_directory
+        # lazily at call time, so this is the binding it actually resolves.
         import app.core.discdb_exporter as exp
 
         monkeypatch.setattr(exp, "get_export_directory", lambda config: tmp_path)

--- a/backend/tests/unit/test_fetch_cover_security.py
+++ b/backend/tests/unit/test_fetch_cover_security.py
@@ -4,11 +4,15 @@ The SSRF guard runs before the job lookup, so a disallowed URL must yield
 HTTP 400 even for a non-existent job_id — proving the guard fires first.
 """
 
+from unittest.mock import AsyncMock, patch
+
+import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.database import get_session
 from app.main import app
+from app.models.disc_job import ContentType, DiscJob, JobState
 from tests.unit.conftest import _unit_session_factory
 
 
@@ -71,3 +75,56 @@ class TestFetchCoverSsrfGuard:
             json={"image_url": "https://m.media-amazon.com/images/I/test.jpg"},
         )
         assert resp.status_code == 404
+
+
+class TestFetchCoverExportPath:
+    """fetch_cover must use the export-dir fallback, not 400, when the path is unset."""
+
+    async def test_empty_export_path_falls_back_and_saves(
+        self, client: AsyncClient, monkeypatch, tmp_path
+    ):
+        """Default config has discdb_export_path="" — the cover must still save.
+
+        Regression for the silent fetch-cover failure: the route used to 400
+        with "No export path configured" instead of falling back to
+        ~/.engram/discdb-exports/ like every other call site.
+        """
+        async with _unit_session_factory() as s:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="X",
+                content_hash="HASH123",
+                content_type=ContentType.MOVIE,
+                state=JobState.COMPLETED,
+            )
+            s.add(job)
+            await s.commit()
+            await s.refresh(job)
+            job_id = job.id
+
+        # Redirect the fallback dir to tmp so the test never writes to ~/.engram.
+        import app.core.discdb_exporter as exp
+
+        monkeypatch.setattr(exp, "get_export_directory", lambda config: tmp_path)
+
+        download = httpx.Response(
+            200,
+            headers={"content-type": "image/jpeg"},
+            content=b"\xff\xd8\xff\xe0fake-jpeg",
+            request=httpx.Request("GET", "https://m.media-amazon.com/x.jpg"),
+        )
+        with patch("app.api.routes.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get.return_value = download
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=False)
+            cls.return_value = mc
+
+            resp = await client.post(
+                f"/api/contributions/{job_id}/fetch-cover",
+                json={"image_url": "https://m.media-amazon.com/images/I/cover.jpg"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["filename"] == "cover.jpg"
+        assert (tmp_path / "HASH123" / "cover.jpg").read_bytes() == b"\xff\xd8\xff\xe0fake-jpeg"

--- a/frontend/src/components/EnhanceWizard.tsx
+++ b/frontend/src/components/EnhanceWizard.tsx
@@ -99,6 +99,7 @@ export default function EnhanceWizard({ job, titles, onSave, onCancel }: Enhance
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [coverSaved, setCoverSaved] = useState(false);
   const [coverSaving, setCoverSaving] = useState(false);
+  const [coverError, setCoverError] = useState<string | null>(null);
 
   const [extraDescriptions, setExtraDescriptions] = useState<Record<number, string>>(() => {
     const init: Record<number, string> = {};
@@ -173,13 +174,21 @@ export default function EnhanceWizard({ job, titles, onSave, onCancel }: Enhance
   const handleFetchCover = async () => {
     if (!selectedImage) return;
     setCoverSaving(true);
+    setCoverError(null);
     try {
       const res = await fetch(`/api/contributions/${job.id}/fetch-cover`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ image_url: selectedImage }),
       });
-      if (res.ok) setCoverSaved(true);
+      if (res.ok) {
+        setCoverSaved(true);
+      } else {
+        const body = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
+        setCoverError(body.detail ?? "Cover fetch failed");
+      }
+    } catch (e) {
+      setCoverError(e instanceof Error ? e.message : "Cover fetch failed");
     } finally {
       setCoverSaving(false);
     }
@@ -420,6 +429,7 @@ export default function EnhanceWizard({ job, titles, onSave, onCancel }: Enhance
                       onClick={() => {
                         setSelectedImage(url);
                         setCoverSaved(false);
+                        setCoverError(null);
                       }}
                       style={{
                         aspectRatio: "2 / 3",
@@ -448,6 +458,11 @@ export default function EnhanceWizard({ job, titles, onSave, onCancel }: Enhance
                   )}
                   {coverSaved ? "Saved" : "Fetch cover"}
                 </SvActionButton>
+              )}
+              {coverError && (
+                <div style={{ marginTop: 12 }}>
+                  <SvNotice tone="error">{coverError}</SvNotice>
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
## Problem

The contribute-flow "Fetch cover" could fail **silently**. For a real multi-disc submission, all disc data + scan logs landed at TheDiscDB but no covers did — and the UI gave no indication anything went wrong.

Two layered bugs (plan: `docs/superpowers/plans/2026-05-05-fetch-cover-silent-failure.md`):

1. **Backend** — `fetch_cover` 400'd with `"No export path configured"` whenever `discdb_export_path` was unset (the **default**), so the cover never reached disk. Every other call site uses `get_export_directory()`, which falls back to `~/.engram/discdb-exports/`.
2. **Frontend** — `handleFetchCover` had no `else` branch; a non-OK response looked identical to success.

## Changes

- **`routes.py`** — `fetch_cover` uses `get_export_directory(config)` instead of raising 400. (SSRF guard / size limits / redirect handling unchanged.)
- **`EnhanceWizard.tsx`** — `handleFetchCover` surfaces failures via a `coverError` `SvNotice` (mirrors the existing `handleUpcLookup` error path), cleared when a different image is selected.
- **`discdb_submitter.py`** — `_upload_release_images` logs an INFO line when no covers are found, so silent skips are visible in `~/.engram/engram.log`.

## Verification

- **TDD**: added `TestFetchCoverExportPath::test_empty_export_path_falls_back_and_saves` — fails on old code with the exact `"No export path configured"` 400, passes after the fix. **35 backend tests pass**, ruff clean.
- **Frontend** `tsc && vite build` ✓ (2327 modules).

## Scope

DiscDB feature stays **gated off** (`DISCDB_ENABLED=False` / `FEATURES.DISCDB`). This unblocks the contribute flow for when the gate flips. Roadmap: GraphQL de-risk ✓ → **this** → re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)