### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-05-31
+
+_Highlights: fingerprint-network contributions now upload far faster — a backlog drains in back-to-back batches instead of trickling out an hour at a time, and rate-limited uploads are retried instead of dropped. Plus a LAN-access fix so a dual-stack host no longer rejects its own requests._
+
+### Changed
+
+- **Faster fingerprint-contribution uploads** — the contribution uploader now drains its queue in back-to-back batches instead of sending one batch and then sleeping an hour, so a backlog (for example right after a bulk library bootstrap) clears promptly rather than over many hours. Rate-limit responses (HTTP 429) are now treated as transient and retried — honoring the server's `Retry-After`, capped so a misbehaving server can't stall uploads — instead of silently dropping the contribution. The steady-state idle poll interval also dropped from 60 to 15 minutes for quicker pickup of newly ripped episodes. (#276)
+
+### Fixed
+
+- **LAN access could reject the host's own requests on dual-stack (IPv6) binds** — with LAN access bound to all interfaces, the host's own loopback connection can arrive as the IPv4-mapped IPv6 address `::ffff:127.0.0.1`, which the localhost-only guard wrongly rejected with HTTP 403. Loopback is now classified via `ipaddress` (with an explicit IPv4-mapped fallback for Python < 3.13), so local requests are recognized correctly. (#273)
+
 ## [0.12.0] - 2026-05-30
 
 _Highlights: a wider setup wizard with a dedicated Data Sharing tab and guided TMDB onboarding; the Import Watch Folder now handles libraries pointed straight at a show and flat folders with no season; and an ASR matcher fix that restores episode matches the new fingerprint-vector scale had started rejecting._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.12.0"
+version = "0.12.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.12.0"
+version = "0.12.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.12.0",
+    "version": "0.12.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.12.1

Patch release. Bumps the version across the six lockstep version files and adds the curated `CHANGELOG.md` section that `release.yml` turns into the GitHub release notes.

Squash-merging this PR (keeping the `chore: release v` title) triggers `tag-release.yml` → tags `v0.12.1` → `release.yml` (Win/Linux/macOS-arm64 binaries + GitHub release) + `docker.yml` (GHCR image). **Leaving the merge to you.**

### Release notes (extracted from CHANGELOG)

_Highlights: fingerprint-network contributions now upload far faster — a backlog drains in back-to-back batches instead of trickling out an hour at a time, and rate-limited uploads are retried instead of dropped. Plus a LAN-access fix so a dual-stack host no longer rejects its own requests._

**Changed**
- **Faster fingerprint-contribution uploads** — the contribution uploader now drains its queue in back-to-back batches instead of sending one batch and then sleeping an hour, so a backlog (e.g. right after a bulk library bootstrap) clears promptly rather than over many hours. Rate-limit responses (HTTP 429) are now treated as transient and retried — honoring the server's `Retry-After`, capped so a misbehaving server can't stall uploads — instead of silently dropping the contribution. The steady-state idle poll interval also dropped from 60 to 15 minutes. (#276)

**Fixed**
- **LAN access could reject the host's own requests on dual-stack (IPv6) binds** — the host's own loopback connection can arrive as the IPv4-mapped IPv6 address `::ffff:127.0.0.1`, which the localhost-only guard wrongly rejected with HTTP 403. Loopback is now classified via `ipaddress` (with an IPv4-mapped fallback for Python < 3.13). (#273)

### Intentionally not in the user-facing release notes

These landed since v0.12.0 but have no user-observable effect, so they're omitted from the release notes (still in git history):

- **#273** also gates the TheDiscDB `/contributions/*` + `flag-discdb` routes behind `require_localhost` — security hardening for a feature that is currently **gated off** (`DISCDB_ENABLED=False`).
- **#272 / #271** — TheDiscDB cover-image upload fixes; same gated-off feature, not reachable by users.
- **#274** — routes the fingerprint server-URL fallback through one constant (value unchanged; de-personalize prep).
- **#275** — CODEOWNERS for branch-protection-sensitive paths (repo hygiene).

### Version files bumped (six, in lockstep)

`backend/pyproject.toml` · `backend/app/__init__.py` · `backend/uv.lock` · `frontend/package.json` · `frontend/package-lock.json` (both self-version fields) · `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
