### PR TITLE
fix(uploader): recover contributions after a sustained transient outage

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1500,12 +1500,18 @@ async def forget_fingerprint_contribution(
             detail="Cannot delete an already-uploaded contribution; the data is already on the server.",
         )
     if contrib.upload_status is None and contrib.upload_attempts > 0:
-        # upload_attempts > 0 means the background uploader has already tried
-        # this row at least once and may be holding it in an active HTTP call.
-        # Deleting now would cause a silent no-op UPDATE on a ghost row.
+        # upload_attempts > 0 means the background uploader has already tried this
+        # row at least once and may be holding it in an active HTTP call; deleting
+        # now could be a silent no-op UPDATE on a ghost row. Transient failures keep
+        # the row pending (status=None) and retry across drains rather than reaching
+        # a terminal "failed", so this guard holds until the row eventually uploads.
         raise HTTPException(
             status_code=409,
-            detail="Contribution may be in-flight (upload already attempted). Try again after the next poll cycle or wait for it to succeed or fail.",
+            detail=(
+                "Contribution upload already attempted; it will keep retrying on "
+                "later drains until it succeeds. To stop contributing it, opt out "
+                "of fingerprint contributions or use the forget action."
+            ),
         )
     await session.delete(contrib)
     await session.commit()

--- a/backend/app/models/fingerprint.py
+++ b/backend/app/models/fingerprint.py
@@ -49,6 +49,10 @@ class FingerprintContribution(SQLModel, table=True):
 
     # Phase 2 uploader state
     uploaded_at: datetime | None = None
-    upload_attempts: int = Field(default=0)
-    upload_status: str | None = Field(default=None)  # None=pending, "success", "failed"
+    upload_attempts: int = Field(default=0)  # cumulative lifetime attempts (diagnostic)
+    # None=pending OR transiently failed (5xx/network/429) and awaiting retry on a
+    # later drain — distinguish via upload_attempts/upload_error_msg; "success";
+    # "failed"=PERMANENT only (4xx or blob-decode). A sustained transient outage
+    # never reaches "failed" — that is what keeps a 503 storm from burning rows.
+    upload_status: str | None = Field(default=None)
     upload_error_msg: str | None = Field(default=None)  # last error text for UI

--- a/backend/app/services/contribution_uploader.py
+++ b/backend/app/services/contribution_uploader.py
@@ -263,6 +263,9 @@ class ContributionUploader:
 
                 contrib.upload_status = "success"
                 contrib.uploaded_at = datetime.now(UTC)
