### PR TITLE
fix(curator): thread known tmdb_id into chromaprint + LLM matcher paths

### DIFF
--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -345,7 +345,7 @@ class EpisodeCurator:
         if series_name:
             try:
                 cp = await self._chromaprint_prepass(
-                    file_path=file_path, series_name=series_name, season=season
+                    file_path=file_path, series_name=series_name, season=season, tmdb_id=tmdb_id
                 )
             except Exception as e:  # noqa: BLE001 — never block matching
                 logger.warning(f"chromaprint prepass failed: {e}", exc_info=True)
@@ -369,9 +369,16 @@ class EpisodeCurator:
                     match_details=details,
                 )
 
-        # Fall through to ASR (the legacy path).
+        # Fall through to ASR (the legacy path). Pass tmdb_id by keyword so it can't be
+        # misrouted if a positional parameter is ever inserted before it.
         asr = await self._run_asr_identify(
-            file_path, series_name, season, progress_callback, num_points, min_vote_count
+            file_path,
+            series_name,
+            season,
+            progress_callback,
+            num_points,
+            min_vote_count,
+            tmdb_id=tmdb_id,
         )
 
         # Cross-validate when BOTH produced an episode.
@@ -410,8 +417,13 @@ class EpisodeCurator:
         progress_callback: Callable[..., None] | None = None,
         num_points: int | None = None,
         min_vote_count: int | None = None,
+        tmdb_id: int | None = None,
     ) -> MatchResult:
-        """Run the ASR/subtitle matching path — the original match_single_file try/except body."""
+        """Run the ASR/subtitle matching path — the original match_single_file try/except body.
+
+        ``tmdb_id`` is forwarded to the LLM fallback so it builds context from the
+        known show identity rather than re-resolving by name (collision-safe).
+        """
         try:
             # Run the matcher in a thread to not block async loop
             logger.debug(f"[Curator] Starting identifying_episode in thread for {file_path.name}")
@@ -453,6 +465,7 @@ class EpisodeCurator:
                         season=season,
                         match_details=details,
                         existing_transcript=existing_transcript,
+                        tmdb_id=tmdb_id,
                     )
                     if enriched is not None:
                         details = enriched
@@ -477,6 +490,7 @@ class EpisodeCurator:
                         season=season,
                         match_details=fallback.match_details or {},
                         existing_transcript=existing_transcript,
+                        tmdb_id=tmdb_id,
                     )
                     if enriched is not None:
                         fallback.match_details = enriched
@@ -493,8 +507,15 @@ class EpisodeCurator:
         file_path: Path,
         series_name: str,
         season: int,
+        tmdb_id: int | None = None,
     ) -> dict | None:
-        """Run chromaprint identification; return its result dict or None if unavailable/empty."""
+        """Run chromaprint identification; return its result dict or None if unavailable/empty.
+
+        When ``tmdb_id`` is known (e.g. the user disambiguated a same-name show), it is
+        used directly to fetch the fingerprint pack — skipping ``fetch_show_id``, which
+        resolves by NAME and cannot tell apart same-name collisions (Frasier 1993 #3452
+        vs the 2023 revival #195241).
+        """
         from app.services.config_service import get_config
 
         cfg = await get_config()
@@ -518,10 +539,13 @@ class EpisodeCurator:
             detected_ffmpeg = detect_ffmpeg()
             ffmpeg = detected_ffmpeg.path if detected_ffmpeg.found else None
 
-        from app.matcher.tmdb_client import fetch_show_id
+        if tmdb_id is not None:
+            show_id = tmdb_id
+        else:
+            from app.matcher.tmdb_client import fetch_show_id
 
-        tmdb_id = await asyncio.to_thread(fetch_show_id, series_name)
-        if not tmdb_id:
+            show_id = await asyncio.to_thread(fetch_show_id, series_name)
+        if not show_id:
             return None
 
         from app.matcher.chromaprint_extractor import ChromaprintExtractor
@@ -532,11 +556,11 @@ class EpisodeCurator:
         pack_cache = getattr(self, "_pack_cache", None)
         if pack_cache is not None:
             try:
