### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-06-01
+
+_Highlights: the in-app auto-update is fixed end to end on Windows — installed builds now actually show the **Restart now** button (it was hidden by a status flag that never reached the UI), and clicking it reliably swaps in the new version and relaunches instead of silently shutting Engram down._
+
+### Fixed
+
+- **The in-app "Restart now" update button never appeared on installed builds** — when a new version finished downloading in the background, the banner showed "ready to install — dev mode, manual download required" and hid the one-click restart button, even on real (frozen) installs that already had the update staged and ready. The build-type flag the button gates on was dropped from the live status push (it rode only the REST endpoint, not the WebSocket message), so the UI always read it as "dev mode." Installed builds now correctly show **Restart now**. The banner is also seeded from the authoritative status endpoint so it appears even if you open the dashboard after the update finished downloading, and stale downloaded versions are now pruned from `~/.engram/update/` instead of accumulating.
+- **Restarting to apply an update could shut Engram down without installing it (Windows)** — the helper that swaps in the new files after Engram exits was launched in a way that let Windows terminate it together with the closing app when Engram was running inside a process Job Object, so the app went down and the update was never applied. The helper now breaks away from the job (and uses a console-independent wait), so the restart reliably swaps in the new version and relaunches.
+
 ## [0.13.0] - 2026-06-01
 
 _Highlights: a new opt-in AI episode-matching fallback for discs that have no reference subtitles — Engram transcribes the rip and matches it against the TMDB synopsis to suggest an episode in Review; the AI key and "AI-Powered Episode Matching" toggle now save and persist; and queued fingerprint contributions survive a sustained server outage instead of being permanently dropped._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -74,8 +74,25 @@ class UpdateChecker:
 
     async def start(self) -> None:
         """Entry point — call once from the FastAPI lifespan as asyncio.create_task()."""
+        self._prune_staging()
         skipped_version = await self._load_skipped_version()
         await self._check(skipped_version)
+
+    def _prune_staging(self) -> None:
+        """Delete staged update dirs for versions already installed (<= current).
+
+        Staging holds only not-yet-applied updates. Without this, every release ever
+        downloaded accumulates under ~/.engram/update/ forever (e.g. 0.9.1 … 0.13.0).
+        Best-effort: never let cleanup failures interfere with the update check.
+        """
+        if not STAGING_BASE.exists():
+            return
+        for child in STAGING_BASE.iterdir():
+            if not child.is_dir():
+                continue
+            if self._is_older_or_equal(child.name, self._current_version):
+                logger.info(f"Pruning stale staged update: {child}")
+                shutil.rmtree(child, ignore_errors=True)
 
     async def _load_skipped_version(self) -> str | None:
         """Load the skipped version preference from AppConfig."""
@@ -389,6 +406,17 @@ class UpdateChecker:
 
         The .bat polls the current PID until it disappears, then copies the staged
         directory over the install directory and relaunches engram.exe.
