### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-01
+
+_Highlights: a new opt-in AI episode-matching fallback for discs that have no reference subtitles — Engram transcribes the rip and matches it against the TMDB synopsis to suggest an episode in Review; the AI key and "AI-Powered Episode Matching" toggle now save and persist; and queued fingerprint contributions survive a sustained server outage instead of being permanently dropped._
+
+### Added
+
+- **AI episode-matching fallback when no subtitles are found** — for discs where no reference subtitles can be downloaded, the normal subtitle-based matcher has nothing to compare against. Engram can now transcribe the ripped file with on-device speech recognition (ASR) and match that transcript against each candidate episode's TMDB synopsis, surfacing a best-guess episode in the Review queue. It is opt-in via the **"AI-Powered Episode Matching"** setting and never auto-organizes — the suggestion is always presented for you to confirm. (#283)
+- **Force-delete a stuck fingerprint contribution** — a contribution retrying against a permanently unreachable server could stay queued indefinitely, and its in-flight guard blocked removal. The single-contribution delete now accepts a `force=true` option to retract such a row. It still refuses to delete anything already uploaded — use **Forget me** to recall data that has left your machine. (#280)
+
+### Fixed
+
+- **The AI API key and "AI-Powered Episode Matching" toggle didn't persist** — the AI/Gemini API key field always rendered blank with no sign a key was saved, and the episode-matching toggle could not be enabled at all, because the underlying config field was missing from the settings API models and was silently dropped on save. Settings now shows a **"Key saved"** indicator once a key is stored, and the toggle persists across restarts. (#283)
+- **Queued fingerprint contributions were permanently dropped during a sustained server outage** — the uploader's retry cap was a lifetime cap, so a prolonged upstream outage (for example 503s during a bulk library bootstrap) could exhaust a contribution's attempts in a single drain and mark it permanently failed, with no automatic recovery. Transient errors (5xx, network, and rate-limit 429) now keep the contribution queued and retry it on later drains; only genuine permanent failures (4xx or undecodable data) are marked failed. (#279)
+
 ## [0.12.1] - 2026-05-31
 
 _Highlights: fingerprint-network contributions now upload far faster — a backlog drains in back-to-back batches instead of trickling out an hour at a time, and rate-limited uploads are retried instead of dropped. Plus a LAN-access fix so a dual-stack host no longer rejects its own requests._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.12.1"
+__version__ = "0.13.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.12.1"
+version = "0.13.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.12.1"
+version = "0.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.12.1",
+    "version": "0.13.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Release **v0.13.0**. A minor bump: the accumulated changes since [v0.12.1](https://github.com/Jsakkos/engram/releases/tag/v0.12.1) include a new user-facing feature plus fixes.

Bumps the version to `0.13.0` across the six lockstep version files (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and **both** self-version fields in `frontend/package-lock.json`) and promotes `[Unreleased]` into a curated `## [0.13.0] - 2026-06-01` CHANGELOG section.

The `chore: release v0.13.0` title triggers `tag-release.yml` on squash-merge, which runs `release.yml` to build the binaries and publish the GitHub release using the extracted CHANGELOG section as the notes.

### What's in this release

Three PRs merged since v0.12.1 (`37083e5..main`):

- **#283** — opt-in AI episode-matching fallback for discs with no reference subtitles (transcribe the rip, match against the TMDB synopsis, suggest an episode in Review; never auto-organizes), plus the AI key "Key saved" indicator and the now-persisting "AI-Powered Episode Matching" toggle. _(PR #283 did not add its own CHANGELOG entry — added here.)_
- **#280** — `force=true` escape hatch to delete a single stuck fingerprint contribution.
- **#279** — sustained-outage contribution recovery: transient 5xx/network/429 errors keep a contribution queued and retried instead of permanently dropping it.

(#276's drain-then-idle + 429 retry work already shipped in v0.12.1 and is not duplicated here.)

### Verification

- `extract_changelog.py --version 0.13.0 --check` → `ok: CHANGELOG has a section for 0.13.0` (mirrors the CI `changelog-version-check` gate, which derives the version from `backend/pyproject.toml`).
- Version-bump diff matches the previous release commit's file set exactly; lockfiles edited by hand (no `npm install` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
