### PR TITLE
fix(identify): tmdb-id show-identity spine + same-name collision review

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1018,7 +1018,9 @@ async def retry_subtitle_download(
     from app.services.job_manager import job_manager
 
     asyncio.create_task(
-        job_manager._download_subtitles(job.id, job.detected_title, job.detected_season)
+        job_manager._download_subtitles(
+            job.id, job.detected_title, job.detected_season, job.tmdb_id
+        )
     )
 
     return {"status": "retry_started", "job_id": job.id}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1000,8 +1000,6 @@ async def retry_subtitle_download(
     job: DiscJob = Depends(get_job_or_404),
 ) -> dict:
     """Retry subtitle download for a job that failed."""
-    import asyncio
-
     if job.subtitle_status not in ("failed", None):
         raise HTTPException(
             status_code=400,

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -451,6 +451,21 @@ class DiscAnalyst:
             result.classification_source = "heuristic"
             return result
 
+        # Same-name collision (item 1): two real same-name TMDB shows. Don't commit
+        # an id — force review and let the user pick via the existing re-identify UI.
+        if getattr(tmdb_signal, "ambiguous_identity", False):
+            result.tmdb_id = None
+            result.tmdb_name = tmdb_signal.tmdb_name
+            result.content_type = tmdb_signal.content_type
+            result.needs_review = True
+            cands = tmdb_signal.candidates or []
+            listed = "; ".join(f"{c['name']} ({c['year']}, #{c['tmdb_id']})" for c in cands)
+            result.review_reason = (
+                f'Multiple shows match "{tmdb_signal.tmdb_name}" on TMDB: {listed}. '
+                f"Pick the correct one."
+            )
+            return result
+
         # Always propagate TMDB metadata
         result.tmdb_id = tmdb_signal.tmdb_id
         result.tmdb_name = tmdb_signal.tmdb_name

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -453,10 +453,11 @@ class DiscAnalyst:
 
         # Same-name collision (item 1): two real same-name TMDB shows. Don't commit
         # an id — force review and let the user pick via the existing re-identify UI.
-        if getattr(tmdb_signal, "ambiguous_identity", False):
+        if tmdb_signal.ambiguous_identity:
             result.tmdb_id = None
             result.tmdb_name = tmdb_signal.tmdb_name
             result.content_type = tmdb_signal.content_type
+            result.classification_source = "tmdb"
             result.needs_review = True
             cands = tmdb_signal.candidates or []
             listed = "; ".join(f"{c['name']} ({c['year']}, #{c['tmdb_id']})" for c in cands)

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -207,6 +207,7 @@ class EpisodeCurator:
         progress_callback: Callable[..., None] | None = None,
         num_points: int | None = None,
         min_vote_count: int | None = None,
+        tmdb_id: int | None = None,
     ) -> MatchResult:
         """Match a file when the season is unknown by searching every candidate season.
 
@@ -230,7 +231,7 @@ class EpisodeCurator:
         best: MatchResult | None = None
         for s in seasons:
             result = await self.match_single_file(
-                file_path, series_name, s, progress_callback, num_points, min_vote_count
+                file_path, series_name, s, progress_callback, num_points, min_vote_count, tmdb_id
             )
             if not result.episode_code:
                 continue
@@ -331,7 +332,7 @@ class EpisodeCurator:
             # Season unknown (e.g. a flat import folder with no Season NN dir):
             # search across every candidate season and keep the best match.
             return await self._match_across_seasons(
-                file_path, series_name, progress_callback, num_points, min_vote_count
+                file_path, series_name, progress_callback, num_points, min_vote_count, tmdb_id
             )
 
         # Phase 3 cascade: chromaprint first (no-op when the flag is off → identical to legacy ASR path).

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -251,6 +251,7 @@ class EpisodeCurator:
         series_name: str | None = None,
         season: int | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
+        tmdb_id: int | None = None,
     ) -> list[MatchResult]:
         """Match a list of MKV files to episodes.
 
@@ -273,7 +274,7 @@ class EpisodeCurator:
                 results.append(self._fallback_result(file_path))
             return results
 
-        if not self._ensure_initialized(series_name):
+        if not self._ensure_initialized(series_name, tmdb_id):
             # Return unmatched results if matcher not available
             for i, file_path in enumerate(files):
                 if progress_callback:
@@ -283,7 +284,9 @@ class EpisodeCurator:
 
         for i, file_path in enumerate(files):
             try:
-                result = await self.match_single_file(file_path, series_name, season)
+                result = await self.match_single_file(
+                    file_path, series_name, season, tmdb_id=tmdb_id
+                )
                 results.append(result)
             except Exception as e:
                 logger.error(f"Error matching {file_path}: {e}")

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -40,14 +40,25 @@ class EpisodeCurator:
         self._cache_dir: Path | None = None
         self._current_show: str | None = None
         self._current_show_id: str | None = None
+        self._current_tmdb_id: int | None = None
 
-    def _ensure_initialized(self, show_name: str) -> bool:
-        """Lazily initialize the matcher library for a specific show."""
-        # Re-initialize if show name changed
-        if self._initialized and self._current_show == show_name:
+    def _ensure_initialized(self, show_name: str, tmdb_id: int | None = None) -> bool:
+        """Lazily initialize the matcher library for a specific show.
+
+        When ``tmdb_id`` is known (e.g. after the user disambiguated a same-name
+        collision), it is used directly instead of resolving by name — and it is
+        passed to EpisodeMatcher as the corpus guard's expected id.
+        """
+        # Re-initialize if show name OR known id changed.
+        if (
+            self._initialized
+            and self._current_show == show_name
+            and self._current_tmdb_id == tmdb_id
+        ):
             return self._matcher is not None
 
         self._current_show = show_name
+        self._current_tmdb_id = tmdb_id
 
         try:
             # Import from local matcher package
@@ -57,15 +68,19 @@ class EpisodeCurator:
             # Get cache directory from config (sync version for non-async context)
             from app.services.config_service import get_config_sync
 
-            # Resolve canonical show name
+            # Resolve canonical show name. Use the caller-supplied tmdb_id directly
+            # when known (skips fetch_show_id, which resolves by NAME and can't tell
+            # two same-named shows apart); otherwise resolve by name.
             canonical_name = show_name
             try:
-                # We need to run async TMDB calls in a sync context here or use sync versions?
-                # tmdb_client functions are synchronous (requests based)
-                tmdb_id = fetch_show_id(show_name)
-                self._current_show_id = str(tmdb_id) if tmdb_id else None
-                if tmdb_id:
-                    details = fetch_show_details(tmdb_id)
+                if tmdb_id is not None:
+                    resolved_id = tmdb_id
+                    self._current_show_id = str(tmdb_id)
+                else:
+                    resolved_id = fetch_show_id(show_name)
+                    self._current_show_id = str(resolved_id) if resolved_id else None
+                if resolved_id:
+                    details = fetch_show_details(resolved_id)
                     if details and "name" in details:
                         canonical_name = details["name"]
                         logger.info(
@@ -87,6 +102,7 @@ class EpisodeCurator:
                 cache_dir=self._cache_dir,
                 show_name=canonical_name,
                 min_confidence=self.LOW_CONFIDENCE_THRESHOLD,
+                expected_tmdb_id=tmdb_id,
             )
             self._initialized = True
             logger.info(
@@ -285,6 +301,7 @@ class EpisodeCurator:
         progress_callback: Callable[..., None] | None = None,
         num_points: int | None = None,
         min_vote_count: int | None = None,
+        tmdb_id: int | None = None,
     ) -> MatchResult:
         """Match a single file to an episode using audio fingerprinting.
 
@@ -301,7 +318,7 @@ class EpisodeCurator:
 
         # Ensure matcher is initialized for this show
         if series_name:
-            initialized = self._ensure_initialized(series_name)
+            initialized = self._ensure_initialized(series_name, tmdb_id)
             logger.info(
                 f"Matcher initialized={initialized}, matcher={'available' if self._matcher else 'None'}"
             )

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -19,6 +19,15 @@ TMDB_SEARCH_MOVIE_URL = "https://api.themoviedb.org/3/search/movie"
 # Popularity threshold for high-confidence matches
 HIGH_POPULARITY_THRESHOLD = 50
 
+# Same-name collision detection (item 1). Flag a job for review only when two
+# distinct same-name TMDB shows are BOTH plausibly real: the runner-up clears
+# this popularity floor AND the top/second popularity ratio is small enough that
+# popularity is not a confident pick. Dominant-twin cases (e.g. Frasier 1993 vs
+# 2023 revival) intentionally fall through — they have no identify-time signal
+# and are handled downstream (item 3). Tunable.
+AMBIGUOUS_POPULARITY_FLOOR = 10.0
+AMBIGUOUS_POPULARITY_RATIO = 4.0
+
 
 def _confidence_from_popularity(popularity: float, ambiguous: bool) -> float:
     """Map a TMDB popularity score to a classification confidence value."""
@@ -64,7 +73,14 @@ def _name_similarity(query: str, candidate: str) -> float:
 class TmdbSignal:
     """Signal from TMDB about content type."""
 
-    __slots__ = ("content_type", "confidence", "tmdb_id", "tmdb_name")
+    __slots__ = (
+        "content_type",
+        "confidence",
+        "tmdb_id",
+        "tmdb_name",
+        "ambiguous_identity",
+        "candidates",
+    )
 
     def __init__(
         self,
@@ -72,17 +88,21 @@ class TmdbSignal:
         confidence: float,
         tmdb_id: int | None = None,
         tmdb_name: str | None = None,
+        ambiguous_identity: bool = False,
+        candidates: list[dict] | None = None,
     ):
         self.content_type = content_type
         self.confidence = confidence
         self.tmdb_id = tmdb_id
         self.tmdb_name = tmdb_name
+        self.ambiguous_identity = ambiguous_identity
+        self.candidates = candidates
 
     def __repr__(self) -> str:
         return (
             f"TmdbSignal(content_type={self.content_type.value}, "
             f"confidence={self.confidence:.0%}, tmdb_id={self.tmdb_id}, "
-            f"tmdb_name={self.tmdb_name!r})"
+            f"tmdb_name={self.tmdb_name!r}, ambiguous_identity={self.ambiguous_identity})"
         )
 
 

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -178,7 +178,6 @@ def classify_from_tmdb(
     headers, base_params = _build_auth(api_key)
 
     # Search both TV and movie endpoints
-    tv_results: list[dict] = []
     tv_result, tv_results = _search_tmdb(TMDB_SEARCH_TV_URL, name, headers, base_params, timeout)
     movie_result, _ = _search_tmdb(TMDB_SEARCH_MOVIE_URL, name, headers, base_params, timeout)
 

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -128,12 +128,11 @@ def _search_tmdb(
     headers: dict,
     base_params: dict,
     timeout: float,
-) -> dict | None:
-    """Search a TMDB endpoint and return the best-matching result.
+) -> tuple[dict | None, list[dict]]:
+    """Search a TMDB endpoint; return (best-matching result, all raw results).
 
     Prefers results whose name closely matches the query over raw popularity.
-    Returns:
-        Best result dict with 'id', 'name'/'title', 'popularity', or None
+    The raw list lets callers detect same-name collisions.
     """
     params = {**base_params, "query": query}
     try:
@@ -141,22 +140,21 @@ def _search_tmdb(
         if response.status_code == 200:
             results = response.json().get("results", [])
             if not results:
-                return None
+                return None, []
             if len(results) == 1:
-                return results[0]
-            # Score each result by name similarity, break ties with popularity
+                return results[0], results
             best = results[0]
             best_name = best.get("name", best.get("title", ""))
             best_sim = _name_similarity(query, best_name)
-            for r in results[1:5]:  # Check top 5 results
+            for r in results[1:5]:
                 r_name = r.get("name", r.get("title", ""))
                 r_sim = _name_similarity(query, r_name)
                 if r_sim > best_sim:
                     best, best_sim = r, r_sim
-            return best
+            return best, results
     except (requests.RequestException, ConnectionError, TimeoutError):
         pass
-    return None
+    return None, []
 
 
 def classify_from_tmdb(
@@ -180,8 +178,9 @@ def classify_from_tmdb(
     headers, base_params = _build_auth(api_key)
 
     # Search both TV and movie endpoints
-    tv_result = _search_tmdb(TMDB_SEARCH_TV_URL, name, headers, base_params, timeout)
-    movie_result = _search_tmdb(TMDB_SEARCH_MOVIE_URL, name, headers, base_params, timeout)
+    tv_results: list[dict] = []
+    tv_result, tv_results = _search_tmdb(TMDB_SEARCH_TV_URL, name, headers, base_params, timeout)
+    movie_result, _ = _search_tmdb(TMDB_SEARCH_MOVIE_URL, name, headers, base_params, timeout)
 
     # If neither returned results, try name variations
     if not tv_result and not movie_result:
@@ -189,8 +188,10 @@ def classify_from_tmdb(
 
         variations = generate_name_variations(name)
         for variation in variations:
-            tv_result = _search_tmdb(TMDB_SEARCH_TV_URL, variation, headers, base_params, timeout)
-            movie_result = _search_tmdb(
+            tv_result, tv_results = _search_tmdb(
+                TMDB_SEARCH_TV_URL, variation, headers, base_params, timeout
+            )
+            movie_result, _ = _search_tmdb(
                 TMDB_SEARCH_MOVIE_URL, variation, headers, base_params, timeout
             )
             if tv_result or movie_result:

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -169,7 +169,7 @@ def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] 
     seen_ids = set()
     for r in results:
         rid = r.get("id")
-        if rid in seen_ids:
+        if rid is None or rid in seen_ids:
             continue
         name = r.get("name", r.get("original_name", ""))
         if _name_similarity(query, name) >= 0.95:
@@ -181,8 +181,13 @@ def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] 
     top, second = same[0].get("popularity", 0.0), same[1].get("popularity", 0.0)
     if second < AMBIGUOUS_POPULARITY_FLOOR:
         return None
+    # `second <= 0` is a division-by-zero rail kept intentionally: the floor check
+    # above covers it for the default floor, but the constants are tunable.
     if second <= 0 or (top / second) > AMBIGUOUS_POPULARITY_RATIO:
         return None
+    # Return ALL same-name candidates (not just the gated top two): a franchise like
+    # Doctor Who has 3+ legitimate same-name shows, and the user may own any of them.
+    # The gate decides whether to flag; the list shows every show they pick between.
     return [
         {
             "tmdb_id": r["id"],

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -102,7 +102,8 @@ class TmdbSignal:
         return (
             f"TmdbSignal(content_type={self.content_type.value}, "
             f"confidence={self.confidence:.0%}, tmdb_id={self.tmdb_id}, "
-            f"tmdb_name={self.tmdb_name!r}, ambiguous_identity={self.ambiguous_identity})"
+            f"tmdb_name={self.tmdb_name!r}, ambiguous_identity={self.ambiguous_identity}, "
+            f"candidates={self.candidates!r})"
         )
 
 

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -157,6 +157,58 @@ def _search_tmdb(
     return None, []
 
 
+def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] | None:
+    """Return same-name collision candidates when the materiality gate fires, else None.
+
+    "Same-name" = normalized name equals the query's (>= 0.95 similarity). The gate
+    fires only when the top two distinct same-name shows are BOTH plausibly real:
+    runner-up popularity >= AMBIGUOUS_POPULARITY_FLOOR AND
+    top/second popularity ratio <= AMBIGUOUS_POPULARITY_RATIO.
+    """
+    same = []
+    seen_ids = set()
+    for r in results:
+        rid = r.get("id")
+        if rid in seen_ids:
+            continue
+        name = r.get("name", r.get("original_name", ""))
+        if _name_similarity(query, name) >= 0.95:
+            seen_ids.add(rid)
+            same.append(r)
+    if len(same) < 2:
+        return None
+    same.sort(key=lambda r: r.get("popularity", 0.0), reverse=True)
+    top, second = same[0].get("popularity", 0.0), same[1].get("popularity", 0.0)
+    if second < AMBIGUOUS_POPULARITY_FLOOR:
+        return None
+    if second <= 0 or (top / second) > AMBIGUOUS_POPULARITY_RATIO:
+        return None
+    return [
+        {
+            "tmdb_id": r["id"],
+            "name": r.get("name", r.get("original_name", "")),
+            "year": (r.get("first_air_date") or "")[:4],
+            "popularity": round(r.get("popularity", 0.0), 1),
+        }
+        for r in same
+    ]
+
+
+def _maybe_flag_tv_ambiguity(signal: TmdbSignal, query: str, tv_results: list[dict]) -> TmdbSignal:
+    """Attach same-name collision info to a TV signal when the gate fires."""
+    if signal.content_type != ContentType.TV:
+        return signal
+    candidates = _detect_same_name_candidates(query, tv_results)
+    if candidates:
+        signal.ambiguous_identity = True
+        signal.candidates = candidates
+        logger.info(
+            f"TMDB: same-name collision for '{query}' — candidates "
+            + ", ".join(f"{c['name']} ({c['year']}, id={c['tmdb_id']})" for c in candidates)
+        )
+    return signal
+
+
 def classify_from_tmdb(
     name: str,
     api_key: str,
@@ -216,7 +268,7 @@ def classify_from_tmdb(
         sim_diff = abs(tv_sim - movie_sim)
         if sim_diff >= 0.2:
             if tv_sim > movie_sim:
-                return _make_tv_signal(tv_result)
+                return _maybe_flag_tv_ambiguity(_make_tv_signal(tv_result), name, tv_results)
             else:
                 return _make_movie_signal(movie_result)
 
@@ -226,17 +278,19 @@ def classify_from_tmdb(
             if ratio < 2:
                 # Close popularity — ambiguous, use the higher one but lower confidence
                 if tv_pop >= movie_pop:
-                    return _make_tv_signal(tv_result, ambiguous=True)
+                    return _maybe_flag_tv_ambiguity(
+                        _make_tv_signal(tv_result, ambiguous=True), name, tv_results
+                    )
                 else:
                     return _make_movie_signal(movie_result, ambiguous=True)
 
         if tv_pop >= movie_pop:
-            return _make_tv_signal(tv_result)
+            return _maybe_flag_tv_ambiguity(_make_tv_signal(tv_result), name, tv_results)
         else:
             return _make_movie_signal(movie_result)
 
     if tv_result:
-        return _make_tv_signal(tv_result)
+        return _maybe_flag_tv_ambiguity(_make_tv_signal(tv_result), name, tv_results)
 
     return _make_movie_signal(movie_result)
 

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -61,7 +61,9 @@ def load_precomputed_manifest(cache_dir) -> dict | None:
     return manifest
 
 
-def precomputed_covers_season(cache_dir, show_name: str, season: int, manifest=None) -> bool:
+def precomputed_covers_season(
+    cache_dir, show_name: str, season: int, manifest=None, expected_tmdb_id=None
+) -> bool:
     """Return True when the precomputed vector cache fully covers show+season.
 
     Mirrors the gate EpisodeMatcher applies at match time (manifest validity,
@@ -71,6 +73,13 @@ def precomputed_covers_season(cache_dir, show_name: str, season: int, manifest=N
 
     ``manifest`` may be a pre-loaded manifest dict to avoid re-reading and
     re-validating manifest.json (callers holding a cached copy pass it in).
+
+    ``expected_tmdb_id`` is the TMDB id the calling job has resolved for the
+    show. When supplied, it is compared against the manifest entry's ``tmdb_id``
+    (string comparison); a mismatch means the corpus is for a *different*
+    same-named show (e.g. Frasier 1993 vs 2023 revival) and this function
+    returns False before inspecting any on-disk files. When either id is
+    unknown the guard is skipped (backward-compatible).
     """
     if manifest is None:
         manifest = load_precomputed_manifest(cache_dir)
@@ -79,6 +88,18 @@ def precomputed_covers_season(cache_dir, show_name: str, season: int, manifest=N
 
     show_entry = manifest.get("shows", {}).get(show_name)
     if not show_entry or season not in show_entry.get("seasons", []):
+        return False
+
+    # Corpus guard: if the job knows its TMDB id and it contradicts the
+    # manifest entry's id, this precomputed corpus is for a DIFFERENT same-named
+    # show — refuse it so we never match e.g. the Frasier 2023 revival against the
+    # 1993 corpus. Skipped when either id is unknown (backward-compatible).
+    entry_id = show_entry.get("tmdb_id")
+    if (
+        expected_tmdb_id is not None
+        and entry_id is not None
+        and str(entry_id) != str(expected_tmdb_id)
+    ):
         return False
 
     show_dir = Path(cache_dir) / "precomputed" / sanitize_filename(show_name)

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -61,6 +61,17 @@ def load_precomputed_manifest(cache_dir) -> dict | None:
     return manifest
 
 
+def _tmdb_id_mismatch(expected, entry_id) -> bool:
+    """True when both ids are known and disagree (string-compared).
+
+    Shared by the corpus guard's two call sites (this module's
+    ``precomputed_covers_season`` and ``EpisodeMatcher._load_precomputed_season``)
+    so the comparison can't silently diverge. Returns False when either id is
+    unknown — backward-compatible with name-only matching.
+    """
+    return expected is not None and entry_id is not None and str(entry_id) != str(expected)
+
+
 def precomputed_covers_season(
     cache_dir, show_name: str, season: int, manifest=None, expected_tmdb_id=None
 ) -> bool:
@@ -94,12 +105,7 @@ def precomputed_covers_season(
     # manifest entry's id, this precomputed corpus is for a DIFFERENT same-named
     # show — refuse it so we never match e.g. the Frasier 2023 revival against the
     # 1993 corpus. Skipped when either id is unknown (backward-compatible).
-    entry_id = show_entry.get("tmdb_id")
-    if (
-        expected_tmdb_id is not None
-        and entry_id is not None
-        and str(entry_id) != str(expected_tmdb_id)
-    ):
+    if _tmdb_id_mismatch(expected_tmdb_id, show_entry.get("tmdb_id")):
         return False
 
     show_dir = Path(cache_dir) / "precomputed" / sanitize_filename(show_name)
@@ -883,11 +889,7 @@ class EpisodeMatcher:
         # wrongly drop a valid entry whose files are present.
         show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
         entry_id = show_entry.get("tmdb_id") if show_entry else None
-        if (
-            self.expected_tmdb_id is not None
-            and entry_id is not None
-            and str(entry_id) != str(self.expected_tmdb_id)
-        ):
+        if _tmdb_id_mismatch(self.expected_tmdb_id, entry_id):
             logger.warning(
                 f"Precomputed corpus for '{self.show_name}' is tmdb_id {entry_id} but this "
                 f"job resolved tmdb_id {self.expected_tmdb_id}; skipping precomputed (wrong show)"

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -719,10 +719,12 @@ class EpisodeMatcher:
         min_vote_count=2,
         match_threshold=0.10,
         model_name="small",
+        expected_tmdb_id=None,
     ):
         self.cache_dir = Path(cache_dir)
         self.min_confidence = min_confidence
         self.show_name = show_name
+        self.expected_tmdb_id = expected_tmdb_id
         self.chunk_duration = 30
         self.skip_initial_duration = (
             90  # Minimal skip for title cards; ranked voting handles intro noise
@@ -876,11 +878,29 @@ class EpisodeMatcher:
         # reuse it for the coverage gate so we read+validate manifest.json at most
         # once per matcher instance instead of once per title.
         manifest = self._load_precomputed_manifest()
+        # Corpus guard: a positive tmdb_id mismatch means the manifest entry is a
+        # different same-named show. Bail BEFORE the stale-prune branch so we don't
+        # wrongly drop a valid entry whose files are present.
+        show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
+        entry_id = show_entry.get("tmdb_id") if show_entry else None
+        if (
+            self.expected_tmdb_id is not None
+            and entry_id is not None
+            and str(entry_id) != str(self.expected_tmdb_id)
+        ):
+            logger.warning(
+                f"Precomputed corpus for '{self.show_name}' is tmdb_id {entry_id} but this "
+                f"job resolved tmdb_id {self.expected_tmdb_id}; skipping precomputed (wrong show)"
+            )
+            return None
         if not precomputed_covers_season(
-            self.cache_dir, self.show_name, season_number, manifest=manifest
+            self.cache_dir,
+            self.show_name,
+            season_number,
+            manifest=manifest,
+            expected_tmdb_id=self.expected_tmdb_id,
         ):
             # Prune the stale season in-memory so the warning fires at most once per matcher.
-            show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
             if show_entry and season_number in show_entry.get("seasons", []):
                 logger.warning(
                     f"Precomputed cache lists {self.show_name} S{season_number:02d} "

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -226,14 +226,29 @@ def _get_os_client(config) -> object | None:
         return client
 
 
-def _precomputed_skip_result(cache_path: Path, show_name: str, season: int) -> dict | None:
+def _precomputed_skip_result(
+    cache_path: Path, show_name: str, season: int, expected_tmdb_id: int | None = None
+) -> dict | None:
     """Build a 'skip download' result when the precomputed cache covers the season.
 
     Returns None when the cache doesn't cover ``show_name`` S``season``. The result
     is sized from the cache's own episode index (no TMDB call), so it works even
     when TMDB is unreachable — the whole point of the precomputed cache.
+
+    ``expected_tmdb_id`` applies the corpus guard: a precomputed corpus whose
+    manifest id contradicts the job's id is for a different same-named show, so
+    we must NOT skip the download against it.
     """
-    from app.matcher.episode_identification import precomputed_episode_codes
+    from app.matcher.episode_identification import (
+        precomputed_covers_season,
+        precomputed_episode_codes,
+    )
+
+    # Corpus guard first — returns False on an id mismatch (different same-named show).
+    if not precomputed_covers_season(
+        cache_path, show_name, season, expected_tmdb_id=expected_tmdb_id
+    ):
+        return None
 
     codes = precomputed_episode_codes(cache_path, show_name, season)
     if not codes:
@@ -255,7 +270,9 @@ def _precomputed_skip_result(cache_path: Path, show_name: str, season: int) -> d
     }
 
 
-def download_subtitles(show_name: str, season: int, *, use_precomputed: bool = True) -> dict:
+def download_subtitles(
+    show_name: str, season: int, *, tmdb_id: int | None = None, use_precomputed: bool = True
+) -> dict:
     """Download SRT subtitle files for a show/season.
 
     Strategy:
@@ -293,14 +310,19 @@ def download_subtitles(show_name: str, season: int, *, use_precomputed: bool = T
     # offline fallback — manifest keys are canonical names, so a hit means this
     # name *is* the canonical key the cache was built under.
     if use_precomputed:
-        skip = _precomputed_skip_result(cache_path, show_name, season)
+        skip = _precomputed_skip_result(cache_path, show_name, season, expected_tmdb_id=tmdb_id)
         if skip is not None:
             return skip
 
-    # Get TMDB show ID to determine episode count
-    show_id = fetch_show_id(show_name)
-    if not show_id:
-        raise ValueError(f"Could not find show '{show_name}' on TMDB")
+    # Resolve the TMDB show id. When the caller already knows it (e.g. after the
+    # user disambiguated a same-name collision), use it directly — fetch_show_id
+    # resolves by NAME and cannot tell two same-named shows apart.
+    if tmdb_id is not None:
+        show_id = str(tmdb_id)
+    else:
+        show_id = fetch_show_id(show_name)
+        if not show_id:
+            raise ValueError(f"Could not find show '{show_name}' on TMDB")
 
     # Fetch canonical details to get the correct show name (e.g., "Southpark6" -> "South Park")
     show_details = fetch_show_details(show_id)
@@ -311,7 +333,9 @@ def download_subtitles(show_name: str, season: int, *, use_precomputed: bool = T
         # Retry the precomputed fast path under the canonical name, for discs whose
         # label differs from the cache's canonical key.
         if use_precomputed:
-            skip = _precomputed_skip_result(cache_path, canonical_show_name, season)
+            skip = _precomputed_skip_result(
+                cache_path, canonical_show_name, season, expected_tmdb_id=tmdb_id
+            )
             if skip is not None:
                 return skip
 

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -383,6 +383,9 @@ class IdentificationCoordinator:
                     await session.commit()
 
                 # Both review and high-confidence paths broadcast the same job update.
+                # review_reason is None for the high-confidence path (omitted by the
+                # broadcaster) and carries the candidate-naming reason for review jobs —
+                # the ReIdentifyModal needs it to show why the disc needs disambiguation.
                 await ws_manager.broadcast_job_update(
                     job_id,
                     job.state.value,
@@ -390,6 +393,7 @@ class IdentificationCoordinator:
                     detected_title=job.detected_title,
                     detected_season=job.detected_season,
                     total_titles=job.total_titles,
+                    review_reason=analysis.review_reason,
                 )
 
                 if analysis.needs_review:
@@ -552,6 +556,10 @@ class IdentificationCoordinator:
                         detected_season=job.detected_season,
                         total_titles=job.total_titles,
                         review_reason=analysis.review_reason,
+                    )
+                    logger.info(
+                        f"Job {job_id}: ambiguous identity for '{job.detected_title}', "
+                        f"routing to REVIEW_NEEDED"
                     )
                     return
 

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -314,7 +314,9 @@ class IdentificationCoordinator:
                     and job.detected_season
                     and not _amb
                 ):
-                    self._start_subtitle_download(job_id, job.detected_title, job.detected_season)
+                    self._start_subtitle_download(
+                        job_id, job.detected_title, job.detected_season, job.tmdb_id
+                    )
                     logger.info(
                         f"Job {job_id}: starting subtitle download for "
                         f"{job.detected_title} S{job.detected_season}"
@@ -528,7 +530,7 @@ class IdentificationCoordinator:
                     # Start subtitle download
                     if job.detected_title and job.detected_season:
                         self._start_subtitle_download(
-                            job_id, job.detected_title, job.detected_season
+                            job_id, job.detected_title, job.detected_season, job.tmdb_id
                         )
                     elif job.detected_title and self._start_subtitle_download_all_seasons:
                         # Season unknown (flat import folder): prefetch references for
@@ -742,7 +744,7 @@ class IdentificationCoordinator:
                 and self._restart_subtitle_download is not None
             )
             restart_args = (
-                (job_id, job.detected_title, job.detected_season)
+                (job_id, job.detected_title, job.detected_season, job.tmdb_id)
                 if should_restart_subtitles
                 else None
             )

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -303,11 +303,18 @@ class IdentificationCoordinator:
                     )
                     return
 
-                # Start subtitle download for ALL TV content
+                # Start subtitle download for ALL TV content — except when identity is
+                # ambiguous (same-name collision). Downloading by the tentative name would
+                # fetch the wrong show's subtitles before the user disambiguates.
+                _amb = bool(
+                    getattr(analysis, "_tmdb_signal", None)
+                    and getattr(analysis._tmdb_signal, "ambiguous_identity", False)
+                )
                 if (
                     job.content_type == ContentType.TV
                     and job.detected_title
                     and job.detected_season
+                    and not _amb
                 ):
                     self._start_subtitle_download(job_id, job.detected_title, job.detected_season)
                     logger.info(

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -272,11 +272,25 @@ class IdentificationCoordinator:
                     )
                     return
 
+                # Compute ambiguous-identity flag before the TMDB-lookup-failed guard so
+                # same-name collisions (which withhold tmdb_id by design) are not
+                # intercepted with the generic "words merged" message.
+                _signal = getattr(analysis, "_tmdb_signal", None)
+                _amb = bool(_signal and _signal.ambiguous_identity)
+
                 # TV show detected but TMDB lookup failed — name cannot be trusted for episode
                 # matching. Block ripping until the user confirms the correct show name.
                 # (Disc-name fallback already ran in _run_classification; if we reach here,
                 # neither the volume label nor the DINFO name resolved on TMDB.)
-                if job.content_type == ContentType.TV and not job.tmdb_id and job.detected_title:
+                # Exclude ambiguous-identity jobs: they have tmdb_id=None by design and
+                # carry a candidate-naming review_reason that the needs_review branch below
+                # will surface.
+                if (
+                    job.content_type == ContentType.TV
+                    and not job.tmdb_id
+                    and job.detected_title
+                    and not _amb
+                ):
                     reason = (
                         f'Could not find "{job.detected_title}" on TMDB — the disc label '
                         f"may have words merged without separators. "
@@ -306,8 +320,6 @@ class IdentificationCoordinator:
                 # Start subtitle download for ALL TV content — except when identity is
                 # ambiguous (same-name collision). Downloading by the tentative name would
                 # fetch the wrong show's subtitles before the user disambiguates.
-                _signal = getattr(analysis, "_tmdb_signal", None)
-                _amb = bool(_signal and _signal.ambiguous_identity)
                 if (
                     job.content_type == ContentType.TV
                     and job.detected_title
@@ -522,6 +534,24 @@ class IdentificationCoordinator:
                         content_type=(job.content_type.value if job.content_type else None),
                         total_titles=job.total_titles,
                         review_reason="Could not determine title. Please enter the title to continue.",
+                    )
+                    return
+
+                # Same-name collision (item 1): route to review with the candidate list
+                # instead of matching against the wrong same-named show's corpus by name.
+                _amb_signal = getattr(analysis, "_tmdb_signal", None)
+                if _amb_signal and _amb_signal.ambiguous_identity:
+                    await self._state_machine.transition_to_review(
+                        job, session, reason=analysis.review_reason, broadcast=False
+                    )
+                    await ws_manager.broadcast_job_update(
+                        job_id,
+                        JobState.REVIEW_NEEDED.value,
+                        content_type=job.content_type.value,
+                        detected_title=job.detected_title,
+                        detected_season=job.detected_season,
+                        total_titles=job.total_titles,
+                        review_reason=analysis.review_reason,
                     )
                     return
 

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -306,10 +306,8 @@ class IdentificationCoordinator:
                 # Start subtitle download for ALL TV content — except when identity is
                 # ambiguous (same-name collision). Downloading by the tentative name would
                 # fetch the wrong show's subtitles before the user disambiguates.
-                _amb = bool(
-                    getattr(analysis, "_tmdb_signal", None)
-                    and getattr(analysis._tmdb_signal, "ambiguous_identity", False)
-                )
+                _signal = getattr(analysis, "_tmdb_signal", None)
+                _amb = bool(_signal and _signal.ambiguous_identity)
                 if (
                     job.content_type == ContentType.TV
                     and job.detected_title

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1947,9 +1947,11 @@ class JobManager:
 
     # --- Convenience access for routes (subtitle download) ---
 
-    async def _download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
+    async def _download_subtitles(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
         """Download subtitles — exposed for test routes."""
-        await self._matching.download_subtitles(job_id, show_name, season)
+        await self._matching.download_subtitles(job_id, show_name, season, tmdb_id)
 
 
 # Singleton instance

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -146,11 +146,13 @@ class MatchingCoordinator:
         """Set DiscDB mappings for a job."""
         self._discdb_mappings[job_id] = mappings
 
-    def start_subtitle_download(self, job_id: int, show_name: str, season: int) -> None:
+    def start_subtitle_download(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
         """Start background subtitle download with tracking."""
         self._subtitle_ready[job_id] = asyncio.Event()
         self._subtitle_tasks[job_id] = asyncio.create_task(
-            self.download_subtitles(job_id, show_name, season)
+            self.download_subtitles(job_id, show_name, season, tmdb_id)
         )
 
     def start_subtitle_download_all_seasons(
@@ -162,7 +164,9 @@ class MatchingCoordinator:
             self.download_subtitles_all_seasons(job_id, show_name, seasons)
         )
 
-    async def restart_subtitle_download(self, job_id: int, show_name: str, season: int) -> None:
+    async def restart_subtitle_download(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
         """Cancel any in-flight subtitle download and start a fresh one.
 
         Used after re-identification corrects the show title. Resets the
@@ -203,7 +207,7 @@ class MatchingCoordinator:
         # progress events as it runs.
         await ws_manager.broadcast_subtitle_event(job_id, "downloading", downloaded=0, total=0)
 
-        self.start_subtitle_download(job_id, show_name, season)
+        self.start_subtitle_download(job_id, show_name, season, tmdb_id)
 
     async def try_discdb_assignment(self, job_id: int, title: "DiscTitle", session) -> bool:
         """Try to assign episode info from TheDiscDB mappings, skipping fingerprinting.
@@ -1351,7 +1355,9 @@ class MatchingCoordinator:
             if job_id in self._subtitle_ready:
                 self._subtitle_ready[job_id].set()
 
-    async def download_subtitles(self, job_id: int, show_name: str, season: int) -> None:
+    async def download_subtitles(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
         """Download subtitles in background. Failure BLOCKS matching."""
         from sqlalchemy import update
 
@@ -1369,7 +1375,7 @@ class MatchingCoordinator:
 
             from app.matcher.testing_service import download_subtitles
 
-            result = await asyncio.to_thread(download_subtitles, show_name, season)
+            result = await asyncio.to_thread(download_subtitles, show_name, season, tmdb_id=tmdb_id)
 
             episodes = result["episodes"]
             # The precomputed vector cache covered the whole season, so no SRTs

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -714,6 +714,7 @@ class MatchingCoordinator:
                     progress_callback=on_progress,
                     num_points=num_points,
                     min_vote_count=min_vote_count,
+                    tmdb_id=job.tmdb_id,
                 )
 
                 elapsed = time.monotonic() - match_start

--- a/backend/tests/integration/test_chromaprint_cascade.py
+++ b/backend/tests/integration/test_chromaprint_cascade.py
@@ -11,7 +11,9 @@ def _setup(monkeypatch):
     """A curator that passes match_single_file's guards (matcher present, init stubbed)."""
     curator = EpisodeCurator()
     curator._matcher = object()  # truthy; real matcher unused because prepass/asr are mocked
-    monkeypatch.setattr(EpisodeCurator, "_ensure_initialized", lambda self, name: True)
+    monkeypatch.setattr(
+        EpisodeCurator, "_ensure_initialized", lambda self, name, tmdb_id=None: True
+    )
     return curator
 
 

--- a/backend/tests/integration/test_show_identity_collision.py
+++ b/backend/tests/integration/test_show_identity_collision.py
@@ -115,6 +115,17 @@ async def test_ambiguous_disc_routes_to_review_with_candidate_reason(monkeypatch
 
     monkeypatch.setattr(coord, "_run_classification", fake_run_classification)
 
+    # Capture WebSocket job updates so we can assert the candidate reason reaches the
+    # client (the ReIdentifyModal banner relies on it), not just the DB.
+    import app.services.identification_coordinator as idc
+
+    broadcasts: list[tuple[str, dict]] = []
+
+    async def record_broadcast(job_id_arg, state, **kwargs):
+        broadcasts.append((state, kwargs))
+
+    monkeypatch.setattr(idc.ws_manager, "broadcast_job_update", record_broadcast)
+
     # Drive the real identify_disc flow.
     await coord.identify_disc(job_id)
 
@@ -130,3 +141,13 @@ async def test_ambiguous_disc_routes_to_review_with_candidate_reason(monkeypatch
         assert "words merged" not in (refreshed.review_reason or ""), (
             f"Generic 'words merged' message incorrectly set: {refreshed.review_reason!r}"
         )
+
+    # The WS broadcast for the review must carry the candidate reason.
+    review_reasons = [
+        kwargs.get("review_reason")
+        for state, kwargs in broadcasts
+        if state == JobState.REVIEW_NEEDED.value
+    ]
+    assert any("Multiple shows match" in (r or "") for r in review_reasons), (
+        f"No REVIEW_NEEDED broadcast carried the candidate reason; saw: {review_reasons!r}"
+    )

--- a/backend/tests/integration/test_show_identity_collision.py
+++ b/backend/tests/integration/test_show_identity_collision.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 from app.core.analyst import DiscAnalysisResult, DiscAnalyst
 from app.core.tmdb_classifier import TmdbSignal
 from app.database import async_session, init_db
-from app.models.disc_job import ContentType
+from app.models.disc_job import ContentType, DiscJob, JobState
 
 
 @pytest.fixture(autouse=True)
@@ -54,3 +54,79 @@ async def test_match_single_file_forwards_tmdb_id(monkeypatch):
 
     await cur.match_single_file(Path("nonexistent.mkv"), "Frasier", 1, tmdb_id=195241)
     assert seen == {"show_name": "Frasier", "tmdb_id": 195241}
+
+
+async def test_ambiguous_disc_routes_to_review_with_candidate_reason(monkeypatch):
+    """Coordinator seam: an ambiguous-identity analysis must NOT be intercepted by the
+    generic 'words merged' TMDB-lookup-failed guard; it must fall through to the
+    needs_review branch and surface the candidate-naming reason.
+    """
+    from app.core.analyst import TitleInfo
+    from app.services.job_manager import job_manager
+
+    coord = job_manager._identification
+
+    # Seed a job in IDENTIFYING with a drive id.
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="FRASIER_S1",
+            drive_id="E:",
+            state=JobState.IDENTIFYING,
+        )
+        session.add(job)
+        await session.commit()
+        job_id = job.id
+
+    # Fake disc scan: return one plausible title so identify_disc doesn't bail early.
+    async def fake_scan_disc(drive, log_dir=None, *, job_id=0):
+        return (
+            [TitleInfo(index=0, duration_seconds=1440, size_bytes=2_000_000_000, chapter_count=7)],
+            "FRASIER_S1",
+        )
+
+    monkeypatch.setattr(coord._extractor, "scan_disc", fake_scan_disc)
+
+    # Craft an ambiguous analysis: TV, no tmdb_id, needs_review, candidate-naming reason.
+    candidate_reason = (
+        'Multiple shows match "Frasier" on TMDB: '
+        "Frasier (1993, #3452); Frasier (2023, #195241). Pick the correct one."
+    )
+    analysis = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.6)
+    analysis.detected_name = "Frasier"
+    analysis.detected_season = 1
+    analysis.needs_review = True
+    analysis.tmdb_id = None
+    analysis.review_reason = candidate_reason
+    analysis._tmdb_signal = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=None,
+        tmdb_name="Frasier",
+        ambiguous_identity=True,
+        candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+        ],
+    )
+    analysis._discdb_signal = None
+
+    async def fake_run_classification(*args, **kwargs):
+        return analysis
+
+    monkeypatch.setattr(coord, "_run_classification", fake_run_classification)
+
+    # Drive the real identify_disc flow.
+    await coord.identify_disc(job_id)
+
+    # Reload from DB and assert correct routing.
+    async with async_session() as session:
+        refreshed = await session.get(DiscJob, job_id)
+        assert refreshed.state == JobState.REVIEW_NEEDED, (
+            f"Expected REVIEW_NEEDED, got {refreshed.state}"
+        )
+        assert "Multiple shows match" in (refreshed.review_reason or ""), (
+            f"Candidate reason not found in review_reason: {refreshed.review_reason!r}"
+        )
+        assert "words merged" not in (refreshed.review_reason or ""), (
+            f"Generic 'words merged' message incorrectly set: {refreshed.review_reason!r}"
+        )

--- a/backend/tests/integration/test_show_identity_collision.py
+++ b/backend/tests/integration/test_show_identity_collision.py
@@ -1,0 +1,56 @@
+import pytest
+from sqlalchemy import text
+
+from app.core.analyst import DiscAnalysisResult, DiscAnalyst
+from app.core.tmdb_classifier import TmdbSignal
+from app.database import async_session, init_db
+from app.models.disc_job import ContentType
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+def test_ambiguous_signal_produces_review_result_without_id():
+    """The analyst seam: an ambiguous TV signal yields needs_review + no tmdb_id."""
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=37854,
+        tmdb_name="One Piece",
+        ambiguous_identity=True,
+        candidates=[
+            {"tmdb_id": 37854, "name": "One Piece", "year": "1999", "popularity": 60.0},
+            {"tmdb_id": 111110, "name": "One Piece", "year": "2023", "popularity": 38.3},
+        ],
+    )
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.needs_review is True
+    assert out.tmdb_id is None
+    assert "One Piece" in out.review_reason
+
+
+async def test_match_single_file_forwards_tmdb_id(monkeypatch):
+    """The curator seam: a known tmdb_id reaches _ensure_initialized."""
+    from app.core.curator import EpisodeCurator
+
+    cur = EpisodeCurator()
+    seen = {}
+
+    def fake_ensure(show_name, tmdb_id=None):
+        seen["show_name"] = show_name
+        seen["tmdb_id"] = tmdb_id
+        return False  # matcher unavailable -> fallback path, no real matching
+
+    monkeypatch.setattr(cur, "_ensure_initialized", fake_ensure)
+    from pathlib import Path
+
+    await cur.match_single_file(Path("nonexistent.mkv"), "Frasier", 1, tmdb_id=195241)
+    assert seen == {"show_name": "Frasier", "tmdb_id": 195241}

--- a/backend/tests/integration/test_subtitle_restart.py
+++ b/backend/tests/integration/test_subtitle_restart.py
@@ -85,7 +85,7 @@ async def test_restart_clears_failed_state_and_starts_new_task(matching_coordina
 
     # Stub the actual download so the test stays offline. The new task will
     # await this and write subtitle_status="completed" to the DB.
-    async def fake_download(self, jid, show_name, season):
+    async def fake_download(self, jid, show_name, season, tmdb_id=None):
         # Capture the show_name the new task was started with.
         fake_download.last_args = (jid, show_name, season)
         from sqlalchemy import update
@@ -152,7 +152,7 @@ async def test_restart_cancels_inflight_task(matching_coordinator):
     # before we trigger restart, so cancellation lands at a real await point.
     await started.wait()
 
-    async def fake_download(self, jid, show_name, season):
+    async def fake_download(self, jid, show_name, season, tmdb_id=None):
         return None
 
     with patch.object(MatchingCoordinator, "download_subtitles", fake_download):
@@ -182,7 +182,7 @@ async def test_restart_preserves_non_subtitle_error_message(matching_coordinator
         await session.refresh(job)
         job_id = job.id
 
-    async def fake_download(self, jid, show_name, season):
+    async def fake_download(self, jid, show_name, season, tmdb_id=None):
         return None
 
     with patch.object(MatchingCoordinator, "download_subtitles", fake_download):

--- a/backend/tests/unit/test_analyst_ambiguity.py
+++ b/backend/tests/unit/test_analyst_ambiguity.py
@@ -33,3 +33,4 @@ def test_non_ambiguous_signal_sets_id_normally():
     out = analyst._apply_tmdb_signal(result, sig)
     assert out.tmdb_id == 1396
     assert out.needs_review is False
+    assert out.review_reason is None

--- a/backend/tests/unit/test_analyst_ambiguity.py
+++ b/backend/tests/unit/test_analyst_ambiguity.py
@@ -1,0 +1,35 @@
+from app.core.analyst import DiscAnalysisResult, DiscAnalyst
+from app.core.tmdb_classifier import TmdbSignal
+from app.models.disc_job import ContentType
+
+
+def test_ambiguous_signal_clears_id_and_forces_review():
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=3452,
+        tmdb_name="Frasier",
+        ambiguous_identity=True,
+        candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+        ],
+    )
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.tmdb_id is None
+    assert out.needs_review is True
+    assert out.review_reason and "Frasier" in out.review_reason
+    assert "1993" in out.review_reason and "2023" in out.review_reason
+
+
+def test_non_ambiguous_signal_sets_id_normally():
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(
+        content_type=ContentType.TV, confidence=0.85, tmdb_id=1396, tmdb_name="Breaking Bad"
+    )
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.tmdb_id == 1396
+    assert out.needs_review is False

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -70,7 +70,7 @@ class TestMatchSingleFile:
         curator = EpisodeCurator()
         f = tmp_path / "Show.S01E04.mkv"
         f.write_text("")
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: False)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: False)
 
         result = await curator.match_single_file(f, "Show", 1)
         assert result.needs_review is True
@@ -82,7 +82,7 @@ class TestMatchSingleFile:
         curator._matcher = Mock()
         f = tmp_path / "Show.S01E04.mkv"
         f.write_text("")
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
         monkeypatch.setattr(curator, "_candidate_seasons", lambda show: [])
 
         result = await curator.match_single_file(f, "Show", None)
@@ -103,7 +103,7 @@ class TestMatchSingleFile:
             "runner_ups": [{"episode": "S01E04"}],
         }
         curator._matcher = mock_matcher
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         result = await curator.match_single_file(f, "Show", 1)
         assert result.episode_code == "S01E03"
@@ -124,7 +124,7 @@ class TestMatchSingleFile:
             "confidence": 0.6,
         }
         curator._matcher = mock_matcher
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         result = await curator.match_single_file(f, "Show", 1)
         assert result.episode_code == "S01E02"
@@ -141,7 +141,7 @@ class TestMatchSingleFile:
             "match_details": {"reason": "no votes"},
         }
         curator._matcher = mock_matcher
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         result = await curator.match_single_file(f, "Show", 1)
         assert result.needs_review is True
@@ -155,7 +155,7 @@ class TestMatchSingleFile:
         mock_matcher = Mock()
         mock_matcher.identify_episode.side_effect = RuntimeError("boom")
         curator._matcher = mock_matcher
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         result = await curator.match_single_file(f, "Show", 3)
         assert result.needs_review is True
@@ -171,7 +171,7 @@ class TestMatchAcrossSeasons:
         curator._matcher = Mock()
         f = tmp_path / "ep.mkv"
         f.write_text("")
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
         sentinel = MatchResult(f, "S04E02", None, 0.8, False)
 
         async def fake_across(fp, series, *a, **k):
@@ -187,7 +187,7 @@ class TestMatchAcrossSeasons:
         curator._matcher = Mock()
         f = tmp_path / "ep.mkv"
         f.write_text("")
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         async def boom(*a, **k):
             raise AssertionError("should not search all seasons when season is known")
@@ -291,7 +291,7 @@ class TestMatchFiles:
         self, tmp_path, monkeypatch
     ):
         curator = EpisodeCurator()
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: False)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: False)
         files = [tmp_path / "a.mkv", tmp_path / "b.mkv"]
         seen: list[tuple[int, int]] = []
 