-                await pack_cache.ensure(int(tmdb_id), server_url)
+                await pack_cache.ensure(int(show_id), server_url)
             except Exception as e:  # noqa: BLE001
                 logger.debug(f"pack ensure failed: {e}")
 
-        cm = ChromaprintMatcher(tmdb_id=int(tmdb_id), server_url=server_url, pack_cache=pack_cache)
+        cm = ChromaprintMatcher(tmdb_id=int(show_id), server_url=server_url, pack_cache=pack_cache)
         extractor = ChromaprintExtractor(fpcalc_path=fpcalc, ffmpeg_path=ffmpeg)
         try:
             video_duration = await asyncio.to_thread(get_video_duration, str(file_path))
@@ -560,6 +584,7 @@ class EpisodeCurator:
         season: int,
         match_details: dict | None = None,
         existing_transcript: str | None = None,
+        tmdb_id: int | None = None,
     ) -> dict | None:
         """Run the LLM matcher when enabled and attach the suggestion to match_details.
 
@@ -568,6 +593,9 @@ class EpisodeCurator:
         ``existing_transcript`` lets callers pass through a transcript the
         primary matcher already produced (via the full-file fallback path),
         avoiding a duplicate Whisper run when the matcher just transcribed.
+
+        ``tmdb_id``, when known, is used directly instead of ``fetch_show_id`` so the
+        LLM gets context for the correct show even when another show shares its name.
         """
         from app.services.config_service import get_config
 
@@ -577,10 +605,13 @@ class EpisodeCurator:
         if not config.ai_api_key:
             return None
 
-        # Resolve TMDB show id (synchronous, run in thread)
-        from app.matcher.tmdb_client import fetch_show_id
+        # Resolve TMDB show id — prefer the known id; otherwise resolve by name.
+        if tmdb_id is not None:
+            tmdb_show_id = tmdb_id
+        else:
+            from app.matcher.tmdb_client import fetch_show_id
 
-        tmdb_show_id = await asyncio.to_thread(fetch_show_id, series_name)
+            tmdb_show_id = await asyncio.to_thread(fetch_show_id, series_name)
         if not tmdb_show_id:
             logger.info(f"LLM fallback: no TMDB show_id for {series_name!r}")
             return None

--- a/backend/tests/unit/test_curator_tmdb_id.py
+++ b/backend/tests/unit/test_curator_tmdb_id.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.core.curator import EpisodeCurator
 
@@ -56,3 +57,171 @@ def test_ensure_initialized_rebuilds_when_tmdb_id_changes():
     assert ok is True
     assert cur._current_tmdb_id == 195241
     assert captured["expected_tmdb_id"] == 195241
