### PR TITLE
fix(identify): detect same-name wrong-show picks (Frasier 1993 vs 2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+_Highlights: discs for a revival or reboot that shares its name with an older show (for example the 2023 **Frasier** vs the 1993 original) are no longer silently matched against the wrong show's subtitles — Engram now flags them for review and suggests the right one._
+
+### Fixed
+
+- **Same-name shows could be silently identified as the wrong one** — a disc whose label has no year (e.g. `FRASIER_S1D1`) was matched to the more popular same-named show on TMDB, so a 2023 revival disc was treated as the 1993 original and every episode matched the wrong subtitles at random, landing in Review with an unhelpful "assign episodes manually" message. Engram now (1) flags a no-year disc that has a real same-name twin for review *before* ripping, suggesting which show to pick, and (2) as a backstop, when a whole TV disc matches no episodes at all and a same-name twin exists, surfaces a clear "this doesn't resemble *Show (year)* — did you mean *Show (other year)*? Re-identify to fix" review instead of the generic message. Re-identifying to the correct show now reliably downloads that show's subtitles. (#287)
+
 ## [0.13.2] - 2026-06-01
 
 _Highlights: Engram can now tell apart two TV shows that share a name — for example **Frasier** (1993) and the 2023 revival. An ambiguous disc is sent to Review with both candidates to choose from, and once you pick one, that exact show drives subtitle download and episode matching instead of whichever same-named show happened to rank first._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -123,6 +123,9 @@ class JobResponse(BaseModel):
     subtitles_total: int | None = None
     subtitles_failed: int | None = None
     review_reason: str | None = None
+    # JSON list of same-name TMDB twins (e.g. Frasier 1993 + 2023) recorded at
+    # identify time; lets the UI offer "did you mean ...?" on a wrong-show review.
+    candidates_json: str | None = None
     # Transient auto-resolution note set during conflict / review escalation
     # (e.g. "Resolving episode conflicts — pass 2 of 3"). Cleared on resolution.
     conflict_status: str | None = None
@@ -197,6 +200,9 @@ class JobDetailResponse(BaseModel):
     disc_number: int = 1
     error_message: str | None = None
     review_reason: str | None = None
+    # JSON list of same-name TMDB twins (e.g. Frasier 1993 + 2023) recorded at
+    # identify time; lets the UI offer "did you mean ...?" on a wrong-show review.
+    candidates_json: str | None = None
     # Transient auto-resolution note (e.g. "Resolving episode conflicts — pass 2 of 3"
     # / "Deep re-matching low-confidence titles — pass 1 of 3"). Set while the
     # finalization coordinator is auto-escalating; cleared on resolution.
@@ -770,6 +776,7 @@ async def build_job_detail(job: DiscJob, session: AsyncSession) -> dict:
         "disc_number": job.disc_number,
         "error_message": job.error_message,
         "review_reason": job.review_reason,
+        "candidates_json": job.candidates_json,
         "conflict_status": job.conflict_status,
         "classification_source": job.classification_source,
         "classification_confidence": job.classification_confidence,

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -226,7 +226,7 @@ def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] 
     return candidates
 
 
-def _should_flag_no_year(candidates: list[dict] | None, has_year: bool) -> bool:
+def should_flag_no_year(candidates: list[dict] | None, has_year: bool) -> bool:
     """Whether a no-year disc with a real same-name twin should be flagged for review.
 
     Backstop to the materiality gate: a label with no year can't pick between

--- a/backend/app/core/tmdb_classifier.py
+++ b/backend/app/core/tmdb_classifier.py
@@ -28,6 +28,13 @@ HIGH_POPULARITY_THRESHOLD = 50
 AMBIGUOUS_POPULARITY_FLOOR = 10.0
 AMBIGUOUS_POPULARITY_RATIO = 4.0
 
+# No-year backstop (item-3 layering). When the disc label carries NO year it
+# cannot self-disambiguate same-name twins, so we proactively flag for review
+# even for dominant-twin cases the materiality gate lets through — provided the
+# runner-up clears this LOW floor (excludes the pop<3 noise tier). With a year in
+# the label, popularity+year already disambiguate and this does not apply. Tunable.
+AMBIGUOUS_NO_YEAR_FLOOR = 3.0
+
 
 def _confidence_from_popularity(popularity: float, ambiguous: bool) -> float:
     """Map a TMDB popularity score to a classification confidence value."""
@@ -80,6 +87,7 @@ class TmdbSignal:
         "tmdb_name",
         "ambiguous_identity",
         "candidates",
+        "all_candidates",
     )
 
     def __init__(
@@ -90,20 +98,27 @@ class TmdbSignal:
         tmdb_name: str | None = None,
         ambiguous_identity: bool = False,
         candidates: list[dict] | None = None,
+        all_candidates: list[dict] | None = None,
     ):
         self.content_type = content_type
         self.confidence = confidence
         self.tmdb_id = tmdb_id
         self.tmdb_name = tmdb_name
         self.ambiguous_identity = ambiguous_identity
+        # `candidates`: same-name twins that tripped the materiality gate (a
+        # proactive, identify-time review prompt). `all_candidates`: EVERY
+        # same-name twin (>=2), recorded regardless of the gate so a downstream
+        # wrong-show detector can suggest the right one even for dominant twins
+        # (e.g. Frasier 1993 vs 2023) that the gate intentionally lets through.
         self.candidates = candidates
+        self.all_candidates = all_candidates
 
     def __repr__(self) -> str:
         return (
             f"TmdbSignal(content_type={self.content_type.value}, "
             f"confidence={self.confidence:.0%}, tmdb_id={self.tmdb_id}, "
             f"tmdb_name={self.tmdb_name!r}, ambiguous_identity={self.ambiguous_identity}, "
-            f"candidates={self.candidates!r})"
+            f"candidates={self.candidates!r}, all_candidates={self.all_candidates!r})"
         )
 
 
@@ -157,13 +172,14 @@ def _search_tmdb(
     return None, []
 
 
-def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] | None:
-    """Return same-name collision candidates when the materiality gate fires, else None.
+def _collect_same_name_candidates(query: str, results: list[dict]) -> list[dict] | None:
+    """Return ALL distinct same-name shows (>= 2), popularity-sorted, else None.
 
-    "Same-name" = normalized name equals the query's (>= 0.95 similarity). The gate
-    fires only when the top two distinct same-name shows are BOTH plausibly real:
-    runner-up popularity >= AMBIGUOUS_POPULARITY_FLOOR AND
-    top/second popularity ratio <= AMBIGUOUS_POPULARITY_RATIO.
+    "Same-name" = normalized name equals the query's (>= 0.95 similarity). This is
+    pure collection with NO materiality gate — it records the ambiguity (e.g.
+    Frasier 1993 #3452 + 2023 revival #195241) so downstream consumers can suggest
+    the right twin even for dominant-twin cases the gate intentionally lets pass.
+    A franchise like Doctor Who legitimately has 3+ same-name shows; all appear.
     """
     same = []
     seen_ids = set()
