### PR TITLE
fix(fingerprint): make server URL a one-constant edit (de-personalize prep)

### DIFF
--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from app.matcher.llm_episode_matcher import match_episode_via_llm
+from app.models.app_config import DEFAULT_FINGERPRINT_SERVER_URL
 
 logger = logging.getLogger(__name__)
 
@@ -506,9 +507,7 @@ class EpisodeCurator:
         from app.matcher.chromaprint_matcher import ChromaprintMatcher, identify_episode_chromaprint
         from app.matcher.episode_identification import get_video_duration
 
-        server_url = (
-            cfg.fingerprint_server_url or "https://engram-fp-prod.jonathansakkos.workers.dev"
-        )
+        server_url = cfg.fingerprint_server_url or DEFAULT_FINGERPRINT_SERVER_URL
         pack_cache = getattr(self, "_pack_cache", None)
         if pack_cache is not None:
             try:

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -10,7 +10,7 @@ from sqlalchemy import text
 import app.services.contribution_uploader as uploader_mod
 from app.database import async_session, init_db
 from app.main import app
-from app.models.app_config import AppConfig
+from app.models.app_config import DEFAULT_FINGERPRINT_SERVER_URL, AppConfig
 from app.models.fingerprint import FingerprintContribution
 
 ContributionUploader = uploader_mod.ContributionUploader
@@ -64,13 +64,34 @@ def test_fingerprint_contribution_has_upload_status_fields():
 def test_app_config_has_fingerprint_server_url():
     """AppConfig defaults fingerprint_server_url to the network base origin.
 
-    The default must be the BASE (no /v1 suffix) — the uploader appends
-    /v1/contribute, so a /v1 here would double to /v1/v1/... and 404.
+    Asserted constant-relative (not the literal string) so de-personalizing the
+    URL is a one-line edit to DEFAULT_FINGERPRINT_SERVER_URL. The default must be
+    the BASE (no /v1 suffix) — the uploader appends /v1/contribute, so a /v1 here
+    would double to /v1/v1/... and 404.
     """
     cfg = AppConfig()
     assert hasattr(cfg, "fingerprint_server_url")
-    assert cfg.fingerprint_server_url == "https://engram-fp-prod.jonathansakkos.workers.dev"
+    assert cfg.fingerprint_server_url == DEFAULT_FINGERPRINT_SERVER_URL
     assert not cfg.fingerprint_server_url.endswith("/v1")