@@ -303,7 +303,7 @@ class TestMatchFiles:
 
     async def test_success_path_reports_progress(self, tmp_path, monkeypatch):
         curator = EpisodeCurator()
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         async def fake_single(fp, series, season):
             return MatchResult(fp, "S01E01", None, 0.9, False)
@@ -319,7 +319,7 @@ class TestMatchFiles:
 
     async def test_per_file_exception_falls_back(self, tmp_path, monkeypatch):
         curator = EpisodeCurator()
-        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: True)
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
         async def boom(fp, series, season):
             raise RuntimeError("x")

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -305,7 +305,7 @@ class TestMatchFiles:
         curator = EpisodeCurator()
         monkeypatch.setattr(curator, "_ensure_initialized", lambda show, tmdb_id=None: True)
 
-        async def fake_single(fp, series, season):
+        async def fake_single(fp, series, season, tmdb_id=None):
             return MatchResult(fp, "S01E01", None, 0.9, False)
 
         monkeypatch.setattr(curator, "match_single_file", fake_single)

--- a/backend/tests/unit/test_curator_tmdb_id.py
+++ b/backend/tests/unit/test_curator_tmdb_id.py
@@ -25,3 +25,34 @@ def test_ensure_initialized_uses_known_id_and_skips_fetch_show_id():
     assert ok is True
     assert captured["expected_tmdb_id"] == 195241
     fake_fetch_id.assert_not_called()
+
+
+def test_ensure_initialized_rebuilds_when_tmdb_id_changes():
+    """A changed tmdb_id (e.g. user re-identified the show) must rebuild the matcher
+    rather than short-circuit — this is what makes a re-identify actually take effect."""
+    cur = EpisodeCurator()
+    # Pretend the matcher is already initialized for the ORIGINAL Frasier (#3452).
+    cur._initialized = True
+    cur._current_show = "Frasier"
+    cur._current_tmdb_id = 3452
+    cur._matcher = object()
+
+    captured = {}
+
+    class FakeMatcher:
+        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None):
+            captured["expected_tmdb_id"] = expected_tmdb_id
+
+    cfg = MagicMock()
+    cfg.subtitles_cache_path = None
+    with (
+        patch("app.matcher.episode_identification.EpisodeMatcher", FakeMatcher),
+        patch("app.matcher.tmdb_client.fetch_show_id", MagicMock()),
+        patch("app.matcher.tmdb_client.fetch_show_details", return_value={"name": "Frasier"}),
+        patch("app.services.config_service.get_config_sync", return_value=cfg),
+    ):
+        # Same show name, DIFFERENT id (the 2023 revival) — must not short-circuit.
+        ok = cur._ensure_initialized("Frasier", tmdb_id=195241)
+    assert ok is True
+    assert cur._current_tmdb_id == 195241
+    assert captured["expected_tmdb_id"] == 195241

--- a/backend/tests/unit/test_curator_tmdb_id.py
+++ b/backend/tests/unit/test_curator_tmdb_id.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from app.core.curator import EpisodeCurator
+
+
+def test_ensure_initialized_uses_known_id_and_skips_fetch_show_id():
+    cur = EpisodeCurator()
+    captured = {}
+
+    class FakeMatcher:
+        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None):
+            captured["expected_tmdb_id"] = expected_tmdb_id
+            captured["show_name"] = show_name
+
+    fake_fetch_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+    cfg = MagicMock()
+    cfg.subtitles_cache_path = None
+    with (
+        patch("app.matcher.episode_identification.EpisodeMatcher", FakeMatcher),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.matcher.tmdb_client.fetch_show_details", return_value={"name": "Frasier"}),
+        patch("app.services.config_service.get_config_sync", return_value=cfg),
+    ):
+        ok = cur._ensure_initialized("Frasier", tmdb_id=195241)
+    assert ok is True
+    assert captured["expected_tmdb_id"] == 195241
+    fake_fetch_id.assert_not_called()