@@ -178,16 +194,6 @@ def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] 
     if len(same) < 2:
         return None
     same.sort(key=lambda r: r.get("popularity", 0.0), reverse=True)
-    top, second = same[0].get("popularity", 0.0), same[1].get("popularity", 0.0)
-    if second < AMBIGUOUS_POPULARITY_FLOOR:
-        return None
-    # `second <= 0` is a division-by-zero rail kept intentionally: the floor check
-    # above covers it for the default floor, but the constants are tunable.
-    if second <= 0 or (top / second) > AMBIGUOUS_POPULARITY_RATIO:
-        return None
-    # Return ALL same-name candidates (not just the gated top two): a franchise like
-    # Doctor Who has 3+ legitimate same-name shows, and the user may own any of them.
-    # The gate decides whether to flag; the list shows every show they pick between.
     return [
         {
             "tmdb_id": r["id"],
@@ -199,10 +205,48 @@ def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] 
     ]
 
 
+def _detect_same_name_candidates(query: str, results: list[dict]) -> list[dict] | None:
+    """Return same-name collision candidates when the materiality gate fires, else None.
+
+    The gate fires only when the top two distinct same-name shows are BOTH plausibly
+    real: runner-up popularity >= AMBIGUOUS_POPULARITY_FLOOR AND top/second popularity
+    ratio <= AMBIGUOUS_POPULARITY_RATIO. Dominant-twin cases (e.g. Frasier 1993 vs the
+    2023 revival) intentionally fall through here — they're caught downstream.
+    """
+    candidates = _collect_same_name_candidates(query, results)
+    if not candidates:
+        return None
+    top, second = candidates[0]["popularity"], candidates[1]["popularity"]
+    if second < AMBIGUOUS_POPULARITY_FLOOR:
+        return None
+    # `second <= 0` is a division-by-zero rail kept intentionally: the floor check
+    # above covers it for the default floor, but the constants are tunable.
+    if second <= 0 or (top / second) > AMBIGUOUS_POPULARITY_RATIO:
+        return None
+    return candidates
+
+
+def _should_flag_no_year(candidates: list[dict] | None, has_year: bool) -> bool:
+    """Whether a no-year disc with a real same-name twin should be flagged for review.
+
+    Backstop to the materiality gate: a label with no year can't pick between
+    same-name twins (e.g. Frasier 1993 vs the 2023 revival), so flag when a twin
+    exists and the runner-up clears the low no-year floor. ``candidates`` is the
+    popularity-sorted same-name list (TmdbSignal.all_candidates); index 1 is the
+    runner-up. Suppressed when a year is present (popularity+year disambiguate).
+    """
+    if has_year or not candidates or len(candidates) < 2:
+        return False
+    return candidates[1].get("popularity", 0.0) >= AMBIGUOUS_NO_YEAR_FLOOR
+
+
 def _maybe_flag_tv_ambiguity(signal: TmdbSignal, query: str, tv_results: list[dict]) -> TmdbSignal:
-    """Attach same-name collision info to a TV signal when the gate fires."""
+    """Record same-name twins on a TV signal; flag for review only when the gate fires."""
     if signal.content_type != ContentType.TV:
         return signal
