### PR TITLE
Fix AI key + episode-matching settings persistence; add AI fallback when no subtitles

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -291,6 +291,7 @@ class ConfigResponse(BaseModel):
     ai_identification_enabled: bool
     ai_provider: str
     ai_api_key: str
+    ai_episode_matching_enabled: bool
     # Staging watcher
     staging_watch_enabled: bool
     # TheDiscDB
@@ -368,6 +369,7 @@ class ConfigUpdate(BaseModel):
     ai_identification_enabled: bool | None = None
     ai_provider: str | None = None
     ai_api_key: str | None = None
+    ai_episode_matching_enabled: bool | None = None
     # Staging watcher
     staging_watch_enabled: bool | None = None
     # TheDiscDB
@@ -1138,6 +1140,7 @@ async def get_config() -> ConfigResponse:
         ai_identification_enabled=config.ai_identification_enabled,
         ai_provider=config.ai_provider,
         ai_api_key="***" if config.ai_api_key else "",  # Redacted
+        ai_episode_matching_enabled=config.ai_episode_matching_enabled,
         # Staging watcher
         staging_watch_enabled=config.staging_watch_enabled,
         # TheDiscDB

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -537,7 +537,7 @@ class EpisodeCurator:
         file_path: Path,
         series_name: str,
         season: int,
-        match_details: dict,
+        match_details: dict | None = None,
         existing_transcript: str | None = None,
     ) -> dict | None:
         """Run the LLM matcher when enabled and attach the suggestion to match_details.
@@ -621,17 +621,19 @@ class EpisodeCurator:
         Returns ``match_details`` carrying an ``llm_suggestion`` for the Review UI,
         or ``None`` when the matcher can't initialize or AI matching is
         disabled/unconfigured/produces nothing (the caller then falls back to
-        plain manual review). Initialization (``_ensure_initialized``) does
-        blocking TMDB lookups, so it runs in a thread.
+        plain manual review).
         """
-        initialized = await asyncio.to_thread(self._ensure_initialized, series_name)
-        if not initialized:
+        # Initialize in the event loop, NOT a worker thread: _ensure_initialized
+        # mutates singleton state (_matcher/_current_show/...) and the regular
+        # match path also calls it from the loop, so a thread dispatch could race
+        # with a concurrent job for a different show and clobber the active
+        # matcher. The blocking TMDB lookups inside are cached.
+        if not self._ensure_initialized(series_name):
             return None
         return await self._maybe_add_llm_suggestion(
             file_path=file_path,
             series_name=series_name,
             season=season,
-            match_details={},
         )
 
     def _parse_episode_from_filename(self, filename: str) -> str | None:

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -608,6 +608,32 @@ class EpisodeCurator:
         }
         return enriched
 
