### PR TITLE
fix(matcher): key precomputed subtitle corpus by tmdb_id (cache v3)

### DIFF
--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -85,10 +85,19 @@ def _resolve_corpus_entry(manifest, show_name: str, tmdb_id):
         return None, None
     if tmdb_id is not None and str(tmdb_id) in shows:
         return str(tmdb_id), shows[str(tmdb_id)]
-    for key, entry in shows.items():
-        if entry.get("name") == show_name:
-            return key, entry
-    return None, None
+    # No (or unknown) tmdb_id: fall back to matching the stored name. A v3 corpus
+    # can legitimately hold two same-named shows (Frasier 1993 + 2023 revival), so
+    # warn when the name is ambiguous — we can only return the first match.
+    name_matches = [(key, entry) for key, entry in shows.items() if entry.get("name") == show_name]
+    if not name_matches:
+        return None, None
+    if len(name_matches) > 1:
+        logger.warning(
+            f"Corpus name-fallback for {show_name!r} is ambiguous across keys "
+            f"{[k for k, _ in name_matches]} (no tmdb_id supplied); using the first. "
+            f"Supply tmdb_id to pick the right same-named show."
+        )
+    return name_matches[0]
 
 
 def _corpus_show_dir(cache_dir, key: str) -> Path:

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -64,12 +64,36 @@ def load_precomputed_manifest(cache_dir) -> dict | None:
 def _tmdb_id_mismatch(expected, entry_id) -> bool:
     """True when both ids are known and disagree (string-compared).
 
-    Shared by the corpus guard's two call sites (this module's
-    ``precomputed_covers_season`` and ``EpisodeMatcher._load_precomputed_season``)
-    so the comparison can't silently diverge. Returns False when either id is
-    unknown — backward-compatible with name-only matching.
+    A safety rail for the name-resolution fallback in ``_resolve_corpus_entry``:
+    when a corpus entry is found by NAME (tmdb_id unknown at lookup) but its id
+    contradicts a later-known expected id, refuse it. Returns False when either id
+    is unknown — backward-compatible with name-only matching.
     """
     return expected is not None and entry_id is not None and str(entry_id) != str(expected)