+
+
+def _chromaprint_cfg() -> MagicMock:
+    """A config that lets _chromaprint_prepass run to the show-id resolution point."""
+    cfg = MagicMock()
+    cfg.enable_fingerprint_identification = True
+    cfg.fpcalc_path = "/fake/fpcalc"  # set → skips detect_fpcalc()
+    cfg.ffmpeg_path = "/fake/ffmpeg"  # set → skips detect_ffmpeg()
+    cfg.fingerprint_server_url = "http://fp.test"
+    return cfg
+
+
+async def test_chromaprint_prepass_uses_known_id_and_skips_fetch_show_id():
+    """The Phase-3 fingerprint prepass must fetch the pack for the KNOWN tmdb_id,
+    not re-resolve by name — otherwise a same-name collision (Frasier 1993 vs the
+    2023 revival) pulls the wrong show's fingerprint pack."""
+    cur = EpisodeCurator()
+    cur._matcher = object()  # must be non-None to proceed
+
+    captured = {}
+
+    class FakeChromaprintMatcher:
+        def __init__(self, tmdb_id, server_url, pack_cache=None):
+            captured["tmdb_id"] = tmdb_id
+
+    fake_fetch_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+    sentinel = {"season": 2, "episode": 5, "confidence": 0.95, "tier": "canonical"}
+
+    with (
+        patch("app.services.config_service.get_config", AsyncMock(return_value=_chromaprint_cfg())),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.matcher.chromaprint_matcher.ChromaprintMatcher", FakeChromaprintMatcher),
+        patch(
+            "app.matcher.chromaprint_matcher.identify_episode_chromaprint",
+            AsyncMock(return_value=sentinel),
+        ),
+        patch("app.matcher.chromaprint_extractor.ChromaprintExtractor", MagicMock()),
+        patch("app.matcher.episode_identification.get_video_duration", return_value=42.0),
+    ):
+        result = await cur._chromaprint_prepass(
+            file_path=Path("ep.mkv"),
+            series_name="Frasier",
+            season=2,
+            tmdb_id=195241,
+        )
+
+    assert result is sentinel
+    assert captured["tmdb_id"] == 195241  # the known id flowed into the matcher
+    fake_fetch_id.assert_not_called()
+
+
+async def test_maybe_add_llm_suggestion_uses_known_id_and_skips_fetch_show_id():
+    """The LLM fallback must build its TMDB context from the KNOWN tmdb_id, not
+    re-resolve by name — same collision hazard as the chromaprint path."""
+    cur = EpisodeCurator()
+    cur._matcher = object()
+
+    config = MagicMock()
+    config.ai_episode_matching_enabled = True
+    config.ai_api_key = "ai-key"
+    config.ai_provider = "anthropic"
+    config.tmdb_api_key = "tmdb-key"
+
+    fake_fetch_id = MagicMock(side_effect=AssertionError("fetch_show_id must not be called"))
+
+    suggestion = MagicMock()
+    suggestion.episode = 5
+    suggestion.confidence = 0.8
+    suggestion.reasoning = "dialogue references the season-2 finale"
+    suggestion.runner_up = None
+    suggestion.model = "claude"
+    fake_llm = AsyncMock(return_value=suggestion)
+
+    with (
+        patch("app.services.config_service.get_config", AsyncMock(return_value=config)),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.core.curator.match_episode_via_llm", fake_llm),
+    ):
+        result = await cur._maybe_add_llm_suggestion(
+            file_path=Path("ep.mkv"),
+            series_name="Frasier",
+            season=2,
+            match_details={},
+            existing_transcript="hello world",  # set → skips transcribe_full
+            tmdb_id=195241,
+        )
+
+    assert result is not None
+    assert result["llm_suggestion"]["episode"] == 5
+    fake_fetch_id.assert_not_called()
+    # The known id flows through to the LLM matcher as a string.
+    assert fake_llm.call_args.kwargs["tmdb_show_id"] == "195241"
+
+
+async def test_chromaprint_prepass_falls_back_to_fetch_show_id_without_tmdb_id():
+    """Without a known id, the prepass must still resolve by name — the legacy path
+    used for the common non-collision case must keep working."""
+    cur = EpisodeCurator()
+    cur._matcher = object()
+
+    captured = {}
+
+    class FakeChromaprintMatcher:
+        def __init__(self, tmdb_id, server_url, pack_cache=None):
+            captured["tmdb_id"] = tmdb_id
+
+    fake_fetch_id = MagicMock(return_value=3452)
+    sentinel = {"season": 1, "episode": 1, "confidence": 0.95, "tier": "canonical"}
+
+    with (
+        patch("app.services.config_service.get_config", AsyncMock(return_value=_chromaprint_cfg())),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.matcher.chromaprint_matcher.ChromaprintMatcher", FakeChromaprintMatcher),
+        patch(
+            "app.matcher.chromaprint_matcher.identify_episode_chromaprint",
+            AsyncMock(return_value=sentinel),
+        ),
+        patch("app.matcher.chromaprint_extractor.ChromaprintExtractor", MagicMock()),
+        patch("app.matcher.episode_identification.get_video_duration", return_value=42.0),
+    ):
+        result = await cur._chromaprint_prepass(
+            file_path=Path("ep.mkv"),
+            series_name="Frasier",
+            season=1,
+        )
+
+    assert result is sentinel
+    fake_fetch_id.assert_called_once_with("Frasier")
+    assert captured["tmdb_id"] == 3452
+
+
+async def test_maybe_add_llm_suggestion_falls_back_to_fetch_show_id_without_tmdb_id():
+    """Without a known id, the LLM fallback must still resolve by name."""
+    cur = EpisodeCurator()
+    cur._matcher = object()
+
+    config = MagicMock()
+    config.ai_episode_matching_enabled = True
+    config.ai_api_key = "ai-key"
+    config.ai_provider = "anthropic"
+    config.tmdb_api_key = "tmdb-key"
+
+    fake_fetch_id = MagicMock(return_value=3452)
+
+    suggestion = MagicMock()
+    suggestion.episode = 1
+    suggestion.confidence = 0.8
+    suggestion.reasoning = "r"
+    suggestion.runner_up = None
+    suggestion.model = "claude"
+    fake_llm = AsyncMock(return_value=suggestion)
+
+    with (
+        patch("app.services.config_service.get_config", AsyncMock(return_value=config)),
+        patch("app.matcher.tmdb_client.fetch_show_id", fake_fetch_id),
+        patch("app.core.curator.match_episode_via_llm", fake_llm),
+    ):
+        result = await cur._maybe_add_llm_suggestion(
+            file_path=Path("ep.mkv"),
+            series_name="Frasier",
+            season=1,
+            match_details={},
+            existing_transcript="hello world",
+        )
+
+    assert result is not None
+    fake_fetch_id.assert_called_once_with("Frasier")
+    assert fake_llm.call_args.kwargs["tmdb_show_id"] == "3452"