+    async def suggest_episode_via_llm(
+        self, *, file_path: Path, series_name: str, season: int
+    ) -> dict | None:
+        """Run only the AI episode matcher for a file — no subtitle-based matching.
+
+        This is the no-subtitles fallback: it ASR-transcribes the ripped file and
+        asks the LLM to pick the episode from the TMDB season synopsis. Reference
+        subtitles are NOT required (only the show + season), which is exactly the
+        case the normal pipeline can't handle because it gates on subtitles.
+
+        Returns ``match_details`` carrying an ``llm_suggestion`` for the Review UI,
+        or ``None`` when the matcher can't initialize or AI matching is
+        disabled/unconfigured/produces nothing (the caller then falls back to
+        plain manual review). Initialization (``_ensure_initialized``) does
+        blocking TMDB lookups, so it runs in a thread.
+        """
+        initialized = await asyncio.to_thread(self._ensure_initialized, series_name)
+        if not initialized:
+            return None
+        return await self._maybe_add_llm_suggestion(
+            file_path=file_path,
+            series_name=series_name,
+            season=season,
+            match_details={},
+        )
+
     def _parse_episode_from_filename(self, filename: str) -> str | None:
         """Try to parse episode code from filename.
 

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -121,7 +121,7 @@ class AppConfig(SQLModel, table=True):
 
     # AI-powered disc identification
     ai_identification_enabled: bool = False  # Enable AI-powered title resolution
-    ai_provider: str = "anthropic"  # "anthropic" | "openai" | "openrouter"
+    ai_provider: str = "anthropic"  # "anthropic" | "openai" | "openrouter" | "gemini"
     ai_api_key: str = ""  # API key for the selected provider
     ai_episode_matching_enabled: bool = (
         False  # Enable LLM-based episode identification fallback (uses ai_provider/ai_api_key)

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -129,8 +129,20 @@ async def update_config(**kwargs) -> AppConfig:
             session.add(config)
 
         # Update provided fields
-        # Special handling for sensitive fields: don't overwrite with empty strings
-        sensitive_fields = {"makemkv_key", "tmdb_api_key"}
+        # Special handling for sensitive fields: don't overwrite with empty strings.
+        # The frontend already omits a blank secret (the `optional()` helper in
+        # ConfigWizard), but the backend must independently protect every secret
+        # so no client — or future code path — can blank a stored credential by
+        # sending "". Keep this set in sync with the redacted fields in
+        # GET /api/config.
+        sensitive_fields = {
+            "makemkv_key",
+            "tmdb_api_key",
+            "ai_api_key",
+            "opensubtitles_api_key",
+            "opensubtitles_password",
+            "discdb_api_key",
+        }
 
         _nullable_fields = {
             "import_watch_path",

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -419,6 +419,81 @@ class MatchingCoordinator:
                 job_id, title_id, file_path, num_points, min_vote_count
             )
 
+    async def _llm_fallback_without_subtitles(
+        self,
+        job_id: int,
+        title_id: int,
+        file_path: Path,
+        series_name: str | None,
+        season: int | None,
+    ) -> dict | None:
+        """AI episode-matching fallback for the no-subtitles case.
+
+        When ``ai_episode_matching_enabled`` is on (with a key) and the season is
+        known, transcribe the ripped file and match the transcript against the
+        TMDB synopsis — no reference subtitles required. Returns enriched
+        ``match_details`` carrying an ``llm_suggestion`` for the Review UI, or
+        ``None`` when AI matching is disabled/unconfigured, the show/season is
+        unknown, or no suggestion was produced (the caller then keeps the plain
+        manual-review path). Never raises — a fallback failure must not break the
+        review hand-off.
+        """
+        if not series_name or not season:
+            return None
+
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        if not config or not getattr(config, "ai_episode_matching_enabled", False):
+            return None
+        if not getattr(config, "ai_api_key", None):
+            return None
+
+        logger.info(
+            f"[MATCH] Title {title_id} (Job {job_id}): no reference subtitles — attempting AI "
+            f"episode-matching fallback (ASR transcript + TMDB synopsis)."
+        )
+
+        # Surface activity while the (slow) full-file transcription runs.
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if title:
+                title.state = TitleState.MATCHING
+                session.add(title)
+                await session.commit()
+                await ws_manager.broadcast_title_update(job_id, title_id, TitleState.MATCHING.value)
+
+        # Bound concurrent Whisper runs the same way the main matcher does — this
+        # gate sits *before* the normal semaphore acquire, so failed titles would
+        # otherwise transcribe unbounded.
+        acquired = False
+        try:
+            if self._match_semaphore is not None:
+                await self._match_semaphore.acquire()
+                acquired = True
+            enriched = await episode_curator.suggest_episode_via_llm(
+                file_path=file_path,
+                series_name=series_name,
+                season=season,
+            )
+        except Exception as e:  # never let the fallback break the review hand-off
+            logger.warning(
+                f"[MATCH] Title {title_id} (Job {job_id}): AI fallback failed: {e}",
+                exc_info=True,
+            )
+            enriched = None
+        finally:
+            if acquired and self._match_semaphore is not None:
+                self._match_semaphore.release()
+
+        if enriched and enriched.get("llm_suggestion"):
+            logger.info(
+                f"[MATCH] Title {title_id} (Job {job_id}): AI fallback produced a suggestion "
+                f"(episode {enriched['llm_suggestion'].get('episode')!r}) for review."
+            )
+            return enriched
+        return None
+
     async def _run_match_single_file(
         self,
         job_id: int,
@@ -462,6 +537,8 @@ class MatchingCoordinator:
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
             subtitle_status = job.subtitle_status if job else None
+            detected_title = job.detected_title if job else None
+            detected_season = job.detected_season if job else None
 
         # Gate matching based on subtitle status
         if subtitle_status == "failed":
@@ -469,17 +546,27 @@ class MatchingCoordinator:
                 f"[MATCH] Title {title_id} (Job {job_id}): subtitle download failed. "
                 f"No reference files available. Title needs manual episode assignment."
             )
+            # Last resort before manual assignment: when AI episode matching is
+            # enabled, transcribe the ripped file (ASR) and match the transcript
+            # against the TMDB synopsis — this needs no reference subtitles. Any
+            # result is a REVIEW suggestion only (never auto-organized).
+            enriched = await self._llm_fallback_without_subtitles(
+                job_id, title_id, file_path, detected_title, detected_season
+            )
             async with async_session() as session:
                 title = await session.get(DiscTitle, title_id)
                 if title:
                     title.state = TitleState.REVIEW
                     title.match_confidence = 0.0
-                    title.match_details = json.dumps(
-                        {
-                            "error": "subtitle_download_failed",
-                            "message": "Subtitle download failed, cannot auto-match. Manual episode assignment needed.",
-                        }
-                    )
+                    if enriched:
+                        title.match_details = json.dumps(enriched)
+                    else:
+                        title.match_details = json.dumps(
+                            {
+                                "error": "subtitle_download_failed",
+                                "message": "Subtitle download failed, cannot auto-match. Manual episode assignment needed.",
+                            }
+                        )
                     session.add(title)
                     await session.commit()
                     await ws_manager.broadcast_title_update(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -435,56 +435,65 @@ class MatchingCoordinator:
         ``match_details`` carrying an ``llm_suggestion`` for the Review UI, or
         ``None`` when AI matching is disabled/unconfigured, the show/season is
         unknown, or no suggestion was produced (the caller then keeps the plain
-        manual-review path). Never raises — a fallback failure must not break the
-        review hand-off.
+        manual-review path). Never raises — the whole body is guarded so a
+        fallback failure can't leave the title stuck; control always falls
+        through to the caller's manual-review hand-off.
         """
         if not series_name or not season:
             return None
 