+    # Always record the full twin list (used by the downstream wrong-show detector),
+    # independent of whether the materiality gate decides to flag proactively.
+    signal.all_candidates = _collect_same_name_candidates(query, tv_results)
     candidates = _detect_same_name_candidates(query, tv_results)
     if candidates:
         signal.ambiguous_identity = True

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -114,13 +114,22 @@ def precomputed_covers_season(
     return npz_path.exists() and index_path.exists()
 
 
-def precomputed_episode_codes(cache_dir, show_name: str, season: int) -> list[str] | None:
+def precomputed_episode_codes(
+    cache_dir, show_name: str, season: int, *, expected_tmdb_id=None
+) -> list[str] | None:
     """Episode codes the precomputed cache holds for show+season, else None.
 
     None means the cache doesn't cover it (caller should download/scrape).
     Lets callers size a result from the cache itself without a TMDB round-trip.
+
+    ``expected_tmdb_id`` is forwarded to the corpus guard so a same-named but
+    different show's corpus (e.g. Frasier 1993 vs the 2023 revival) is refused
+    here too — otherwise a "skip download" result would be sized from the wrong
+    show's episode list. Skipped when the id is unknown (backward-compatible).
     """
-    if not precomputed_covers_season(cache_dir, show_name, season):
+    if not precomputed_covers_season(
+        cache_dir, show_name, season, expected_tmdb_id=expected_tmdb_id
+    ):
         return None
 
     index_path = (

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -250,7 +250,9 @@ def _precomputed_skip_result(
     ):
         return None
 
-    codes = precomputed_episode_codes(cache_path, show_name, season)
+    codes = precomputed_episode_codes(
+        cache_path, show_name, season, expected_tmdb_id=expected_tmdb_id
+    )
     if not codes:
         return None
 

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -63,6 +63,11 @@ class DiscJob(SQLModel, table=True):
     )
     tmdb_id: int | None = Field(default=None)
     tmdb_name: str | None = Field(default=None)
+    # Same-name TMDB collision candidates (JSON list of {tmdb_id, name, year,
+    # popularity}). Recorded at identify time whenever >=2 same-name shows exist
+    # (e.g. Frasier 1993 #3452 vs 2023 revival #195241) so the downstream
+    # wrong-show detector can suggest the right twin without re-querying TMDB.
+    candidates_json: str | None = Field(default=None)
     play_all_indices_json: str | None = Field(default=None)
     is_ambiguous_movie: bool = Field(default=False, sa_column_kwargs={"server_default": "0"})
 

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -550,6 +550,11 @@ class FinalizationCoordinator:
         if wrong_show:
             reason = _wrong_show_review_reason(wrong_show, job)
             logger.warning(f"Job {job_id}: wrong-show suspected — {reason}")
+            # We only get here after _maybe_escalate_reviews exhausted the ladder,
+            # so _review_passes is pinned at max. REVIEW_NEEDED isn't terminal, so
+            # reset_conflict_passes never fires — clear it now or a re-identify to
+            # the correct show would skip deep re-match for its low-confidence titles.
+            await self._clear_review_state(session, job)
             await self._state_machine.transition_to_review(job, session, reason=reason)
             return
 

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -23,6 +23,64 @@ from app.services.job_state_machine import JobStateMachine
 logger = logging.getLogger(__name__)
 
 
+def _detect_wrong_show(job, titles) -> dict | None:
+    """Detect a same-name wrong-show pick from a wholesale match failure.
+
+    Frasier-class bug: a disc identified as the dominant same-name twin (e.g. the
+    1993 original #3452) when it's actually the other twin (the 2023 revival
+    #195241). Every episode then matches the wrong reference corpus at noise floor,
+    so the WHOLE disc returns ``matched_episode is None``. Combined with a persisted
+    same-name twin (``candidates_json``), that is a confident wrong-show signal.
+
+    Returns ``{"current", "twin", "unmatched"}`` (candidate dicts) when detected,
+    else None. Pure — no DB/IO. The signal is AGGREGATE (all episode candidates
+    matched nothing), never an absolute per-chunk score, so it's robust to the
+    structurally-low chunk-cosine scale. A merely low-confidence disc still carries
+    an episode code, so it is excluded here and handled by the normal review path.
+    """
+    if job.content_type != ContentType.TV:
+        return None
+
+    try:
+        candidates = json.loads(job.candidates_json) if job.candidates_json else []
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(candidates, list) or len(candidates) < 2:
+        return None
+
+    # Episode-candidate titles = the selected, non-extra tracks we tried to match.
+    episode_candidates = [t for t in titles if t.is_selected and not t.is_extra]
+    if len(episode_candidates) < 2:
+        return None
+    if not all(t.matched_episode is None for t in episode_candidates):
+        return None
+
+    twin = next((c for c in candidates if str(c.get("tmdb_id")) != str(job.tmdb_id)), None)
+    if not twin:
+        return None
+    current = next((c for c in candidates if str(c.get("tmdb_id")) == str(job.tmdb_id)), None)
+    return {"current": current, "twin": twin, "unmatched": len(episode_candidates)}
+
+
+def _wrong_show_review_reason(detection: dict, job) -> str:
+    """Human-readable, actionable review reason naming the suspected correct twin."""
+
+    def _label(cand, fallback_name):
+        if not cand:
+            return fallback_name
+        year = cand.get("year")
+        name = cand.get("name") or fallback_name
+        return f"{name} ({year})" if year else name
+
+    current = _label(detection.get("current"), job.tmdb_name or job.detected_title or "this show")
+    twin = _label(detection.get("twin"), "another same-named show")
+    return (
+        f"Content doesn't resemble {current} — none of the "
+        f"{detection['unmatched']} episodes matched its subtitles. This is likely a "
+        f"different same-named show; did you mean {twin}? Re-identify to fix."
+    )
+
+
 def _library_path_for_job(job, content_type: str) -> "Path | None":
     """Return a library_path override for in_place jobs, or None for library mode."""
     if job.destination_mode != "in_place":
@@ -482,6 +540,17 @@ class FinalizationCoordinator:
         # Then give plain low-confidence reviews (no collision) escalating deep
         # re-match passes before surfacing them for manual assignment.
         if await self._maybe_escalate_reviews(session, job, titles):
+            return
+
+        # Wrong-show detector (Frasier 1993 vs 2023): if deep re-match still left
+        # EVERY episode candidate unmatched and a same-name twin exists, the disc
+        # was identified as the wrong same-named show. Surface an actionable
+        # re-identify review instead of the generic "assign episodes" message.
+        wrong_show = _detect_wrong_show(job, titles)
+        if wrong_show:
+            reason = _wrong_show_review_reason(wrong_show, job)
+            logger.warning(f"Job {job_id}: wrong-show suspected — {reason}")
+            await self._state_machine.transition_to_review(job, session, reason=reason)
             return
 
         # Review takes priority: while ANY title still needs manual review, do

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -17,7 +17,7 @@ from sqlmodel import select
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
 from app.core.extractor import MakeMKVExtractor, ScanTimeoutError
-from app.core.tmdb_classifier import _should_flag_no_year
+from app.core.tmdb_classifier import should_flag_no_year
 from app.database import async_session
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
@@ -44,8 +44,16 @@ def _label_has_year(*texts: str | None) -> bool:
 
 
 def _no_year_collision_reason(name, candidates) -> str:
-    """Review reason for a no-year disc with same-name twins — lists every twin."""
-    listed = "; ".join(f"{c['name']} ({c['year']}, #{c['tmdb_id']})" for c in (candidates or []))
+    """Review reason for a no-year disc with same-name twins — lists every twin.
+
+    Uses ``.get()`` so a candidate list deserialized from a DB value with a
+    missing key degrades gracefully instead of raising (matches the access style
+    in the finalization-side wrong-show helpers).
+    """
+    listed = "; ".join(
+        f"{c.get('name', '?')} ({c.get('year') or '?'}, #{c.get('tmdb_id', '?')})"
+        for c in (candidates or [])
+    )
     return (
         f'"{name}" has multiple same-name shows on TMDB and the disc label has no '
         f"year to tell them apart: {listed}. Pick the correct one."
@@ -324,7 +332,7 @@ class IdentificationCoordinator:
                     _signal
                     and not _amb
                     and job.content_type == ContentType.TV
-                    and _should_flag_no_year(
+                    and should_flag_no_year(
                         _signal.all_candidates, _label_has_year(job.volume_label, disc_name)
                     )
                 )
@@ -613,7 +621,7 @@ class IdentificationCoordinator:
                     _amb_signal
                     and not _amb
                     and job.content_type == ContentType.TV
-                    and _should_flag_no_year(
+                    and should_flag_no_year(
                         _amb_signal.all_candidates, _label_has_year(job.volume_label)
                     )
                 )

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -17,6 +17,7 @@ from sqlmodel import select
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
 from app.core.extractor import MakeMKVExtractor, ScanTimeoutError
+from app.core.tmdb_classifier import _should_flag_no_year
 from app.database import async_session
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
@@ -25,6 +26,41 @@ from app.services.job_state_machine import JobStateMachine
 from app.services.ripping_helpers import build_title_list
 
 logger = logging.getLogger(__name__)
+
+
+# Digit-boundary (not \b) so underscores/parens count as separators:
+# FRASIER_2023 and FRASIER (2023) match; a longer number like 20231 does not.
+_YEAR_RE = re.compile(r"(?<!\d)(?:19|20)\d{2}(?!\d)")
+
+
+def _label_has_year(*texts: str | None) -> bool:
+    """True when any of the disc label/name strings contains a 19xx/20xx year.
+
+    A year lets popularity+year disambiguate same-name twins, so the no-year
+    proactive review flag is suppressed. Season-disc labels like ``FRASIER_S1D1``
+    have no 4-digit year and return False.
+    """
+    return any(t and _YEAR_RE.search(t) for t in texts)
+
+
+def _no_year_collision_reason(name, candidates) -> str:
+    """Review reason for a no-year disc with same-name twins — lists every twin."""
+    listed = "; ".join(f"{c['name']} ({c['year']}, #{c['tmdb_id']})" for c in (candidates or []))
+    return (
+        f'"{name}" has multiple same-name shows on TMDB and the disc label has no '
+        f"year to tell them apart: {listed}. Pick the correct one."
+    )
+
+
+def _candidates_json_from_signal(signal) -> str | None:
+    """Serialize a TMDB signal's same-name twins for persistence on the job, else None.
+
+    Records EVERY same-name twin (>=2) — e.g. Frasier 1993 #3452 + 2023 revival
+    #195241 — regardless of whether the materiality gate flagged the job, so the
+    downstream wrong-show detector can suggest the right one without re-querying TMDB.
+    """
+    cands = getattr(signal, "all_candidates", None) if signal else None
+    return json.dumps(cands) if cands else None
 
 
 class IdentificationCoordinator:
@@ -155,6 +191,7 @@ class IdentificationCoordinator:
                 job.classification_source = analysis.classification_source
                 job.tmdb_id = analysis.tmdb_id
                 job.tmdb_name = analysis.tmdb_name
+                job.candidates_json = _candidates_json_from_signal(tmdb_signal)
                 job.is_ambiguous_movie = analysis.is_ambiguous_movie
                 if analysis.play_all_title_indices:
                     job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
@@ -278,18 +315,39 @@ class IdentificationCoordinator:
                 _signal = getattr(analysis, "_tmdb_signal", None)
                 _amb = bool(_signal and _signal.ambiguous_identity)
 
+                # No-year backstop (Frasier 1993 vs 2023): a label with no year can't
+                # pick between same-name twins, so flag for review BEFORE ripping rather
+                # than silently matching the popularity-best show's subtitles. The
+                # popularity-best tmdb_id stays as the pre-selected guess; the user
+                # confirms or switches via the existing re-identify UI.
+                _noyear = bool(
+                    _signal
+                    and not _amb
+                    and job.content_type == ContentType.TV
+                    and _should_flag_no_year(
+                        _signal.all_candidates, _label_has_year(job.volume_label, disc_name)
+                    )
+                )
+                if _noyear:
+                    analysis.needs_review = True
+                    analysis.review_reason = _no_year_collision_reason(
+                        job.detected_title, _signal.all_candidates
+                    )
+                # Either form of same-name collision skips auto subtitle download and the
+                # words-merged guard below.
+                _collision = _amb or _noyear
+
                 # TV show detected but TMDB lookup failed — name cannot be trusted for episode
                 # matching. Block ripping until the user confirms the correct show name.
                 # (Disc-name fallback already ran in _run_classification; if we reach here,
                 # neither the volume label nor the DINFO name resolved on TMDB.)
-                # Exclude ambiguous-identity jobs: they have tmdb_id=None by design and
-                # carry a candidate-naming review_reason that the needs_review branch below
-                # will surface.
+                # Exclude collision jobs: they carry a candidate-naming review_reason that
+                # the needs_review branch below will surface.
                 if (
                     job.content_type == ContentType.TV
                     and not job.tmdb_id
                     and job.detected_title
-                    and not _amb
+                    and not _collision
                 ):
                     reason = (
                         f'Could not find "{job.detected_title}" on TMDB — the disc label '
@@ -318,13 +376,14 @@ class IdentificationCoordinator:
                     return
 
                 # Start subtitle download for ALL TV content — except when identity is
-                # ambiguous (same-name collision). Downloading by the tentative name would
-                # fetch the wrong show's subtitles before the user disambiguates.
+                # ambiguous (same-name collision) or a no-year twin needs disambiguation.
+                # Downloading by the tentative name would fetch the wrong show's subtitles
+                # before the user disambiguates.
                 if (
                     job.content_type == ContentType.TV
                     and job.detected_title
                     and job.detected_season
-                    and not _amb
+                    and not _collision
                 ):
                     self._start_subtitle_download(
                         job_id, job.detected_title, job.detected_season, job.tmdb_id
@@ -487,6 +546,9 @@ class IdentificationCoordinator:
                 job.classification_source = analysis.classification_source or "staging_import"
                 job.tmdb_id = analysis.tmdb_id
                 job.tmdb_name = analysis.tmdb_name
+                job.candidates_json = _candidates_json_from_signal(
+                    getattr(analysis, "_tmdb_signal", None)
+                )
                 job.is_ambiguous_movie = analysis.is_ambiguous_movie
                 if analysis.play_all_title_indices:
                     job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
@@ -541,12 +603,30 @@ class IdentificationCoordinator:
                     )
                     return
 
-                # Same-name collision (item 1): route to review with the candidate list
-                # instead of matching against the wrong same-named show's corpus by name.
+                # Same-name collision: route to review with the candidate list instead of
+                # matching against the wrong same-named show's corpus by name. Covers both
+                # the materiality-gate case (item 1) and the no-year backstop (Frasier
+                # 1993 vs 2023) where the folder name has no year to disambiguate twins.
                 _amb_signal = getattr(analysis, "_tmdb_signal", None)
-                if _amb_signal and _amb_signal.ambiguous_identity:
+                _amb = bool(_amb_signal and _amb_signal.ambiguous_identity)
+                _noyear = bool(
+                    _amb_signal
+                    and not _amb
+                    and job.content_type == ContentType.TV
+                    and _should_flag_no_year(
+                        _amb_signal.all_candidates, _label_has_year(job.volume_label)
+                    )
+                )
+                if _amb or _noyear:
+                    reason = (
+                        analysis.review_reason
+                        if _amb
+                        else _no_year_collision_reason(
+                            job.detected_title, _amb_signal.all_candidates
+                        )
+                    )
                     await self._state_machine.transition_to_review(
-                        job, session, reason=analysis.review_reason, broadcast=False
+                        job, session, reason=reason, broadcast=False
                     )
                     await ws_manager.broadcast_job_update(
                         job_id,
@@ -555,11 +635,11 @@ class IdentificationCoordinator:
                         detected_title=job.detected_title,
                         detected_season=job.detected_season,
                         total_titles=job.total_titles,
-                        review_reason=analysis.review_reason,
+                        review_reason=reason,
                     )
                     logger.info(
-                        f"Job {job_id}: ambiguous identity for '{job.detected_title}', "
-                        f"routing to REVIEW_NEEDED"
+                        f"Job {job_id}: same-name collision for '{job.detected_title}' "
+                        f"(ambiguous={_amb}, no_year={_noyear}), routing to REVIEW_NEEDED"
                     )
                     return
 

--- a/backend/migrations/versions/c4d8e1f0a2b3_add_disc_jobs_candidates_json.py
+++ b/backend/migrations/versions/c4d8e1f0a2b3_add_disc_jobs_candidates_json.py
@@ -1,0 +1,35 @@
+"""add disc_jobs.candidates_json
+
+Persists same-name TMDB collision candidates on a job (JSON list of
+{tmdb_id, name, year, popularity}). Recorded at identify time whenever >=2
+same-name shows exist (e.g. Frasier 1993 #3452 vs the 2023 revival #195241) so
+the downstream wrong-show detector can suggest the right twin without
+re-querying TMDB. Mirrors the database.py reconciler path used by frozen builds
+(which skip Alembic) — the two must stay in agreement.
+
+Revision ID: c4d8e1f0a2b3
+Revises: b7f4c2e9a318
+Create Date: 2026-06-01 18:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d8e1f0a2b3"
+down_revision: str | Sequence[str] | None = "b7f4c2e9a318"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("candidates_json", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("candidates_json")

--- a/backend/tests/integration/test_show_identity_collision.py
+++ b/backend/tests/integration/test_show_identity_collision.py
@@ -151,3 +151,113 @@ async def test_ambiguous_disc_routes_to_review_with_candidate_reason(monkeypatch
     assert any("Multiple shows match" in (r or "") for r in review_reasons), (
         f"No REVIEW_NEEDED broadcast carried the candidate reason; saw: {review_reasons!r}"
     )
+
+
+def _frasier_signal(tmdb_id, ambiguous=False):
+    return TmdbSignal(
+        content_type=ContentType.TV,
+        confidence=0.85,
+        tmdb_id=tmdb_id,
+        tmdb_name="Frasier",
+        ambiguous_identity=ambiguous,
+        all_candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+        ],
+    )
+
+
+async def _drive_identify(monkeypatch, *, volume_label, signal):
+    """Drive the real identify_disc with a crafted (non-ambiguous) analysis + signal.
+
+    Returns (job_id, started_subtitles: bool, ran_ripping: bool).
+    """
+    from app.core.analyst import TitleInfo
+    from app.services.job_manager import job_manager
+
+    coord = job_manager._identification
+
+    async with async_session() as session:
+        job = DiscJob(volume_label=volume_label, drive_id="E:", state=JobState.IDENTIFYING)
+        session.add(job)
+        await session.commit()
+        job_id = job.id
+
+    async def fake_scan_disc(drive, log_dir=None, *, job_id=0):
+        return (
+            [TitleInfo(index=0, duration_seconds=1440, size_bytes=2_000_000_000, chapter_count=7)],
+            volume_label,
+        )
+
+    monkeypatch.setattr(coord._extractor, "scan_disc", fake_scan_disc)
+
+    analysis = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.85)
+    analysis.detected_name = "Frasier"
+    analysis.detected_season = 1
+    analysis.needs_review = False
+    analysis.tmdb_id = signal.tmdb_id
+    analysis.tmdb_name = "Frasier"
+    analysis.review_reason = None
+    analysis._tmdb_signal = signal
+    analysis._discdb_signal = None
+
+    async def fake_run_classification(*args, **kwargs):
+        return analysis
+
+    monkeypatch.setattr(coord, "_run_classification", fake_run_classification)
+
+    flags = {"subtitles": False, "ripping": False}
+
+    def fake_subtitles(*a, **k):
+        flags["subtitles"] = True
+
+    async def fake_run_ripping(*a, **k):
+        flags["ripping"] = True
+
+    monkeypatch.setattr(coord, "_start_subtitle_download", fake_subtitles)
+    monkeypatch.setattr(coord, "_run_ripping", fake_run_ripping)
+
+    import app.services.identification_coordinator as idc
+
+    async def noop_broadcast(*a, **k):
+        return None
+
+    monkeypatch.setattr(idc.ws_manager, "broadcast_job_update", noop_broadcast)
+
+    await coord.identify_disc(job_id)
+    return job_id, flags["subtitles"], flags["ripping"]
+
+
+async def test_no_year_twin_routes_to_review_before_ripping(monkeypatch):
+    """Frasier backstop: a no-year disc with a same-name twin must go to REVIEW
+    (with a no-year candidate reason) and must NOT download subtitles or rip — even
+    though the materiality gate did not fire and a popularity-best tmdb_id is set."""
+    job_id, started_subtitles, ran_ripping = await _drive_identify(
+        monkeypatch, volume_label="FRASIER_S1D1", signal=_frasier_signal(3452)
+    )
+
+    async with async_session() as session:
+        refreshed = await session.get(DiscJob, job_id)
+        assert refreshed.state == JobState.REVIEW_NEEDED
+        assert "no year" in (refreshed.review_reason or "").lower()
+        assert "195241" in (refreshed.review_reason or "")
+        # The popularity-best guess is kept as the pre-selection; twins are persisted.
+        assert refreshed.tmdb_id == 3452
+        assert "195241" in (refreshed.candidates_json or "")
+
+    assert started_subtitles is False
+    assert ran_ripping is False
+
+
+async def test_year_in_label_skips_no_year_flag_and_rips(monkeypatch):
+    """A year in the label disambiguates twins, so identify proceeds normally."""
+    job_id, started_subtitles, ran_ripping = await _drive_identify(
+        monkeypatch, volume_label="FRASIER_2023_S1D1", signal=_frasier_signal(195241)
+    )
+
+    async with async_session() as session:
+        refreshed = await session.get(DiscJob, job_id)
+        assert refreshed.state != JobState.REVIEW_NEEDED
+
+    assert started_subtitles is True
+    assert ran_ripping is True

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -133,6 +133,24 @@ class TestJobEndpoints:
         response = await client.get("/api/jobs/999")
         assert response.status_code == 404
 
+    async def test_candidates_json_exposed_in_job_and_detail(self, client):
+        """Same-name twin candidates must survive the serializers in both the
+        job response and the detail response, or the UI can't surface the
+        "did you mean Frasier (2023)?" disambiguation (three-way-sync rule)."""
+        payload = (
+            '[{"tmdb_id": 3452, "name": "Frasier", "year": "1993"}, '
+            '{"tmdb_id": 195241, "name": "Frasier", "year": "2023"}]'
+        )
+        job = await _seed_job(candidates_json=payload)
+
+        resp = await client.get(f"/api/jobs/{job.id}")
+        assert resp.status_code == 200
+        assert resp.json()["candidates_json"] == payload
+
+        detail = await client.get(f"/api/jobs/{job.id}/detail")
+        assert detail.status_code == 200
+        assert detail.json()["candidates_json"] == payload
+
     async def test_get_job_titles(self, client):
         job = await _seed_job()
         await _seed_titles(job.id, count=3)

--- a/backend/tests/unit/test_database_migration.py
+++ b/backend/tests/unit/test_database_migration.py
@@ -437,3 +437,38 @@ class TestSchemaMigration:
             assert "legacy_plain" not in actual
         finally:
             db_mod.engine = original_engine
+
+    async def test_candidates_json_round_trips(self, migration_engine, migration_factory):
+        """disc_jobs must persist candidates_json so the downstream wrong-show
+        detector can suggest the same-name twin without re-querying TMDB.
+
+        Regression guard for the same-name collision fix (Frasier 1993 vs 2023):
+        same-name TMDB candidates are recorded at identify time and read at
+        finalization. The column must exist in the model (so frozen-build
+        _add_missing_columns adds it) and round-trip a JSON string.
+        """
+        async with migration_engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        # The model must expose candidates_json for the frozen-build reconciler
+        # (_get_expected_columns derives from model metadata).
+        import app.database as db_mod
+
+        assert "candidates_json" in db_mod._get_expected_columns("disc_jobs")
+
+        payload = (
+            '[{"tmdb_id": 3452, "name": "Frasier", "year": "1993"}, '
+            '{"tmdb_id": 195241, "name": "Frasier", "year": "2023"}]'
+        )
+        async with migration_factory() as session:
+            session.add(
+                DiscJob(drive_id="E:", volume_label="FRASIER_S1D1", candidates_json=payload)
+            )
+            await session.commit()
+
+        async with migration_factory() as session:
+            row = (
+                await session.execute(text("SELECT candidates_json FROM disc_jobs LIMIT 1"))
+            ).fetchone()
+            assert row is not None
+            assert row[0] == payload

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -556,6 +556,37 @@ class TestWrongShowRoutingInCompletion:
         assert "re-identify" in job.review_reason.lower()
         coord.finalize_disc_job.assert_not_called()
 
+    async def test_wrong_show_clears_review_pass_counter(self, tmp_path):
+        # The wrong-show branch fires only after the review-escalation ladder is
+        # EXHAUSTED, where _maybe_escalate_reviews intentionally leaves
+        # _review_passes pinned at max (so re-entries bail). REVIEW_NEEDED isn't
+        # terminal, so reset_conflict_passes never fires — the wrong-show block
+        # must clear it, else a re-identify to the right show skips deep re-match.
+        job_id = await _seed_job(
+            [
+                (0, None, None, TitleState.REVIEW),
+                (1, None, None, TitleState.REVIEW),
+            ],
+            staging=str(tmp_path),
+            tmdb_id=3452,
+            candidates_json=FRASIER_CANDS,
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+        # A non-None rematch callback so _maybe_escalate_reviews doesn't take its
+        # early "no callback" branch (which clears the counter itself); a pinned
+        # counter forces the exhausted-ladder branch that LEAVES it set.
+        coord._rematch_title = AsyncMock()
+        coord._review_passes[job_id] = 999
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        coord._rematch_title.assert_not_awaited()  # ladder exhausted, no dispatch
+        assert job_id not in coord._review_passes
+
     async def test_partial_match_keeps_generic_review_reason(self, tmp_path):
         # One title matched -> not a wrong-show disc; keep the generic message.
         job_id = await _seed_job(

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -15,9 +15,19 @@ from sqlmodel import select
 from app.api.websocket import manager as ws_manager
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
-from app.services.finalization_coordinator import FinalizationCoordinator
+from app.services.finalization_coordinator import (
+    FinalizationCoordinator,
+    _detect_wrong_show,
+)
 from app.services.job_state_machine import JobStateMachine
 from tests.unit.conftest import _unit_session_factory
+
+FRASIER_CANDS = json.dumps(
+    [
+        {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+        {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+    ]
+)
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +70,7 @@ async def _seed_job(
     state=JobState.MATCHING,
     match_details_by_idx=None,
     tmdb_id=None,
+    candidates_json=None,
 ) -> int:
     """Seed a job with the given (title_index, episode, output_filename, title_state) titles."""
     md = match_details_by_idx or {}
@@ -73,6 +84,7 @@ async def _seed_job(
             detected_season=1,
             staging_path=staging,
             tmdb_id=tmdb_id,
+            candidates_json=candidates_json,
         )
         session.add(job)
         await session.commit()
@@ -454,6 +466,116 @@ class TestCheckJobCompletion:
         # Escalation dispatched a re-match, so finalization is deferred.
         coord.finalize_disc_job.assert_not_called()
         assert coord._conflict_passes.get(job_id) == 25
+
+
+@pytest.mark.unit
+class TestDetectWrongShow:
+    """The pure wrong-show signal: a whole TV disc that matched NOTHING against
+    its reference, plus a same-name twin, means the disc was identified as the
+    wrong same-named show (e.g. Frasier 1993 corpus vs a 2023-revival disc)."""
+
+    def _job(self, **kw):
+        base = dict(
+            drive_id="E:",
+            volume_label="FRASIER_S1D1",
+            content_type=ContentType.TV,
+            tmdb_id=3452,
+            tmdb_name="Frasier",
+            candidates_json=FRASIER_CANDS,
+        )
+        base.update(kw)
+        return DiscJob(**base)
+
+    def _ttl(self, idx, matched_episode=None, is_extra=False, is_selected=True):
+        return DiscTitle(
+            job_id=1,
+            title_index=idx,
+            duration_seconds=1380,
+            matched_episode=matched_episode,
+            is_extra=is_extra,
+            is_selected=is_selected,
+            state=TitleState.REVIEW,
+        )
+
+    def test_all_zero_match_with_twin_detects_and_names_twin(self):
+        titles = [self._ttl(0), self._ttl(1), self._ttl(2)]
+        res = _detect_wrong_show(self._job(), titles)
+        assert res is not None
+        assert res["twin"]["tmdb_id"] == 195241
+        assert res["twin"]["year"] == "2023"
+        assert res["unmatched"] == 3
+
+    def test_none_when_any_title_matched(self):
+        titles = [self._ttl(0), self._ttl(1, matched_episode="S01E02"), self._ttl(2)]
+        assert _detect_wrong_show(self._job(), titles) is None
+
+    def test_none_without_persisted_twin(self):
+        titles = [self._ttl(0), self._ttl(1)]
+        assert _detect_wrong_show(self._job(candidates_json=None), titles) is None
+
+    def test_none_when_only_one_episode_candidate(self):
+        titles = [self._ttl(0)]
+        assert _detect_wrong_show(self._job(), titles) is None
+
+    def test_excludes_extras_from_candidate_count(self):
+        # 1 real episode candidate + 2 extras -> below the >=2 episode floor.
+        titles = [self._ttl(0), self._ttl(1, is_extra=True), self._ttl(2, is_extra=True)]
+        assert _detect_wrong_show(self._job(), titles) is None
+
+    def test_none_for_movie(self):
+        titles = [self._ttl(0), self._ttl(1)]
+        assert _detect_wrong_show(self._job(content_type=ContentType.MOVIE), titles) is None
+
+
+@pytest.mark.unit
+class TestWrongShowRoutingInCompletion:
+    """check_job_completion must surface the wrong-show review (naming the twin)
+    instead of the generic "needs manual episode assignment" message."""
+
+    async def test_all_zero_match_with_twin_routes_to_wrong_show_review(self, tmp_path):
+        job_id = await _seed_job(
+            [
+                (0, None, None, TitleState.REVIEW),
+                (1, None, None, TitleState.REVIEW),
+                (2, None, None, TitleState.REVIEW),
+            ],
+            staging=str(tmp_path),
+            tmdb_id=3452,
+            candidates_json=FRASIER_CANDS,
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        assert "Frasier" in job.review_reason
+        assert "2023" in job.review_reason
+        assert "re-identify" in job.review_reason.lower()
+        coord.finalize_disc_job.assert_not_called()
+
+    async def test_partial_match_keeps_generic_review_reason(self, tmp_path):
+        # One title matched -> not a wrong-show disc; keep the generic message.
+        job_id = await _seed_job(
+            [
+                (0, "S01E01", None, TitleState.MATCHED),
+                (1, None, None, TitleState.REVIEW),
+            ],
+            staging=str(tmp_path),
+            tmdb_id=3452,
+            candidates_json=FRASIER_CANDS,
+        )
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        job, _ = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        assert "manual episode assignment" in job.review_reason
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_identification_coordinator.py
+++ b/backend/tests/unit/test_identification_coordinator.py
@@ -6,6 +6,7 @@ DiscDB supplements, and the AI re-query fallback. The method does not touch the
 DB session, so a transient DiscJob and session=None are sufficient.
 """
 
+import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
@@ -13,9 +14,14 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from app.core.analyst import DiscAnalysisResult
+from app.core.tmdb_classifier import TmdbSignal
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType
-from app.services.identification_coordinator import IdentificationCoordinator
+from app.services.identification_coordinator import (
+    IdentificationCoordinator,
+    _candidates_json_from_signal,
+    _label_has_year,
+)
 
 
 def _make_coord(analyst):
@@ -59,6 +65,54 @@ def _job(volume_label="THE_OFFICE_S1D1"):
 
 def _patch_config(monkeypatch, config):
     monkeypatch.setattr("app.services.config_service.get_config", AsyncMock(return_value=config))
+
+
+@pytest.mark.unit
+class TestCandidatesJsonFromSignal:
+    """The persisted candidates_json must capture all same-name twins so the
+    downstream wrong-show detector can suggest the right one (e.g. Frasier 2023)."""
+
+    def test_serializes_all_candidates(self):
+        sig = TmdbSignal(
+            content_type=ContentType.TV,
+            confidence=0.85,
+            tmdb_id=3452,
+            tmdb_name="Frasier",
+            all_candidates=[
+                {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+                {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+            ],
+        )
+        out = _candidates_json_from_signal(sig)
+        assert {c["tmdb_id"] for c in json.loads(out)} == {3452, 195241}
+
+    def test_none_when_no_twins(self):
+        sig = TmdbSignal(
+            content_type=ContentType.TV, confidence=0.85, tmdb_id=1396, tmdb_name="Breaking Bad"
+        )
+        assert _candidates_json_from_signal(sig) is None
+
+    def test_none_for_missing_signal(self):
+        assert _candidates_json_from_signal(None) is None
+
+
+@pytest.mark.unit
+class TestLabelHasYear:
+    """A 4-digit 19xx/20xx in the disc label/name lets popularity+year
+    disambiguate same-name twins, so the no-year proactive flag is suppressed."""
+
+    def test_detects_year_in_various_forms(self):
+        assert _label_has_year("FRASIER_2023") is True
+        assert _label_has_year("FRASIER (2023)") is True
+        assert _label_has_year("THE_OFFICE_2005") is True
+        assert _label_has_year("", "Frasier 1993") is True  # second arg carries it
+
+    def test_no_year_for_season_disc_labels(self):
+        assert _label_has_year("FRASIER_S1D1") is False
+        assert _label_has_year("FRASIER") is False
+        assert _label_has_year("2_BROKE_GIRLS_S1D1") is False
+        assert _label_has_year("") is False
+        assert _label_has_year(None) is False
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_precomputed_guard.py
+++ b/backend/tests/unit/test_precomputed_guard.py
@@ -1,8 +1,30 @@
-from app.matcher.episode_identification import EpisodeMatcher, precomputed_covers_season
+import json
+
+from app.matcher.episode_identification import (
+    EpisodeMatcher,
+    precomputed_covers_season,
+    precomputed_episode_codes,
+)
+from app.matcher.vectorizer_config import CACHE_FORMAT_VERSION, vectorizer_config_hash
 
 
 def _manifest(tmdb_id):
     return {"shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {"1": 24}}}}
+
+
+def _write_corpus(tmp_path, tmdb_id, codes=("S01E01",)):
+    """Write a valid on-disk precomputed corpus for Frasier S1 keyed to ``tmdb_id``."""
+    pre = tmp_path / "precomputed"
+    show_dir = pre / "Frasier"
+    show_dir.mkdir(parents=True)
+    (show_dir / "S01.npz").write_bytes(b"x")
+    (show_dir / "S01.index.json").write_text(json.dumps(list(codes)))
+    manifest = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "vectorizer_config_hash": vectorizer_config_hash(),
+        "shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {}}},
+    }
+    (pre / "manifest.json").write_text(json.dumps(manifest))
 
 
 def test_guard_rejects_mismatched_tmdb_id(tmp_path):
@@ -47,6 +69,28 @@ def test_guard_passes_on_matching_id_then_checks_files(tmp_path):
         )
         is True
     )
+
+
+def test_episode_codes_guard_rejects_mismatched_tmdb_id(tmp_path):
+    # Corpus is the 1993 original (3452); the job is the 2023 revival (195241).
+    # precomputed_episode_codes must forward the guard and refuse, else it would
+    # size a "skip download" result from the WRONG show's episode list.
+    _write_corpus(tmp_path, "3452", codes=["S01E01", "S01E02"])
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=195241) is None
+
+
+def test_episode_codes_returned_on_matching_id(tmp_path):
+    _write_corpus(tmp_path, "3452", codes=["S01E01", "S01E02"])
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=3452) == [
+        "S01E01",
+        "S01E02",
+    ]
+
+
+def test_episode_codes_backward_compatible_without_id(tmp_path):
+    # No expected id -> guard skipped (backward compatible name-only matching).
+    _write_corpus(tmp_path, "3452", codes=["S01E01"])
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1) == ["S01E01"]
 
 
 def test_matcher_stores_expected_tmdb_id(tmp_path):

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -10,6 +10,7 @@ def test_tmdb_signal_defaults_not_ambiguous():
     )
     assert sig.ambiguous_identity is False
     assert sig.candidates is None