### PR DESCRIPTION
## What

Threads the job's known `tmdb_id` into the two matcher paths that still resolved show identity **by name** via `fetch_show_id(series_name)`:

- `EpisodeCurator._chromaprint_prepass` — the Phase-3 fingerprint cascade (fetches the fingerprint pack for a TMDB id).
- `EpisodeCurator._maybe_add_llm_suggestion` — the LLM episode-matching fallback (builds TMDB context for the LLM).

It also threads `tmdb_id` through `_run_asr_identify`, which is the only caller of `_maybe_add_llm_suggestion`.

## Why

[PR #278](https://github.com/Jsakkos/engram/pull/278) made `tmdb_id` a first-class identity through the **ASR** path — `match_single_file(..., tmdb_id=...)` forwards a known id to `_ensure_initialized` and the corpus guard. But the chromaprint prepass and the LLM fallback were left out of scope (the reported Frasier bug uses the ASR path; chromaprint is feature-gated).

For a same-name collision — e.g. **Frasier 1993 (#3452)** vs the **2023 revival (#195241)** — resolving by name picks whichever show `fetch_show_id` ranks first, so these two paths would fetch the **wrong** show's fingerprint pack / LLM context the moment fingerprint identification is enabled for a collision show. This closes that gap so the whole identity spine uses the known id.

## How

Each path now uses the known id directly when present and falls back to name resolution otherwise:

```python
if tmdb_id is not None:
    show_id = tmdb_id
else:
    show_id = await asyncio.to_thread(fetch_show_id, series_name)
```

The legacy name-resolution path is unchanged when no `tmdb_id` is supplied (the common non-collision case).

## Tests

Extends `backend/tests/unit/test_curator_tmdb_id.py`:

- **Bypass** (new behavior): for both paths, assert `fetch_show_id` is **not** called when `tmdb_id` is provided and the known id flows through (to `ChromaprintMatcher(tmdb_id=...)` / `match_episode_via_llm(tmdb_show_id=...)`).
- **Fallback** (regression guards): without `tmdb_id`, `fetch_show_id(series_name)` is still called and its result flows through.

Verification:
- `uv run pytest tests/unit/ -q` → **1445 passed**
- `tests/integration/test_chromaprint_cascade.py` + `test_llm_matching_workflow.py` → **8 passed** (calling-convention check, since both monkeypatch these methods)
- `ruff check` / `ruff format --check` → clean

## Note

Stacked on `claude/confident-ritchie-1aea2c` (PR #278), since the `tmdb_id` parameter on `match_single_file` exists only there. Base will need re-targeting to `main` after #278 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
