### PR TITLE
feat(uploader): add force=true escape hatch to delete a stuck contribution

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1482,12 +1482,21 @@ async def list_fingerprint_contributions(
 @router.delete("/fingerprint/contributions/{contrib_id}", dependencies=[Depends(require_localhost)])
 async def forget_fingerprint_contribution(
     contrib_id: int,
+    force: bool = False,
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     """Delete a locally-queued fingerprint contribution (forget).
 
     Returns 400 if the contribution was already uploaded — the data already
-    exists on the server and cannot be recalled from here.
+    exists on the server and cannot be recalled from here (use /fingerprint/forget
+    to recall server-side data). Returns 409 if the row has been attempted and is
+    still retrying, unless `force=true` is passed.
+
+    `force=true` is the escape hatch for the resilience behavior: transient upload
+    failures keep a row pending (`upload_status=None`, `upload_attempts>0`) and
+    retry across drains indefinitely, so without force a row stuck against a dead
+    server could never be deleted individually. force overrides ONLY that retry
+    guard — it never bypasses the already-uploaded (400) guard.
     """
     from app.models.fingerprint import FingerprintContribution
 
@@ -1495,11 +1504,12 @@ async def forget_fingerprint_contribution(
     if contrib is None:
         raise HTTPException(status_code=404, detail="Contribution not found")
     if contrib.upload_status == "success":
+        # Never bypassed, even with force — the data is already on the server.
         raise HTTPException(
             status_code=400,
             detail="Cannot delete an already-uploaded contribution; the data is already on the server.",
         )
-    if contrib.upload_status is None and contrib.upload_attempts > 0:
+    if not force and contrib.upload_status is None and contrib.upload_attempts > 0:
         # upload_attempts > 0 means the background uploader has already tried this
         # row at least once and may be holding it in an active HTTP call; deleting
         # now could be a silent no-op UPDATE on a ghost row. Transient failures keep
@@ -1509,13 +1519,13 @@ async def forget_fingerprint_contribution(
             status_code=409,
             detail=(
                 "Contribution upload already attempted; it will keep retrying on "
-                "later drains until it succeeds. To stop contributing it, opt out "
-                "of fingerprint contributions or use the forget action."
+                "later drains until it succeeds. To retract it now, retry with "
+                "force=true, or opt out / use the forget action."
             ),
         )
     await session.delete(contrib)
     await session.commit()
-    return {"status": "deleted", "contrib_id": contrib_id}
+    return {"status": "deleted", "contrib_id": contrib_id, "forced": force}
 
 
 @router.post(

--- a/backend/tests/integration/test_contribution_uploader.py
+++ b/backend/tests/integration/test_contribution_uploader.py
@@ -1485,3 +1485,84 @@ async def test_sustained_5xx_does_not_loop_and_recovers_on_later_drain(
     assert all(r.upload_error_msg is None for r in rows), (
         "upload_error_msg must be cleared when a previously-transient row succeeds"
     )
+
+
+@pytest.mark.asyncio
+async def test_force_delete_removes_retrying_contribution(setup_db, client):
+    """`?force=true` deletes a transiently-stuck row that the plain delete 409s.
+
+    Escape hatch for the new resilience behavior: transient failures keep a row
+    pending (`upload_status=None`, `upload_attempts>0`) and retry forever, so the
+    plain delete's in-flight guard would otherwise block it permanently. force
+    lets the user retract a single row that won't upload.
+    """
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            row = FingerprintContribution(
+                chromaprint_blob=b"\x06",
+                tmdb_id=66,
+                season=1,
+                episode=1,
+                match_confidence=0.7,
+                match_source="engram_asr",
+                pseudonym="iiiiiiii-iiii-4iii-8iii-iiiiiiiiiiii",
+                upload_attempts=5,  # attempted and retrying: status None, attempts>0
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            contrib_id = row.id
+
+        # Plain delete is blocked — the row has been attempted and keeps retrying.
+        blocked = await client.delete(f"/api/fingerprint/contributions/{contrib_id}")
+        assert blocked.status_code == 409
+
+        # force=true overrides the retry guard and removes the row.
+        forced = await client.delete(f"/api/fingerprint/contributions/{contrib_id}?force=true")
+        assert forced.status_code == 200
+        assert forced.json()["status"] == "deleted"
+
+        async with async_session() as session:
+            assert await session.get(FingerprintContribution, contrib_id) is None
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)
+
+
+@pytest.mark.asyncio
+async def test_force_delete_still_rejects_uploaded_contribution(setup_db, client):
+    """`?force=true` must NOT delete an already-uploaded row — the data is on the
+    server and a local delete can't recall it (use /fingerprint/forget instead)."""
+    from app.api.routes import require_localhost
+    from app.database import async_session
+    from app.main import app
+
+    app.dependency_overrides[require_localhost] = lambda: None
+    try:
+        async with async_session() as session:
+            row = FingerprintContribution(
+                chromaprint_blob=b"\x07",
+                tmdb_id=55,
+                season=2,
+                episode=4,
+                match_confidence=0.9,
+                match_source="engram_asr",
+                pseudonym="jjjjjjjj-jjjj-4jjj-8jjj-jjjjjjjjjjjj",
+                upload_status="success",
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            contrib_id = row.id
+
+        resp = await client.delete(f"/api/fingerprint/contributions/{contrib_id}?force=true")
+        assert resp.status_code == 400
+
+        async with async_session() as session:
+            assert await session.get(FingerprintContribution, contrib_id) is not None
+    finally:
+        app.dependency_overrides.pop(require_localhost, None)


### PR DESCRIPTION
## Summary

Follow-up to #279 (per the review discussion). #279 made the contribution uploader resilient to sustained transient outages by keeping transiently-failed rows `upload_status=None` and retrying them across drains. A side effect: a row stuck retrying against a permanently dead/removed server stays `None` with `upload_attempts>0` indefinitely, and the single-row delete's in-flight guard (`409`) would block deleting it forever.

This adds a per-row force-delete escape hatch.

## Change

`DELETE /api/fingerprint/contributions/{id}` gains a `force: bool = False` query param:

- `force=true` overrides **only** the `409` retry guard (`upload_status=None AND upload_attempts>0`).
- It **never** bypasses the `400` already-uploaded guard — once `upload_status="success"` the data is on the server and a local delete can't recall it (that's what `POST /api/fingerprint/forget` is for).
- The `404`-not-found check is unchanged.
- The response echoes `"forced": <bool>`, and the `409` message now points users at `force=true` as the retract path.

Note: the bulk `POST /api/fingerprint/forget` already deletes all pending rows (`uploaded_at IS NULL`) regardless of attempts, so stuck data was never truly trapped — this just adds a precise single-row option.

## Tests (TDD)

- `test_force_delete_removes_retrying_contribution` — a stuck row (`status=None, attempts=5`): plain delete → 409; `?force=true` → 200 and the row is gone.
- `test_force_delete_still_rejects_uploaded_contribution` — `force=true` on a `success` row still → 400, row preserved.

## Verification

- `tests/integration/test_contribution_uploader.py`: **34 passed**
- `ruff check` + `ruff format --check`: clean

## ⚠️ Stacking note

**This PR is based on the #279 branch (`fix/uploader-transient-outage-recovery`), not `main`** — both PRs edit the same `routes.py` delete-guard block, so stacking keeps this diff focused on just the force-delete change and avoids a conflict. GitHub retargets the base to `main` when #279 merges; because #279 squash-merges, a quick rebase onto `main` may be needed afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