+
+        Two robustness details, each fixing a way the helper could silently fail to
+        run the swap:
+          * Spawned with CREATE_BREAKAWAY_FROM_JOB. If engram runs inside a Windows
+            Job Object that terminates children when the parent exits (some
+            launchers/sandboxes/packagers do), a plain DETACHED_PROCESS child is
+            killed at os._exit() *before* it can swap — the app just goes down with
+            no update applied. Breaking away from the job lets the helper outlive us.
+          * Uses ``ping`` instead of ``timeout`` for the poll delay. ``timeout``
+            aborts immediately ("input redirection is not supported") in the helper's
+            console-less DETACHED_PROCESS context, so it can't be relied on there.
         """
         assert self.staging_path is not None
         new_engram_dir = self.staging_path / "engram"
@@ -405,7 +433,7 @@ class UpdateChecker:
             ":wait\n"
             f'tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL\n'
             "if not errorlevel 1 (\n"
-            "    timeout /t 1 /nobreak > nul\n"
+            "    ping -n 2 127.0.0.1 >nul\n"
             "    goto wait\n"
             ")\n"
             f'xcopy /Y /E /I "{new_engram_dir}\\*" "{install_dir}\\"\n'
@@ -417,13 +445,29 @@ class UpdateChecker:
             f.write(bat_content)
 
         logger.info(f"Launching update helper: {bat_path}")
-        subprocess.Popen(
-            ["cmd", "/c", str(bat_path)],
-            shell=False,
-            close_fds=True,
-            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
+        self._spawn_detached_helper(["cmd", "/c", str(bat_path)])
         os._exit(0)  # Hard exit: avoids asyncio catching SystemExit
+
+    @staticmethod
+    def _spawn_detached_helper(args: list[str]) -> None:
+        """Spawn a helper that outlives this process and any owning Job Object.
+
+        Tries CREATE_BREAKAWAY_FROM_JOB first so the helper escapes a kill-on-close
+        job. The flag is a no-op when we're not in a job; if we're in a job that
+        forbids breakaway, CreateProcess raises and we fall back to a plain detached
+        spawn (best effort — that's the pre-existing behavior).
+        """
+        # Resolve the Windows creationflags via getattr so this module stays
+        # importable and unit-testable on non-Windows CI, where they're absent.
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+        new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+        breakaway = getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
+        base = detached | new_group
+        try:
+            subprocess.Popen(args, shell=False, close_fds=True, creationflags=base | breakaway)
+        except OSError as exc:
+            logger.warning(f"Update helper breakaway spawn failed ({exc}); retrying detached")
+            subprocess.Popen(args, shell=False, close_fds=True, creationflags=base)
 
     async def _broadcast(self) -> None:
         """Push current update state to all WebSocket clients."""

--- a/backend/app/services/event_broadcaster.py
+++ b/backend/app/services/event_broadcaster.py
@@ -199,15 +199,19 @@ class EventBroadcaster:
     ) -> None:
         """Broadcast update availability status to all connected clients.
 
-        current_version is always the running build's __version__ — injected here
-        so UpdateChecker doesn't need to import it separately.
+        current_version and is_frozen are build-level facts injected here so they
+        ride every push: the frontend gates the "Restart now" button on is_frozen,
+        and it learns update state only from this message. Dropping is_frozen made
+        the UI default it to false and hide the button even on frozen builds.
         """
         from app import __version__
+        from app.config import is_frozen
 
         data: dict = {
             "type": "update_status",
             "state": state,
             "current_version": __version__,
+            "is_frozen": is_frozen(),
         }
         if latest_version is not None:
             data["latest_version"] = latest_version

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.13.0"
+version = "0.13.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/unit/test_event_broadcaster.py
+++ b/backend/tests/unit/test_event_broadcaster.py
@@ -379,3 +379,31 @@ class TestFingerprintDisclosureEvents:
         assert sent["pending_count"] == 3
         assert sent["pseudonym"] == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
         assert sent["server_url"] == "https://fp.example.com/v1"
+
+
+@pytest.mark.asyncio
+class TestUpdateStatusEvents:
+    """Test auto-update status broadcasting."""
+
+    async def test_broadcast_update_status_carries_is_frozen(self, broadcaster, mock_ws_manager):
+        """The WS payload MUST carry is_frozen — the frontend gates the Restart button on it.
+
+        Regression for the dropped-field bug: broadcast_update_status() previously omitted
+        is_frozen, so the frontend defaulted it to false and hid "Restart now" even on frozen
+        builds that had already staged an update. is_frozen and current_version are build-level
+        facts injected by the broadcaster (same as current_version), so they ride every push.
+        """
+        await broadcaster.broadcast_update_status(
+            state="ready",
+            latest_version="99.0.0",
+            release_url="https://github.com/Jsakkos/engram/releases/tag/v99.0.0",
+        )
+
+        mock_ws_manager.broadcast.assert_called_once()
+        sent = mock_ws_manager.broadcast.call_args[0][0]
+        assert sent["type"] == "update_status"
+        assert sent["state"] == "ready"
+        assert sent["latest_version"] == "99.0.0"
+        assert "current_version" in sent
+        assert "is_frozen" in sent
+        assert isinstance(sent["is_frozen"], bool)

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -4,6 +4,7 @@ Patches async_session so no test touches engram.db.
 httpx is mocked via unittest.mock so no real network calls are made.
 """
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -297,17 +298,15 @@ class TestSpawnDetachedHelper:
     """The Windows update helper must escape a kill-on-close Job Object."""
 
     def _breakaway_flag(self):
-        import app.core.updater as updater_mod
-
-        return getattr(updater_mod.subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
+        # app.core.updater calls subprocess.Popen (module-qualified), so the stdlib
+        # subprocess module here is the same object it uses.
+        return getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
 
     def test_spawns_with_breakaway_from_job(self, monkeypatch):
         """First attempt must include CREATE_BREAKAWAY_FROM_JOB so a job can't kill it."""
-        import app.core.updater as updater_mod
-
         flags_seen = []
         monkeypatch.setattr(
-            updater_mod.subprocess,
+            subprocess,
             "Popen",
             lambda *a, **kw: flags_seen.append(kw.get("creationflags", 0)) or MagicMock(),
         )
@@ -318,8 +317,6 @@ class TestSpawnDetachedHelper:
 
     def test_falls_back_without_breakaway_on_oserror(self, monkeypatch):
         """If the job forbids breakaway (CreateProcess raises), retry plain-detached."""
-        import app.core.updater as updater_mod
-
         breakaway = self._breakaway_flag()
         flags_seen = []
 
@@ -330,7 +327,7 @@ class TestSpawnDetachedHelper:
                 raise OSError("Access is denied")
             return MagicMock()
 
-        monkeypatch.setattr(updater_mod.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
         UpdateChecker._spawn_detached_helper(["cmd", "/c", "x.bat"])
 
         assert len(flags_seen) == 2

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -267,3 +267,72 @@ class TestUpdateCheckerStates:
         assert asset is not None
         assert asset["name"].endswith(".zip")
         assert "windows" in asset["name"]
+
+
+class TestPruneStaging:
+    """Staging holds only not-yet-installed updates; older ones are pruned."""
+
+    def test_prunes_installed_versions_keeps_newer(self, monkeypatch, tmp_path):
+        """Staged dirs <= current version are removed; strictly newer ones kept."""
+        monkeypatch.setattr("app.core.updater.STAGING_BASE", tmp_path)
+        for v in ("0.11.0", "0.12.1", "0.13.0"):
+            (tmp_path / v).mkdir()
+
+        checker = UpdateChecker()
+        checker._current_version = "0.12.1"
+        checker._prune_staging()
+
+        remaining = sorted(p.name for p in tmp_path.iterdir())
+        assert remaining == ["0.13.0"]
+
+    def test_prune_missing_base_is_noop(self, monkeypatch, tmp_path):
+        """No staging dir yet → prune does nothing and doesn't raise."""
+        monkeypatch.setattr("app.core.updater.STAGING_BASE", tmp_path / "nope")
+        checker = UpdateChecker()
+        checker._current_version = "0.12.1"
+        checker._prune_staging()  # must not raise
+
+
+class TestSpawnDetachedHelper:
+    """The Windows update helper must escape a kill-on-close Job Object."""
+
+    def _breakaway_flag(self):
+        import app.core.updater as updater_mod
+
+        return getattr(updater_mod.subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
+
+    def test_spawns_with_breakaway_from_job(self, monkeypatch):
+        """First attempt must include CREATE_BREAKAWAY_FROM_JOB so a job can't kill it."""
+        import app.core.updater as updater_mod
+
+        flags_seen = []
+        monkeypatch.setattr(
+            updater_mod.subprocess,
+            "Popen",
+            lambda *a, **kw: flags_seen.append(kw.get("creationflags", 0)) or MagicMock(),
+        )
+        UpdateChecker._spawn_detached_helper(["cmd", "/c", "x.bat"])
+
+        assert flags_seen, "Popen was never called"
+        assert flags_seen[0] & self._breakaway_flag()
+
+    def test_falls_back_without_breakaway_on_oserror(self, monkeypatch):
+        """If the job forbids breakaway (CreateProcess raises), retry plain-detached."""
+        import app.core.updater as updater_mod
+
+        breakaway = self._breakaway_flag()
+        flags_seen = []
+
+        def fake_popen(*a, **kw):
+            flags = kw.get("creationflags", 0)
+            flags_seen.append(flags)
+            if flags & breakaway:
+                raise OSError("Access is denied")
+            return MagicMock()
+
+        monkeypatch.setattr(updater_mod.subprocess, "Popen", fake_popen)
+        UpdateChecker._spawn_detached_helper(["cmd", "/c", "x.bat"])
+
+        assert len(flags_seen) == 2
+        assert flags_seen[0] & breakaway  # tried with breakaway
+        assert not (flags_seen[1] & breakaway)  # then fell back without

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.13.0"
+version = "0.13.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.13.0",
+    "version": "0.13.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/frontend/src/app/components/__tests__/UpdateBanner.test.tsx
+++ b/frontend/src/app/components/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { UpdateBanner } from "../UpdateBanner";
+import type { UpdateStatus } from "../../../types";
+
+// The banner imports the toast helper; stub it so no portal is needed.
+vi.mock("sonner", () => ({ toast: { info: vi.fn(), error: vi.fn() } }));
+
+function status(overrides: Partial<UpdateStatus>): UpdateStatus {
+  return {
+    state: "ready",
+    current_version: "0.12.1",
+    latest_version: "0.13.0",
+    release_notes: null,
+    release_url: "https://example.com",
+    download_progress: null,
+    error: null,
+    is_frozen: false,
+    ...overrides,
+  };
+}
+
+describe("UpdateBanner", () => {
+  afterEach(cleanup);
+
+  it("shows 'Restart now' and hides the dev-mode note on frozen builds", () => {
+    render(
+      <UpdateBanner
+        updateStatus={status({ is_frozen: true })}
+        onShowNotes={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    // The whole point of the fix: a frozen build offers the one-click restart.
+    expect(screen.getByText(/Restart now/i)).toBeTruthy();
+    expect(screen.queryByText(/dev mode/i)).toBeNull();
+  });
+
+  it("hides 'Restart now' and shows the dev-mode note when not frozen", () => {
+    render(
+      <UpdateBanner
+        updateStatus={status({ is_frozen: false })}
+        onShowNotes={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/Restart now/i)).toBeNull();
+    expect(screen.getByText(/dev mode/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -6,7 +6,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { apiFetch, apiFetchVoid } from '../../api/client';
-import type { Job, DiscTitle, WebSocketMessage } from '../../types';
+import type { Job, DiscTitle, WebSocketMessage, UpdateStatus, UpdateStatusMessage } from '../../types';
 
 // Trailing-debounce window for refetches triggered by a burst of unknown
 // `job_update` messages, so we issue one fetch instead of N.
@@ -29,22 +29,23 @@ const STATE_PRIORITY: Record<string, number> = {
 const TERMINAL_TITLE_STATES = ['matched', 'completed', 'review', 'failed'];
 
 /**
- * A WebSocket reconnect often follows a backend restart — notably after the
- * auto-updater applies a new build. If the backend now reports a different
- * version than the one THIS bundle was compiled from (`__APP_VERSION__`), the
- * open tab is stale, so hard-reload to pull the new UI. `index.html` is served
- * `no-cache`, so the reload fetches the new content-hashed bundles; the new
- * bundle's `__APP_VERSION__` then matches, so this fires exactly once.
+ * Normalize an update-status payload into the UpdateStatus snapshot stored in
+ * state. Shared by BOTH the WebSocket `update_status` handler and the REST seed
+ * so the two channels can never disagree on a field again — the original bug was
+ * that the WS push dropped `is_frozen`, so it silently defaulted to `false` and
+ * hid the "Restart now" button on frozen builds.
  */
-async function reloadIfVersionChanged(): Promise<void> {
-    try {
-        const status = await apiFetch<{ current_version?: string }>('/api/updates/status');
-        if (status.current_version && status.current_version !== __APP_VERSION__) {
-            window.location.reload();
-        }
-    } catch {
-        // Transient blip during reconnect — skip; we re-check on the next reconnect.
-    }
+function toUpdateStatus(raw: Omit<UpdateStatusMessage, 'type'>): UpdateStatus {
+    return {
+        state: raw.state,
+        current_version: raw.current_version,
+        latest_version: raw.latest_version ?? null,
+        release_notes: raw.release_notes ?? null,
+        release_url: raw.release_url ?? null,
+        download_progress: raw.download_progress ?? null,
+        error: raw.error ?? null,
+        is_frozen: raw.is_frozen ?? false,
+    };
 }
 
 export function useJobManagement(devMode: boolean = false) {
@@ -145,6 +146,26 @@ export function useJobManagement(devMode: boolean = false) {
         }, UNKNOWN_JOB_REFETCH_DEBOUNCE_MS);
     }, []);
 
+    // Seed the update banner from the authoritative REST status. The one-shot
+    // startup check broadcasts over WebSocket, so a tab that connects *after* it
+    // would otherwise never see the banner; this also pulls `is_frozen` from the
+    // source of truth. A reconnect may follow an update+restart, so if the running
+    // build no longer matches THIS bundle, hard-reload to pull the new UI (fires
+    // once: `index.html` is `no-cache`, so the reloaded bundle's __APP_VERSION__
+    // then matches).
+    const syncUpdateStatus = useCallback(async () => {
+        try {
+            const status = await apiFetch<Omit<UpdateStatusMessage, 'type'>>('/api/updates/status');
+            if (status.current_version && status.current_version !== __APP_VERSION__) {
+                window.location.reload();
+                return;
+            }
+            setUpdateStatus(toUpdateStatus(status));
+        } catch {
+            // Transient blip (e.g. during reconnect) — retry on the next sync.
+        }
+    }, []);
+
     // Resync on (re)connect so the UI recovers from any drift while disconnected.
     const handleSocketOpen = useCallback(() => {
         if (initialConnectRef.current) {
@@ -155,10 +176,9 @@ export function useJobManagement(devMode: boolean = false) {
         if (import.meta.env.DEV) {
             console.log('🔌 WebSocket reconnected — resyncing jobs');
         }
-        // The reconnect may follow an update+restart — reload if the build changed.
-        void reloadIfVersionChanged();
+        void syncUpdateStatus();
         fetchRef.current?.();
-    }, []);
+    }, [syncUpdateStatus]);
 
     const { isConnected, addMessageListener } = useWebSocket(wsUrl, { onOpen: handleSocketOpen });
 
@@ -173,8 +193,9 @@ export function useJobManagement(devMode: boolean = false) {
     useEffect(() => {
         if (!devMode) {
             fetchJobsAndTitles();
+            void syncUpdateStatus();
         }
-    }, [devMode, fetchJobsAndTitles]);
+    }, [devMode, fetchJobsAndTitles, syncUpdateStatus]);
 
     async function cancelJob(jobId: string) {
         try {
@@ -377,17 +398,7 @@ export function useJobManagement(devMode: boolean = false) {
                     break;
 
                 case 'update_status': {
-                    const msg = message as import('../../types').UpdateStatusMessage;
-                    setUpdateStatus({
-                        state: msg.state,
-                        current_version: msg.current_version,
-                        latest_version: msg.latest_version ?? null,
-                        release_notes: msg.release_notes ?? null,
-                        release_url: msg.release_url ?? null,
-                        download_progress: msg.download_progress ?? null,
-                        error: msg.error ?? null,
-                        is_frozen: msg.is_frozen ?? false,
-                    });
+                    setUpdateStatus(toUpdateStatus(message as UpdateStatusMessage));
                     break;
                 }
 

--- a/frontend/src/hooks/__tests__/useJobManagement.test.ts
+++ b/frontend/src/hooks/__tests__/useJobManagement.test.ts
@@ -460,6 +460,34 @@ describe("useJobManagement hook integration", () => {
     // @ts-expect-error — restore the real location for other tests.
     window.location = realLocation;
   });
+
+  it("seeds updateStatus (incl. is_frozen) from /api/updates/status on mount", async () => {
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const urlStr = String(input);
+      if (urlStr.includes("/api/updates/status"))
+        return Promise.resolve(
+          okJson({
+            state: "ready",
+            current_version: __APP_VERSION__,
+            latest_version: "9.9.9",
+            release_url: "https://example.com",
+            is_frozen: true,
+          }),
+        );
+      return Promise.resolve(okJson([]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useJobManagement(false));
+
+    await waitFor(() => {
+      expect(result.current.updateStatus?.state).toBe("ready");
+    });
+    // Regression: is_frozen must survive the REST seed. It was dropped on the WS
+    // push, defaulting to false and hiding the "Restart now" button on frozen builds.
+    expect(result.current.updateStatus?.is_frozen).toBe(true);
+    expect(result.current.updateStatus?.latest_version).toBe("9.9.9");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Release **v0.13.1**, rebased onto `main` (`0.13.0`). Bumps the version across `__init__.py`, `pyproject.toml`, `uv.lock`, `package.json`, and `package-lock.json` (×2), and moves the entries into the `## [0.13.1]` changelog section. Squash-merging (title `chore: release v0.13.1`) triggers `tag-release.yml` → `release.yml`, which builds the binaries that contain these fixes.

## Why this release exists

A staged `0.13.0` update sat ready with the backend reporting `is_frozen: true`, yet the banner read `ready to install — dev mode, manual download required` and hid the Restart button. Investigating, then verifying the restart live, surfaced **two** bugs — the button never showed, *and* the restart itself didn't work on Windows. This release ships both fixes so the in-app auto-update works end to end.

### Bug 1 — button never appeared (REST/WS contract drift)
`get_status()` (REST) included `is_frozen`; `broadcast_update_status()` (the WebSocket push that feeds the banner) **omitted** it, so the UI defaulted it to `false` → "dev mode" + hidden button on every build. **Fix:** inject `is_frozen` into the WS payload (mirroring `current_version`); add a shared `toUpdateStatus()` mapper used by both the WS handler and a new REST seed on mount/reconnect (also fixes a tab connecting after the one-shot startup check never seeing the banner).

### Bug 2 — restart took the app down without installing (Windows Job Object)
Verified live (twice): `POST /api/updates/restart` → `{"ok":true}`, engram exits, but the detached helper **never ran the swap** — the app stayed down and the bat was orphaned. engram runs inside a kill-on-close **Job Object**, and a `DETACHED_PROCESS` child is killed with the parent at `os._exit()`. A controlled ctypes probe confirmed it: child dies without `CREATE_BREAKAWAY_FROM_JOB`, survives with it. **Fix:** spawn the helper with `CREATE_BREAKAWAY_FROM_JOB` (no-op when not in a job; falls back if the job forbids breakaway) and replace `timeout` with `ping` (timeout aborts in the helper's console-less context).

### Also
Prune staged updates `<=` the running version on startup so `~/.engram/update/` stops accumulating every release downloaded.

## Tests
WS-payload regression, prune, breakaway-then-fallback, REST-seed, and banner-gating tests added. 1495 backend unit + 99 frontend tests green; `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)