+    assert sig.all_candidates is None
 
 
 def test_tmdb_signal_can_carry_candidates():
@@ -29,6 +30,38 @@ def test_tmdb_signal_can_carry_candidates():
 def test_materiality_constants_have_sane_defaults():
     assert tc.AMBIGUOUS_POPULARITY_FLOOR == 10.0
     assert tc.AMBIGUOUS_POPULARITY_RATIO == 4.0
+    # Lower floor for the no-year backstop (label can't self-disambiguate twins).
+    assert tc.AMBIGUOUS_NO_YEAR_FLOOR == 3.0
+
+
+# all_candidates are popularity-sorted desc; runner-up is index 1.
+_FRASIER_CANDS = [
+    {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 75.6},
+    {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 5.7},
+]
+
+
+def test_should_flag_no_year_flags_dominant_twin_without_year():
+    # No year on the disc label + a real twin (runner-up 5.7 >= floor 3.0) -> flag.
+    assert tc._should_flag_no_year(_FRASIER_CANDS, has_year=False) is True
+
+
+def test_should_flag_no_year_skips_when_year_present():
+    # A year disambiguates via popularity+year, so no proactive flag.
+    assert tc._should_flag_no_year(_FRASIER_CANDS, has_year=True) is False
+
+
+def test_should_flag_no_year_skips_noise_runner_up():
+    noise = [
+        {"tmdb_id": 73586, "name": "Yellowstone", "year": "2018", "popularity": 159.7},
+        {"tmdb_id": 19355, "name": "Yellowstone", "year": "2009", "popularity": 1.2},
+    ]
+    assert tc._should_flag_no_year(noise, has_year=False) is False
+
+
+def test_should_flag_no_year_skips_without_twin():
+    assert tc._should_flag_no_year(None, has_year=False) is False
+    assert tc._should_flag_no_year([_FRASIER_CANDS[0]], has_year=False) is False
 
 
 def _resp(results):