+
+
+def _resolve_corpus_entry(manifest, show_name: str, tmdb_id):
+    """Return ``(key, entry)`` for a show in a v3 id-keyed manifest, else ``(None, None)``.
+
+    Prefers an exact ``tmdb_id`` match (the manifest is keyed by ``str(tmdb_id)``),
+    falling back to the first entry whose stored ``name`` matches when the id is
+    unknown (e.g. a flat import that never resolved a TMDB id). ``key`` is also the
+    on-disk corpus dir name (see ``corpus_dir_name``).
+    """
+    shows = (manifest or {}).get("shows", {})
+    if not shows:
+        return None, None
+    if tmdb_id is not None and str(tmdb_id) in shows:
+        return str(tmdb_id), shows[str(tmdb_id)]
+    for key, entry in shows.items():
+        if entry.get("name") == show_name:
+            return key, entry
+    return None, None
+
+
+def _corpus_show_dir(cache_dir, key: str) -> Path:
+    """On-disk precomputed dir for a resolved manifest ``key`` (a tmdb_id string)."""
+    return Path(cache_dir) / "precomputed" / sanitize_filename(str(key))
 
 
 def precomputed_covers_season(
@@ -86,29 +110,25 @@ def precomputed_covers_season(
     re-validating manifest.json (callers holding a cached copy pass it in).
 
     ``expected_tmdb_id`` is the TMDB id the calling job has resolved for the
-    show. When supplied, it is compared against the manifest entry's ``tmdb_id``
-    (string comparison); a mismatch means the corpus is for a *different*
-    same-named show (e.g. Frasier 1993 vs 2023 revival) and this function
-    returns False before inspecting any on-disk files. When either id is
-    unknown the guard is skipped (backward-compatible).
+    show. The manifest is keyed by tmdb_id (v3), so a known id resolves the right
+    same-named show directly; when unknown, the entry is found by name. A
+    name-resolved entry whose id contradicts ``expected_tmdb_id`` is refused.
     """
     if manifest is None:
         manifest = load_precomputed_manifest(cache_dir)
     if not manifest:
         return False
 
-    show_entry = manifest.get("shows", {}).get(show_name)
+    key, show_entry = _resolve_corpus_entry(manifest, show_name, expected_tmdb_id)
     if not show_entry or season not in show_entry.get("seasons", []):
         return False
 
-    # Corpus guard: if the job knows its TMDB id and it contradicts the
-    # manifest entry's id, this precomputed corpus is for a DIFFERENT same-named
-    # show — refuse it so we never match e.g. the Frasier 2023 revival against the
-    # 1993 corpus. Skipped when either id is unknown (backward-compatible).
+    # Safety rail for the name-resolution fallback: a found-by-name entry whose
+    # id contradicts a known expected id is a DIFFERENT same-named show — refuse.
     if _tmdb_id_mismatch(expected_tmdb_id, show_entry.get("tmdb_id")):
         return False
 
-    show_dir = Path(cache_dir) / "precomputed" / sanitize_filename(show_name)
+    show_dir = _corpus_show_dir(cache_dir, key)
     npz_path = show_dir / f"S{season:02d}.npz"
     index_path = show_dir / f"S{season:02d}.index.json"
     return npz_path.exists() and index_path.exists()
@@ -122,19 +142,17 @@ def precomputed_episode_codes(
     None means the cache doesn't cover it (caller should download/scrape).
     Lets callers size a result from the cache itself without a TMDB round-trip.
 
-    ``expected_tmdb_id`` is forwarded to the corpus guard so a same-named but
-    different show's corpus (e.g. Frasier 1993 vs the 2023 revival) is refused
-    here too — otherwise a "skip download" result would be sized from the wrong
-    show's episode list. Skipped when the id is unknown (backward-compatible).
+    ``expected_tmdb_id`` resolves the right same-named show's corpus (the manifest
+    is keyed by tmdb_id); without it the show is found by name.
     """
+    manifest = load_precomputed_manifest(cache_dir)
     if not precomputed_covers_season(
-        cache_dir, show_name, season, expected_tmdb_id=expected_tmdb_id
+        cache_dir, show_name, season, manifest=manifest, expected_tmdb_id=expected_tmdb_id
     ):
         return None
 
-    index_path = (
-        Path(cache_dir) / "precomputed" / sanitize_filename(show_name) / f"S{season:02d}.index.json"
-    )
+    key, _ = _resolve_corpus_entry(manifest, show_name, expected_tmdb_id)
+    index_path = _corpus_show_dir(cache_dir, key) / f"S{season:02d}.index.json"
     try:
         with open(index_path, encoding="utf-8") as fh:
             codes = json.load(fh)
@@ -944,10 +962,11 @@ class EpisodeMatcher:
         # reuse it for the coverage gate so we read+validate manifest.json at most
         # once per matcher instance instead of once per title.
         manifest = self._load_precomputed_manifest()
-        # Corpus guard: a positive tmdb_id mismatch means the manifest entry is a
-        # different same-named show. Bail BEFORE the stale-prune branch so we don't
-        # wrongly drop a valid entry whose files are present.
-        show_entry = (manifest or {}).get("shows", {}).get(self.show_name)
+        # Resolve the show by tmdb_id (manifest is id-keyed in v3), falling back to
+        # name when the id is unknown. A name-resolved entry whose id contradicts a
+        # known expected id is a different same-named show — refuse it BEFORE the
+        # stale-prune branch so we don't wrongly drop a valid entry.
+        key, show_entry = _resolve_corpus_entry(manifest, self.show_name, self.expected_tmdb_id)
         entry_id = show_entry.get("tmdb_id") if show_entry else None
         if _tmdb_id_mismatch(self.expected_tmdb_id, entry_id):
             logger.warning(
@@ -970,11 +989,11 @@ class EpisodeMatcher:
                 )
                 show_entry["seasons"] = [s for s in show_entry["seasons"] if s != season_number]
                 if not show_entry["seasons"]:
-                    manifest["shows"].pop(self.show_name, None)
+                    manifest["shows"].pop(key, None)
             return None
 
         precomputed_dir = self.cache_dir / "precomputed"
-        show_dir = precomputed_dir / sanitize_filename(self.show_name)
+        show_dir = _corpus_show_dir(self.cache_dir, key)
         npz_path = show_dir / f"S{season_number:02d}.npz"
         index_path = show_dir / f"S{season_number:02d}.index.json"
 

--- a/backend/app/matcher/subtitle_utils.py
+++ b/backend/app/matcher/subtitle_utils.py
@@ -183,3 +183,16 @@ def sanitize_filename(filename: str) -> str:
     filename = re.sub(r'[<>:"/\\|?*]', "", filename)
 
     return filename.strip()
+
+
+def corpus_dir_name(tmdb_id, show_name: str) -> str:
+    """On-disk dir name / manifest key for a show's precomputed corpus + subtitle cache.
+
+    Keyed by ``tmdb_id`` so two same-named shows (e.g. Frasier 1993 #3452 vs the
+    2023 revival #195241) never collide into one directory. Falls back to the
+    sanitized show name only when no tmdb_id is known (legacy caches, or a flat
+    import that never resolved an id).
+    """
+    if tmdb_id is not None and str(tmdb_id).strip():
+        return str(tmdb_id)
+    return sanitize_filename(show_name)

--- a/backend/app/matcher/vectorizer_config.py
+++ b/backend/app/matcher/vectorizer_config.py
@@ -23,7 +23,10 @@ from sklearn.preprocessing import normalize as _sk_normalize
 # and a cache manifest invalidates the cache (runtime falls back to scraping).
 # v2: on-disk format switched to uint16 hashed counts; the loader applies
 # apply_tfidf at startup. Cuts tarball size ~57% vs v1's float64 TF-IDF rows.
-CACHE_FORMAT_VERSION = "2"
+# v3: corpus dirs + manifest keyed by tmdb_id (was sanitized show name) so two
+# same-named shows (Frasier 1993 #3452 vs 2023 revival #195241) don't collide.
+# The bump invalidates v2 caches; the id-keyed v3 cache auto-downloads on startup.
+CACHE_FORMAT_VERSION = "3"
 
 HASHING_N_FEATURES = 2**18
 

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -52,8 +52,8 @@ from rich.progress import (
 from scipy import sparse
 
 from app.matcher import coverage_tracker
-from app.matcher.episode_identification import SubtitleCache
-from app.matcher.subtitle_utils import corpus_dir_name, discover_season_srts, sanitize_filename
+from app.matcher.episode_identification import SubtitleCache, _corpus_show_dir
+from app.matcher.subtitle_utils import discover_season_srts, sanitize_filename
 from app.matcher.testing_service import download_subtitles, get_last_quota, probe_os_quota
 from app.matcher.tmdb_client import (
     fetch_show_details,
@@ -646,8 +646,10 @@ def main() -> int:
     # .npz collapses the long runs of 1s much better than it ever could on
     # floats — measured ~85% reduction (~8 KB/episode vs. ~66 KB for v1).
     u16_max = np.iinfo(np.uint16).max
-    for tmdb_id_b, show_name, season, codes, counts in blocks:
-        show_dir = precomputed_dir / corpus_dir_name(tmdb_id_b, show_name)
+    for tmdb_id_b, _show_name, season, codes, counts in blocks:
+        # Write to the runtime's canonical id-keyed dir (matches the str(tmdb_id)
+        # manifest key) via the shared formula so write/read can't drift.
+        show_dir = _corpus_show_dir(cache_dir, str(tmdb_id_b))
         show_dir.mkdir(parents=True, exist_ok=True)
         # HashingVectorizer emits float64 counts even with alternate_sign=False;
         # cast to uint16 (clipped defensively — real per-episode token counts

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -53,7 +53,7 @@ from scipy import sparse
 
 from app.matcher import coverage_tracker
 from app.matcher.episode_identification import SubtitleCache
-from app.matcher.subtitle_utils import corpus_dir_name, discover_season_srts
+from app.matcher.subtitle_utils import corpus_dir_name, discover_season_srts, sanitize_filename
 from app.matcher.testing_service import download_subtitles, get_last_quota, probe_os_quota
 from app.matcher.tmdb_client import (
     fetch_show_details,
@@ -260,10 +260,11 @@ def _harvest_show(
     """
     harvested: list[tuple[int, str, Path]] = []
     canonical = show["name"]
-    # Harvest dir keyed by tmdb_id so two same-named shows (Frasier 1993 vs the
-    # 2023 revival) don't share one scratch dir during a build. (Scratch only —
-    # the shipped tarball contains precomputed/ vectors, not data/ SRTs.)
-    season_data_dir = cache_dir / "data" / corpus_dir_name(show["tmdb_id"], canonical)
+    # The data/ SRT scrape cache stays NAME-keyed (it must match where
+    # download_subtitles writes and what normalize_subtitle_cache processes —
+    # re-keying data/ by tmdb_id is a separate follow-up). Only the precomputed
+    # OUTPUT below is keyed by tmdb_id.
+    season_data_dir = cache_dir / "data" / sanitize_filename(canonical)
     for season in range(1, show["seasons"] + 1):
         # Complete-on-disk fast path: a season that previously reached the
         # coverage threshold is shipped straight from the SRTs already on disk

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -53,7 +53,7 @@ from scipy import sparse
 
 from app.matcher import coverage_tracker
 from app.matcher.episode_identification import SubtitleCache
-from app.matcher.subtitle_utils import discover_season_srts, sanitize_filename
+from app.matcher.subtitle_utils import corpus_dir_name, discover_season_srts
 from app.matcher.testing_service import download_subtitles, get_last_quota, probe_os_quota
 from app.matcher.tmdb_client import (
     fetch_show_details,
@@ -260,7 +260,10 @@ def _harvest_show(
     """
     harvested: list[tuple[int, str, Path]] = []
     canonical = show["name"]
-    season_data_dir = cache_dir / "data" / sanitize_filename(canonical)
+    # Harvest dir keyed by tmdb_id so two same-named shows (Frasier 1993 vs the
+    # 2023 revival) don't share one scratch dir during a build. (Scratch only —
+    # the shipped tarball contains precomputed/ vectors, not data/ SRTs.)
+    season_data_dir = cache_dir / "data" / corpus_dir_name(show["tmdb_id"], canonical)
     for season in range(1, show["seasons"] + 1):
         # Complete-on-disk fast path: a season that previously reached the
         # coverage threshold is shipped straight from the SRTs already on disk
@@ -515,8 +518,8 @@ def main() -> int:
 
     # --- Harvest SRT + extract cleaned full text per episode -------------------
     subtitle_cache = SubtitleCache()
-    # blocks: list of (show_name, season, [episode_codes], count_csr)
-    blocks: list[tuple[str, int, list[str], object]] = []
+    # blocks: list of (tmdb_id, show_name, season, [episode_codes], count_csr)
+    blocks: list[tuple[int, str, int, list[str], object]] = []
     hv = build_hashing_vectorizer()
     manifest_shows: dict[str, dict] = {}
     tally = RunTally()
@@ -610,13 +613,16 @@ def main() -> int:
                 if not texts:
                     continue
                 counts = hv.transform(texts)  # raw hashed term counts
-                blocks.append((show["name"], season, codes, counts))
+                blocks.append((show["tmdb_id"], show["name"], season, codes, counts))
                 show_seasons.append(season)
                 episode_counts[str(season)] = len(codes)
 
             if show_seasons:
-                manifest_shows[show["name"]] = {
+                # v3: keyed by tmdb_id so same-named shows don't collide; the name
+                # is stored so the runtime can still resolve when no id is known.
+                manifest_shows[str(show["tmdb_id"])] = {
                     "tmdb_id": show["tmdb_id"],
+                    "name": show["name"],
                     "seasons": show_seasons,
                     "episode_counts": episode_counts,
                 }
@@ -626,7 +632,7 @@ def main() -> int:
         return 1
 
     # --- Fit one global IDF across the whole corpus ----------------------------
-    all_counts = sparse.vstack([b[3] for b in blocks], format="csr")
+    all_counts = sparse.vstack([b[4] for b in blocks], format="csr")
     idf = compute_idf(all_counts)
     np.save(precomputed_dir / "idf.npy", idf)
     logger.info(f"Global IDF fit over {all_counts.shape[0]} episodes")
@@ -639,8 +645,8 @@ def main() -> int:
     # .npz collapses the long runs of 1s much better than it ever could on
     # floats — measured ~85% reduction (~8 KB/episode vs. ~66 KB for v1).
     u16_max = np.iinfo(np.uint16).max
-    for show_name, season, codes, counts in blocks:
-        show_dir = precomputed_dir / sanitize_filename(show_name)
+    for tmdb_id_b, show_name, season, codes, counts in blocks:
+        show_dir = precomputed_dir / corpus_dir_name(tmdb_id_b, show_name)
         show_dir.mkdir(parents=True, exist_ok=True)
         # HashingVectorizer emits float64 counts even with alternate_sign=False;
         # cast to uint16 (clipped defensively — real per-episode token counts
@@ -691,7 +697,7 @@ def main() -> int:
             shutil.rmtree(data_dir)
             logger.info("Deleted harvested SRT files (--clean-srt)")
 
-    total_episodes = sum(len(c) for _, _, c, _ in blocks)
+    total_episodes = sum(len(c) for _, _, _, c, _ in blocks)
     size_mb = output_path.stat().st_size / (1024 * 1024)
     logger.info(
         f"Built cache: {len(manifest_shows)} shows, {total_episodes} episodes, "

--- a/backend/scripts/pack_subtitle_cache.py
+++ b/backend/scripts/pack_subtitle_cache.py
@@ -2,19 +2,18 @@
 
 Unlike ``scripts/build_subtitle_cache.py``, this NEVER downloads subtitles. It
 walks the local subtitle cache (``<cache>/data/<show>/<show> - SxxExx.srt``),
-reduces every episode to the shared v2 hashed-TF-IDF vector format, verifies the
-artifact, and optionally publishes it to the rolling GitHub release. Use it to
-ship whatever is already on disk -- including shows added manually that
+reduces every episode to the shared hashed-TF-IDF vector format (cache v3),
+verifies the artifact, and optionally publishes it to the rolling GitHub release.
+Use it to ship whatever is already on disk -- including shows added manually that
 popularity-mode selection in ``build_subtitle_cache.py`` would never pick.
 
-Show directories are stored under *sanitized* names (``sanitize_filename`` maps
-``:`` -> `` -``, ``/`` -> ``-``, ...), but the runtime matcher looks the cache up
-by the *canonical* TMDB show name (``manifest["shows"][show_name]``). By default
-each show dir is resolved to its canonical name via TMDB (cache-first; this is
-metadata only, never a subtitle download) and accepted only if it sanitizes back
-to the dir name -- guaranteeing the runtime lookup + on-disk subdir handshake.
-``--offline`` skips TMDB entirely and keys the manifest by the dir name; shows
-whose real title contains ``:`` or ``/`` then won't be matched at runtime.
+Show directories on disk are stored under *sanitized* names, but the published
+cache (v3) is keyed by ``tmdb_id`` so two same-named shows (Frasier 1993 vs the
+2023 revival) never collide. Each dir is resolved to its canonical TMDB
+title+id (cache-first; metadata only, never a subtitle download); the precomputed
+subdir + manifest key become ``str(tmdb_id)`` and the canonical name is stored in
+the entry for runtime name resolution. ``--offline`` skips TMDB and falls back to
+keying by the sanitized dir name (so same-named shows can still collide offline).
 
 Usage (from backend/):
     uv run python scripts/pack_subtitle_cache.py            # build + verify
@@ -55,7 +54,7 @@ from app.matcher.subtitle_utils import (
 from app.matcher.subtitle_utils import (
     SINGLE_EP_RE as _SINGLE_EP_RE,
 )
-from app.matcher.subtitle_utils import sanitize_filename
+from app.matcher.subtitle_utils import corpus_dir_name, sanitize_filename
 from app.matcher.tmdb_client import fetch_show_details, fetch_show_id
 from app.matcher.vectorizer_config import (
     CACHE_FORMAT_VERSION,
@@ -173,9 +172,13 @@ def _verify(precomputed_dir: Path, output_path: Path, manifest: dict) -> None:
                 raise SystemExit(f"verify: row/index mismatch for {key} S{season:02d}")
 
     # End-to-end consumer round-trip: extract the tarball and load it through the
-    # exact runtime path. Prefer a colon-titled show -- that's the case a dir-name
-    # key would silently break.
-    sample_keys = [k for k in manifest["shows"] if ":" in k or "/" in k][:1]
+    # exact runtime path. v3 keys by tmdb_id, so prefer a show whose NAME has
+    # special characters (a name-resolution edge) plus a couple of others.
+    sample_keys = [
+        k
+        for k, e in manifest["shows"].items()
+        if ":" in e.get("name", "") or "/" in e.get("name", "")
+    ][:1]
     sample_keys += [k for k in manifest["shows"] if k not in sample_keys][:2]
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -186,8 +189,15 @@ def _verify(precomputed_dir: Path, output_path: Path, manifest: dict) -> None:
             # project already standardizes on 3.11.4+ for tarball extraction.
             tar.extractall(tmp_path, filter="data")
         for key in sample_keys:
-            matcher = EpisodeMatcher(cache_dir=tmp_path, show_name=key)
-            season = manifest["shows"][key]["seasons"][0]
+            entry = manifest["shows"][key]
+            # v3: load via the runtime path keyed by tmdb_id (the manifest key),
+            # passing the canonical name as the matcher's show_name.
+            matcher = EpisodeMatcher(
+                cache_dir=tmp_path,
+                show_name=entry.get("name", key),
+                expected_tmdb_id=entry.get("tmdb_id"),
+            )
+            season = entry["seasons"][0]
             loaded = matcher.load_precomputed_season(season)
             if loaded is None or loaded[0].shape[0] == 0:
                 raise SystemExit(f"verify: consumer round-trip failed for {key} S{season:02d}")
@@ -256,9 +266,12 @@ def main() -> int:
     fallbacks: list[str] = []
 
     for dir_name, by_season in discovered.items():
-        key, tmdb_id, resolved = _resolve_canonical(dir_name, args.offline)
+        canonical, tmdb_id, resolved = _resolve_canonical(dir_name, args.offline)
         if not args.offline and not resolved:
             fallbacks.append(dir_name)
+        # v3: dir + manifest key by tmdb_id (falls back to the sanitized name when
+        # offline / unresolved). The canonical name is stored for name resolution.
+        corpus_key = corpus_dir_name(tmdb_id, canonical)
 
         show_seasons: list[int] = []
         episode_counts: dict[str, int] = {}
@@ -273,13 +286,14 @@ def main() -> int:
             if not texts:
                 continue
             counts = hv.transform(texts)  # raw hashed term counts
-            blocks.append((key, season, codes, counts))
+            blocks.append((corpus_key, season, codes, counts))
             show_seasons.append(season)
             episode_counts[str(season)] = len(codes)
 
         if show_seasons:
-            manifest_shows[key] = {
+            manifest_shows[corpus_key] = {
                 "tmdb_id": tmdb_id,
+                "name": canonical,
                 "seasons": show_seasons,
                 "episode_counts": episode_counts,
             }
@@ -296,8 +310,8 @@ def main() -> int:
 
     # --- Write per-(show, season) uint16 hashed-count matrices (cache v2) -----
     u16_max = np.iinfo(np.uint16).max
-    for show_name, season, codes, counts in blocks:
-        show_dir = precomputed_dir / sanitize_filename(show_name)
+    for corpus_key, season, codes, counts in blocks:
+        show_dir = precomputed_dir / sanitize_filename(corpus_key)
         show_dir.mkdir(parents=True, exist_ok=True)
         counts_u16 = sparse.csr_matrix(
             (

--- a/backend/scripts/pack_subtitle_cache.py
+++ b/backend/scripts/pack_subtitle_cache.py
@@ -47,7 +47,11 @@ from build_subtitle_cache import _bootstrap_config_from_env, _ensure_db_schema
 from loguru import logger
 from scipy import sparse
 
-from app.matcher.episode_identification import EpisodeMatcher, SubtitleCache
+from app.matcher.episode_identification import (
+    EpisodeMatcher,
+    SubtitleCache,
+    _corpus_show_dir,
+)
 from app.matcher.subtitle_utils import (
     MULTI_EP_RE as _MULTI_EP_RE,
 )
@@ -308,10 +312,12 @@ def main() -> int:
     np.save(precomputed_dir / "idf.npy", idf)
     logger.info(f"Global IDF fit over {all_counts.shape[0]} episodes")
 
-    # --- Write per-(show, season) uint16 hashed-count matrices (cache v2) -----
+    # --- Write per-(show, season) uint16 hashed-count matrices (cache v3) -----
     u16_max = np.iinfo(np.uint16).max
     for corpus_key, season, codes, counts in blocks:
-        show_dir = precomputed_dir / sanitize_filename(corpus_key)
+        # Use the runtime's canonical dir formula so the write path can never
+        # drift from where the matcher looks (_corpus_show_dir).
+        show_dir = _corpus_show_dir(cache_dir, corpus_key)
         show_dir.mkdir(parents=True, exist_ok=True)
         counts_u16 = sparse.csr_matrix(
             (

--- a/backend/scripts/validate_subtitle_cache.py
+++ b/backend/scripts/validate_subtitle_cache.py
@@ -166,16 +166,28 @@ def validate(assets_dir: Path) -> ValidationResult:
             sanitize_filename = None  # type: ignore[assignment]
 
         if sanitize_filename is not None:
-            for show_name, entry in shows.items():
-                seasons = (entry or {}).get("seasons", []) if isinstance(entry, dict) else []
-                show_slug = sanitize_filename(show_name)
+            # v3: shows is keyed by str(tmdb_id); each entry must carry a "name"
+            # so the runtime's name-fallback (when a job has no resolved tmdb_id)
+            # can still find the corpus. A missing name silently strands the show.
+            for corpus_key, entry in shows.items():
+                if not isinstance(entry, dict):
+                    failures.append(f"manifest shows entry {corpus_key!r} is not a dict")
+                    continue
+                show_display = entry.get("name") or corpus_key
+                if not entry.get("name"):
+                    failures.append(
+                        f"manifest shows entry {corpus_key!r} is missing the required "
+                        f"'name' field (runtime name-fallback would never find it)"
+                    )
+                seasons = entry.get("seasons", [])
+                show_slug = sanitize_filename(corpus_key)
                 for season in seasons:
                     npz_member = f"precomputed/{show_slug}/S{season:02d}.npz"
                     idx_member = f"precomputed/{show_slug}/S{season:02d}.index.json"
                     missing_files = [m for m in (npz_member, idx_member) if m not in members]
                     if missing_files:
                         failures.append(
-                            f"manifest lists {show_name!r} S{season:02d} but the tarball "
+                            f"manifest lists {show_display!r} S{season:02d} but the tarball "
                             f"is missing {missing_files}"
                         )
 

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -203,11 +203,11 @@ class TestHarvestShowCompleteOnDisk:
         path.write_text("1\n00:00:01,000 --> 00:01:00,000\nhello\n", encoding="utf-8")
 
     def test_covered_season_shipped_from_disk_without_network(self, bsc, tmp_path):
-        from app.matcher.subtitle_utils import corpus_dir_name
+        from app.matcher.subtitle_utils import sanitize_filename
 
         show = {"name": "Disk Show", "tmdb_id": 555, "seasons": 1}
-        # v3: the build harvests under a tmdb_id-keyed data dir.
-        data_dir = tmp_path / "data" / corpus_dir_name(show["tmdb_id"], show["name"])
+        # The data/ scrape cache stays name-keyed (only precomputed/ is id-keyed).
+        data_dir = tmp_path / "data" / sanitize_filename(show["name"])
         for code in ("S01E01", "S01E02"):
             self._write_min_srt(data_dir / f"{show['name']} - {code}.srt")
         # Prior attempt at full coverage → is_done() returns True.

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -203,10 +203,11 @@ class TestHarvestShowCompleteOnDisk:
         path.write_text("1\n00:00:01,000 --> 00:01:00,000\nhello\n", encoding="utf-8")
 
     def test_covered_season_shipped_from_disk_without_network(self, bsc, tmp_path):
-        from app.matcher.subtitle_utils import sanitize_filename
+        from app.matcher.subtitle_utils import corpus_dir_name
 
         show = {"name": "Disk Show", "tmdb_id": 555, "seasons": 1}
-        data_dir = tmp_path / "data" / sanitize_filename(show["name"])
+        # v3: the build harvests under a tmdb_id-keyed data dir.
+        data_dir = tmp_path / "data" / corpus_dir_name(show["tmdb_id"], show["name"])
         for code in ("S01E01", "S01E02"):
             self._write_min_srt(data_dir / f"{show['name']} - {code}.srt")
         # Prior attempt at full coverage → is_done() returns True.
@@ -434,8 +435,10 @@ class TestMainRoundTrip:
         assert release_manifest["n_features"] == HASHING_N_FEATURES
         assert release_manifest["vectorizer_config_hash"] == vectorizer_config_hash()
         assert release_manifest["content_version"] == "test-run"
-        assert _SHOW in release_manifest["shows"]
-        assert release_manifest["shows"][_SHOW]["seasons"] == [1]
+        # v3: manifest is keyed by str(tmdb_id); the canonical name is stored.
+        assert "1" in release_manifest["shows"]
+        assert release_manifest["shows"]["1"]["name"] == _SHOW
+        assert release_manifest["shows"]["1"]["seasons"] == [1]
 
         # sha256 in the release manifest matches the actual file — and is
         # computed via the validator's streaming helper so this test also
@@ -461,8 +464,8 @@ class TestMainRoundTrip:
             tar.extractall(unpack_dir, filter="data")
         precomputed = unpack_dir / "precomputed"
         assert (precomputed / "idf.npy").exists()
-        assert (precomputed / _SHOW / "S01.npz").exists()
-        assert (precomputed / _SHOW / "S01.index.json").exists()
+        assert (precomputed / "1" / "S01.npz").exists()
+        assert (precomputed / "1" / "S01.index.json").exists()
         assert (precomputed / "manifest.json").exists()
 
         # Re-home the cache so EpisodeMatcher sees it under the expected layout.

--- a/backend/tests/unit/test_corpus_rekey.py
+++ b/backend/tests/unit/test_corpus_rekey.py
@@ -68,6 +68,42 @@ def test_resolve_corpus_entry_by_id_and_by_name():
     assert _resolve_corpus_entry(manifest, "Cheers", 999) == (None, None)
 
 
+def test_name_fallback_warns_on_ambiguity():
+    # Two same-named shows in a v3 corpus + no tmdb_id: we can only return the
+    # first, so a warning must fire (silently picking the wrong twin's vectors
+    # would produce confident-but-wrong episode codes).
+    from loguru import logger as loguru_logger
+
+    manifest = {
+        "shows": {
+            "3452": {"tmdb_id": 3452, "name": "Frasier", "seasons": [1]},
+            "195241": {"tmdb_id": 195241, "name": "Frasier", "seasons": [1]},
+        }
+    }
+    msgs: list[str] = []
+    sink = loguru_logger.add(lambda m: msgs.append(str(m)), level="WARNING")
+    try:
+        key, entry = _resolve_corpus_entry(manifest, "Frasier", None)
+    finally:
+        loguru_logger.remove(sink)
+    assert key in ("3452", "195241") and entry is not None
+    assert any("ambiguous" in m.lower() for m in msgs)
+
+
+def test_name_fallback_silent_when_unambiguous():
+    from loguru import logger as loguru_logger
+
+    manifest = {"shows": {"3452": {"tmdb_id": 3452, "name": "Frasier", "seasons": [1]}}}
+    msgs: list[str] = []
+    sink = loguru_logger.add(lambda m: msgs.append(str(m)), level="WARNING")
+    try:
+        key, _ = _resolve_corpus_entry(manifest, "Frasier", None)
+    finally:
+        loguru_logger.remove(sink)
+    assert key == "3452"
+    assert not any("ambiguous" in m.lower() for m in msgs)
+
+
 def test_same_name_shows_get_distinct_corpora(tmp_path):
     _write_corpus(
         tmp_path,

--- a/backend/tests/unit/test_corpus_rekey.py
+++ b/backend/tests/unit/test_corpus_rekey.py
@@ -1,0 +1,94 @@
+"""Part E: precomputed corpus + subtitle cache keyed by tmdb_id (v3 layout).
+
+Two same-named shows (Frasier 1993 #3452 vs the 2023 revival #195241) must get
+DISTINCT on-disk corpora instead of colliding into one ``precomputed/Frasier/``
+dir. The cache format version is bumped so old name-keyed (v2) caches are
+ignored and auto-replaced by the id-keyed (v3) download.
+"""
+
+import json
+
+from app.matcher.episode_identification import (
+    _resolve_corpus_entry,
+    precomputed_covers_season,
+    precomputed_episode_codes,
+)
+from app.matcher.subtitle_utils import corpus_dir_name
+from app.matcher.vectorizer_config import CACHE_FORMAT_VERSION, vectorizer_config_hash
+
+
+def test_corpus_dir_name_prefers_tmdb_id():
+    assert corpus_dir_name(3452, "Frasier") == "3452"
+    assert corpus_dir_name("195241", "Frasier") == "195241"
+
+
+def test_corpus_dir_name_falls_back_to_sanitized_name():
+    assert corpus_dir_name(None, "Frasier") == "Frasier"
+    assert corpus_dir_name(None, "Marvel's: Daredevil") == "Marvel's - Daredevil"
+
+
+def _write_corpus(root, *shows):
+    """Write a v3 id-keyed precomputed corpus. ``shows`` = (tmdb_id, name, codes)."""
+    pre = root / "precomputed"
+    pre.mkdir(parents=True, exist_ok=True)
+    manifest_shows = {}
+    for tmdb_id, name, codes in shows:
+        key = str(tmdb_id)
+        d = pre / key
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "S01.npz").write_bytes(b"x")
+        (d / "S01.index.json").write_text(json.dumps(list(codes)))
+        manifest_shows[key] = {
+            "tmdb_id": tmdb_id,
+            "name": name,
+            "seasons": [1],
+            "episode_counts": {"1": len(codes)},
+        }
+    manifest = {
+        "cache_format_version": CACHE_FORMAT_VERSION,
+        "vectorizer_config_hash": vectorizer_config_hash(),
+        "shows": manifest_shows,
+    }
+    (pre / "manifest.json").write_text(json.dumps(manifest))
+
+
+def test_resolve_corpus_entry_by_id_and_by_name():
+    manifest = {
+        "shows": {
+            "3452": {"tmdb_id": 3452, "name": "Frasier", "seasons": [1]},
+            "195241": {"tmdb_id": 195241, "name": "Frasier", "seasons": [1]},
+        }
+    }
+    key, entry = _resolve_corpus_entry(manifest, "Frasier", 195241)
+    assert key == "195241" and entry["tmdb_id"] == 195241
+    # Unknown id -> first entry whose name matches.
+    key, entry = _resolve_corpus_entry(manifest, "Frasier", None)
+    assert entry is not None and entry["name"] == "Frasier"
+    # No such show.
+    assert _resolve_corpus_entry(manifest, "Cheers", 999) == (None, None)
+
+
+def test_same_name_shows_get_distinct_corpora(tmp_path):
+    _write_corpus(
+        tmp_path,
+        (3452, "Frasier", ["S01E01"]),
+        (195241, "Frasier", ["S01E01", "S01E02"]),
+    )
+    # The 1993 job resolves its own 1-episode corpus...
+    assert precomputed_covers_season(tmp_path, "Frasier", 1, expected_tmdb_id=3452) is True
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=3452) == ["S01E01"]
+    # ...and the 2023 revival resolves ITS own 2-episode corpus, not the 1993 one.
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=195241) == [
+        "S01E01",
+        "S01E02",
+    ]
+
+
+def test_unknown_tmdb_id_resolves_by_name(tmp_path):
+    _write_corpus(tmp_path, (3452, "Frasier", ["S01E01"]))
+    assert precomputed_episode_codes(tmp_path, "Frasier", 1) == ["S01E01"]
+
+
+def test_missing_show_returns_false(tmp_path):
+    _write_corpus(tmp_path, (3452, "Frasier", ["S01E01"]))
+    assert precomputed_covers_season(tmp_path, "Cheers", 1, expected_tmdb_id=999) is False

--- a/backend/tests/unit/test_episode_identification.py
+++ b/backend/tests/unit/test_episode_identification.py
@@ -355,10 +355,13 @@ class TestPrecomputedCache:
 
         precomputed = cache_dir / "precomputed"
         precomputed.mkdir(parents=True, exist_ok=True)
+        # v3 manifest entries carry a "name" used to resolve a show when no
+        # tmdb_id is supplied; inject it from the key for these minimal fixtures.
+        shows = {k: ({"name": k, **v}) for k, v in (shows or {}).items()}
         manifest = {
             "cache_format_version": CACHE_FORMAT_VERSION if valid else "BOGUS",
             "vectorizer_config_hash": vectorizer_config_hash(),
-            "shows": shows or {},
+            "shows": shows,
         }
         (precomputed / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
         return manifest
@@ -429,6 +432,9 @@ class TestStaleManifestPruning:
 
         precomputed = cache_dir / "precomputed"
         precomputed.mkdir(parents=True, exist_ok=True)
+        # v3 manifest entries carry a "name" used to resolve a show when no
+        # tmdb_id is supplied; inject it from the key for these minimal fixtures.
+        shows = {k: ({"name": k, **v}) for k, v in shows.items()}
         manifest = {
             "cache_format_version": CACHE_FORMAT_VERSION,
             "vectorizer_config_hash": vectorizer_config_hash(),

--- a/backend/tests/unit/test_precomputed_cache.py
+++ b/backend/tests/unit/test_precomputed_cache.py
@@ -97,8 +97,9 @@ class TestEpisodeMatcherCacheLoader:
     def _write_cache(self, tmp_path, manifest_overrides=None):
         """Write a minimal valid precomputed cache under tmp_path. Returns the show name."""
         show = "Test Show"
+        tmdb_id = 1
         precomputed = tmp_path / "precomputed"
-        show_dir = precomputed / show  # sanitize_filename("Test Show") == "Test Show"
+        show_dir = precomputed / str(tmdb_id)  # v3: dirs keyed by tmdb_id
         show_dir.mkdir(parents=True)
 
         counts, idf = _build_counts()
@@ -110,7 +111,7 @@ class TestEpisodeMatcherCacheLoader:
             "cache_format_version": CACHE_FORMAT_VERSION,
             "vectorizer_config_hash": vectorizer_config_hash(),
             "content_version": "test",
-            "shows": {show: {"tmdb_id": 1, "seasons": [1]}},
+            "shows": {str(tmdb_id): {"tmdb_id": tmdb_id, "name": show, "seasons": [1]}},
         }
         manifest.update(manifest_overrides or {})
         (precomputed / "manifest.json").write_text(json.dumps(manifest))
@@ -157,8 +158,9 @@ class TestPrecomputedCoversSeason:
 
     def _write_cache(self, tmp_path, manifest_overrides=None, write_files=True):
         show = "Test Show"
+        tmdb_id = 1
         precomputed = tmp_path / "precomputed"
-        show_dir = precomputed / show  # sanitize_filename("Test Show") == "Test Show"
+        show_dir = precomputed / str(tmdb_id)  # v3: dirs keyed by tmdb_id
         show_dir.mkdir(parents=True)
 
         if write_files:
@@ -171,7 +173,7 @@ class TestPrecomputedCoversSeason:
             "cache_format_version": CACHE_FORMAT_VERSION,
             "vectorizer_config_hash": vectorizer_config_hash(),
             "content_version": "test",
-            "shows": {show: {"tmdb_id": 1, "seasons": [1]}},
+            "shows": {str(tmdb_id): {"tmdb_id": tmdb_id, "name": show, "seasons": [1]}},
         }
         manifest.update(manifest_overrides or {})
         (precomputed / "manifest.json").write_text(json.dumps(manifest))

--- a/backend/tests/unit/test_precomputed_cache_service.py
+++ b/backend/tests/unit/test_precomputed_cache_service.py
@@ -102,7 +102,7 @@ def _build_precomputed_tree(root) -> dict:
         "vectorizer_config_hash": vectorizer_config_hash(),
         "content_version": _CONTENT_VERSION,
         "n_features": HASHING_N_FEATURES,
-        "shows": {_SHOW: {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}},
+        "shows": {_SHOW: {"tmdb_id": 1, "name": _SHOW, "seasons": [1], "episode_counts": {"1": 3}}},
     }
     (precomputed / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
     return manifest

--- a/backend/tests/unit/test_precomputed_cache_service.py
+++ b/backend/tests/unit/test_precomputed_cache_service.py
@@ -40,7 +40,8 @@ from app.services.precomputed_cache_service import (
     ensure_precomputed_cache,
 )
 
-_SHOW = "Test Show"  # sanitize_filename("Test Show") == "Test Show"
+_SHOW = "Test Show"
+_TMDB_ID = 1  # v3 corpus is keyed by str(tmdb_id), not the show name
 _CODES = ["S01E01", "S01E02", "S01E03"]
 _DOCS = [
     "detective solves the murder in the old mansion at midnight",
@@ -80,7 +81,7 @@ def _free_port() -> int:
 def _build_precomputed_tree(root) -> dict:
     """Write a valid ``precomputed/`` tree under ``root``; return its in-tar manifest."""
     precomputed = root / "precomputed"
-    show_dir = precomputed / _SHOW
+    show_dir = precomputed / str(_TMDB_ID)  # v3: dir keyed by str(tmdb_id)
     show_dir.mkdir(parents=True)
 
     counts = build_hashing_vectorizer().transform(_DOCS)
@@ -102,7 +103,14 @@ def _build_precomputed_tree(root) -> dict:
         "vectorizer_config_hash": vectorizer_config_hash(),
         "content_version": _CONTENT_VERSION,
         "n_features": HASHING_N_FEATURES,
-        "shows": {_SHOW: {"tmdb_id": 1, "name": _SHOW, "seasons": [1], "episode_counts": {"1": 3}}},
+        "shows": {
+            str(_TMDB_ID): {
+                "tmdb_id": _TMDB_ID,
+                "name": _SHOW,
+                "seasons": [1],
+                "episode_counts": {"1": 3},
+            }
+        },
     }
     (precomputed / _MANIFEST_NAME).write_text(json.dumps(manifest, indent=2))
     return manifest
@@ -191,11 +199,13 @@ async def test_happy_path_installs_and_matches(tmp_path, monkeypatch, patched_co
     precomputed = cache_dir / "precomputed"
     assert (precomputed / _MANIFEST_NAME).exists()
     assert (precomputed / "idf.npy").exists()
-    assert (precomputed / _SHOW / "S01.npz").exists()
+    assert (precomputed / str(_TMDB_ID) / "S01.npz").exists()
     assert updates.get("precomputed_cache_version") == _CONTENT_VERSION
 
     # End to end: the installed cache loads and matches through the matcher.
-    matcher = EpisodeMatcher(cache_dir=cache_dir, show_name=_SHOW)
+    # Pass the id so the v3 id-keyed lookup (str(tmdb_id) in shows) is exercised,
+    # not just the name-fallback path.
+    matcher = EpisodeMatcher(cache_dir=cache_dir, show_name=_SHOW, expected_tmdb_id=_TMDB_ID)
     loaded = matcher._load_precomputed_season(1)
     assert loaded is not None
     tfidf = TfidfMatcher()

--- a/backend/tests/unit/test_precomputed_guard.py
+++ b/backend/tests/unit/test_precomputed_guard.py
@@ -8,88 +8,97 @@ from app.matcher.episode_identification import (
 from app.matcher.vectorizer_config import CACHE_FORMAT_VERSION, vectorizer_config_hash
 
 
-def _manifest(tmdb_id):
-    return {"shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {"1": 24}}}}
+def _manifest(tmdb_id, name="Frasier"):
+    # v3: keyed by str(tmdb_id); the entry carries the name for the no-id fallback.
+    return {
+        "shows": {
+            str(tmdb_id): {
+                "tmdb_id": tmdb_id,
+                "name": name,
+                "seasons": [1],
+                "episode_counts": {"1": 24},
+            }
+        }
+    }
 
 
-def _write_corpus(tmp_path, tmdb_id, codes=("S01E01",)):
-    """Write a valid on-disk precomputed corpus for Frasier S1 keyed to ``tmdb_id``."""
+def _write_corpus(tmp_path, tmdb_id, codes=("S01E01",), name="Frasier"):
+    """Write a valid on-disk v3 (id-keyed) precomputed corpus for season 1."""
     pre = tmp_path / "precomputed"
-    show_dir = pre / "Frasier"
+    show_dir = pre / str(tmdb_id)
     show_dir.mkdir(parents=True)
     (show_dir / "S01.npz").write_bytes(b"x")
     (show_dir / "S01.index.json").write_text(json.dumps(list(codes)))
     manifest = {
         "cache_format_version": CACHE_FORMAT_VERSION,
         "vectorizer_config_hash": vectorizer_config_hash(),
-        "shows": {"Frasier": {"tmdb_id": tmdb_id, "seasons": [1], "episode_counts": {}}},
+        "shows": {
+            str(tmdb_id): {"tmdb_id": tmdb_id, "name": name, "seasons": [1], "episode_counts": {}}
+        },
     }
     (pre / "manifest.json").write_text(json.dumps(manifest))
 
 
 def test_guard_rejects_mismatched_tmdb_id(tmp_path):
-    # Manifest says Frasier == 3452; job expects 195241 -> no coverage, regardless of files.
+    # Manifest holds only Frasier 3452; a job for the 2023 revival 195241 gets no
+    # coverage (resolved-by-name entry's id contradicts the expected id).
     assert (
         precomputed_covers_season(
-            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=195241
+            tmp_path, "Frasier", 1, manifest=_manifest(3452), expected_tmdb_id=195241
         )
         is False
     )
 
 
-def test_guard_skipped_when_no_expected_id(tmp_path):
-    # No expected id -> guard does not apply; coverage depends only on files.
-    assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452")) is False
-    # Files present -> True. Proves the guard was SKIPPED (not that the file gate
-    # masked an inverted guard): an int/string id mismatch is irrelevant when no
-    # expected_tmdb_id is supplied.
-    show_dir = tmp_path / "precomputed" / "Frasier"
-    show_dir.mkdir(parents=True)
-    (show_dir / "S01.npz").write_bytes(b"x")
-    (show_dir / "S01.index.json").write_text("[]")
-    assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest("3452")) is True
-
-
-def test_guard_passes_on_matching_id_then_checks_files(tmp_path):
-    # Matching id -> guard passes; files absent so coverage is still False (file gate).
+def test_guard_resolves_by_id_then_checks_files(tmp_path):
+    # Known id resolves the id-keyed entry; files absent -> False (file gate)...
     assert (
         precomputed_covers_season(
-            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+            tmp_path, "Frasier", 1, manifest=_manifest(3452), expected_tmdb_id=3452
         )
         is False
     )
-    # Create the on-disk files so the file gate passes too.
-    show_dir = tmp_path / "precomputed" / "Frasier"
+    # ...then present -> True.
+    show_dir = tmp_path / "precomputed" / "3452"
     show_dir.mkdir(parents=True)
     (show_dir / "S01.npz").write_bytes(b"x")
     (show_dir / "S01.index.json").write_text("[]")
     assert (
         precomputed_covers_season(
-            tmp_path, "Frasier", 1, manifest=_manifest("3452"), expected_tmdb_id=3452
+            tmp_path, "Frasier", 1, manifest=_manifest(3452), expected_tmdb_id=3452
         )
         is True
     )
+
+
+def test_resolves_by_name_when_no_expected_id(tmp_path):
+    # No expected id -> resolve by the entry's stored name; files present -> True.
+    show_dir = tmp_path / "precomputed" / "3452"
+    show_dir.mkdir(parents=True)
+    (show_dir / "S01.npz").write_bytes(b"x")
+    (show_dir / "S01.index.json").write_text("[]")
+    assert precomputed_covers_season(tmp_path, "Frasier", 1, manifest=_manifest(3452)) is True
 
 
 def test_episode_codes_guard_rejects_mismatched_tmdb_id(tmp_path):
     # Corpus is the 1993 original (3452); the job is the 2023 revival (195241).
     # precomputed_episode_codes must forward the guard and refuse, else it would
     # size a "skip download" result from the WRONG show's episode list.
-    _write_corpus(tmp_path, "3452", codes=["S01E01", "S01E02"])
+    _write_corpus(tmp_path, 3452, codes=["S01E01", "S01E02"])
     assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=195241) is None
 
 
 def test_episode_codes_returned_on_matching_id(tmp_path):
-    _write_corpus(tmp_path, "3452", codes=["S01E01", "S01E02"])
+    _write_corpus(tmp_path, 3452, codes=["S01E01", "S01E02"])
     assert precomputed_episode_codes(tmp_path, "Frasier", 1, expected_tmdb_id=3452) == [
         "S01E01",
         "S01E02",
     ]
 
 
-def test_episode_codes_backward_compatible_without_id(tmp_path):
-    # No expected id -> guard skipped (backward compatible name-only matching).
-    _write_corpus(tmp_path, "3452", codes=["S01E01"])
+def test_episode_codes_resolved_by_name_without_id(tmp_path):
+    # No expected id -> resolve by name (backward compatible name-only matching).
+    _write_corpus(tmp_path, 3452, codes=["S01E01"])
     assert precomputed_episode_codes(tmp_path, "Frasier", 1) == ["S01E01"]
 
 
@@ -100,10 +109,18 @@ def test_matcher_stores_expected_tmdb_id(tmp_path):
 
 def test_load_precomputed_returns_none_on_id_mismatch_without_pruning(tmp_path, monkeypatch):
     m = EpisodeMatcher(cache_dir=tmp_path, show_name="Frasier", expected_tmdb_id=195241)
+    # v3 id-keyed manifest holding only the 1993 original.
     manifest = {
-        "shows": {"Frasier": {"tmdb_id": "3452", "seasons": [1], "episode_counts": {"1": 24}}}
+        "shows": {
+            "3452": {
+                "tmdb_id": "3452",
+                "name": "Frasier",
+                "seasons": [1],
+                "episode_counts": {"1": 24},
+            }
+        }
     }
     monkeypatch.setattr(m, "_load_precomputed_manifest", lambda: manifest)
     assert m._load_precomputed_season(1) is None
     # The valid 3452 entry must survive (not pruned as "files missing").
-    assert manifest["shows"]["Frasier"]["seasons"] == [1]
+    assert manifest["shows"]["3452"]["seasons"] == [1]

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -34,7 +34,7 @@ def _write_precomputed_cache(cache_dir, show_name, season=1, episode_codes=None)
                 "cache_format_version": CACHE_FORMAT_VERSION,
                 "vectorizer_config_hash": vectorizer_config_hash(),
                 "content_version": "test",
-                "shows": {show_name: {"tmdb_id": 1, "seasons": [season]}},
+                "shows": {show_name: {"tmdb_id": 1, "name": show_name, "seasons": [season]}},
             }
         )
     )

--- a/backend/tests/unit/test_validate_subtitle_cache.py
+++ b/backend/tests/unit/test_validate_subtitle_cache.py
@@ -52,7 +52,10 @@ def _make_assets(
     )  # in-tar manifest; validator only checks members
 
     # Default manifest used to drive vector-file placement; tests can override.
-    default_shows = {"Some Show": {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}}
+    # v3: keyed by str(tmdb_id), with the required "name" field.
+    default_shows = {
+        "1": {"tmdb_id": 1, "name": "Some Show", "seasons": [1], "episode_counts": {"1": 3}}
+    }
     effective_shows = (manifest_overrides or {}).get("shows", default_shows) or {}
     if tarball_members is None:
         for show_name, entry in effective_shows.items():
@@ -84,7 +87,9 @@ def _make_assets(
         "cache_format_version": CACHE_FORMAT_VERSION,
         "vectorizer_config_hash": vectorizer_config_hash(),
         "n_features": HASHING_N_FEATURES,
-        "shows": {"Some Show": {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}},
+        "shows": {
+            "1": {"tmdb_id": 1, "name": "Some Show", "seasons": [1], "episode_counts": {"1": 3}}
+        },
     }
     manifest.update(manifest_overrides or {})
     (assets_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
@@ -126,6 +131,19 @@ class TestValidate:
         _make_assets(vsc, tmp_path, manifest_overrides={"shows": {}})
         failures = vsc.validate(tmp_path).failures
         assert any("shows dict in manifest is empty" in f for f in failures)
+
+    def test_missing_name_field_reported(self, vsc, tmp_path):
+        # v3 invariant: a show entry without "name" strands the runtime
+        # name-fallback (jobs with no resolved tmdb_id can't find the corpus).
+        _make_assets(
+            vsc,
+            tmp_path,
+            manifest_overrides={
+                "shows": {"1": {"tmdb_id": 1, "seasons": [1], "episode_counts": {"1": 3}}}
+            },
+        )
+        failures = vsc.validate(tmp_path).failures
+        assert any("missing the required 'name'" in f for f in failures)
 
     def test_consistency_check_records_failure_when_helper_unavailable(
         self, vsc, tmp_path, monkeypatch


### PR DESCRIPTION
**Stacked on #287** (base = its branch; re-target to `main` after #287 merges). This is the "item 2" corpus re-key follow-up.

## Problem

Two shows that share a name (Frasier 1993 #3452 vs the 2023 revival #195241) collided into one `precomputed/<name>/` directory and one manifest key, so the shipped vector corpus could only ever hold **one** of them. The A–D corpus guard (#287) refuses a wrong-id corpus, but it can't conjure a corpus the build never shipped.

## Fix — re-key the precomputed corpus by `tmdb_id` (cache v3)

- **Keystone** `corpus_dir_name(tmdb_id, show_name)` → `str(tmdb_id)` (or sanitized name when no id).
- **Version bump** `CACHE_FORMAT_VERSION` 2 → 3. Old name-keyed v2 caches are ignored; the id-keyed v3 cache auto-downloads on startup (so the re-distribution is automatic — no manual user action).
- **Reader** `_resolve_corpus_entry` resolves a show by `tmdb_id` (manifest keyed by `str(tmdb_id)`), falling back to the stored `name` when the id is unknown. Threaded through `precomputed_covers_season`, `precomputed_episode_codes`, and `_load_precomputed_season`; dirs derived via `_corpus_show_dir`.
- **Build + pack scripts** write id-keyed dirs + an id-keyed manifest (with the canonical `name` stored); `pack`'s file-verify and consumer round-trip load by id.
- **Scope:** the runtime `data/` SRT **scrape** cache stays name-keyed (writer + every reader agree end to end). Re-keying it touches the scraper chain (some sites have no `tmdb_id` in scope), so a *partial* re-key would silently break matching — it's intentionally deferred to its own follow-up.

## Release sequencing (out-of-band)

The rolling `subtitle-cache-latest` release must be **rebuilt id-keyed (v3) and published before/with** the code that bumps to v3 — otherwise a v3 client rejects the still-v2 published cache and falls back to scraping until the v3 cache lands. Rebuild via `build_subtitle_cache.py` / `pack_subtitle_cache.py` (both updated here) then `gh release upload --clobber`.

## Tests

New `test_corpus_rekey.py` proves two same-name shows get distinct corpora and resolve independently by id (+ name fallback). v3 updates across the precomputed / build / pack / validate suites. 1556 unit + collision integration green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)