--- a/backend/tests/unit/test_download_subtitles_tmdb_id.py
+++ b/backend/tests/unit/test_download_subtitles_tmdb_id.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import app.matcher.testing_service as ts
+
+
+def _mock_config(tmp_path):
+    cfg = Mock()
+    cfg.subtitles_cache_path = str(tmp_path)
+    cfg.opensubtitles_api_key = None
+    cfg.opensubtitles_username = None
+    cfg.opensubtitles_password = None
+    return cfg
+
+
+def test_download_subtitles_uses_known_id_and_skips_fetch_show_id(tmp_path):
+    """When tmdb_id is supplied, fetch_show_id is never called; the id is used directly."""
+    fake_fetch_show_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+    with (
+        patch("app.services.config_service.get_config_sync", return_value=_mock_config(tmp_path)),
+        patch.object(ts, "fetch_show_id", fake_fetch_show_id),
+        patch.object(ts, "fetch_show_details", return_value={"name": "Frasier"}),
+        patch.object(ts, "fetch_season_details", return_value=0) as season,
+        patch.object(ts, "_precomputed_skip_result", return_value=None),
+    ):
+        # season count 0 -> raises ValueError AFTER id resolution, which is fine:
+        # we only assert that fetch_show_id was bypassed and the known id was used.
+        with pytest.raises(ValueError):
+            ts.download_subtitles("Frasier", 1, tmdb_id=195241)
+    fake_fetch_show_id.assert_not_called()
+    season.assert_called_once_with("195241", 1)
+
+
+def test_download_subtitles_without_id_still_resolves_by_name(tmp_path):
+    with (
+        patch("app.services.config_service.get_config_sync", return_value=_mock_config(tmp_path)),
+        patch.object(ts, "fetch_show_id", return_value="3452") as fid,
+        patch.object(ts, "fetch_show_details", return_value={"name": "Frasier"}),
+        patch.object(ts, "fetch_season_details", return_value=0),
+        patch.object(ts, "_precomputed_skip_result", return_value=None),
+    ):
+        with pytest.raises(ValueError):
+            ts.download_subtitles("Frasier", 1)
+    fid.assert_called_once_with("Frasier")

--- a/backend/tests/unit/test_download_subtitles_tmdb_id.py
+++ b/backend/tests/unit/test_download_subtitles_tmdb_id.py
@@ -4,6 +4,10 @@ import pytest
 
 import app.matcher.testing_service as ts
 
+# download_subtitles does `from app.services.config_service import get_config_sync`
+# at call time, so patching the source module (not `ts.get_config_sync`) is what
+# the function actually resolves.
+
 
 def _mock_config(tmp_path):
     cfg = Mock()

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -305,7 +305,10 @@ class TestDownloadSubtitlesAllSeasons:
         monkeypatch.setattr(ws_manager, "broadcast_subtitle_event", _noop)
         monkeypatch.setattr(
             "app.matcher.testing_service.download_subtitles",
-            lambda show, season: {"episodes": per_season.get(season, []), "show_name": show},
+            lambda show, season, tmdb_id=None: {
+                "episodes": per_season.get(season, []),
+                "show_name": show,
+            },
         )
 
     async def test_completes_when_any_season_has_references(self, monkeypatch):

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -250,7 +250,7 @@ class TestDownloadSubtitlesMessaging:
         monkeypatch.setattr(ws_manager, "broadcast_subtitle_event", _noop)
         monkeypatch.setattr(
             "app.matcher.testing_service.download_subtitles",
-            lambda show, season: {"episodes": episodes, "show_name": show},
+            lambda show, season, tmdb_id=None: {"episodes": episodes, "show_name": show},
         )
 
     async def test_no_subtitles_sets_actionable_show_specific_message(self, monkeypatch):

--- a/backend/tests/unit/test_precomputed_guard.py
+++ b/backend/tests/unit/test_precomputed_guard.py
@@ -1,0 +1,41 @@
+from app.matcher.episode_identification import precomputed_covers_season
+
+
+def _manifest(tmdb_id):
+    return {"shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {"1": 24}}}}
+
+
+def test_guard_rejects_mismatched_tmdb_id(tmp_path):
+    # Manifest says Frasier == 3452; job expects 195241 -> no coverage, regardless of files.
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=195241
+        )
+        is False
+    )
+
+
+def test_guard_skipped_when_no_expected_id(tmp_path):
+    # No expected id -> guard does not apply; falls through to file existence (absent -> False).
+    assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452")) is False
+
+
+def test_guard_passes_on_matching_id_then_checks_files(tmp_path):
+    # Matching id -> guard passes; files absent so coverage is still False (file gate).
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+        )
+        is False
+    )
+    # Create the on-disk files so the file gate passes too.
+    show_dir = tmp_path / "precomputed" / "Frasier"
+    show_dir.mkdir(parents=True)
+    (show_dir / "S01.npz").write_bytes(b"x")
+    (show_dir / "S01.index.json").write_text("[]")
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+        )
+        is True
+    )

--- a/backend/tests/unit/test_precomputed_guard.py
+++ b/backend/tests/unit/test_precomputed_guard.py
@@ -16,8 +16,16 @@ def test_guard_rejects_mismatched_tmdb_id(tmp_path):
 
 
 def test_guard_skipped_when_no_expected_id(tmp_path):
-    # No expected id -> guard does not apply; falls through to file existence (absent -> False).
+    # No expected id -> guard does not apply; coverage depends only on files.
     assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452")) is False
+    # Files present -> True. Proves the guard was SKIPPED (not that the file gate
+    # masked an inverted guard): an int/string id mismatch is irrelevant when no
+    # expected_tmdb_id is supplied.
+    show_dir = tmp_path / "precomputed" / "Frasier"
+    show_dir.mkdir(parents=True)
+    (show_dir / "S01.npz").write_bytes(b"x")
+    (show_dir / "S01.index.json").write_text("[]")
+    assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452")) is True
 
 
 def test_guard_passes_on_matching_id_then_checks_files(tmp_path):

--- a/backend/tests/unit/test_precomputed_guard.py
+++ b/backend/tests/unit/test_precomputed_guard.py
@@ -1,4 +1,4 @@
-from app.matcher.episode_identification import precomputed_covers_season
+from app.matcher.episode_identification import EpisodeMatcher, precomputed_covers_season
 
 
 def _manifest(tmdb_id):
@@ -47,3 +47,19 @@ def test_guard_passes_on_matching_id_then_checks_files(tmp_path):
         )
         is True
     )
+
+
+def test_matcher_stores_expected_tmdb_id(tmp_path):
+    m = EpisodeMatcher(cache_dir=tmp_path, show_name="Frasier", expected_tmdb_id=195241)
+    assert m.expected_tmdb_id == 195241
+
+
+def test_load_precomputed_returns_none_on_id_mismatch_without_pruning(tmp_path, monkeypatch):
+    m = EpisodeMatcher(cache_dir=tmp_path, show_name="Frasier", expected_tmdb_id=195241)
+    manifest = {
+        "shows": {"Frasier": {"tmdb_id": "3452", "seasons": [1], "episode_counts": {"1": 24}}}
+    }
+    monkeypatch.setattr(m, "_load_precomputed_manifest", lambda: manifest)
+    assert m._load_precomputed_season(1) is None
+    # The valid 3452 entry must survive (not pruned as "files missing").
+    assert manifest["shows"]["Frasier"]["seasons"] == [1]

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -1,23 +1,20 @@
 from unittest.mock import MagicMock, patch
 
 import app.core.tmdb_classifier as tc
-from app.core.tmdb_classifier import (
-    AMBIGUOUS_POPULARITY_FLOOR,
-    AMBIGUOUS_POPULARITY_RATIO,
-    TmdbSignal,
-)
 from app.models.disc_job import ContentType
 
 
 def test_tmdb_signal_defaults_not_ambiguous():