+
+
+def test_curator_routes_fallback_through_constant():
+    """curator.py must use DEFAULT_FINGERPRINT_SERVER_URL for its server-URL
+    fallback, not a re-hardcoded literal. Guarantees the URL value lives in
+    exactly one place (app_config.py), so de-personalizing is a one-line edit.
+    """
+    import inspect
+
+    import app.core.curator as curator_mod
+
+    source = inspect.getsource(curator_mod)
+    assert "DEFAULT_FINGERPRINT_SERVER_URL" in source, (
+        "curator.py should reference the shared constant for its server-URL fallback"
+    )
+    assert ".workers.dev" not in source, (
+        "curator.py must not hardcode a fingerprint host literal; route through "
+        "DEFAULT_FINGERPRINT_SERVER_URL instead"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -85,9 +85,16 @@ def test_curator_routes_fallback_through_constant():
     import app.core.curator as curator_mod
 
     source = inspect.getsource(curator_mod)
+    # The durable guard: curator must reference the shared constant by name. This
+    # holds regardless of the URL's value, so it survives the upcoming rename.
     assert "DEFAULT_FINGERPRINT_SERVER_URL" in source, (
         "curator.py should reference the shared constant for its server-URL fallback"
     )
+    # Belt-and-suspenders catch for the *current* hostname while it still ends in
+    # .workers.dev. DURABILITY LIMIT (revisit at URL migration): getsource() also
+    # scans comments/strings, and once the URL no longer ends in .workers.dev this
+    # check can no longer catch a re-hardcoded literal — the assertion above is the
+    # one that keeps protecting the single-source-of-truth invariant.
     assert ".workers.dev" not in source, (
         "curator.py must not hardcode a fingerprint host literal; route through "
         "DEFAULT_FINGERPRINT_SERVER_URL instead"
@@ -101,7 +108,6 @@ async def test_uploader_falls_back_to_default_url_when_unset(setup_db, monkeypat
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from app.database import async_session
-    from app.models.app_config import DEFAULT_FINGERPRINT_SERVER_URL
 
     async with async_session() as session:
         row = FingerprintContribution(

--- a/docs/superpowers/plans/2026-05-30-depersonalize-fingerprint-server-url.md
+++ b/docs/superpowers/plans/2026-05-30-depersonalize-fingerprint-server-url.md
@@ -1,0 +1,148 @@
+# De-personalize Fingerprint Server URL (code-prep) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the fingerprint-server default URL a single-constant edit by routing `curator.py`'s hardcoded fallback through `DEFAULT_FINGERPRINT_SERVER_URL`, and assert tests against the constant rather than the literal — without changing the URL value.
+
+**Architecture:** `DEFAULT_FINGERPRINT_SERVER_URL` in `backend/app/models/app_config.py` is already the source of truth (the `fingerprint_server_url` field default references it). The only drift point is `curator.py:398`, which re-hardcodes the same literal as an `or` fallback. We replace that literal with the constant and rewrite the URL-default tests to be constant-relative, so a future rename touches exactly one line.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLModel, pytest, ruff (pre-commit).
+
+**Source of truth:** `docs/superpowers/specs/2026-05-30-depersonalize-fingerprint-server-url-design.md`
+
+---
+
+### Task 1: Make the test suite constant-relative (test-first)
+
+**Files:**
+- Test: `backend/tests/integration/test_contribution_uploader.py:64-73` (modify existing `test_app_config_has_fingerprint_server_url`)
+- Test: `backend/tests/integration/test_contribution_uploader.py` (add `test_curator_routes_fallback_through_constant`)
+
+- [ ] **Step 1: Rewrite the value-equality assertion to reference the constant**
+
+Replace the hardcoded-literal assertion (line 72) so renaming the URL never requires touching this test. Import the constant at module top alongside the existing imports (or inside the test — the existing `test_uploader_falls_back_to_default_url_when_unset` already imports it locally; prefer a module-level import for reuse).
+
+```python
+# at top of file, near the other app.* imports
+from app.models.app_config import DEFAULT_FINGERPRINT_SERVER_URL
+```
+
+```python
+def test_app_config_has_fingerprint_server_url():
+    """AppConfig defaults fingerprint_server_url to the network base origin.
+
+    Asserted constant-relative (not the literal string) so de-personalizing the
+    URL is a one-line edit to DEFAULT_FINGERPRINT_SERVER_URL. The default must be
+    the BASE (no /v1 suffix) — the uploader appends /v1/contribute, so a /v1 here
+    would double to /v1/v1/... and 404.
+    """
+    cfg = AppConfig()
+    assert hasattr(cfg, "fingerprint_server_url")
+    assert cfg.fingerprint_server_url == DEFAULT_FINGERPRINT_SERVER_URL
+    assert not cfg.fingerprint_server_url.endswith("/v1")
+```
+
+- [ ] **Step 2: Add a guard test proving curator routes through the constant**
+
+This is the real regression anchor: it fails *before* the curator fix (the source still holds the literal) and stays green through any future rename, because `curator.py` will reference the constant by name rather than embedding a host literal.
+
+```python
+def test_curator_routes_fallback_through_constant():
+    """curator.py must use DEFAULT_FINGERPRINT_SERVER_URL for its server-URL
+    fallback, not a re-hardcoded literal. Guarantees the URL value lives in
+    exactly one place (app_config.py), so de-personalizing is a one-line edit.
+    """
+    import inspect
+
+    import app.core.curator as curator_mod
+
+    source = inspect.getsource(curator_mod)
+    assert "DEFAULT_FINGERPRINT_SERVER_URL" in source, (
+        "curator.py should reference the shared constant for its server-URL fallback"
+    )
+    assert ".workers.dev" not in source, (
+        "curator.py must not hardcode a fingerprint host literal; route through "
+        "DEFAULT_FINGERPRINT_SERVER_URL instead"
+    )
+```
+
+- [ ] **Step 3: Run the tests to verify the guard fails (red)**
+
+Run: `cd backend; uv run pytest tests/integration/test_contribution_uploader.py::test_curator_routes_fallback_through_constant tests/integration/test_contribution_uploader.py::test_app_config_has_fingerprint_server_url -v`
+Expected: `test_curator_routes_fallback_through_constant` FAILS on the `.workers.dev` assertion (literal still present in `curator.py`); `test_app_config_has_fingerprint_server_url` PASSES (constant == literal value today).
+
+- [ ] **Step 4: Commit the tests**
+
+```bash
+git add backend/tests/integration/test_contribution_uploader.py
+git commit -m "test(fingerprint): assert server URL against the shared constant"
+```
+
+---
+
+### Task 2: Route curator's fallback through the constant (green)
+
+**Files:**
+- Modify: `backend/app/core/curator.py` (top-of-file imports + line ~398)
+
+- [ ] **Step 1: Import the constant at module top**
+
+Add next to the existing `from app.matcher.llm_episode_matcher import match_episode_via_llm` import (line 12). `app_config.py` imports only sqlalchemy/sqlmodel, so there is no circular-import risk.
+
+```python
+from app.matcher.llm_episode_matcher import match_episode_via_llm
+from app.models.app_config import DEFAULT_FINGERPRINT_SERVER_URL
+```
+
+- [ ] **Step 2: Replace the hardcoded fallback literal**
+
+```python
+        server_url = cfg.fingerprint_server_url or DEFAULT_FINGERPRINT_SERVER_URL
+```
+
+(Replaces the multi-line `cfg.fingerprint_server_url or "https://engram-fp-prod.jonathansakkos.workers.dev"` at line 397-399.)
+
+- [ ] **Step 3: Run the guard + URL-default tests to verify green**
+
+Run: `cd backend; uv run pytest tests/integration/test_contribution_uploader.py -v`
+Expected: all PASS, including `test_curator_routes_fallback_through_constant`.
+
+- [ ] **Step 4: Run curator unit tests + lint to confirm no regression**
+
+Run: `cd backend; uv run pytest tests/unit/test_curator.py -v; uv run ruff check app/core/curator.py tests/integration/test_contribution_uploader.py`
+Expected: tests PASS, ruff reports no issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/curator.py
+git commit -m "fix(fingerprint): route curator server-URL fallback through DEFAULT_FINGERPRINT_SERVER_URL"
+```
+
+---
+
+### Task 3: Verify no other production code hardcodes the hostname
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Grep for the personal hostname across the repo**
+
+Run (Grep tool, or): `cd backend; rg -n "jonathansakkos|engram-fp-prod" app`
+Expected: the only remaining match under `backend/app/` is the constant definition in `app/models/app_config.py:19`. (The `frontend/src/components/ConfigWizard.tsx` input *placeholder* is display-only UI text, cannot import a Python constant, and is out of scope for this code-prep — note it in the PR but do not change it.)
+
+- [ ] **Step 2: Full backend test sanity pass (optional but recommended)**
+
+Run: `cd backend; uv run pytest tests/integration/test_contribution_uploader.py tests/unit/test_curator.py -q`
+Expected: all PASS.
+
+---
+
+## Notes for the PR description
+
+Summarize the two maintainer-driven Cloudflare ops options (from the spec) and the migration note — the URL value itself is intentionally unchanged in this PR:
+
+- **Option 1 (recommended): custom domain.** Point a neutral domain (e.g. `fp.engram.app`) at the worker via a `routes`/custom-domain entry in `wrangler.toml` + a Cloudflare DNS record. Decouples the public URL from both the account subdomain and the worker name; keeps the old `*.workers.dev` URL resolving alongside it.
+- **Option 2: rename the account's `workers.dev` subdomain.** Cloudflare dashboard → Workers → Subdomain → rename `jonathansakkos` to something neutral. Free, but account-wide and still ends in `.workers.dev`.
+- **Migration:** NULL-config installs resolve to `DEFAULT_FINGERPRINT_SERVER_URL` at call time, so they pick up the new default automatically on update. Installs that explicitly saved the old URL keep sending there — keep the old URL alive until clients update (trivial with the custom-domain option). Low risk: the catalog is freshly bootstrapped with effectively one contributor.
+
+After this PR, de-personalizing is a one-line edit to `DEFAULT_FINGERPRINT_SERVER_URL`.


### PR DESCRIPTION
## What & why

Code-prep half of the [de-personalize fingerprint server URL design](docs/superpowers/specs/2026-05-30-depersonalize-fingerprint-server-url-design.md). The default fingerprint-server URL embeds the maintainer's name (`engram-fp-prod.jonathansakkos.workers.dev`). Removing the name is primarily a **Cloudflare ops decision** (the maintainer's to make); this PR only makes swapping the URL a **single-constant edit** and fixes a latent duplicate.

`DEFAULT_FINGERPRINT_SERVER_URL` in `backend/app/models/app_config.py` is already the source of truth (the `fingerprint_server_url` field default references it). The drift point was `curator.py`, which re-hardcoded the same literal as an `or` fallback — so a future URL change would silently fail to track there.

**The URL value is intentionally unchanged here** — that waits on the Cloudflare decision below.

## Changes

- **`backend/app/core/curator.py`** — replace the hardcoded `"https://engram-fp-prod.jonathansakkos.workers.dev"` fallback with `DEFAULT_FINGERPRINT_SERVER_URL` (imported at module top). The URL value now lives in exactly one place.
- **`backend/tests/integration/test_contribution_uploader.py`** — assert the default against `DEFAULT_FINGERPRINT_SERVER_URL` instead of the literal string (keeping the structural "does not end with `/v1`" check), and add `test_curator_routes_fallback_through_constant`, a guard test (via `inspect.getsource`) that fails if curator ever re-hardcodes a host literal. Test-first: the guard went red before the curator fix, green after.

Verified: the only remaining occurrence of the hostname under `backend/app/` is the constant definition itself. (The `frontend/src/components/ConfigWizard.tsx` input **placeholder** still shows the old URL — that's display-only hint text and can't import a Python constant; refresh it when the URL value actually changes.)

After this PR, de-personalizing is a one-line edit to `DEFAULT_FINGERPRINT_SERVER_URL`.

## Maintainer follow-up — Cloudflare ops (pick one)

The personal part is `jonathansakkos`, the account-wide `workers.dev` subdomain. Two options from the spec:

1. **Custom domain (recommended).** Point a neutral domain you control (e.g. `fp.engram.app`) at the worker via a `routes`/custom-domain entry in `wrangler.toml` + a Cloudflare DNS record. Stable, professional, and decouples the public URL from both the account subdomain and the worker name forever.
2. **Rename the account's `workers.dev` subdomain.** Cloudflare dashboard → Workers → Subdomain → rename `jonathansakkos` to something neutral (e.g. `engram`). Free, no domain needed, but **account-wide** (renames the subdomain for every worker in the account) and still ends in `.workers.dev`.

**Migration / backward compatibility:** Installs with a NULL stored `fingerprint_server_url` resolve to `DEFAULT_FINGERPRINT_SERVER_URL` at call time, so they pick up the new default automatically on update. Installs that explicitly saved the old URL keep sending there — **keep the old URL reachable** until those clients update (trivial with the custom-domain option, since the old `*.workers.dev` URL keeps resolving alongside the new domain). Low risk regardless: the catalog is freshly bootstrapped with effectively one contributor.

## Testing

`uv run pytest tests/integration/test_contribution_uploader.py tests/unit/test_curator.py` → 48 passed. ruff clean.

> Stacked on #273 (`spec/fingerprint-upload-followups`) — base will auto-retarget to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