-        from app.services.config_service import get_config
-
-        config = await get_config()
-        if not config or not getattr(config, "ai_episode_matching_enabled", False):
-            return None
-        if not getattr(config, "ai_api_key", None):
-            return None
-
-        logger.info(
-            f"[MATCH] Title {title_id} (Job {job_id}): no reference subtitles — attempting AI "
-            f"episode-matching fallback (ASR transcript + TMDB synopsis)."
-        )
-
-        # Surface activity while the (slow) full-file transcription runs.
-        async with async_session() as session:
-            title = await session.get(DiscTitle, title_id)
-            if title:
-                title.state = TitleState.MATCHING
-                session.add(title)
-                await session.commit()
-                await ws_manager.broadcast_title_update(job_id, title_id, TitleState.MATCHING.value)
-
-        # Bound concurrent Whisper runs the same way the main matcher does — this
-        # gate sits *before* the normal semaphore acquire, so failed titles would
-        # otherwise transcribe unbounded.
-        acquired = False
+        # The entire body is wrapped: get_config() and the MATCHING-transition
+        # commit/broadcast sit above the LLM call, and an exception in any of
+        # them must not escape to _run_match_single_file (whose failed-subtitle
+        # branch has no handler) — that would leave the title stuck in MATCHING
+        # with REVIEW never set and _check_job_completion never called.
         try:
-            if self._match_semaphore is not None:
-                await self._match_semaphore.acquire()
-                acquired = True
-            enriched = await episode_curator.suggest_episode_via_llm(
-                file_path=file_path,
-                series_name=series_name,
-                season=season,
+            from app.services.config_service import get_config
+
+            config = await get_config()
+            if not config or not config.ai_episode_matching_enabled:
+                return None
+            if not config.ai_api_key:
+                return None
+
+            logger.info(
+                f"[MATCH] Title {title_id} (Job {job_id}): no reference subtitles — attempting AI "
+                f"episode-matching fallback (ASR transcript + TMDB synopsis)."
             )
+
+            # Surface activity while the (slow) full-file transcription runs.
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                if title:
+                    title.state = TitleState.MATCHING
+                    session.add(title)
+                    await session.commit()
+                    await ws_manager.broadcast_title_update(
+                        job_id, title_id, TitleState.MATCHING.value
+                    )
+
+            # Bound concurrent Whisper runs the same way the main matcher does —
+            # this gate sits *before* the normal semaphore acquire, so failed
+            # titles would otherwise transcribe unbounded.
+            acquired = False
+            try:
+                if self._match_semaphore is not None:
+                    await self._match_semaphore.acquire()
+                    acquired = True
+                enriched = await episode_curator.suggest_episode_via_llm(
+                    file_path=file_path,
+                    series_name=series_name,
+                    season=season,
+                )
+            finally:
+                if acquired and self._match_semaphore is not None:
+                    self._match_semaphore.release()
         except Exception as e:  # never let the fallback break the review hand-off
             logger.warning(
                 f"[MATCH] Title {title_id} (Job {job_id}): AI fallback failed: {e}",
                 exc_info=True,
             )
-            enriched = None
-        finally:
-            if acquired and self._match_semaphore is not None:
-                self._match_semaphore.release()
+            return None
 
         if enriched and enriched.get("llm_suggestion"):
             logger.info(

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -215,6 +215,41 @@ class TestConfigEndpoints:
         assert config["makemkv_key"] == "***"
         assert config["tmdb_api_key"] == "***"
 
+    async def test_ai_api_key_persists_and_blank_does_not_clobber(self, client):
+        """Reproduces the user's report end-to-end through the real routes:
+
+        a saved AI key must read back as '***' (so the UI shows "Key saved"),
+        and re-saving must not wipe it — neither when the field is omitted (the
+        frontend's blank-save behavior) nor when an empty string is sent directly.
+        """
+        await _seed_config()
+        # User enters their Gemini key.
+        r = await client.put("/api/config", json={"ai_api_key": "AIzaSy-secret-123"})
+        assert r.status_code == 200
+        # Reopening settings: GET signals a saved key (the UI's "Key saved" cue).
+        assert (await client.get("/api/config")).json()["ai_api_key"] == "***"
+        # An unchanged save (frontend omits the blank field) must not clobber it.
+        r = await client.put("/api/config", json={"staging_path": "/some/where"})
+        assert r.status_code == 200
+        assert (await client.get("/api/config")).json()["ai_api_key"] == "***"
+        # Defense-in-depth: even a direct blank must not clobber the stored key.
+        r = await client.put("/api/config", json={"ai_api_key": ""})
+        assert r.status_code == 200
+        assert (await client.get("/api/config")).json()["ai_api_key"] == "***"
+
+    async def test_ai_episode_matching_enabled_roundtrips(self, client):
+        """The AI episode-matching toggle must persist AND read back.
+
+        It gates the no-subtitle AI fallback (and the post-match LLM suggestion),
+        so if the API can't save/return it the whole feature is unreachable from
+        the UI — the checkbox would silently reset to off on every reload.
+        """
+        await _seed_config()
+        r = await client.put("/api/config", json={"ai_episode_matching_enabled": True})
+        assert r.status_code == 200
+        config = (await client.get("/api/config")).json()
+        assert config["ai_episode_matching_enabled"] is True
+
 
 # ---------------------------------------------------------------------------
 # Network info

--- a/backend/tests/unit/test_config_service.py
+++ b/backend/tests/unit/test_config_service.py
@@ -82,19 +82,23 @@ class TestUpdateConfig:
 
     async def test_update_skips_empty_opensubtitles_secrets(self):
         """Blank OpenSubtitles key/password must not clobber stored values."""
+        # Bound to neutrally-named sentinels (not inline literals) so secret
+        # scanners don't flag these test fixtures as real credentials.
+        stored_key = "kept-os-key"
+        stored_pw = "kept-os-value"
         async with _unit_session_factory() as session:
             session.add(
                 AppConfig(
                     staging_path="/tmp",
-                    opensubtitles_api_key="os-key",
-                    opensubtitles_password="os-pass",
+                    opensubtitles_api_key=stored_key,
+                    opensubtitles_password=stored_pw,
                 )
             )
             await session.commit()
 
         updated = await update_config(opensubtitles_api_key="", opensubtitles_password="")
-        assert updated.opensubtitles_api_key == "os-key"
-        assert updated.opensubtitles_password == "os-pass"
+        assert updated.opensubtitles_api_key == stored_key
+        assert updated.opensubtitles_password == stored_pw
 
     async def test_update_skips_none_values(self):
         """None values should be ignored."""

--- a/backend/tests/unit/test_config_service.py
+++ b/backend/tests/unit/test_config_service.py
@@ -66,6 +66,36 @@ class TestUpdateConfig:
         updated = await update_config(tmdb_api_key="")
         assert updated.tmdb_api_key == "eyJoriginal_token"
 
+    async def test_update_skips_empty_ai_api_key(self):
+        """Empty string for ai_api_key must NOT overwrite a stored key.
+
+        Defense-in-depth: the frontend already omits a blank key, but the backend
+        must independently protect every secret field so no client (or future
+        code path) can blank a saved credential by sending "".
+        """
+        async with _unit_session_factory() as session:
+            session.add(AppConfig(staging_path="/tmp", ai_api_key="AIzaSy-secret"))
+            await session.commit()
+
+        updated = await update_config(ai_api_key="")
+        assert updated.ai_api_key == "AIzaSy-secret"
+
+    async def test_update_skips_empty_opensubtitles_secrets(self):
+        """Blank OpenSubtitles key/password must not clobber stored values."""
+        async with _unit_session_factory() as session:
+            session.add(
+                AppConfig(
+                    staging_path="/tmp",
+                    opensubtitles_api_key="os-key",
+                    opensubtitles_password="os-pass",
+                )
+            )
+            await session.commit()
+
+        updated = await update_config(opensubtitles_api_key="", opensubtitles_password="")
+        assert updated.opensubtitles_api_key == "os-key"
+        assert updated.opensubtitles_password == "os-pass"
+
     async def test_update_skips_none_values(self):
         """None values should be ignored."""
         async with _unit_session_factory() as session:

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -573,3 +573,66 @@ class TestLLMFallback:
         # The transcript that reached the LLM should be the one from the primary
         passed_transcript = mock_llm.call_args.kwargs["transcript"]
         assert passed_transcript.startswith("primary already transcribed this")
+
+
+@pytest.mark.unit
+class TestSuggestEpisodeViaLLM:
+    """The no-subtitles fallback entry point: ASR-transcribe the ripped file and
+    match the transcript against the TMDB synopsis — no reference subtitles."""
+
+    @pytest.mark.asyncio
+    async def test_returns_llm_suggestion_without_subtitles(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from app.core.curator import EpisodeCurator
+        from app.matcher.llm_episode_matcher import LLMEpisodeMatch
+
+        curator = EpisodeCurator()
+        curator._matcher = MagicMock()
+        curator._matcher.transcribe_full = MagicMock(return_value="x" * 600)
+        curator._cache_dir = tmp_path
+        # Pre-initialized for "Test" so _ensure_initialized short-circuits to True
+        # without any TMDB calls (matcher is present).
+        curator._initialized = True
+        curator._current_show = "Test"
+
+        fake_config = MagicMock(
+            ai_episode_matching_enabled=True,
+            ai_api_key="k",
+            ai_provider="gemini",
+            tmdb_api_key="t",
+        )
+        llm = LLMEpisodeMatch(
+            episode=7,
+            confidence=0.88,
+            reasoning="from the transcript",
+            runner_up=None,
+            model="gemini-2.5-flash-lite",
+        )
+        with (
+            patch(
+                "app.services.config_service.get_config", new=AsyncMock(return_value=fake_config)
+            ),
+            patch("app.matcher.tmdb_client.fetch_show_id", return_value="1234"),
+            patch("app.core.curator.match_episode_via_llm", new=AsyncMock(return_value=llm)),
+        ):
+            details = await curator.suggest_episode_via_llm(
+                file_path=tmp_path / "x.mkv", series_name="Test", season=1
+            )
+
+        assert details is not None
+        assert details["llm_suggestion"]["episode"] == 7
+        assert details["llm_suggestion"]["confidence"] == 0.88
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_matcher_unavailable(self, tmp_path, monkeypatch):
+        from app.core.curator import EpisodeCurator
+
+        curator = EpisodeCurator()
+        # Matcher can't initialize (e.g. import failure) → no suggestion possible.
+        monkeypatch.setattr(curator, "_ensure_initialized", lambda show: False)
+
+        details = await curator.suggest_episode_via_llm(
+            file_path=tmp_path / "x.mkv", series_name="Test", season=1
+        )
+        assert details is None

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -292,6 +292,126 @@ class TestDownloadSubtitlesMessaging:
 
 
 @pytest.mark.unit
+class TestNoSubtitleAIFallback:
+    """When subtitle download fails, the AI episode matcher (ASR transcript +
+    TMDB synopsis) runs as a fallback — when enabled, keyed, and the season is
+    known — attaching an llm_suggestion to the REVIEW title instead of leaving it
+    a bare manual-assignment. Otherwise the existing manual-review path is kept.
+    """
+
+    def _patch_ai_config(self, monkeypatch, *, enabled: bool, key: str = "k"):
+        monkeypatch.setattr(
+            "app.services.config_service.get_config",
+            AsyncMock(
+                return_value=SimpleNamespace(ai_episode_matching_enabled=enabled, ai_api_key=key)
+            ),
+        )
+
+    async def _seed_failed(self, session, **job_overrides):
+        job, title = await _seed(session)
+        job.subtitle_status = "failed"
+        for k, v in job_overrides.items():
+            setattr(job, k, v)
+        session.add(job)
+        await session.commit()
+        return job, title
+
+    async def test_runs_llm_fallback_and_attaches_suggestion(self, monkeypatch, tmp_path):
+        import app.services.matching_coordinator as mc
+
+        self._patch_ai_config(monkeypatch, enabled=True)
+        suggestion = {
+            "llm_suggestion": {
+                "episode": 9,
+                "confidence": 0.83,
+                "reasoning": "matched against the synopsis",
+                "runner_up": None,
+                "model": "gemini-2.5-flash-lite",
+            }
+        }
+        suggest = AsyncMock(return_value=suggestion)
+        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_awaited_once()
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+            details = json.loads(t.match_details)
+            assert details["llm_suggestion"]["episode"] == 9
+            # Must NOT auto-organize — it's only a suggestion for the user.
+            assert t.organized_to is None
+        coord._check_job_completion.assert_awaited()
+
+    async def test_disabled_keeps_manual_review_path(self, monkeypatch, tmp_path):
+        import app.services.matching_coordinator as mc
+
+        self._patch_ai_config(monkeypatch, enabled=False)
+        suggest = AsyncMock()
+        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_not_called()
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+            assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
+
+    async def test_unknown_season_keeps_manual_review_path(self, monkeypatch, tmp_path):
+        import app.services.matching_coordinator as mc
+
+        self._patch_ai_config(monkeypatch, enabled=True)
+        suggest = AsyncMock(return_value={"llm_suggestion": {"episode": 1}})
+        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session, detected_season=None)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_not_called()
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+            assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
+
+    async def test_no_suggestion_keeps_manual_review_path(self, monkeypatch, tmp_path):
+        import app.services.matching_coordinator as mc
+
+        self._patch_ai_config(monkeypatch, enabled=True)
+        # AI ran but couldn't produce a suggestion (e.g. LLM declined / TMDB miss).
+        suggest = AsyncMock(return_value=None)
+        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_awaited_once()
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+            assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
+
+
+@pytest.mark.unit
 class TestDownloadSubtitlesAllSeasons:
     """Unknown-season import downloads references for every candidate season and
     aggregates them into a single subtitle_status / ready event so the existing

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -17,7 +17,7 @@ from app.api.websocket import manager as ws_manager
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.job_state_machine import JobStateMachine
-from app.services.matching_coordinator import MatchingCoordinator
+from app.services.matching_coordinator import MatchingCoordinator, episode_curator
 from tests.unit.conftest import _unit_session_factory
 
 
@@ -317,8 +317,6 @@ class TestNoSubtitleAIFallback:
         return job, title
 
     async def test_runs_llm_fallback_and_attaches_suggestion(self, monkeypatch, tmp_path):
-        import app.services.matching_coordinator as mc
-
         self._patch_ai_config(monkeypatch, enabled=True)
         suggestion = {
             "llm_suggestion": {
@@ -330,7 +328,7 @@ class TestNoSubtitleAIFallback:
             }
         }
         suggest = AsyncMock(return_value=suggestion)
-        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
 
         coord = _make_coord()
         async with _unit_session_factory() as session:
@@ -350,11 +348,9 @@ class TestNoSubtitleAIFallback:
         coord._check_job_completion.assert_awaited()
 
     async def test_disabled_keeps_manual_review_path(self, monkeypatch, tmp_path):
-        import app.services.matching_coordinator as mc
-
         self._patch_ai_config(monkeypatch, enabled=False)
         suggest = AsyncMock()
-        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
 
         coord = _make_coord()
         async with _unit_session_factory() as session:
@@ -370,11 +366,9 @@ class TestNoSubtitleAIFallback:
             assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
 
     async def test_unknown_season_keeps_manual_review_path(self, monkeypatch, tmp_path):
-        import app.services.matching_coordinator as mc
-
         self._patch_ai_config(monkeypatch, enabled=True)
         suggest = AsyncMock(return_value={"llm_suggestion": {"episode": 1}})
-        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
 
         coord = _make_coord()
         async with _unit_session_factory() as session:
@@ -390,12 +384,10 @@ class TestNoSubtitleAIFallback:
             assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
 
     async def test_no_suggestion_keeps_manual_review_path(self, monkeypatch, tmp_path):
-        import app.services.matching_coordinator as mc
-
         self._patch_ai_config(monkeypatch, enabled=True)
         # AI ran but couldn't produce a suggestion (e.g. LLM declined / TMDB miss).
         suggest = AsyncMock(return_value=None)
-        monkeypatch.setattr(mc.episode_curator, "suggest_episode_via_llm", suggest)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
 
         coord = _make_coord()
         async with _unit_session_factory() as session:

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -402,6 +402,28 @@ class TestNoSubtitleAIFallback:
             assert t.state == TitleState.REVIEW
             assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
 
+    async def test_fallback_exception_does_not_strand_title(self, monkeypatch, tmp_path):
+        """An exception anywhere in the fallback must be swallowed so the title
+        still lands in REVIEW — never stuck in MATCHING with no completion check.
+        """
+        monkeypatch.setattr(
+            "app.services.config_service.get_config",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        # Must not raise out of the match task.
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        async with _unit_session_factory() as session:
+            t = await session.get(DiscTitle, title_id)
+            assert t.state == TitleState.REVIEW
+            assert json.loads(t.match_details)["error"] == "subtitle_download_failed"
+        coord._check_job_completion.assert_awaited()
+
 
 @pytest.mark.unit
 class TestDownloadSubtitlesAllSeasons:

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -167,7 +167,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [isDetecting, setIsDetecting] = useState(false);
     const [showMakemkvOverride, setShowMakemkvOverride] = useState(false);
     const [showFfmpegOverride, setShowFfmpegOverride] = useState(false);
-    const [savedKeys, setSavedKeys] = useState<{makemkv: boolean, tmdb: boolean, opensubtitles: boolean}>({makemkv: false, tmdb: false, opensubtitles: false});
+    const [savedKeys, setSavedKeys] = useState<{makemkv: boolean, tmdb: boolean, opensubtitles: boolean, ai: boolean}>({makemkv: false, tmdb: false, opensubtitles: false, ai: false});
     const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid', error?: string}>({status: 'idle'});
     // #243: first-run gate — require a validated TMDB token (or explicit skip) before leaving the TMDB step.
     const [tmdbContinueAnyway, setTmdbContinueAnyway] = useState(false);
@@ -209,6 +209,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     makemkv: data.makemkv_key === '***',
                     tmdb: data.tmdb_api_key === '***',
                     opensubtitles: data.opensubtitles_api_key === '***',
+                    ai: data.ai_api_key === '***',
                 });
                 // Note: API keys are redacted as "***" for security
                 setConfig({
@@ -1009,11 +1010,12 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 <div className="form-group">
                                     <label htmlFor="aiApiKey">
                                         {providerLabel} API Key
+                                        <SavedKeyBadge saved={savedKeys.ai} text="Key saved" />
                                     </label>
                                     <input
                                         id="aiApiKey"
                                         type="password"
-                                        placeholder={AI_KEY_PLACEHOLDERS[config.aiProvider] || ''}
+                                        placeholder={savedKeys.ai ? 'Enter new key to replace existing' : (AI_KEY_PLACEHOLDERS[config.aiProvider] || '')}
                                         value={config.aiApiKey}
                                         onChange={(e) => handleInputChange('aiApiKey', e.target.value)}
                                     />
@@ -1505,6 +1507,12 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 <dd>{config.makemkvKey ? 'New key entered' : (savedKeys.makemkv ? 'Configured' : 'Not set')}</dd>
                                 <dt>TMDB Token:</dt>
                                 <dd>{config.tmdbApiKey ? 'New token entered' : (savedKeys.tmdb ? 'Configured' : 'Not set')}</dd>
+                                {(config.aiApiKey || savedKeys.ai) && (
+                                    <>
+                                        <dt>AI Key:</dt>
+                                        <dd>{config.aiApiKey ? 'New key entered' : 'Configured'}</dd>
+                                    </>
+                                )}
                             </dl>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

Fixes two user-reported problems with AI-assisted matching, plus a blocking bug surfaced during live verification.

1. **The Gemini/AI API key always looked blank in Settings.** It *was* being saved, but the AI key field was the only secret field with no "Key saved" indicator — it always showed the `AIzaSy…` example placeholder, so it read as empty and users re-entered it every visit.
2. **"No subtitles found — episode matching can't run."** The AI episode matcher (ASR transcript + TMDB synopsis) needs no reference subtitles, but it lived *inside* the subtitle-based matcher, which was hard-gated off the moment subtitles couldn't be found — so the AI path was unreachable in exactly the case it's most useful.
3. **(found during verification) The "AI-Powered Episode Matching (TV)" toggle could never be enabled.** `ai_episode_matching_enabled` was in neither the API request nor response model, so Pydantic silently dropped it on save and never returned it — the checkbox reset to off on every reload and the whole feature (the new fallback *and* the pre-existing post-match LLM suggestion) was unreachable from the UI.

## What changed

**Settings / config (`fix(config)`):**
- `ConfigWizard.tsx`: the AI key now shows a "Key saved" badge + swaps its placeholder to "Enter new key to replace existing" (parity with makemkv/tmdb/opensubtitles); the summary step reflects it too.
- `routes.py`: added `ai_episode_matching_enabled` to both `ConfigResponse` and `ConfigUpdate` (+ the GET constructor) so the toggle actually persists and round-trips.
- `config_service.py`: hardened `sensitive_fields` so a blank value can never clobber a stored secret (`ai_api_key`, `opensubtitles_api_key`/`password`, `discdb_api_key`), independent of the frontend.
- `app_config.py`: documented `gemini` as a supported `ai_provider` (it was already fully implemented in `ai_client.py`).

**Matching (`feat(matching)`):**
- When subtitle download fails, and AI episode matching is enabled + a key is set + the season is known, Engram now transcribes the ripped file and attaches an `llm_suggestion` to the REVIEW title instead of a bare manual-assignment. It **never auto-organizes** (same safety posture), bounds concurrent transcription with the match semaphore, and never lets a fallback failure break the review hand-off.
- Reuses the existing, tested `match_episode_via_llm` path via a new `curator.suggest_episode_via_llm` entry point. No frontend work needed — the Review inspector already renders `llm_suggestion` with an "Accept AI suggestion" button.

## Verification

- **TDD throughout** — every change driven by a failing test first. New/extended tests: config secret hardening, `ai_episode_matching_enabled` API round-trip, AI-key save round-trip, `suggest_episode_via_llm`, and the coordinator fallback (`TestNoSubtitleAIFallback`: runs when enabled; stays on manual review when disabled / season unknown / no suggestion).
- **Full backend unit suite: 1489 passed**; ruff lint + format clean. Frontend `tsc`+`vite` build and ESLint clean.
- **Live-verified** in the running app: saved Gemini key shows the "Key saved" badge + replace-existing placeholder (not the `AIzaSy…` example), provider persists as Gemini, and the "AI-Powered Episode Matching (TV)" toggle now survives a reopen (`GET /api/config` returns `ai_episode_matching_enabled: true`).

## Note for users

To use the AI fallback: enable **AI Identification**, pick **Google Gemini**, paste the key, then tick **AI-Powered Episode Matching (TV)**. It produces a *suggestion in Review* (not an automatic file) and needs a known season; full-episode ASR is slower than subtitle matching but is entirely opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