-    sig = TmdbSignal(content_type=ContentType.TV, confidence=0.7, tmdb_id=3452, tmdb_name="Frasier")
+    sig = tc.TmdbSignal(
+        content_type=ContentType.TV, confidence=0.7, tmdb_id=3452, tmdb_name="Frasier"
+    )
     assert sig.ambiguous_identity is False
     assert sig.candidates is None
 
 
 def test_tmdb_signal_can_carry_candidates():
     cands = [{"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6}]
-    sig = TmdbSignal(
+    sig = tc.TmdbSignal(
         content_type=ContentType.TV,
         confidence=0.6,
         tmdb_id=None,
@@ -30,8 +27,8 @@ def test_tmdb_signal_can_carry_candidates():
 
 
 def test_materiality_constants_have_sane_defaults():
-    assert AMBIGUOUS_POPULARITY_FLOOR == 10.0
-    assert AMBIGUOUS_POPULARITY_RATIO == 4.0
+    assert tc.AMBIGUOUS_POPULARITY_FLOOR == 10.0
+    assert tc.AMBIGUOUS_POPULARITY_RATIO == 4.0
 
 
 def _resp(results):

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -1,3 +1,6 @@
+from unittest.mock import MagicMock, patch
+
+import app.core.tmdb_classifier as tc
 from app.core.tmdb_classifier import (
     AMBIGUOUS_POPULARITY_FLOOR,
     AMBIGUOUS_POPULARITY_RATIO,
@@ -29,3 +32,28 @@ def test_tmdb_signal_can_carry_candidates():
 def test_materiality_constants_have_sane_defaults():
     assert AMBIGUOUS_POPULARITY_FLOOR == 10.0
     assert AMBIGUOUS_POPULARITY_RATIO == 4.0
+
+
+def _resp(results):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {"results": results}
+    return r
+
+
+def test_search_tmdb_returns_best_and_results():
+    results = [
+        {"id": 1, "name": "Frasier", "popularity": 75.6},
+        {"id": 2, "name": "Frasier", "popularity": 5.7},
+    ]
+    with patch.object(tc.requests, "get", return_value=_resp(results)):
+        best, raw = tc._search_tmdb(tc.TMDB_SEARCH_TV_URL, "Frasier", {}, {}, 5.0)
+    assert best is not None and best["id"] == 1
+    assert raw == results
+
+
+def test_search_tmdb_empty_returns_none_and_empty_list():
+    with patch.object(tc.requests, "get", return_value=_resp([])):
+        best, raw = tc._search_tmdb(tc.TMDB_SEARCH_TV_URL, "Nothing", {}, {}, 5.0)
+    assert best is None
+    assert raw == []

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -57,3 +57,60 @@ def test_search_tmdb_empty_returns_none_and_empty_list():
         best, raw = tc._search_tmdb(tc.TMDB_SEARCH_TV_URL, "Nothing", {}, {}, 5.0)
     assert best is None
     assert raw == []
+
+
+def _patch_searches(tv_results, movie_results=None):
+    """Patch _search_tmdb to return canned TV/movie results regardless of URL."""
+    movie_results = movie_results or []
+
+    def fake(url, query, headers, params, timeout):
+        if url == tc.TMDB_SEARCH_TV_URL:
+            return (tv_results[0] if tv_results else None), tv_results
+        return (movie_results[0] if movie_results else None), movie_results
+
+    return patch.object(tc, "_search_tmdb", side_effect=fake)
+
+
+def test_collision_flagged_when_both_substantial_and_close():
+    # One Piece: anime 1999 p60 vs live-action 2023 p38.3 -> ratio 1.57, both >= 10
+    tv = [
+        {"id": 37854, "name": "One Piece", "popularity": 60.0, "first_air_date": "1999-10-20"},
+        {"id": 111110, "name": "One Piece", "popularity": 38.3, "first_air_date": "2023-08-31"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("One Piece", "k" * 41)
+    assert sig is not None
+    assert sig.ambiguous_identity is True
+    assert sig.tmdb_id is not None  # tentative best still reported
+    ids = {c["tmdb_id"] for c in sig.candidates}
+    assert ids == {37854, 111110}
+
+
+def test_dominant_twin_not_flagged():
+    # Frasier: 1993 p75.6 vs 2023 p5.7 -> ratio 13.3 AND runner-up below floor.
+    tv = [
+        {"id": 3452, "name": "Frasier", "popularity": 75.6, "first_air_date": "1993-09-16"},
+        {"id": 195241, "name": "Frasier", "popularity": 5.7, "first_air_date": "2023-10-12"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Frasier", "k" * 41)
+    assert sig is not None
+    assert sig.ambiguous_identity is False
+
+
+def test_noise_twin_not_flagged():
+    # Yellowstone 2018 p159 vs 2009 p1.2 -> runner-up below floor.
+    tv = [
+        {"id": 73586, "name": "Yellowstone", "popularity": 159.7, "first_air_date": "2018-06-20"},
+        {"id": 19355, "name": "Yellowstone", "popularity": 1.2, "first_air_date": "2009-01-01"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Yellowstone", "k" * 41)
+    assert sig.ambiguous_identity is False
+
+
+def test_unique_name_not_flagged():
+    tv = [{"id": 1396, "name": "Breaking Bad", "popularity": 300.0, "first_air_date": "2008-01-20"}]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Breaking Bad", "k" * 41)
+    assert sig.ambiguous_identity is False

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -114,3 +114,19 @@ def test_unique_name_not_flagged():
     with _patch_searches(tv):
         sig = tc.classify_from_tmdb("Breaking Bad", "k" * 41)
     assert sig.ambiguous_identity is False
+
+
+def test_collision_lists_all_same_name_candidates():
+    # Doctor Who: 2005 p109 vs 1963 p62 (gate fires on these two) plus a 2024 entry.
+    # All three legitimate same-name shows must appear in candidates — the user may
+    # own any of them — even though only the top two drove the materiality gate.
+    tv = [
+        {"id": 57243, "name": "Doctor Who", "popularity": 109.9, "first_air_date": "2005-03-26"},
+        {"id": 121, "name": "Doctor Who", "popularity": 62.7, "first_air_date": "1963-11-23"},
+        {"id": 239770, "name": "Doctor Who", "popularity": 21.9, "first_air_date": "2024-01-01"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Doctor Who", "k" * 41)
+    assert sig.ambiguous_identity is True
+    ids = {c["tmdb_id"] for c in sig.candidates}
+    assert ids == {57243, 121, 239770}

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -1,0 +1,31 @@
+from app.core.tmdb_classifier import (
+    AMBIGUOUS_POPULARITY_FLOOR,
+    AMBIGUOUS_POPULARITY_RATIO,
+    TmdbSignal,
+)
+from app.models.disc_job import ContentType
+
+
+def test_tmdb_signal_defaults_not_ambiguous():
+    sig = TmdbSignal(content_type=ContentType.TV, confidence=0.7, tmdb_id=3452, tmdb_name="Frasier")
+    assert sig.ambiguous_identity is False
+    assert sig.candidates is None
+
+
+def test_tmdb_signal_can_carry_candidates():
+    cands = [{"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6}]
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=None,
+        tmdb_name="Frasier",
+        ambiguous_identity=True,
+        candidates=cands,
+    )
+    assert sig.ambiguous_identity is True
+    assert sig.candidates == cands
+
+
+def test_materiality_constants_have_sane_defaults():
+    assert AMBIGUOUS_POPULARITY_FLOOR == 10.0
+    assert AMBIGUOUS_POPULARITY_RATIO == 4.0

--- a/docs/superpowers/plans/2026-05-30-tmdb-id-show-identity-spine.md
+++ b/docs/superpowers/plans/2026-05-30-tmdb-id-show-identity-spine.md
@@ -1,0 +1,1442 @@
+# TMDB-ID Show-Identity Spine + Same-Name Collision Review — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `tmdb_id` a first-class identity that flows through subtitle download → matcher reference selection → corpus lookup, detect genuinely-ambiguous same-name TMDB collisions and route them into the existing re-identify review workflow, and add a corpus guard that refuses a precomputed corpus whose `tmdb_id` contradicts the job's resolved id.
+
+**Architecture:** `tmdb_id` is threaded as an **optional** companion to the existing show-name string. Where present it is authoritative (corpus guard, download id); where absent, behavior falls back to today's name-based logic — backward-compatible, no cache migration. Collision detection lives in `tmdb_classifier`; ambiguity propagates through `analyst._apply_tmdb_signal` into the existing `needs_review`/`review_reason` path, which the coordinator already routes to `transition_to_review` and the `ReIdentifyModal` already surfaces.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLModel/aiosqlite, pytest (async), `uv` for all commands. Backend lives in `backend/`; run everything from there with `uv run …`.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-tmdb-id-show-identity-spine-design.md`
+
+**Conventions for every task:**
+- All commands run from `backend/` unless stated. Use `uv run pytest …`, `uv run ruff check .`, `uv run ruff format .`.
+- Ruff: line length 100, double quotes. Run `uv run ruff format .` before each commit.
+- Worktree note: the worktree's `backend/engram.db` may be a 0-byte stub. Unit tests below do **not** need the DB. If a test errors with `no such table: app_config`, that's the empty-DB env gap, not your code.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/app/core/tmdb_classifier.py` | Name→TMDB classification | Add `TmdbSignal.ambiguous_identity`/`candidates`; materiality constants; `_search_tmdb` returns raw results; collision detection + gate in `classify_from_tmdb` |
+| `backend/app/core/analyst.py` | Disc analysis result assembly | `_apply_tmdb_signal` propagates ambiguity → clear `tmdb_id`, set `needs_review`/`review_reason` |
+| `backend/app/services/identification_coordinator.py` | Identification orchestration | Skip subtitle download when ambiguous identity; thread `tmdb_id` into subtitle-download call sites + re-identify restart |
+| `backend/app/matcher/episode_identification.py` | Corpus lookup + matcher | `precomputed_covers_season(expected_tmdb_id=…)`; `EpisodeMatcher.expected_tmdb_id`; guard in `_load_precomputed_season` before stale-prune |
+| `backend/app/matcher/testing_service.py` | Subtitle download entrypoint | `download_subtitles(tmdb_id=…)` bypasses `fetch_show_id`; `_precomputed_skip_result(expected_tmdb_id=…)` |
+| `backend/app/services/matching_coordinator.py` | Match + subtitle orchestration | `tmdb_id` params on `download_subtitles`/`start_subtitle_download`/`restart_subtitle_download`; `_match_single_file_inner` passes `job.tmdb_id` |
+| `backend/app/core/curator.py` | Matcher integration | `match_single_file(tmdb_id=…)`; `_ensure_initialized` uses known id (skips `fetch_show_id`) + passes `expected_tmdb_id` to `EpisodeMatcher` |
+| `backend/tests/unit/…`, `backend/tests/integration/…` | Tests | New unit + integration tests |
+
+**Out of scope (later items):** on-disk cache re-key/migration (item 2); the noise-floor "wrong show" UX signal (item 3); the chromaprint/LLM `fetch_show_id(series_name)` calls in `curator._chromaprint_prepass`/`_match_via_llm` (documented follow-up — Frasier uses the ASR path, which this plan covers).
+
+---
+
+## Task 1: TmdbSignal carries ambiguity + materiality constants
+
+**Files:**
+- Modify: `backend/app/core/tmdb_classifier.py`
+- Test: `backend/tests/unit/test_tmdb_classifier_collision.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_tmdb_classifier_collision.py`:
+
+```python
+from app.core.tmdb_classifier import (
+    AMBIGUOUS_POPULARITY_FLOOR,
+    AMBIGUOUS_POPULARITY_RATIO,
+    TmdbSignal,
+)
+from app.models.disc_job import ContentType
+
+
+def test_tmdb_signal_defaults_not_ambiguous():
+    sig = TmdbSignal(content_type=ContentType.TV, confidence=0.7, tmdb_id=3452, tmdb_name="Frasier")
+    assert sig.ambiguous_identity is False
+    assert sig.candidates is None
+
+
+def test_tmdb_signal_can_carry_candidates():
+    cands = [{"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6}]
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=None,
+        tmdb_name="Frasier",
+        ambiguous_identity=True,
+        candidates=cands,
+    )
+    assert sig.ambiguous_identity is True
+    assert sig.candidates == cands
+
+
+def test_materiality_constants_have_sane_defaults():
+    assert AMBIGUOUS_POPULARITY_FLOOR == 10.0
+    assert AMBIGUOUS_POPULARITY_RATIO == 4.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -v`
+Expected: FAIL — `ImportError` for `AMBIGUOUS_POPULARITY_FLOOR` / `TypeError` for unexpected `ambiguous_identity` kwarg.
+
+- [ ] **Step 3: Add constants and extend TmdbSignal**
+
+In `backend/app/core/tmdb_classifier.py`, add the constants near the top (below `HIGH_POPULARITY_THRESHOLD = 50`):
+
+```python
+# Same-name collision detection (item 1). Flag a job for review only when two
+# distinct same-name TMDB shows are BOTH plausibly real: the runner-up clears
+# this popularity floor AND the top/second popularity ratio is small enough that
+# popularity is not a confident pick. Dominant-twin cases (e.g. Frasier 1993 vs
+# 2023 revival) intentionally fall through — they have no identify-time signal
+# and are handled downstream (item 3). Tunable.
+AMBIGUOUS_POPULARITY_FLOOR = 10.0
+AMBIGUOUS_POPULARITY_RATIO = 4.0
+```
+
+Replace the `TmdbSignal` class with the extended version (add two `__slots__` + ctor args):
+
+```python
+class TmdbSignal:
+    """Signal from TMDB about content type."""
+
+    __slots__ = (
+        "content_type",
+        "confidence",
+        "tmdb_id",
+        "tmdb_name",
+        "ambiguous_identity",
+        "candidates",
+    )
+
+    def __init__(
+        self,
+        content_type: ContentType,
+        confidence: float,
+        tmdb_id: int | None = None,
+        tmdb_name: str | None = None,
+        ambiguous_identity: bool = False,
+        candidates: list[dict] | None = None,
+    ):
+        self.content_type = content_type
+        self.confidence = confidence
+        self.tmdb_id = tmdb_id
+        self.tmdb_name = tmdb_name
+        self.ambiguous_identity = ambiguous_identity
+        self.candidates = candidates
+
+    def __repr__(self) -> str:
+        return (
+            f"TmdbSignal(content_type={self.content_type.value}, "
+            f"confidence={self.confidence:.0%}, tmdb_id={self.tmdb_id}, "
+            f"tmdb_name={self.tmdb_name!r}, ambiguous_identity={self.ambiguous_identity})"
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uv run ruff format app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git add app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git commit -m "feat(tmdb): TmdbSignal carries ambiguous_identity + candidates"
+```
+
+---
+
+## Task 2: `_search_tmdb` returns raw results alongside the best match
+
+The collision gate needs the full TV result list, which `_search_tmdb` currently discards. Change its return to `(best, results)` and update the three call sites in `classify_from_tmdb`. `_search_tmdb` is module-private (only called inside `classify_from_tmdb`), so this is a safe local contract change.
+
+**Files:**
+- Modify: `backend/app/core/tmdb_classifier.py`
+- Test: `backend/tests/unit/test_tmdb_classifier_collision.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_tmdb_classifier_collision.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+import app.core.tmdb_classifier as tc
+
+
+def _resp(results):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {"results": results}
+    return r
+
+
+def test_search_tmdb_returns_best_and_results():
+    results = [
+        {"id": 1, "name": "Frasier", "popularity": 75.6},
+        {"id": 2, "name": "Frasier", "popularity": 5.7},
+    ]
+    with patch.object(tc.requests, "get", return_value=_resp(results)):
+        best, raw = tc._search_tmdb(tc.TMDB_SEARCH_TV_URL, "Frasier", {}, {}, 5.0)
+    assert best is not None and best["id"] == 1
+    assert raw == results
+
+
+def test_search_tmdb_empty_returns_none_and_empty_list():
+    with patch.object(tc.requests, "get", return_value=_resp([])):
+        best, raw = tc._search_tmdb(tc.TMDB_SEARCH_TV_URL, "Nothing", {}, {}, 5.0)
+    assert best is None
+    assert raw == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -k search_tmdb -v`
+Expected: FAIL — `_search_tmdb` returns a single dict/None, so tuple-unpacking raises `TypeError` / `cannot unpack non-iterable`.
+
+- [ ] **Step 3: Change `_search_tmdb` to return a tuple and update callers**
+
+Replace the body of `_search_tmdb` so every return path yields `(best_or_None, results_list)`:
+
+```python
+def _search_tmdb(
+    url: str,
+    query: str,
+    headers: dict,
+    base_params: dict,
+    timeout: float,
+) -> tuple[dict | None, list[dict]]:
+    """Search a TMDB endpoint; return (best-matching result, all raw results).
+
+    Prefers results whose name closely matches the query over raw popularity.
+    The raw list lets callers detect same-name collisions.
+    """
+    params = {**base_params, "query": query}
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=timeout)
+        if response.status_code == 200:
+            results = response.json().get("results", [])
+            if not results:
+                return None, []
+            if len(results) == 1:
+                return results[0], results
+            best = results[0]
+            best_name = best.get("name", best.get("title", ""))
+            best_sim = _name_similarity(query, best_name)
+            for r in results[1:5]:
+                r_name = r.get("name", r.get("title", ""))
+                r_sim = _name_similarity(query, r_name)
+                if r_sim > best_sim:
+                    best, best_sim = r, r_sim
+            return best, results
+    except (requests.RequestException, ConnectionError, TimeoutError):
+        pass
+    return None, []
+```
+
+In `classify_from_tmdb`, update the three search call sites to unpack the tuple. Replace:
+
+```python
+    tv_result = _search_tmdb(TMDB_SEARCH_TV_URL, name, headers, base_params, timeout)
+    movie_result = _search_tmdb(TMDB_SEARCH_MOVIE_URL, name, headers, base_params, timeout)
+```
+
+with:
+
+```python
+    tv_result, tv_results = _search_tmdb(TMDB_SEARCH_TV_URL, name, headers, base_params, timeout)
+    movie_result, _ = _search_tmdb(TMDB_SEARCH_MOVIE_URL, name, headers, base_params, timeout)
+```
+
+And in the variation-retry loop, replace:
+
+```python
+            tv_result = _search_tmdb(TMDB_SEARCH_TV_URL, variation, headers, base_params, timeout)
+            movie_result = _search_tmdb(
+                TMDB_SEARCH_MOVIE_URL, variation, headers, base_params, timeout
+            )
+```
+
+with:
+
+```python
+            tv_result, tv_results = _search_tmdb(
+                TMDB_SEARCH_TV_URL, variation, headers, base_params, timeout
+            )
+            movie_result, _ = _search_tmdb(
+                TMDB_SEARCH_MOVIE_URL, variation, headers, base_params, timeout
+            )
+```
+
+Initialize `tv_results: list[dict] = []` before the first search so the variable always exists for Task 3.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uv run ruff format app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git add app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git commit -m "refactor(tmdb): _search_tmdb returns raw results for collision detection"
+```
+
+---
+
+## Task 3: Materiality-gated collision detection in `classify_from_tmdb`
+
+**Files:**
+- Modify: `backend/app/core/tmdb_classifier.py`
+- Test: `backend/tests/unit/test_tmdb_classifier_collision.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_tmdb_classifier_collision.py`:
+
+```python
+def _patch_searches(tv_results, movie_results=None):
+    """Patch _search_tmdb to return canned TV/movie results regardless of URL."""
+    movie_results = movie_results or []
+
+    def fake(url, query, headers, params, timeout):
+        if url == tc.TMDB_SEARCH_TV_URL:
+            return (tv_results[0] if tv_results else None), tv_results
+        return (movie_results[0] if movie_results else None), movie_results
+
+    return patch.object(tc, "_search_tmdb", side_effect=fake)
+
+
+def test_collision_flagged_when_both_substantial_and_close():
+    # One Piece: anime 1999 p60 vs live-action 2023 p38.3 -> ratio 1.57, both >= 10
+    tv = [
+        {"id": 37854, "name": "One Piece", "popularity": 60.0, "first_air_date": "1999-10-20"},
+        {"id": 111110, "name": "One Piece", "popularity": 38.3, "first_air_date": "2023-08-31"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("One Piece", "k" * 41)
+    assert sig is not None
+    assert sig.ambiguous_identity is True
+    assert sig.tmdb_id is not None  # tentative best still reported
+    ids = {c["tmdb_id"] for c in sig.candidates}
+    assert ids == {37854, 111110}
+
+
+def test_dominant_twin_not_flagged():
+    # Frasier: 1993 p75.6 vs 2023 p5.7 -> ratio 13.3 AND runner-up below floor.
+    tv = [
+        {"id": 3452, "name": "Frasier", "popularity": 75.6, "first_air_date": "1993-09-16"},
+        {"id": 195241, "name": "Frasier", "popularity": 5.7, "first_air_date": "2023-10-12"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Frasier", "k" * 41)
+    assert sig is not None
+    assert sig.ambiguous_identity is False
+
+
+def test_noise_twin_not_flagged():
+    # Yellowstone 2018 p159 vs 2009 p1.2 -> runner-up below floor.
+    tv = [
+        {"id": 73586, "name": "Yellowstone", "popularity": 159.7, "first_air_date": "2018-06-20"},
+        {"id": 19355, "name": "Yellowstone", "popularity": 1.2, "first_air_date": "2009-01-01"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Yellowstone", "k" * 41)
+    assert sig.ambiguous_identity is False
+
+
+def test_unique_name_not_flagged():
+    tv = [{"id": 1396, "name": "Breaking Bad", "popularity": 300.0, "first_air_date": "2008-01-20"}]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Breaking Bad", "k" * 41)
+    assert sig.ambiguous_identity is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -k "collision or twin or unique" -v`
+Expected: FAIL — `ambiguous_identity` stays `False` (detection not implemented).
+
+- [ ] **Step 3: Add the detection helper and apply it to the TV signal**
+
+In `backend/app/core/tmdb_classifier.py`, add a helper above `classify_from_tmdb`:
+
+```python
+def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] | None:
+    """Return same-name collision candidates when the materiality gate fires, else None.
+
+    "Same-name" = normalized name equals the query's (>= 0.95 similarity). The gate
+    fires only when the top two distinct same-name shows are BOTH plausibly real:
+    runner-up popularity >= AMBIGUOUS_POPULARITY_FLOOR AND
+    top/second popularity ratio <= AMBIGUOUS_POPULARITY_RATIO.
+    """
+    same = []
+    seen_ids = set()
+    for r in results:
+        rid = r.get("id")
+        if rid in seen_ids:
+            continue
+        name = r.get("name", r.get("original_name", ""))
+        if _name_similarity(query, name) >= 0.95:
+            seen_ids.add(rid)
+            same.append(r)
+    if len(same) < 2:
+        return None
+    same.sort(key=lambda r: r.get("popularity", 0.0), reverse=True)
+    top, second = same[0].get("popularity", 0.0), same[1].get("popularity", 0.0)
+    if second < AMBIGUOUS_POPULARITY_FLOOR:
+        return None
+    if second <= 0 or (top / second) > AMBIGUOUS_POPULARITY_RATIO:
+        return None
+    return [
+        {
+            "tmdb_id": r["id"],
+            "name": r.get("name", r.get("original_name", "")),
+            "year": (r.get("first_air_date") or "")[:4],
+            "popularity": round(r.get("popularity", 0.0), 1),
+        }
+        for r in same
+    ]
+```
+
+Then, in `classify_from_tmdb`, immediately before **each** path that returns a TV signal via `_make_tv_signal(...)`, the cleanest single insertion point is to wrap the final return. Replace the tail of the function (from the `if tv_result and movie_result:` block's TV returns down to the bottom) is error-prone; instead capture the signal once. Restructure the function's return points so TV signals pass through a helper. Add this helper:
+
+```python
+def _maybe_flag_tv_ambiguity(signal: TmdbSignal, query: str, tv_results: list[dict]) -> TmdbSignal:
+    """Attach same-name collision info to a TV signal when the gate fires."""
+    if signal.content_type != ContentType.TV:
+        return signal
+    candidates = _detect_same_name_candidates(query, tv_results)
+    if candidates:
+        signal.ambiguous_identity = True
+        signal.candidates = candidates
+        logger.info(
+            f"TMDB: same-name collision for '{query}' — candidates "
+            + ", ".join(f"{c['name']} ({c['year']}, id={c['tmdb_id']})" for c in candidates)
+        )
+    return signal
+```
+
+Now wrap every `return _make_tv_signal(...)` in `classify_from_tmdb` with `_maybe_flag_tv_ambiguity(..., name, tv_results)`. There are four such returns (lines for `sim_diff` branch, the `ratio < 2` ambiguous branch, the `tv_pop >= movie_pop` branch, and the `if tv_result:` tail). Example — change:
+
+```python
+            if tv_sim > movie_sim:
+                return _make_tv_signal(tv_result)
+```
+to:
+```python
+            if tv_sim > movie_sim:
+                return _maybe_flag_tv_ambiguity(_make_tv_signal(tv_result), name, tv_results)
+```
+
+Apply the same wrap to:
+- `return _make_tv_signal(tv_result, ambiguous=True)` → `return _maybe_flag_tv_ambiguity(_make_tv_signal(tv_result, ambiguous=True), name, tv_results)`
+- the `if tv_pop >= movie_pop: return _make_tv_signal(tv_result)` → wrapped
+- the final `if tv_result: return _make_tv_signal(tv_result)` → wrapped
+
+Leave all `_make_movie_signal(...)` returns unchanged (movies have no corpus collision).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py -v`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+uv run ruff format app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git add app/core/tmdb_classifier.py tests/unit/test_tmdb_classifier_collision.py
+git commit -m "feat(tmdb): materiality-gated same-name collision detection"
+```
+
+---
+
+## Task 4: Analyst propagates ambiguity into review fields
+
+`analyst._apply_tmdb_signal` is the single point where a `TmdbSignal` becomes part of `DiscAnalysisResult`. When the signal is ambiguous, it must NOT commit a `tmdb_id`, and must force review with a candidate-naming reason.
+
+**Files:**
+- Modify: `backend/app/core/analyst.py`
+- Test: `backend/tests/unit/test_analyst_ambiguity.py` (create)
+
+- [ ] **Step 1: Read the current method**
+
+Read `backend/app/core/analyst.py` around `_apply_tmdb_signal` (≈ lines 443–476) to confirm the exact field assignments before editing.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/tests/unit/test_analyst_ambiguity.py`:
+
+```python
+from app.core.analyst import DiscAnalysisResult, DiscAnalyst
+from app.core.tmdb_classifier import TmdbSignal
+from app.models.disc_job import ContentType
+
+
+def test_ambiguous_signal_clears_id_and_forces_review():
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=3452,
+        tmdb_name="Frasier",
+        ambiguous_identity=True,
+        candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+        ],
+    )
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.tmdb_id is None
+    assert out.needs_review is True
+    assert out.review_reason and "Frasier" in out.review_reason
+    assert "1993" in out.review_reason and "2023" in out.review_reason
+
+
+def test_non_ambiguous_signal_sets_id_normally():
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(content_type=ContentType.TV, confidence=0.85, tmdb_id=1396, tmdb_name="Breaking Bad")
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.tmdb_id == 1396
+    assert out.needs_review is False
+```
+
+(If `DiscAnalysisResult`'s constructor requires more fields, check its dataclass definition near the top of `analyst.py` and add the minimal required kwargs — it uses defaults for `needs_review=False`, `review_reason=None`, `tmdb_id=None`.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_analyst_ambiguity.py -v`
+Expected: FAIL — ambiguous case still sets `tmdb_id=3452`, `needs_review=False`.
+
+- [ ] **Step 4: Implement ambiguity propagation**
+
+In `_apply_tmdb_signal`, after the early `if tmdb_signal is None or tmdb_signal.content_type == ContentType.UNKNOWN: return result` guard and BEFORE `result.tmdb_id = tmdb_signal.tmdb_id`, insert:
+
+```python
+        # Same-name collision (item 1): two real same-name TMDB shows. Don't commit
+        # an id — force review and let the user pick via the existing re-identify UI.
+        if getattr(tmdb_signal, "ambiguous_identity", False):
+            result.tmdb_id = None
+            result.tmdb_name = tmdb_signal.tmdb_name
+            result.content_type = tmdb_signal.content_type
+            result.needs_review = True
+            cands = tmdb_signal.candidates or []
+            listed = "; ".join(f"{c['name']} ({c['year']}, #{c['tmdb_id']})" for c in cands)
+            result.review_reason = (
+                f'Multiple shows match "{tmdb_signal.tmdb_name}" on TMDB: {listed}. '
+                f"Pick the correct one."
+            )
+            return result
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_analyst_ambiguity.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Format + commit**
+
+```bash
+uv run ruff format app/core/analyst.py tests/unit/test_analyst_ambiguity.py
+git add app/core/analyst.py tests/unit/test_analyst_ambiguity.py
+git commit -m "feat(analyst): ambiguous TMDB signal forces review, withholds tmdb_id"
+```
+
+---
+
+## Task 5: Skip subtitle download for ambiguous-identity jobs
+
+`_run_classification` stashes the signal on `analysis._tmdb_signal`. In the identify flow, subtitle download starts (for TV with title+season) *before* the `needs_review` branch — for an ambiguous job that would download the wrong show's subtitles. Guard it.
+
+**Files:**
+- Modify: `backend/app/services/identification_coordinator.py`
+
+- [ ] **Step 1: Locate the subtitle-download trigger**
+
+In `identification_coordinator.py`, find the block (≈ lines 306–316):
+
+```python
+                # Start subtitle download for ALL TV content
+                if (
+                    job.content_type == ContentType.TV
+                    and job.detected_title
+                    and job.detected_season
+                ):
+                    self._start_subtitle_download(job_id, job.detected_title, job.detected_season)
+```
+
+- [ ] **Step 2: Add the ambiguity guard**
+
+Replace the condition with one that also checks the stashed signal:
+
+```python
+                # Start subtitle download for ALL TV content — except when identity is
+                # ambiguous (same-name collision). Downloading by the tentative name would
+                # fetch the wrong show's subtitles before the user disambiguates.
+                _amb = bool(
+                    getattr(analysis, "_tmdb_signal", None)
+                    and getattr(analysis._tmdb_signal, "ambiguous_identity", False)
+                )
+                if (
+                    job.content_type == ContentType.TV
+                    and job.detected_title
+                    and job.detected_season
+                    and not _amb
+                ):
+                    self._start_subtitle_download(job_id, job.detected_title, job.detected_season)
+```
+
+(The `tmdb_id` argument is added to this call in Task 7; leave it 3-arg for now.)
+
+- [ ] **Step 3: Verify the existing test suite still imports/loads**
+
+Run: `uv run pytest tests/unit/ -q`
+Expected: PASS (no import errors; existing unit tests unaffected).
+
+- [ ] **Step 4: Format + commit**
+
+```bash
+uv run ruff format app/services/identification_coordinator.py
+git add app/services/identification_coordinator.py
+git commit -m "feat(identify): skip subtitle download for ambiguous-identity jobs"
+```
+
+---
+
+## Task 6: Corpus guard — refuse a precomputed corpus whose tmdb_id contradicts the job
+
+**Files:**
+- Modify: `backend/app/matcher/episode_identification.py`
+- Test: `backend/tests/unit/test_precomputed_guard.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_precomputed_guard.py`:
+
+```python
+from app.matcher.episode_identification import precomputed_covers_season
+
+
+def _manifest(tmdb_id):
+    return {"shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {"1": 24}}}}
+
+
+def test_guard_rejects_mismatched_tmdb_id(tmp_path):
+    # Manifest says Frasier == 3452; job expects 195241 -> no coverage, regardless of files.
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=195241
+        )
+        is False
+    )
+
+
+def test_guard_skipped_when_no_expected_id(tmp_path):
+    # No expected id -> guard does not apply; falls through to file existence (absent -> False).
+    assert (
+        precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452"))
+        is False
+    )
+
+
+def test_guard_passes_on_matching_id_then_checks_files(tmp_path):
+    # Matching id -> guard passes; files absent so coverage is still False (file gate).
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+        )
+        is False
+    )
+    # Create the on-disk files so the file gate passes too.
+    show_dir = tmp_path / "precomputed" / "Frasier"
+    show_dir.mkdir(parents=True)
+    (show_dir / "S01.npz").write_bytes(b"x")
+    (show_dir / "S01.index.json").write_text("[]")
+    assert (
+        precomputed_covers_season(
+            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+        )
+        is True
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_precomputed_guard.py -v`
+Expected: FAIL — `precomputed_covers_season` has no `expected_tmdb_id` kwarg (`TypeError`).
+
+- [ ] **Step 3: Add `expected_tmdb_id` to `precomputed_covers_season`**
+
+Change the signature and add the guard right after `show_entry` is fetched:
+
+```python
+def precomputed_covers_season(
+    cache_dir, show_name: str, season: int, manifest=None, expected_tmdb_id=None
+) -> bool:
+```
+
+After:
+
+```python
+    show_entry = manifest.get("shows", {}).get(show_name)
+    if not show_entry or season not in show_entry.get("seasons", []):
+        return False
+```
+
+insert:
+
+```python
+    # Corpus guard (item 1): if the job knows its TMDB id and it contradicts the
+    # manifest entry's id, this precomputed corpus is for a DIFFERENT same-named
+    # show — refuse it so we never match e.g. the Frasier 2023 revival against the
+    # 1993 corpus. Skipped when either id is unknown (backward-compatible).
+    entry_id = show_entry.get("tmdb_id")
+    if expected_tmdb_id is not None and entry_id is not None and str(entry_id) != str(
+        expected_tmdb_id
+    ):
+        return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_precomputed_guard.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run ruff format app/matcher/episode_identification.py tests/unit/test_precomputed_guard.py
+git add app/matcher/episode_identification.py tests/unit/test_precomputed_guard.py
+git commit -m "feat(matcher): precomputed_covers_season honors expected_tmdb_id guard"
+```
+
+---
+
+## Task 7: EpisodeMatcher carries `expected_tmdb_id`; guard before stale-prune
+
+The matcher must pass its known id into the guard, and `_load_precomputed_season`'s stale-prune branch must NOT wrongly prune a valid entry when the guard rejects on id mismatch (the files exist; it's just the wrong show).
+
+**Files:**
+- Modify: `backend/app/matcher/episode_identification.py`
+- Test: `backend/tests/unit/test_precomputed_guard.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_precomputed_guard.py`:
+
+```python
+from app.matcher.episode_identification import EpisodeMatcher
+
+
+def test_matcher_stores_expected_tmdb_id(tmp_path):
+    m = EpisodeMatcher(cache_dir=tmp_path, show_name="Frasier", expected_tmdb_id=195241)
+    assert m.expected_tmdb_id == 195241
+
+
+def test_load_precomputed_returns_none_on_id_mismatch_without_pruning(tmp_path, monkeypatch):
+    m = EpisodeMatcher(cache_dir=tmp_path, show_name="Frasier", expected_tmdb_id=195241)
+    manifest = {"shows": {"Frasier": {"tmdb_id": "3452", "seasons": [1], "episode_counts": {"1": 24}}}}
+    monkeypatch.setattr(m, "_load_precomputed_manifest", lambda: manifest)
+    assert m._load_precomputed_season(1) is None
+    # The valid 3452 entry must survive (not pruned as "files missing").
+    assert manifest["shows"]["Frasier"]["seasons"] == [1]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_precomputed_guard.py -k "matcher or mismatch" -v`
+Expected: FAIL — `EpisodeMatcher.__init__` has no `expected_tmdb_id` (`TypeError`).
+
+- [ ] **Step 3: Add the constructor param + guard logic**
+
+In `EpisodeMatcher.__init__`, add the parameter (after `show_name`) and store it:
+
+```python
+    def __init__(
+        self,
+        cache_dir,
+        show_name,
+        min_confidence=0.6,
+        device=None,
+        use_ranked_voting=True,
+        min_vote_count=2,
+        match_threshold=0.10,
+        model_name="small",
+        expected_tmdb_id=None,
+    ):
+        self.cache_dir = Path(cache_dir)
+        self.min_confidence = min_confidence
+        self.show_name = show_name
+        self.expected_tmdb_id = expected_tmdb_id
+```
+
+(Keep the rest of `__init__` unchanged.)
+
+In `_load_precomputed_season`, pass the id into the gate and special-case the mismatch so the prune branch is skipped. Replace:
+
+```python
+        manifest = self._load_precomputed_manifest()
+        if not precomputed_covers_season(
+            self.cache_dir, self.show_name, season_number, manifest=manifest
+        ):
+            # Prune the stale season in-memory so the warning fires at most once per matcher.
+            show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
+            if show_entry and season_number in show_entry.get("seasons", []):
+                logger.warning(
+                    f"Precomputed cache lists {self.show_name} S{season_number:02d} "
+                    f"but its files are missing; using scraping"
+                )
+                show_entry["seasons"] = [s for s in show_entry["seasons"] if s != season_number]
+                if not show_entry["seasons"]:
+                    manifest["shows"].pop(self.show_name, None)
+            return None
+```
+
+with:
+
+```python
+        manifest = self._load_precomputed_manifest()
+        # Corpus guard: a positive tmdb_id mismatch means the manifest entry is a
+        # different same-named show. Bail BEFORE the stale-prune branch so we don't
+        # wrongly drop a valid entry whose files are present.
+        show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
+        entry_id = show_entry.get("tmdb_id") if show_entry else None
+        if (
+            self.expected_tmdb_id is not None
+            and entry_id is not None
+            and str(entry_id) != str(self.expected_tmdb_id)
+        ):
+            logger.warning(
+                f"Precomputed corpus for '{self.show_name}' is tmdb_id {entry_id} but this "
+                f"job resolved tmdb_id {self.expected_tmdb_id}; skipping precomputed (wrong show)"
+            )
+            return None
+        if not precomputed_covers_season(
+            self.cache_dir,
+            self.show_name,
+            season_number,
+            manifest=manifest,
+            expected_tmdb_id=self.expected_tmdb_id,
+        ):
+            # Prune the stale season in-memory so the warning fires at most once per matcher.
+            if show_entry and season_number in show_entry.get("seasons", []):
+                logger.warning(
+                    f"Precomputed cache lists {self.show_name} S{season_number:02d} "
+                    f"but its files are missing; using scraping"
+                )
+                show_entry["seasons"] = [s for s in show_entry["seasons"] if s != season_number]
+                if not show_entry["seasons"]:
+                    manifest["shows"].pop(self.show_name, None)
+            return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_precomputed_guard.py -v`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run ruff format app/matcher/episode_identification.py tests/unit/test_precomputed_guard.py
+git add app/matcher/episode_identification.py tests/unit/test_precomputed_guard.py
+git commit -m "feat(matcher): EpisodeMatcher.expected_tmdb_id drives corpus guard"
+```
+
+---
+
+## Task 8: Subtitle download bypasses `fetch_show_id` when tmdb_id is known
+
+**Files:**
+- Modify: `backend/app/matcher/testing_service.py`
+- Test: `backend/tests/unit/test_download_subtitles_tmdb_id.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_download_subtitles_tmdb_id.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.matcher.testing_service as ts
+
+
+def test_download_subtitles_uses_known_id_and_skips_fetch_show_id():
+    """When tmdb_id is supplied, fetch_show_id is never called; the id is used directly."""
+    fake_fetch_show_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+    with (
+        patch.object(ts, "fetch_show_id", fake_fetch_show_id),
+        patch.object(ts, "fetch_show_details", return_value={"name": "Frasier"}),
+        patch.object(ts, "fetch_season_details", return_value=0) as season,
+        patch.object(ts, "_precomputed_skip_result", return_value=None),
+    ):
+        # season count 0 -> raises ValueError AFTER id resolution, which is fine:
+        # we only assert that fetch_show_id was bypassed and the known id was used.
+        with pytest.raises(ValueError):
+            ts.download_subtitles("Frasier", 1, tmdb_id=195241)
+    fake_fetch_show_id.assert_not_called()
+    season.assert_called_once_with("195241", 1)
+
+
+def test_download_subtitles_without_id_still_resolves_by_name():
+    with (
+        patch.object(ts, "fetch_show_id", return_value="3452") as fid,
+        patch.object(ts, "fetch_show_details", return_value={"name": "Frasier"}),
+        patch.object(ts, "fetch_season_details", return_value=0),
+        patch.object(ts, "_precomputed_skip_result", return_value=None),
+    ):
+        with pytest.raises(ValueError):
+            ts.download_subtitles("Frasier", 1)
+    fid.assert_called_once_with("Frasier")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_download_subtitles_tmdb_id.py -v`
+Expected: FAIL — `download_subtitles` has no `tmdb_id` kwarg (`TypeError`).
+
+- [ ] **Step 3: Add `tmdb_id` and the bypass**
+
+Change the signature:
+
+```python
+def download_subtitles(
+    show_name: str, season: int, *, tmdb_id: int | None = None, use_precomputed: bool = True
+) -> dict:
+```
+
+Thread `expected_tmdb_id` into the two precomputed fast-path checks. Replace:
+
+```python
+    if use_precomputed:
+        skip = _precomputed_skip_result(cache_path, show_name, season)
+        if skip is not None:
+            return skip
+
+    # Get TMDB show ID to determine episode count
+    show_id = fetch_show_id(show_name)
+    if not show_id:
+        raise ValueError(f"Could not find show '{show_name}' on TMDB")
+```
+
+with:
+
+```python
+    if use_precomputed:
+        skip = _precomputed_skip_result(cache_path, show_name, season, expected_tmdb_id=tmdb_id)
+        if skip is not None:
+            return skip
+
+    # Resolve the TMDB show id. When the caller already knows it (e.g. after the
+    # user disambiguated a same-name collision), use it directly — fetch_show_id
+    # resolves by NAME and cannot tell two same-named shows apart.
+    if tmdb_id is not None:
+        show_id = str(tmdb_id)
+    else:
+        show_id = fetch_show_id(show_name)
+        if not show_id:
+            raise ValueError(f"Could not find show '{show_name}' on TMDB")
+```
+
+And the canonical-name retry fast path — replace:
+
+```python
+        if use_precomputed:
+            skip = _precomputed_skip_result(cache_path, canonical_show_name, season)
+            if skip is not None:
+                return skip
+```
+
+with:
+
+```python
+        if use_precomputed:
+            skip = _precomputed_skip_result(
+                cache_path, canonical_show_name, season, expected_tmdb_id=tmdb_id
+            )
+            if skip is not None:
+                return skip
+```
+
+- [ ] **Step 4: Update `_precomputed_skip_result` to honor the id guard**
+
+`_precomputed_skip_result` (≈ line 229) currently calls `precomputed_episode_codes(cache_path, show_name, season)`, which internally calls `precomputed_covers_season` **without** the id — so it would still return a (wrong-show) skip result on an id mismatch. Add an explicit guard check first. Change the signature and the top of the body. Replace:
+
+```python
+def _precomputed_skip_result(cache_path: Path, show_name: str, season: int) -> dict | None:
+    """Build a 'skip download' result when the precomputed cache covers the season.
+
+    Returns None when the cache doesn't cover ``show_name`` S``season``. The result
+    is sized from the cache's own episode index (no TMDB call), so it works even
+    when TMDB is unreachable — the whole point of the precomputed cache.
+    """
+    from app.matcher.episode_identification import precomputed_episode_codes
+
+    codes = precomputed_episode_codes(cache_path, show_name, season)
+    if not codes:
+        return None
+```
+
+with:
+
+```python
+def _precomputed_skip_result(
+    cache_path: Path, show_name: str, season: int, expected_tmdb_id: int | None = None
+) -> dict | None:
+    """Build a 'skip download' result when the precomputed cache covers the season.
+
+    Returns None when the cache doesn't cover ``show_name`` S``season``. The result
+    is sized from the cache's own episode index (no TMDB call), so it works even
+    when TMDB is unreachable — the whole point of the precomputed cache.
+
+    ``expected_tmdb_id`` applies the corpus guard: a precomputed corpus whose
+    manifest id contradicts the job's id is for a different same-named show, so
+    we must NOT skip the download against it.
+    """
+    from app.matcher.episode_identification import (
+        precomputed_covers_season,
+        precomputed_episode_codes,
+    )
+
+    # Corpus guard first — returns False on an id mismatch (different same-named show).
+    if not precomputed_covers_season(
+        cache_path, show_name, season, expected_tmdb_id=expected_tmdb_id
+    ):
+        return None
+
+    codes = precomputed_episode_codes(cache_path, show_name, season)
+    if not codes:
+        return None
+```
+
+(The rest of the function — the `logger.info`, `series_cache_dir`, and return dict — is unchanged.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_download_subtitles_tmdb_id.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+uv run ruff format app/matcher/testing_service.py tests/unit/test_download_subtitles_tmdb_id.py
+git add app/matcher/testing_service.py tests/unit/test_download_subtitles_tmdb_id.py
+git commit -m "feat(subtitles): download_subtitles bypasses fetch_show_id with known tmdb_id"
+```
+
+---
+
+## Task 9: Thread tmdb_id through the subtitle-download coordinator chain
+
+`MatchingCoordinator.download_subtitles` → `to_thread(testing_service.download_subtitles, …)` and its `start_subtitle_download` / `restart_subtitle_download` wrappers must carry `tmdb_id`. The identify + re-identify call sites pass `job.tmdb_id`.
+
+**Files:**
+- Modify: `backend/app/services/matching_coordinator.py`
+- Modify: `backend/app/services/identification_coordinator.py`
+
+- [ ] **Step 1: Add `tmdb_id` to the coordinator methods**
+
+In `matching_coordinator.py`, change `download_subtitles`:
+
+```python
+    async def download_subtitles(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
+```
+
+and its `to_thread` call:
+
+```python
+            result = await asyncio.to_thread(
+                download_subtitles, show_name, season, tmdb_id=tmdb_id
+            )
+```
+
+Change `start_subtitle_download`:
+
+```python
+    def start_subtitle_download(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
+        """Start background subtitle download with tracking."""
+        self._subtitle_ready[job_id] = asyncio.Event()
+        self._subtitle_tasks[job_id] = asyncio.create_task(
+            self.download_subtitles(job_id, show_name, season, tmdb_id)
+        )
+```
+
+Change `restart_subtitle_download`:
+
+```python
+    async def restart_subtitle_download(
+        self, job_id: int, show_name: str, season: int, tmdb_id: int | None = None
+    ) -> None:
+```
+
+and its final line:
+
+```python
+        self.start_subtitle_download(job_id, show_name, season, tmdb_id)
+```
+
+- [ ] **Step 2: Pass `job.tmdb_id` at the identify call site**
+
+In `identification_coordinator.py`, the trigger from Task 5 — add the id argument:
+
+```python
+                    self._start_subtitle_download(
+                        job_id, job.detected_title, job.detected_season, job.tmdb_id
+                    )
+```
+
+The other `self._start_subtitle_download(` call is the post-identify "files already exist" path (≈ lines 525–527), where `job` is in scope. Replace:
+
+```python
+                    if job.detected_title and job.detected_season:
+                        self._start_subtitle_download(
+                            job_id, job.detected_title, job.detected_season
+                        )
+```
+
+with:
+
+```python
+                    if job.detected_title and job.detected_season:
+                        self._start_subtitle_download(
+                            job_id, job.detected_title, job.detected_season, job.tmdb_id
+                        )
+```
+
+- [ ] **Step 3: Pass `job.tmdb_id` in the re-identify restart**
+
+In `re_identify` (≈ lines 739–743), change `restart_args` to include the id:
+
+```python
+            restart_args = (
+                (job_id, job.detected_title, job.detected_season, job.tmdb_id)
+                if should_restart_subtitles
+                else None
+            )
+```
+
+`self._restart_subtitle_download(*restart_args)` then forwards the 4th positional arg.
+
+- [ ] **Step 4: Verify imports + suite load**
+
+Run: `uv run pytest tests/unit/ -q`
+Expected: PASS (no import/signature errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+uv run ruff format app/services/matching_coordinator.py app/services/identification_coordinator.py
+git add app/services/matching_coordinator.py app/services/identification_coordinator.py
+git commit -m "feat(subtitles): thread tmdb_id through download coordinator + call sites"
+```
+
+---
+
+## Task 10: Curator + match call thread tmdb_id into the matcher
+
+`curator.match_single_file` gains `tmdb_id`; `_ensure_initialized` uses the known id (skipping `fetch_show_id`) and passes `expected_tmdb_id` to `EpisodeMatcher`. `_match_single_file_inner` passes `job.tmdb_id`.
+
+**Files:**
+- Modify: `backend/app/core/curator.py`
+- Modify: `backend/app/services/matching_coordinator.py`
+- Test: `backend/tests/unit/test_curator_tmdb_id.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_curator_tmdb_id.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+from app.core.curator import EpisodeCurator
+
+
+def test_ensure_initialized_uses_known_id_and_skips_fetch_show_id():
+    cur = EpisodeCurator()
+    captured = {}
+
+    class FakeMatcher:
+        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None):
+            captured["expected_tmdb_id"] = expected_tmdb_id
+            captured["show_name"] = show_name
+
+    fake_fetch_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+    cfg = MagicMock()
+    cfg.subtitles_cache_path = None
+    with (
+        patch("app.matcher.episode_identification.EpisodeMatcher", FakeMatcher),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.matcher.tmdb_client.fetch_show_details", return_value={"name": "Frasier"}),
+        patch("app.services.config_service.get_config_sync", return_value=cfg),
+    ):
+        ok = cur._ensure_initialized("Frasier", tmdb_id=195241)
+    assert ok is True
+    assert captured["expected_tmdb_id"] == 195241
+    fake_fetch_id.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_curator_tmdb_id.py -v`
+Expected: FAIL — `_ensure_initialized` has no `tmdb_id` parameter (`TypeError`).
+
+- [ ] **Step 3: Update `_ensure_initialized` and `match_single_file`**
+
+In `curator.py`, add `_current_tmdb_id` to `__init__`:
+
+```python
+        self._current_show_id: str | None = None
+        self._current_tmdb_id: int | None = None
+```
+
+Change `_ensure_initialized` signature + re-init condition + id resolution:
+
+```python
+    def _ensure_initialized(self, show_name: str, tmdb_id: int | None = None) -> bool:
+        """Lazily initialize the matcher library for a specific show.
+
+        When ``tmdb_id`` is known (e.g. after the user disambiguated a same-name
+        collision), it is used directly instead of resolving by name — and it is
+        passed to EpisodeMatcher as the corpus guard's expected id.
+        """
+        # Re-initialize if show name OR known id changed.
+        if (
+            self._initialized
+            and self._current_show == show_name
+            and self._current_tmdb_id == tmdb_id
+        ):
+            return self._matcher is not None
+
+        self._current_show = show_name
+        self._current_tmdb_id = tmdb_id
+```
+
+Inside the `try:` block, replace the canonical-name resolution so it uses the known id when present:
+
+```python
+            canonical_name = show_name
+            try:
+                if tmdb_id is not None:
+                    resolved_id = tmdb_id
+                    self._current_show_id = str(tmdb_id)
+                else:
+                    resolved_id = fetch_show_id(show_name)
+                    self._current_show_id = str(resolved_id) if resolved_id else None
+                if resolved_id:
+                    details = fetch_show_details(resolved_id)
+                    if details and "name" in details:
+                        canonical_name = details["name"]
+                        logger.info(
+                            f"Resolved '{show_name}' to canonical '{canonical_name}' for matching"
+                        )
+            except Exception as e:
+                logger.warning(f"Failed to resolve canonical name for '{show_name}': {e}")
+```
+
+Update the `EpisodeMatcher(...)` construction to pass the guard id:
+
+```python
+            self._matcher = EpisodeMatcher(
+                cache_dir=self._cache_dir,
+                show_name=canonical_name,
+                min_confidence=self.LOW_CONFIDENCE_THRESHOLD,
+                expected_tmdb_id=tmdb_id,
+            )
+```
+
+Change `match_single_file` signature + the `_ensure_initialized` call inside it:
+
+```python
+    async def match_single_file(
+        self,
+        file_path: Path,
+        series_name: str | None,
+        season: int | None,
+        progress_callback: Callable[..., None] | None = None,
+        num_points: int | None = None,
+        min_vote_count: int | None = None,
+        tmdb_id: int | None = None,
+    ) -> MatchResult:
+```
+
+and:
+
+```python
+        if series_name:
+            initialized = self._ensure_initialized(series_name, tmdb_id)
+```
+
+- [ ] **Step 4: Pass `job.tmdb_id` from the matching coordinator**
+
+In `matching_coordinator.py` `_match_single_file_inner`, change the `match_single_file` call (≈ line 706) to forward the id:
+
+```python
+                result = await episode_curator.match_single_file(
+                    file_path,
+                    series_name=job.detected_title,
+                    season=job.detected_season,
+                    progress_callback=on_progress,
+                    num_points=num_points,
+                    min_vote_count=min_vote_count,
+                    tmdb_id=job.tmdb_id,
+                )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_curator_tmdb_id.py -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+uv run ruff format app/core/curator.py app/services/matching_coordinator.py tests/unit/test_curator_tmdb_id.py
+git add app/core/curator.py app/services/matching_coordinator.py tests/unit/test_curator_tmdb_id.py
+git commit -m "feat(curator): thread tmdb_id into matcher init + corpus guard"
+```
+
+---
+
+## Task 11: Integration test — ambiguous collision routes to review; re-identify re-keys
+
+Validates the end-to-end seams using the app's real async session. Per project guidance, integration tests run against the real app DB — set up state **directly in the DB**, never let the test organize real files.
+
+**Files:**
+- Test: `backend/tests/integration/test_show_identity_collision.py` (create)
+
+- [ ] **Step 1: Write the test**
+
+Create `backend/tests/integration/test_show_identity_collision.py`:
+
+```python
+import pytest
+from sqlalchemy import text
+
+from app.core.analyst import DiscAnalysisResult, DiscAnalyst
+from app.core.tmdb_classifier import TmdbSignal
+from app.database import async_session, init_db
+from app.models.disc_job import ContentType
+
+
+@pytest.fixture(autouse=True)
+async def setup_db():
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs"))
+        await session.commit()
+
+
+def test_ambiguous_signal_produces_review_result_without_id():
+    """The analyst seam: an ambiguous TV signal yields needs_review + no tmdb_id."""
+    analyst = DiscAnalyst()
+    result = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    sig = TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.6,
+        tmdb_id=37854,
+        tmdb_name="One Piece",
+        ambiguous_identity=True,
+        candidates=[
+            {"tmdb_id": 37854, "name": "One Piece", "year": "1999", "popularity": 60.0},
+            {"tmdb_id": 111110, "name": "One Piece", "year": "2023", "popularity": 38.3},
+        ],
+    )
+    out = analyst._apply_tmdb_signal(result, sig)
+    assert out.needs_review is True
+    assert out.tmdb_id is None
+    assert "One Piece" in out.review_reason
+
+
+async def test_match_single_file_forwards_tmdb_id(monkeypatch):
+    """The curator seam: a known tmdb_id reaches _ensure_initialized."""
+    from app.core.curator import EpisodeCurator
+
+    cur = EpisodeCurator()
+    seen = {}
+
+    def fake_ensure(show_name, tmdb_id=None):
+        seen["show_name"] = show_name
+        seen["tmdb_id"] = tmdb_id
+        return False  # matcher unavailable -> fallback path, no real matching
+
+    monkeypatch.setattr(cur, "_ensure_initialized", fake_ensure)
+    from pathlib import Path
+
+    await cur.match_single_file(Path("nonexistent.mkv"), "Frasier", 1, tmdb_id=195241)
+    assert seen == {"show_name": "Frasier", "tmdb_id": 195241}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/integration/test_show_identity_collision.py -v`
+Expected: PASS (2 passed). If it errors with `no such table: app_config`, run once more after `init_db()` populates the worktree DB; the autouse fixture calls it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+uv run ruff format tests/integration/test_show_identity_collision.py
+git add tests/integration/test_show_identity_collision.py
+git commit -m "test(identity): integration coverage for collision review + tmdb_id threading"
+```
+
+---
+
+## Task 12: Full regression + lint sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the unit suite**
+
+Run: `uv run pytest tests/unit/ -q`
+Expected: PASS. Note: `test_movie_ambiguous_rip_first_workflow` is a known pre-existing flaky failure (staging cleanup race) — unrelated to this change.
+
+- [ ] **Step 2: Run the targeted new tests together**
+
+Run: `uv run pytest tests/unit/test_tmdb_classifier_collision.py tests/unit/test_analyst_ambiguity.py tests/unit/test_precomputed_guard.py tests/unit/test_download_subtitles_tmdb_id.py tests/unit/test_curator_tmdb_id.py tests/integration/test_show_identity_collision.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 3: Lint + format check**
+
+Run: `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/`
+Expected: no errors. Fix any reported issues, re-run.
+
+- [ ] **Step 4: Final commit if lint produced changes**
+
+```bash
+git add -A
+git commit -m "chore(identity): lint/format sweep for show-identity spine"
+```
+
+---
+
+## Manual Verification (real disc / simulation — optional, after merge readiness)
+
+Per CLAUDE.md "Real-disc testing setup": run exactly ONE backend against the real config DB (`DATABASE_URL` → the populated `backend/engram.db`), observe via WebSocket + `rip.log`. With the Frasier 2023 disc:
+1. Insert → expect job identifies as Frasier 1993 (dominant), matching abstains → `REVIEW_NEEDED` (this is correct for item 1; item 3 will add the explanatory reason).
+2. Open Re-Identify, pick the 2023 entry → confirm `job.tmdb_id` updates, subtitle download re-runs keyed by id (check `rip.log` / `~/.engram/engram.log` for the id), and the corpus guard logs "skipping precomputed (wrong show)".
+3. Confirm matching then proceeds against the freshly-downloaded 2023 subtitles.
+
+**Cleanup before PR (scoped to this session's ports):** stop the uvicorn/makemkvcon processes this session started (see CLAUDE.md "Parallel sessions / worktree isolation").
+
+---
+
+## Notes / Known Follow-ups (still item 1 scope, low priority)
+
+- `curator._chromaprint_prepass` and the LLM fallback call `fetch_show_id(series_name)` independently (curator ≈ lines 501, 563). For a same-name collision these would also mis-resolve. The Frasier case uses the ASR path (chromaprint gated off), which this plan fixes. A follow-up can thread `tmdb_id` into those two calls the same way (`if tmdb_id: show_id = str(tmdb_id)`). Out of the critical path; do not block this plan on it.
+- `start_subtitle_download_all_seasons` (multi-season import) is left name-keyed; the unknown-season import flow is a separate path and not part of the reported bug.

--- a/docs/superpowers/specs/2026-05-30-tmdb-id-show-identity-spine-design.md
+++ b/docs/superpowers/specs/2026-05-30-tmdb-id-show-identity-spine-design.md
@@ -1,0 +1,268 @@
+# TMDB-ID Show-Identity Spine + Same-Name Collision Review
+
+- **Date:** 2026-05-30
+- **Status:** Design — approved approach, pending spec review
+- **Scope:** Item 1 of a 3-item decomposition (this doc). Items 2 and 3 sketched under "Sequencing".
+
+## Problem
+
+Episode matching can silently abstain when a disc's show name maps to the **wrong TMDB
+show**. Discovered with a "Frasier Season 1" disc that is actually the **Frasier (2023)
+revival** (TMDB `195241`), not the original **Frasier (1993)** (TMDB `3452`). The subtitle
+corpus contains only the original, so every ASR chunk scores at the noise floor
+(~0.03–0.05 cosine) against all 263 original episodes → no match → generic "needs review",
+with no explanation.
+
+The matcher is behaving correctly (it should abstain — there is no right answer in the
+reference set). The defect is **upstream**: identity is carried as a **show-name string**,
+and the `tmdb_id` that *would* disambiguate is computed, stored on the job, and then
+**never used downstream**. Subtitle download (`download_subtitles(show_name, season)`) and
+matching (`match_single_file(series_name=detected_title, …)`) both key on the name only.
+Two same-named shows are indistinguishable by name, so neither automatic nor manual
+re-identification can currently fix it.
+
+### How big is the problem? (empirical, measured against the real 181-show corpus)
+
+| Bucket | Count | Notes |
+|---|---:|---|
+| Any same-name TMDB twin | 54 / 181 (29%) | ≥2 distinct TMDB TV shows normalize to the same name |
+| **Tier A** — both variants substantial (twin popularity ≥ 10) | **~8–9** | Real reboots / international remakes, both with physical media |
+| Tier B — real-but-smaller twin (pop 3–10) | 15 | Includes the reported **Frasier** (75.6 vs 5.7) |
+| Tier C — twin is noise (pop < 3) | 31 | Coincidental / foreign one-offs; effectively never owned or picked |
+| Today's heuristic **actively** mispicks (top-popularity ≠ corpus id) | **1** | `ONE PIECE` (corpus = 2023 live-action; popularity favors 1999 anime) |
+
+Tier A: Avatar: The Last Airbender (2005 vs 2024), Battlestar Galactica (2004/1978/2003),
+Charmed (1998 vs 2018), Doctor Who (2005 vs 1963), One Piece (1999 anime vs 2023
+live-action), Rebelde, Shameless (US 2011 vs UK 2004), The Flash (2014 vs 1990), plus The
+Office (UK/US — scan errored, known collision). Scaled to the full ~599-show curated list,
+expect ~25–30 Tier A and ~50 Tier B.
+
+**Key consequence for the design.** The bug splits into two populations needing *different*
+triggers:
+
+- **Comparable-popularity twins (Tier A):** genuinely ambiguous *at identify time*. A
+  materiality-gated collision check can catch these and route to review. This is item 1's
+  collision-detection win (~8–9 shows).
+- **Dominant-twin mispicks (Frasier, most of Tier B):** popularity *confidently* picks the
+  wrong-for-this-disc show and the disc carries no year — **there is no identify-time
+  signal**. A "flag any 2nd same-name entry" rule would instead nag on 29% of all shows.
+  These are only catchable **downstream**, when matching fails at the noise floor →
+  **item 3 is the real trigger** for the reported Frasier case.
+
+So the reported failure is fixed by the chain: **item 3 explains it → user re-identifies →
+item 1's spine makes the `tmdb_id` pick drive download + matching → corpus then contains the
+right subtitles** (on-demand download by `tmdb_id`; on-disk re-key hardened by item 2).
+
+## Goals
+
+1. Make `tmdb_id` a **first-class identity** that flows through subtitle download → matcher
+   reference selection → corpus lookup, alongside (not replacing) the human-facing show name.
+2. Detect **genuinely-ambiguous same-name collisions** (Tier A) at identify time and route
+   them into the **existing** re-identify review workflow — no new UI.
+3. Add a **corpus guard**: never match a disc against a precomputed corpus whose `tmdb_id`
+   contradicts the job's resolved `tmdb_id` (prevents wrong-corpus false matches; produces a
+   clean "no coverage" outcome that item 3 will explain).
+4. Make manual **re-identify** with a `tmdb_id` actually re-key subtitle download + matching,
+   so a human pick distinguishes 1993 from 2023.
+
+## Non-goals (explicit scope boundaries)
+
+- **No cache re-key / migration.** The on-disk corpus layout
+  (`precomputed/<sanitize_filename(name)>/…`, `data/<sanitize_filename(name)>/…`) stays
+  name-keyed. Making two same-named shows coexist on disk by keying paths on `tmdb_id`
+  (plus rebuilding/migrating the existing cache) is **item 2**.
+- **No new "wrong show / content doesn't resemble reference" UX signal.** That is **item 3**.
+- **No automatic year-based auto-pick.** No disc-year signal exists today (volume labels like
+  "Frasier Season 1" carry none; MakeMKV metadata has no year field), so it would be
+  speculative. Deferred.
+
+## Approach
+
+**Approach A — `tmdb_id` as an optional authoritative companion to the show name.** Thread an
+optional `tmdb_id` parameter alongside the existing name through the download and matching
+call chains. Where `tmdb_id` is present it is authoritative (OpenSubtitles `parent_tmdb_id`,
+`fetch_season_details(tmdb_id)`, corpus guard); where absent (legacy paths, unresolved id)
+behavior falls back to today's name-based logic. Backward-compatible, no cache migration.
+
+Rejected: **B** — a `ShowIdentity{tmdb_id,name,year}` value object passed everywhere (cleaner
+long-term but large signature churn, overlaps item 2); **C** — resolve name→id only at the
+two entry points (smallest, but keeps name-as-identity and can't power the corpus guard).
+
+## Detailed Design
+
+### 1. Identity model
+
+`tmdb_id` becomes an optional parameter threaded through the chain. The show name is retained
+for human display and as the fallback search key. Comparison against the manifest normalizes
+both to `str` (the manifest stores `tmdb_id` as a string, e.g. `"3452"`; the job stores it as
+`int`).
+
+### 2. Collision detection + materiality gate (`backend/app/core/tmdb_classifier.py`)
+
+- Extend the TMDB TV search so `classify_from_tmdb` can see **all same-name candidates**, not
+  just the single best. A candidate is "same-name" when its normalized name (or
+  `original_name`) equals the normalized query.
+- Extend `TmdbSignal` with `ambiguous_identity: bool = False` and
+  `candidates: list[dict] | None = None` (each `{tmdb_id, name, year, popularity}`).
+- **Materiality gate** — flag `ambiguous_identity=True` only when **both** hold for the top
+  two same-name candidates:
+  - `second.popularity >= AMBIGUOUS_POPULARITY_FLOOR` (default **10.0**)
+  - `first.popularity / second.popularity <= AMBIGUOUS_POPULARITY_RATIO` (default **4.0**)
+
+  Thresholds are module-level tunable constants (documented). Behaviour on the real corpus:
+
+  | Show | top vs 2nd popularity | ratio | flagged? |
+  |---|---|---:|:--:|
+  | Avatar: The Last Airbender | 26.9 / 23.0 | 1.17 | ✅ |
+  | Doctor Who | 109.9 / 62.7 | 1.75 | ✅ |
+  | One Piece | 60.0 / 38.3 | 1.57 | ✅ (fixes the 1 active mispick) |
+  | Battlestar Galactica | 38.7 / 13.0 | 2.98 | ✅ |
+  | Rebelde | 30.4 / 15.2 | 2.00 | ✅ |
+  | Charmed | 84.0 / 15.2 | 5.5 | ❌ (dominant → trust popularity; item 3 covers mispick) |
+  | Shameless | 153.5 / 23.4 | 6.6 | ❌ |
+  | **Frasier** | 75.6 / 5.7 | 13.3 | ❌ (by design → item 3) |
+  | Tier C long tail | * / <3 | — | ❌ (floor excludes) |
+
+- When ambiguous, `classify_from_tmdb` still reports the best tentative pick (so non-TV logic
+  is unaffected) but with the flag + candidate list set.
+
+### 3. Review routing (reuse existing workflow — `identification_coordinator.py`)
+
+In `_run_classification`, when the TMDB signal is `ambiguous_identity`:
+
+- **Do not** set `job.tmdb_id` (leave it `None` so nothing downstream commits to a guess).
+- Set `job.review_reason` to a human-readable message naming the candidates, e.g.
+  *"Multiple shows match \"Frasier\" — the 1993 original (#3452) and a 2023 series (#195241).
+  Pick the correct one."* (built from `signal.candidates`).
+- `await self._state_machine.transition_to_review(job, session, reason=…)`.
+
+No frontend work: the dashboard already shows the **Re-Identify** affordance when
+`needsReview && title`, and `ReIdentifyModal` already provides a live `GET /api/tmdb/search`
+candidate picker (name + year + poster + type) that returns `tmdb_id`. The user picks; the
+existing re-identify round trip (§7) carries the chosen id.
+
+### 4. Spine — subtitle download path
+
+Thread `tmdb_id` through:
+
+- `identification_coordinator._start_subtitle_download(job_id, title, season)` → add
+  `tmdb_id` param; pass `job.tmdb_id`.
+- `MatchingCoordinator.download_subtitles(show_name, season, tmdb_id=None)` → pass through.
+- `backend/app/matcher/testing_service.download_subtitles(show_name, season, tmdb_id=None)`:
+  when `tmdb_id` is provided, **bypass `fetch_show_id(name)`** (the collision point — it
+  returns the first name search result) and use `tmdb_id` directly for
+  `fetch_season_details(tmdb_id)` and provider search. `OpenSubtitlesProvider.get_subtitles`
+  already accepts `tmdb_id` and searches by `parent_tmdb_id`; ensure the id is forwarded.
+
+When `tmdb_id` is `None`, the path is unchanged (today's name-based `fetch_show_id`).
+
+### 5. Spine — matching path
+
+- `MatchingCoordinator._match_single_file_inner` → call
+  `episode_curator.match_single_file(file_path, series_name=detected_title,
+  season=detected_season, tmdb_id=job.tmdb_id, …)`.
+- `curator.match_single_file(…, tmdb_id=None)` → forward into the matcher / `EpisodeMatcher`
+  so the identifier carries `tmdb_id` alongside `show_name`.
+
+### 6. Corpus guard (`backend/app/matcher/episode_identification.py`)
+
+The precomputed manifest entry already records `tmdb_id` per show
+(`manifest["shows"]["Frasier"]["tmdb_id"] == "3452"`). Add an `expected_tmdb_id` to the
+identifier and apply it in `precomputed_covers_season` / `_load_precomputed_season`:
+
+- If `expected_tmdb_id` is set **and** the manifest entry has a `tmdb_id` **and**
+  `str(entry.tmdb_id) != str(expected_tmdb_id)` → treat as **no precomputed coverage**
+  (return `False` / `None`), and log a warning that the corpus is for a different show.
+- If `expected_tmdb_id` is `None`, or the manifest entry lacks a `tmdb_id` (older builds) →
+  **skip the guard** (today's name-only behavior). Backward-compatible; the only behavioral
+  change is refusing a corpus whose id positively contradicts the job's id.
+
+Effect: a revival disc never matches against the original's corpus. With no precomputed
+coverage, the matcher falls back to the live reference path (`data/<name>/`), where the
+`tmdb_id`-keyed download (§4) has placed the *correct* subtitles.
+
+### 7. Re-identify round trip (already wired; make it id-driven)
+
+`POST /api/jobs/{job_id}/re-identify` (`ReIdentifyRequest` already has `tmdb_id`) →
+`identification_coordinator.re_identify` already restarts subtitle download and re-matches.
+The only change: the restarted download (§4) and re-match (§5) now pass the **chosen**
+`tmdb_id`, so re-identifying "Frasier" to `195241` fetches the 2023 subtitles and the guard
+(§6) skips the 1993 precomputed corpus. The Frasier disc is post-rip (files already staged),
+so `re_identify` routes to `_rerun_matching`.
+
+## Data Flow — Frasier walkthrough (end-to-end, with item 1 only)
+
+1. Disc "Frasier Season 1" (2023 revival, no year). Classifier: 1993 dominates (ratio 13.3,
+   **not** flagged ambiguous) → `job.tmdb_id = 3452`.
+2. Matching: precomputed "Frasier" entry `tmdb_id == "3452"` == job id → guard **passes** →
+   match against 1993 corpus → all chunks at noise floor → **no match → needs review**.
+   *(Item 3 will later attach a "content doesn't resemble reference show" reason here.)*
+3. User opens Re-Identify, searches "Frasier", sees both entries with years, picks **2023
+   (#195241)** → `re-identify {tmdb_id: 195241}`.
+4. `job.tmdb_id = 195241`. Subtitle download keyed by `195241` → fetches 2023 subtitles into
+   `data/Frasier/`. Re-match: precomputed "Frasier" `tmdb_id "3452" != 195241` → guard skips
+   precomputed → live path reads the 2023 subtitles → **matches**. ✅
+
+A Tier-A example (e.g. Battlestar Galactica) diverges at step 1: classifier flags
+`ambiguous_identity` → review *before* any wrong-corpus match, user picks at the outset.
+
+## Edge Cases & Error Handling
+
+- **Manifest entry missing `tmdb_id`** (pre-v2 builds): guard skipped, name-only behavior,
+  warning logged.
+- **`job.tmdb_id` unresolved (`None`)**: entire chain falls back to today's name-based logic.
+  No regression for the 127/181 shows with no collision.
+- **String/int `tmdb_id` mismatch**: always compare as `str`.
+- **On-disk dir collision (shared `data/Frasier/` or `precomputed/Frasier/`)**: acknowledged
+  residual. The guard prevents *false matches*; correct subtitles land via id-keyed download.
+  Full isolation (paths keyed by `tmdb_id`) is **item 2**. Until then, a re-identified twin
+  works as long as the shared name-dir isn't polluted by the other twin's files.
+- **Ambiguous flag false-positives**: thresholds are tunable; default ratio 4.0 / floor 10.0
+  flags ~5–6 Tier-A shows and stays silent on the 29% tail.
+
+## Testing
+
+- **Unit (`tmdb_classifier`):** mock TMDB returning two "Frasier"-named shows — assert the
+  gate flags ambiguous only when floor+ratio satisfied; assert Frasier-with-dominant-original
+  is **not** flagged; assert candidate list shape.
+- **Unit (corpus guard):** manifest entry `tmdb_id "3452"`; identifier `expected_tmdb_id
+  195241` → `precomputed_covers_season` returns `False`; `3452` → `True`; `None` → `True`
+  (skip).
+- **Unit (download bypass):** `download_subtitles(..., tmdb_id=195241)` does **not** call
+  `fetch_show_id`; uses the id for season details + `parent_tmdb_id` search.
+- **Integration:** ambiguous-collision job → lands in `REVIEW_NEEDED` with a `review_reason`
+  naming candidates; re-identify with `tmdb_id` re-keys download + match (assert the id is
+  threaded into `match_single_file`). *(Per project guidance, integration tests run against
+  the real app DB — set up job state directly in the DB; do not let it organize real files.)*
+
+## Files Touched (item 1)
+
+| File | Change |
+|---|---|
+| `backend/app/core/tmdb_classifier.py` | same-name candidate collection; `TmdbSignal.ambiguous_identity` + `candidates`; materiality gate + tunable constants |
+| `backend/app/services/identification_coordinator.py` | route ambiguous → review (reason + no id); thread `tmdb_id` into `_start_subtitle_download` and re-identify restart |
+| `backend/app/services/matching_coordinator.py` | `tmdb_id` params on `download_subtitles` + `_match_single_file_inner` → `match_single_file` |
+| `backend/app/matcher/testing_service.py` | `download_subtitles(..., tmdb_id=None)`; bypass `fetch_show_id` when id known |
+| `backend/app/matcher/subtitle_provider.py` | ensure `tmdb_id` forwarded to `OpenSubtitlesProvider` search |
+| `backend/app/core/curator.py` | `match_single_file(..., tmdb_id=None)` forward |
+| `backend/app/matcher/episode_identification.py` | `expected_tmdb_id` on identifier; guard in `precomputed_covers_season` / `_load_precomputed_season` |
+| `backend/tests/unit/…`, `backend/tests/integration/…` | tests above |
+
+No DB migration, no cache rebuild, **no frontend changes**.
+
+## Sequencing — how items 2 and 3 slot in
+
+- **Item 1 (this doc):** identity spine + Tier-A collision review + corpus guard. Makes the
+  re-identify pick functional and prevents wrong-corpus false matches.
+- **Item 2 (next spec):** re-key the corpus by `tmdb_id` — `build_subtitle_cache.py` writes
+  `precomputed/<tmdb_id>/…` and `data/<tmdb_id>/…`, manifest keyed by id; migrate the
+  existing on-disk cache; matcher lookup by id. Removes the residual shared-dir caveat and
+  lets same-named twins coexist. Rides on item 1's `tmdb_id` plumbing.
+- **Item 3 (next spec):** the load-bearing fix for Frasier-class — in
+  `episode_identification.identify_episode`'s no-match path, detect "all sampled chunks at the
+  noise floor with near-zero top1/top2 margin" and emit a distinct reason
+  (`no_match_reason = "wrong_show_or_season"`); carry it on `MatchResult.match_details`
+  → `DiscTitle.match_details` → review UI banner. Self-explains the failure so users know to
+  re-identify. (NB: confirm the current shape of the chunk-vote gate / `select_chunk_vote` in
+  `episode_identification.py` when speccing — the no-match return already carries per-episode
+  best-cosine data needed to compute the signal.)


### PR DESCRIPTION
## Summary

Makes `tmdb_id` a first-class identity that flows through subtitle download → matcher reference selection → corpus lookup, so two same-named TMDB shows (e.g. **Frasier 1993 #3452** vs the **2023 revival #195241**) are finally distinguishable. Also detects genuinely-ambiguous same-name collisions at identify time and routes them into the **existing** re-identify review workflow, and adds a corpus guard that refuses a precomputed corpus whose `tmdb_id` contradicts the job's.

This is **item 1 of 3** of the show-identity collision fix (spec + plan committed under `docs/superpowers/`). No DB migration, no cache rebuild, **no frontend changes**.

## Why

A "Frasier Season 1" disc that is actually the 2023 revival couldn't match: the subtitle cache holds only the original (#3452), so every ASR chunk scored at the noise floor → "needs review" with no explanation. Root cause was upstream: identity was carried as a **show-name string**, and the `tmdb_id` that would disambiguate was computed, stored on the job, then **never used downstream** — subtitle download and matching both keyed on the name only, which is identical for both shows.

## What changed (the chain)

- **`tmdb_classifier`** — `TmdbSignal` carries `ambiguous_identity` + `candidates`; `classify_from_tmdb` detects a same-name collision behind a **materiality gate** (runner-up popularity ≥ 10.0 **and** top/second ratio ≤ 4.0 — tunable constants).
- **`analyst._apply_tmdb_signal`** — an ambiguous signal withholds `tmdb_id`, sets `needs_review` + a candidate-naming `review_reason`. (Non-ambiguous path unchanged.)
- **`identification_coordinator`** — ambiguous jobs skip the premature by-name subtitle download and route to review with the candidate list (reusing the existing `ReIdentifyModal` picker). `job.tmdb_id` now threads into subtitle download + re-identify restart + the manual subtitle-retry route.
- **`testing_service.download_subtitles`** — bypasses `fetch_show_id` (the name-resolution collision point) when a `tmdb_id` is known.
- **`curator` / `episode_identification`** — `match_single_file`/`_ensure_initialized` thread `tmdb_id` into `EpisodeMatcher(expected_tmdb_id=…)`; the precomputed corpus is **guarded** — a manifest entry whose `tmdb_id` contradicts the job's is refused (before the stale-prune branch, so a valid same-name entry isn't dropped).

End to end: an ambiguous disc → review with candidates → user picks → the chosen `tmdb_id` drives subtitle re-download + matching + the corpus guard.

## How big is the problem (measured against the real 181-show corpus)

54/181 (29%) have a same-name TMDB twin, but only **~8–9 are genuinely ambiguous** (both variants substantial — BSG, Charmed, Doctor Who, One Piece, Shameless, …) and exactly **1 actively mispicks today** (One Piece: corpus has the 2023 live-action, popularity favors the 1999 anime). The materiality gate intentionally stays silent on the 29% long tail; dominant-twin cases like Frasier (no identify-time signal) are handled by item 3 (a later PR).

## Design decisions

- **Approach:** `tmdb_id` as an optional authoritative companion to the show name — backward-compatible (id absent → today's behavior), no cache migration.
- **Force-review, reuse existing UI:** collisions route through `review_reason` + `ReIdentifyModal` (already has a TMDB candidate picker), so zero new frontend.
- **Deferred (out of scope):** corpus on-disk re-key/migration (item 2); the noise-floor "wrong show" UX signal that self-explains Frasier-class failures (item 3); `curator._chromaprint_prepass` + LLM fallback still resolve by name (live mis-resolution only once fingerprint ID is enabled for a collision show — tracked).

## Reviewer note

A final cross-cutting review caught a real seam the per-task reviews couldn't: the pre-existing `not job.tmdb_id` guard in the coordinator was intercepting ambiguous jobs (which withhold `tmdb_id` by design) with a generic "words merged" message and returning early — clobbering the candidate reason. Fixed with an `and not _amb` exclusion + a symmetric staging-path guard, plus a coordinator-level regression test that drives the real `identify_disc` flow (the missing coverage that let it slip).

## Test plan

- [x] `uv run pytest tests/unit/` — **1441 passed**
- [x] New: `test_tmdb_classifier_collision`, `test_analyst_ambiguity`, `test_precomputed_guard`, `test_download_subtitles_tmdb_id`, `test_curator_tmdb_id`, integration `test_show_identity_collision` (incl. coordinator-level ambiguous→review)
- [x] `uv run ruff check` / `ruff format --check` clean
- [ ] Manual (post-merge): insert the Frasier 2023 disc → lands in review → re-identify to the 2023 entry → confirm subtitle re-download keys by id and the corpus guard logs "skipping precomputed (wrong show)"

Before release, a `CHANGELOG.md` `[Unreleased]` entry is worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)