+                # Clear any transient-error message from a prior drain so a
+                # recovered row doesn't surface a stale error next to "success".
+                contrib.upload_error_msg = None
                 await session.commit()
                 self._append_audit_log(contrib)
                 logger.info(

--- a/backend/app/services/contribution_uploader.py
+++ b/backend/app/services/contribution_uploader.py
@@ -101,6 +101,12 @@ class ContributionUploader:
 
         drained = 0
         semaphore = asyncio.Semaphore(_CONCURRENCY)
+        # Id-cursor so the drain sweeps the pending queue exactly once. Transient
+        # failures leave the row pending (upload_status=None) for a later drain to
+        # retry — without the cursor those still-None rows would be re-selected
+        # within this same drain forever. A *new* _drain() resets last_id to 0 and
+        # re-sweeps, which is what makes a recovered server re-pick burned rows.
+        last_id = 0
         # One client for the whole drain → HTTP keep-alive across every batch/row.
         async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
             while True:
@@ -120,13 +126,17 @@ class ContributionUploader:
                     stmt = (
                         select(FingerprintContribution.id)
                         .where(FingerprintContribution.upload_status.is_(None))
-                        .where(FingerprintContribution.upload_attempts < _MAX_ATTEMPTS)
+                        .where(FingerprintContribution.id > last_id)
+                        .order_by(FingerprintContribution.id)
                         .limit(_BATCH_SIZE)
                     )
                     row_ids = (await session.execute(stmt)).scalars().all()
 
                 if not row_ids:
                     break
+                # Advance past this batch so transiently-failed rows (still None)
+                # aren't re-selected later in this same drain.
+                last_id = row_ids[-1]
 
                 if not cfg.fingerprint_disclosure_accepted:
                     # Data is queued but the user hasn't consented yet. Prompt; don't upload.
@@ -238,9 +248,11 @@ class ContributionUploader:
             await session.commit()
             return
 
-        # Honour the lifetime attempt cap: prior failures consumed some budget.
-        remaining = _MAX_ATTEMPTS - contrib.upload_attempts
-        for attempt in range(remaining):
+        # Per-drain retry budget — _MAX_ATTEMPTS is NOT a lifetime cap. Exhausting
+        # it on transient errors leaves the row pending (see the post-loop block)
+        # so a later drain retries; a sustained-but-transient outage (e.g. a 503
+        # storm) must never permanently burn a row.
+        for attempt in range(_MAX_ATTEMPTS):
             backoff: float = 2**attempt
             try:
                 resp = await client.post(
@@ -293,14 +305,23 @@ class ContributionUploader:
                 await session.commit()
                 logger.warning(f"Contrib {contrib.id}: network error, attempt {attempt + 1}: {e}")
 
-            if attempt < remaining - 1:
+            if attempt < _MAX_ATTEMPTS - 1:
                 await asyncio.sleep(backoff)
 
-        # Exhausted retries
-        contrib.upload_status = "failed"
-        contrib.upload_error_msg = f"Retries exhausted after {_MAX_ATTEMPTS} attempts"
+        # Transient retries exhausted for THIS drain. Leave upload_status=None so a
+        # later drain re-picks the row once the server recovers — permanent failures
+        # (4xx / blob-decode) already returned above with upload_status="failed".
+        # upload_attempts keeps climbing as a lifetime diagnostic, and the row stays
+        # NULL so rotate-pseudonym still re-tags it before its eventual upload.
+        contrib.upload_error_msg = (
+            f"Transient errors after {contrib.upload_attempts} attempt(s); "
+            "will retry on a later drain"
+        )
         await session.commit()
-        logger.error(f"Contrib {contrib.id}: upload failed after {_MAX_ATTEMPTS} attempts")
+        logger.warning(
+            f"Contrib {contrib.id}: transient errors persisted this drain ("
+            f"{contrib.upload_attempts} total attempts); left pending for retry"
+        )
 
     @staticmethod
     def _append_audit_log(contrib: FingerprintContribution) -> None:

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -1479,3 +1479,9 @@ async def test_sustained_5xx_does_not_loop_and_recovers_on_later_drain(
     async with async_session() as session:
         rows = (await session.execute(select(FingerprintContribution))).scalars().all()
     assert all(r.upload_status == "success" for r in rows)
+    # The transient-error message from drain #1 must not linger on a row that
+    # later uploaded cleanly — the listing endpoint returns it verbatim, so a
+    # stale message would surface a phantom error next to a "success" status.
+    assert all(r.upload_error_msg is None for r in rows), (
+        "upload_error_msg must be cleared when a previously-transient row succeeds"
+    )

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -556,7 +556,9 @@ async def test_uploader_posts_wire_format_v1(setup_db, tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_uploader_increments_attempts_on_5xx(setup_db, monkeypatch):
-    """A 5xx response exhausts retries and marks upload_status='failed'."""
+    """A 5xx response consumes the per-drain retry budget but leaves the row
+    recoverable (upload_status stays None) — transient errors never permanently
+    burn a row, so a later drain can retry once the server recovers."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     from app.database import async_session
@@ -602,8 +604,10 @@ async def test_uploader_increments_attempts_on_5xx(setup_db, monkeypatch):
     async with async_session() as session:
         refreshed = await session.get(FingerprintContribution, contrib_id)
 
-    # After _MAX_ATTEMPTS transient failures the row is permanently failed
-    assert refreshed.upload_status == "failed"
+    # 5xx is transient: the per-drain budget is consumed (attempts == _MAX_ATTEMPTS)
+    # but the row stays pending (None), not permanently "failed" — a later drain
+    # retries it once the upstream outage clears.
+    assert refreshed.upload_status is None
     assert refreshed.upload_attempts == _MAX_ATTEMPTS
 
 
@@ -1123,7 +1127,8 @@ async def test_uploader_retries_on_429_then_succeeds(setup_db, tmp_path, monkeyp
 async def test_uploader_429_falls_back_to_exponential_without_retry_after(
     setup_db, tmp_path, monkeypatch
 ):
-    """429 without a Retry-After header falls back to exponential backoff (not permanent)."""
+    """429 without a Retry-After header falls back to exponential backoff and,
+    like a 5xx, stays recoverable (upload_status=None) — never permanently failed."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", tmp_path / "contrib.jsonl")
@@ -1175,8 +1180,9 @@ async def test_uploader_429_falls_back_to_exponential_without_retry_after(
     async with async_session() as session:
         refreshed = await session.get(FingerprintContribution, contrib_id)
 
-    # 429 is transient: it consumes the budget like a 5xx, not an instant 4xx fail.
-    assert refreshed.upload_status == "failed"
+    # 429 is transient: it consumes the per-drain budget like a 5xx but leaves the
+    # row recoverable (None), not an instant 4xx fail and not a permanent "failed".
+    assert refreshed.upload_status is None
     assert refreshed.upload_attempts == _MAX_ATTEMPTS
 
 
@@ -1379,3 +1385,97 @@ async def test_drain_respects_midstream_optout(setup_db, tmp_path, monkeypatch):
             .all()
         )
     assert len(pending) == 2
+
+
+@pytest.mark.asyncio
+async def test_sustained_5xx_does_not_loop_and_recovers_on_later_drain(
+    setup_db, tmp_path, monkeypatch
+):
+    """A sustained 5xx outage must NOT permanently burn rows.
+
+    Regression guard for the lifetime-cap bug: during a server-side incident
+    where every request 503s, a row used to exhaust _MAX_ATTEMPTS (a *lifetime*
+    cap persisted across drains) and stick at upload_status='failed' with no
+    automatic recovery — requiring a manual SQL reset. Now transient exhaustion
+    leaves the row pending (upload_status=None) so a later drain re-picks it once
+    the server recovers.
+
+    _BATCH_SIZE=1 forces the drain to advance past each transiently-failed row.
+    Without an id-cursor the still-None rows would be re-selected forever
+    (in-drain infinite loop), so this also guards drain termination.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from sqlmodel import select
+
+    monkeypatch.setattr(uploader_mod, "CONTRIBUTION_LOG_PATH", tmp_path / "contrib.jsonl")
+    monkeypatch.setattr(uploader_mod, "_BATCH_SIZE", 1)
+
+    async with async_session() as session:
+        for i in range(2):
+            session.add(
+                FingerprintContribution(
+                    chromaprint_blob=_make_valid_blob(),
+                    tmdb_id=1399,
+                    season=1,
+                    episode=i + 1,
+                    match_confidence=0.9,
+                    match_source="engram_asr",
+                    pseudonym="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                )
+            )
+        await session.commit()
+
+    monkeypatch.setattr(
+        uploader_mod,
+        "get_config",
+        AsyncMock(
+            return_value=MagicMock(
+                fingerprint_server_url="https://fp.example.com",
+                contribution_pseudonym="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+                enable_fingerprint_contributions=True,
+                fingerprint_disclosure_accepted=True,
+            )
+        ),
+    )
+
+    server_down = httpx.HTTPStatusError(
+        "503", request=MagicMock(), response=MagicMock(status_code=503)
+    )
+
+    # Drain #1: the server 503s on every request. The drain must terminate (no
+    # infinite in-drain loop) and leave both rows recoverable, not failed.
+    with patch("httpx.AsyncClient") as MockClient, patch("asyncio.sleep", AsyncMock()):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=server_down)
+        MockClient.return_value = mock_client
+
+        drained_during_outage = await ContributionUploader()._drain()
+
+    assert drained_during_outage == 0
+    async with async_session() as session:
+        rows = (await session.execute(select(FingerprintContribution))).scalars().all()
+    assert all(r.upload_status is None for r in rows), (
+        "sustained 5xx must not permanently fail rows"
+    )
+    assert all(r.upload_attempts == _MAX_ATTEMPTS for r in rows)
+
+    # Drain #2: the server has recovered. The previously-stuck rows must re-pick
+    # and upload successfully — automatic recovery, no manual SQL reset needed.
+    ok_resp = MagicMock()
+    ok_resp.raise_for_status = MagicMock()
+    with patch("httpx.AsyncClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=ok_resp)
+        MockClient.return_value = mock_client
+
+        drained_after_recovery = await ContributionUploader()._drain()
+
+    assert drained_after_recovery == 2
+    async with async_session() as session:
+        rows = (await session.execute(select(FingerprintContribution))).scalars().all()
+    assert all(r.upload_status == "success" for r in rows)


### PR DESCRIPTION
## Problem

The `ContributionUploader` treated HTTP 5xx and network errors as transient and retried with exponential backoff up to `_MAX_ATTEMPTS = 5` — but that cap was a **lifetime** cap. `_upload_one` computed `remaining = _MAX_ATTEMPTS - contrib.upload_attempts` against a counter persisted on the row across drains, and `_drain` filtered `upload_attempts < _MAX_ATTEMPTS`.

So during a **sustained-but-transient** upstream outage (the fingerprint server returning 503 on every large-fingerprint request during a bootstrap upload), a row burned all 5 attempts in a single drain and was permanently stamped `upload_status="failed"`. The `IS NULL` drain filter then excluded it forever — no automatic recovery. Re-uploading required a manual SQL reset:

```sql
UPDATE fingerprint_contributions
SET upload_status=NULL, upload_attempts=0, upload_error_msg=NULL
WHERE upload_status='failed';
```

This was exposed by a server-side CPU-limit 503 storm, now fixed upstream in engram-fingerprint-server #31 (minhash CPU optimization). The already-burned rows were recovered manually; **this PR prevents recurrence.**

## Fix (approach (a): transient ≠ permanent)

- **`_MAX_ATTEMPTS` is now a per-drain retry budget**, not a lifetime cap. The in-drain loop uses a fresh `range(_MAX_ATTEMPTS)` rather than subtracting persisted attempts.
- **Transient errors (5xx / network / 429) leave `upload_status=None`** so a later drain re-picks the row once the server recovers. Only **permanent** failures (4xx + blob-decode) reach the terminal `"failed"` state. `upload_attempts` keeps climbing as a lifetime diagnostic; the exhaustion log dropped from `error` to `warning` to reflect that it's no longer terminal.
- **`_drain` sweeps with an id-cursor** (`id > last_id`, ascending). Because transient rows stay `None`, without a cursor they'd be re-selected within the *same* drain forever (infinite loop). The cursor sweeps the queue exactly once per drain; a fresh `_drain()` resets it to 0 and re-sweeps. This also scales better than a `NOT IN (...)` set for large bootstrap queues. The `upload_attempts < _MAX_ATTEMPTS` query filter (part of the lifetime-cap bug) was removed.

### Why not a distinct `deferred` / `temporarily_failed` status?

`rotate-pseudonym` re-tags pending rows with `WHERE upload_status IS NULL` (`app/api/routes.py`). Keeping transient rows `None` means they correctly receive a fresh pseudonym before their eventual upload. A separate status value would be skipped by that filter → the row would later upload under a **stale pseudonym** — a privacy regression. Keeping the `None`/`success`/`failed` vocabulary also means zero changes to the routes/forget/listing surfaces, which already treat `status=None AND attempts>0` as "in-flight, retrying."

A startup-sweep / re-queue endpoint (approach (b)) was rejected because it only recovers on restart — a long-running backend would keep burning rows mid-outage.

## Tests (TDD)

- **New:** `test_sustained_5xx_does_not_loop_and_recovers_on_later_drain` — drains under a constant 503, asserts both rows stay recoverable (`upload_status is None`, not `"failed"`), then a second drain against a recovered server uploads them. `_BATCH_SIZE=1` forces the cursor to advance past transiently-failed rows, guarding against the in-drain infinite loop.
- **Updated:** `test_uploader_increments_attempts_on_5xx` and `test_uploader_429_falls_back_to_exponential_without_retry_after` — these had encoded the old "sustained transient → permanently failed" contract; flipped to assert the row stays recoverable.
- **Doc:** sharpened the `upload_status` comment in `models/fingerprint.py` — `"failed"` is now permanent-only.

## Verification

- `tests/integration/test_contribution_uploader.py`: **32 passed**
- Other contribution tests (unit + discdb): **44 passed**
- `tests/unit` + `tests/pipeline`: **1574 passed**
- `ruff check` + `ruff format --check`: clean on all three changed files

The full `tests/integration` suite was intentionally not run locally (its `test_workflow.py` organizes files into the real library); the change is isolated to the uploader and fully covered by the contribution tests above.

## Note for reviewers

During a *total* outage the queue now retries every poll interval (900s) indefinitely rather than going quiet — the intended trade-off for resilience, and gentle (~5 requests/row per 15 min). If a true dead-letter ceiling (give up after N days of transient failures) is ever wanted, it's a small follow-up on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