@@ -111,6 +144,43 @@ def test_unique_name_not_flagged():
     with _patch_searches(tv):
         sig = tc.classify_from_tmdb("Breaking Bad", "k" * 41)
     assert sig.ambiguous_identity is False
+
+
+def test_all_candidates_records_dominant_twin_even_when_gate_does_not_fire():
+    # Frasier dominant twin: the materiality gate stays False (revival below the
+    # popularity floor), but BOTH ids must still be RECORDED in all_candidates so
+    # the downstream wrong-show detector can suggest the 2023 revival. This is the
+    # "record the ambiguity" vs "proactively flag it" split.
+    tv = [
+        {"id": 3452, "name": "Frasier", "popularity": 75.6, "first_air_date": "1993-09-16"},
+        {"id": 195241, "name": "Frasier", "popularity": 5.7, "first_air_date": "2023-10-12"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Frasier", "k" * 41)
+    assert sig.ambiguous_identity is False
+    assert sig.all_candidates is not None
+    ids = {c["tmdb_id"] for c in sig.all_candidates}
+    assert ids == {3452, 195241}
+
+
+def test_all_candidates_none_for_unique_name():
+    tv = [{"id": 1396, "name": "Breaking Bad", "popularity": 300.0, "first_air_date": "2008-01-20"}]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("Breaking Bad", "k" * 41)
+    assert sig.all_candidates is None
+
+
+def test_all_candidates_populated_when_gate_fires():
+    tv = [
+        {"id": 37854, "name": "One Piece", "popularity": 60.0, "first_air_date": "1999-10-20"},
+        {"id": 111110, "name": "One Piece", "popularity": 38.3, "first_air_date": "2023-08-31"},
+    ]
+    with _patch_searches(tv):
+        sig = tc.classify_from_tmdb("One Piece", "k" * 41)
+    assert sig.ambiguous_identity is True
+    assert sig.all_candidates is not None
+    ids = {c["tmdb_id"] for c in sig.all_candidates}
+    assert ids == {37854, 111110}
 
 
 def test_collision_lists_all_same_name_candidates():

--- a/backend/tests/unit/test_tmdb_classifier_collision.py
+++ b/backend/tests/unit/test_tmdb_classifier_collision.py
@@ -43,12 +43,12 @@ _FRASIER_CANDS = [
 
 def test_should_flag_no_year_flags_dominant_twin_without_year():
     # No year on the disc label + a real twin (runner-up 5.7 >= floor 3.0) -> flag.
-    assert tc._should_flag_no_year(_FRASIER_CANDS, has_year=False) is True
+    assert tc.should_flag_no_year(_FRASIER_CANDS, has_year=False) is True
 
 
 def test_should_flag_no_year_skips_when_year_present():
     # A year disambiguates via popularity+year, so no proactive flag.
-    assert tc._should_flag_no_year(_FRASIER_CANDS, has_year=True) is False
+    assert tc.should_flag_no_year(_FRASIER_CANDS, has_year=True) is False
 
 
 def test_should_flag_no_year_skips_noise_runner_up():
@@ -56,12 +56,12 @@ def test_should_flag_no_year_skips_noise_runner_up():
         {"tmdb_id": 73586, "name": "Yellowstone", "year": "2018", "popularity": 159.7},
         {"tmdb_id": 19355, "name": "Yellowstone", "year": "2009", "popularity": 1.2},
     ]
-    assert tc._should_flag_no_year(noise, has_year=False) is False
+    assert tc.should_flag_no_year(noise, has_year=False) is False
 
 
 def test_should_flag_no_year_skips_without_twin():
-    assert tc._should_flag_no_year(None, has_year=False) is False
-    assert tc._should_flag_no_year([_FRASIER_CANDS[0]], has_year=False) is False
+    assert tc.should_flag_no_year(None, has_year=False) is False
+    assert tc.should_flag_no_year([_FRASIER_CANDS[0]], has_year=False) is False
 
 
 def _resp(results):


### PR DESCRIPTION
## Problem

A real disc `FRASIER_S1D1` (the **2023 Frasier revival**, TMDB #195241) was silently identified as the **1993 original** (#3452) because the label has no year and TMDB popularity dominates. Every episode then matched the 1993 reference corpus at noise floor (`0 matched / 10 rejected chunks`, best score `0.000`) and the job landed in review with a misleading *"N titles need manual episode assignment"* message.

This is **not a regression** — the shipped collision review (#278/#282) deliberately scopes out dominant same-name twins via its materiality gate. The load-bearing fix for this class ("item 3") simply hadn't been built.

## Fix (layered; A–D — corpus re-key by tmdb_id deferred to a follow-up)

- **A — persist candidates (foundation):** new `DiscJob.candidates_json` column (model + Alembic `c4d8e1f0a2b3`; frozen builds get it via the metadata-driven `_add_missing_columns`). `tmdb_classifier` now records **every** same-name twin (`all_candidates`) regardless of the materiality gate, persisted at identify time and exposed in both job serializers — so both layers can suggest the right twin without a second TMDB call.
- **C — downstream backstop (load-bearing):** `finalization_coordinator._detect_wrong_show`, wired into `check_job_completion` after escalation. A TV disc whose episode candidates **all** matched nothing + a persisted twin → REVIEW with *"Content doesn't resemble Frasier (1993)… did you mean Frasier (2023)? Re-identify to fix."* Uses an **aggregate** signal (all-zero match), never an absolute per-chunk cosine.
- **B — identify-time layer (no-year-gated):** a label with no year + a real twin (runner-up popularity ≥ `AMBIGUOUS_NO_YEAR_FLOOR=3.0`) flags for review **before** ripping, in both `identify_disc` and `identify_from_staging`. A year in the label suppresses it (popularity+year disambiguate).
- **D — hardening:** `precomputed_episode_codes` now forwards `expected_tmdb_id` to the corpus guard (was bypassed — defense-in-depth gap).

## Recovery for an already mis-identified disc

The recovery path already exists on builds with #278/#282: re-identify the job to the correct twin's `tmdb_id` via the ReIdentify modal → the corpus guard refuses the wrong corpus and the revival's subtitles download. (The residual shared `data/<name>/` dir caveat is removed by the deferred corpus re-key.)

## Follow-up (not in this PR)

- **Re-key the corpus + subtitle cache on disk by `tmdb_id`** so two same-named shows can't share a directory. Needs backward-compat (read old name-keyed layout) + `CACHE_FORMAT_VERSION` bump + an out-of-band rebuild of the rolling `subtitle-cache-latest` release.

## Tests

1559 unit + offline integration + 29 pipeline green; ruff clean. New coverage: candidates persistence + migration, gate-independent collector, no-year helpers, the wrong-show detector (pure + via `check_job_completion`), the guard wiring, and an end-to-end `identify_disc` no-year routing test (verified RED when the wiring is neutralized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)