### PR TITLE
fix(updater): reject incomplete/corrupt staged builds; always bundle certifi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
         working-directory: backend
         run: |
           uv sync --no-install-project
-          uv pip install pyinstaller
+          # Pin the build toolchain so release artifacts are reproducible and a
+          # PyInstaller / hooks-contrib release can't silently change what gets
+          # bundled (a hooks-contrib change is what dropped certifi from 0.14.0).
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
       - name: Fetch fpcalc (bundled audio fingerprinter)
         working-directory: backend
         run: uv run python scripts/fetch_fpcalc.py
@@ -105,13 +108,42 @@ jobs:
             Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
           }
 
+      - name: Verify CA bundle + TLS self-test
+        shell: pwsh
+        run: |
+          # Deterministic guard: the build MUST contain certifi's CA bundle. Its
+          # absence is what broke 0.14.0 (every HTTPS call -> FileNotFoundError).
+          $ca = "backend/dist/engram/_internal/certifi/cacert.pem"
+          if (-not (Test-Path $ca)) { throw "certifi CA bundle missing from build ($ca)" }
+          if ((Get-Item $ca).Length -lt 50000) { throw "certifi CA bundle suspiciously small" }
+          Write-Host "certifi CA bundle present: $((Get-Item $ca).Length) bytes"
+          # Prove the frozen runtime can actually complete a TLS handshake.
+          & "backend/dist/engram/engram.exe" --selftest
+          if ($LASTEXITCODE -ne 0) { throw "TLS self-test failed (exit $LASTEXITCODE)" }
+
+      - name: Generate file manifest
+        shell: pwsh
+        run: |
+          # sha256sum-style manifest, paths relative to the engram/ dir. The updater
+          # verifies every listed path exists after extraction -> catches a truncated
+          # download/extract (the 181-of-825-files failure) before it can be applied.
+          $root = (Resolve-Path "backend/dist/engram").Path
+          Get-ChildItem -Recurse -File $root | ForEach-Object {
+            $rel = $_.FullName.Substring($root.Length + 1) -replace '\\','/'
+            $hash = (Get-FileHash -Algorithm SHA256 $_.FullName).Hash.ToLower()
+            "$hash  $rel"
+          } | Set-Content -Encoding ascii engram-windows-x64.manifest.sha256
+          Write-Host "manifest entries: $((Get-Content engram-windows-x64.manifest.sha256).Count)"
+
       - name: Package
         run: Compress-Archive -Path backend/dist/engram -DestinationPath engram-windows-x64.zip
         shell: pwsh
       - uses: actions/upload-artifact@v7
         with:
           name: engram-windows-x64
-          path: engram-windows-x64.zip
+          path: |
+            engram-windows-x64.zip
+            engram-windows-x64.manifest.sha256
 
   build-linux:
     name: Build Linux Executable
@@ -148,7 +180,10 @@ jobs:
         working-directory: backend
         run: |
           uv sync --no-install-project
-          uv pip install pyinstaller
+          # Pin the build toolchain so release artifacts are reproducible and a
+          # PyInstaller / hooks-contrib release can't silently change what gets
+          # bundled (a hooks-contrib change is what dropped certifi from 0.14.0).
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
       - name: Fetch fpcalc (bundled audio fingerprinter)
         working-directory: backend
         run: uv run python scripts/fetch_fpcalc.py
@@ -205,12 +240,31 @@ jobs:
           fi
           echo "smoke test passed"
 
+      - name: Verify CA bundle + TLS self-test
+        run: |
+          ca="backend/dist/engram/_internal/certifi/cacert.pem"
+          test -f "$ca" || { echo "certifi CA bundle missing from build ($ca)"; exit 1; }
+          size=$(stat -c%s "$ca")
+          [ "$size" -ge 50000 ] || { echo "certifi CA bundle suspiciously small ($size)"; exit 1; }
+          echo "certifi CA bundle present: $size bytes"
+          ./backend/dist/engram/engram --selftest || { echo "TLS self-test failed"; exit 1; }
+
+      - name: Generate file manifest
+        run: |
+          # sha256sum-style manifest, paths relative to the engram/ dir (no leading
+          # ./). The updater verifies every listed path exists after extraction.
+          ( cd backend/dist/engram && find . -type f -printf '%P\0' | sort -z | xargs -0 sha256sum ) \
+            > engram-linux-x64.manifest.sha256
+          echo "manifest entries: $(wc -l < engram-linux-x64.manifest.sha256)"
+
       - name: Package
         run: tar -czf engram-linux-x64.tar.gz -C backend/dist engram
       - uses: actions/upload-artifact@v7
         with:
           name: engram-linux-x64
-          path: engram-linux-x64.tar.gz
+          path: |
+            engram-linux-x64.tar.gz
+            engram-linux-x64.manifest.sha256
 
   build-macos:
     name: Build macOS Executable (${{ matrix.arch }})
@@ -252,7 +306,10 @@ jobs:
         working-directory: backend
         run: |
           uv sync --no-install-project
-          uv pip install pyinstaller
+          # Pin the build toolchain so release artifacts are reproducible and a
+          # PyInstaller / hooks-contrib release can't silently change what gets
+          # bundled (a hooks-contrib change is what dropped certifi from 0.14.0).
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
       - name: Fetch fpcalc (bundled audio fingerprinter)
         working-directory: backend
         run: uv run python scripts/fetch_fpcalc.py
@@ -309,12 +366,31 @@ jobs:
           fi
           echo "smoke test passed"
 
+      - name: Verify CA bundle + TLS self-test
+        run: |
+          ca="backend/dist/engram/_internal/certifi/cacert.pem"
+          test -f "$ca" || { echo "certifi CA bundle missing from build ($ca)"; exit 1; }
+          size=$(stat -f%z "$ca")
+          [ "$size" -ge 50000 ] || { echo "certifi CA bundle suspiciously small ($size)"; exit 1; }
+          echo "certifi CA bundle present: $size bytes"
+          ./backend/dist/engram/engram --selftest || { echo "TLS self-test failed"; exit 1; }
+
+      - name: Generate file manifest
+        run: |
+          # BSD find lacks -printf; strip the leading ./ with sed. shasum on macOS.
+          ( cd backend/dist/engram && find . -type f -print0 | sort -z \
+            | xargs -0 shasum -a 256 | sed 's#  \./#  #' ) \
+            > engram-macos-${{ matrix.arch }}.manifest.sha256
+          echo "manifest entries: $(wc -l < engram-macos-${{ matrix.arch }}.manifest.sha256)"
+
       - name: Package
         run: tar -czf engram-macos-${{ matrix.arch }}.tar.gz -C backend/dist engram
       - uses: actions/upload-artifact@v7
         with:
           name: engram-macos-${{ matrix.arch }}
-          path: engram-macos-${{ matrix.arch }}.tar.gz
+          path: |
+            engram-macos-${{ matrix.arch }}.tar.gz
+            engram-macos-${{ matrix.arch }}.manifest.sha256
 
   create-release:
     name: Create GitHub Release
@@ -368,6 +444,9 @@ jobs:
           tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             engram-windows-x64.zip
+            engram-windows-x64.manifest.sha256
             engram-linux-x64.tar.gz
+            engram-linux-x64.manifest.sha256
             engram-macos-arm64.tar.gz
+            engram-macos-arm64.manifest.sha256
             sha256sums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The auto-updater could stage and apply an incomplete build, breaking the app** — if an update's extraction was interrupted (or files were removed afterward, e.g. by antivirus), Engram could leave a half-unpacked build that still looked "ready to install": the integrity check only validated the downloaded archive, never the unpacked files. Applying it would copy a broken build over your working install — in one case a build missing its TLS certificate bundle, which silently breaks every network request (update checks, TMDB, subtitle downloads). The updater now unpacks to a temporary location and only swaps it into place once the build is verified complete (against a per-release file manifest plus required-file sentinels), then re-checks completeness one more time immediately before applying — so a truncated or tampered update is refused instead of installed. As extra safeguards the TLS certificate bundle is now always bundled, the build toolchain is pinned, and the release smoke test fails if a build can't complete an HTTPS request.
+
 ## [0.14.0] - 2026-06-02
 
 _Highlights: a one-click "Did you mean?" candidate picker for discs that share a name with another show (for example the 2023 **Frasier** vs the 1993 original) — pick the right show in the Re-Identify dialog without re-typing a TMDB search — plus matching fixes so a re-identified revival's episodes match and file correctly instead of being shunted to Extras or matched against the wrong show's subtitles._

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -187,6 +187,15 @@ class UpdateChecker:
             await self._broadcast()
             return
 
+        manifest_asset = next(
+            (
+                a
+                for a in release_data.get("assets", [])
+                if a["name"] == self._manifest_name(asset["name"])
+            ),
+            None,
+        )
+
         version = self.latest_version or "unknown"
         staging_dir = STAGING_BASE / version
         staging_dir.mkdir(parents=True, exist_ok=True)
@@ -194,12 +203,19 @@ class UpdateChecker:
 
         try:
             checksums_text: str | None = None
+            manifest_text: str | None = None
             async with httpx.AsyncClient(timeout=300.0, follow_redirects=True) as client:
                 # Download checksum file first (small — ~200 bytes)
                 if checksum_asset:
                     resp = await client.get(checksum_asset["browser_download_url"])
                     resp.raise_for_status()
                     checksums_text = resp.text
+
+                # Download the per-build file manifest if the release ships one (small).
+                if manifest_asset:
+                    resp = await client.get(manifest_asset["browser_download_url"])
+                    resp.raise_for_status()
+                    manifest_text = resp.text
 
                 # Stream-download the platform asset
                 async with client.stream("GET", asset["browser_download_url"]) as resp:
@@ -218,9 +234,37 @@ class UpdateChecker:
             if checksums_text:
                 self._verify_checksum(archive_path, asset["name"], checksums_text)
 
-            # Extract archive
-            self._extract(archive_path, staging_dir)
+            # Extract into a temp dir, verify completeness, then atomically promote.
+            # A partially-extracted tree must never become the staged engram/ dir that
+            # apply_update() swaps over the install — that is how a truncated build
+            # (missing certifi/cacert.pem and ~640 other files) reached the user.
+            incoming = staging_dir / ".incoming"
+            shutil.rmtree(incoming, ignore_errors=True)
+            incoming.mkdir(parents=True, exist_ok=True)
+            self._extract(archive_path, incoming)
             archive_path.unlink(missing_ok=True)  # Remove the archive; keep extracted dir
+
+            extracted = incoming / "engram"
+            if not extracted.is_dir():
+                raise UpdateError(f"Archive did not contain an 'engram' directory: {asset['name']}")
+            self._verify_extracted(extracted, manifest_text)
+
+            # Atomic promote: only once the new build is fully extracted and verified
+            # does it replace any previously staged build. os.replace() on a directory
+            # is an atomic rename within the same filesystem.
+            final = staging_dir / "engram"
+            shutil.rmtree(final, ignore_errors=True)
+            os.replace(extracted, final)
+            shutil.rmtree(incoming, ignore_errors=True)
+
+            # Persist the manifest beside the staged build so apply_update() can
+            # re-verify completeness right before the swap (catches post-stage loss,
+            # e.g. AV quarantine).
+            manifest_path = staging_dir / "engram.manifest.sha256"
+            if manifest_text is not None:
+                manifest_path.write_text(manifest_text, encoding="utf-8")
+            else:
+                manifest_path.unlink(missing_ok=True)
 
             self.staging_path = staging_dir
             self.state = UpdateStatus.READY
@@ -303,6 +347,78 @@ class UpdateChecker:
         else:
             raise UpdateError(f"Unknown archive format: {name}")
 
+    @staticmethod
+    def _manifest_name(asset_name: str) -> str:
+        """Map a platform asset name to its file-manifest asset name.
+
+        ``engram-windows-x64.zip`` -> ``engram-windows-x64.manifest.sha256``
+        ``engram-linux-x64.tar.gz`` -> ``engram-linux-x64.manifest.sha256``
+        """
+        base = asset_name
+        for suffix in (".tar.gz", ".zip"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        return f"{base}.manifest.sha256"
+
+    @staticmethod
+    def _manifest_paths(manifest_text: str) -> list[str]:
+        """Parse relative file paths from a ``sha256sum``-style manifest.
+
+        Each line is ``<64-hex-hash>  <relative/path>`` (two spaces; binary-mode
+        entries prefix the path with ``*``). Paths are relative to the build's
+        ``engram/`` directory. Blank/garbage lines are skipped.
+        """
+        paths: list[str] = []
+        for line in manifest_text.strip().splitlines():
+            parts = line.strip().split(None, 1)
+            if len(parts) != 2:
+                continue
+            rel = parts[1].lstrip("*").strip()
+            if rel.startswith("./"):
+                rel = rel[2:]  # tolerate sha256sum's leading ./ (BSD find output)
+            if rel:
+                paths.append(rel.replace("/", os.sep))
+        return paths
+
+    def _verify_extracted(self, engram_dir: Path, manifest_text: str | None) -> None:
+        """Verify the extracted build is complete. Raises UpdateError if not.
+
+        Two layers:
+          * Always: sentinel files every healthy onedir build must contain. This
+            catches a grossly truncated extraction even for releases that ship no
+            manifest (the failure that delivered a build with no certifi/cacert.pem).
+          * If a manifest is present: every file it lists must exist, which catches
+            arbitrary missing files (e.g. 181 of 825 extracted).
+        """
+        binary = "engram.exe" if sys.platform == "win32" else "engram"
+        sentinels = [
+            engram_dir / binary,
+            engram_dir / "_internal" / "base_library.zip",
+            engram_dir / "_internal" / "certifi" / "cacert.pem",
+        ]
+        missing_sentinels = [str(p.relative_to(engram_dir)) for p in sentinels if not p.exists()]
+        if missing_sentinels:
+            raise UpdateError(
+                f"Staged build is incomplete (missing {', '.join(missing_sentinels)}); "
+                "refusing to apply."
+            )
+
+        if not manifest_text:
+            logger.debug("No manifest for staged build — sentinel check only")
+            return
+
+        missing = [
+            rel for rel in self._manifest_paths(manifest_text) if not (engram_dir / rel).exists()
+        ]
+        if missing:
+            sample = ", ".join(missing[:5])
+            raise UpdateError(
+                f"Staged build is missing {len(missing)} manifest file(s) (e.g. {sample}); "
+                "refusing to apply."
+            )
+        logger.debug("Staged build verified complete against manifest")
+
     def get_status(self) -> dict:
         """Return a JSON-serialisable status dict for GET /api/updates/status."""
         return {
@@ -356,6 +472,17 @@ class UpdateChecker:
             raise UpdateError("No staged update is ready to apply.")
 
         await self._check_no_active_jobs()
+
+        # Re-verify the staged build is still complete right before the swap. It
+        # passed verification at download time, but files can disappear afterwards
+        # (AV quarantine, partial deletion). Never swap an incomplete build over a
+        # working install.
+        if self.staging_path is not None:
+            manifest_path = self.staging_path / "engram.manifest.sha256"
+            manifest_text = (
+                manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else None
+            )
+            self._verify_extracted(self.staging_path / "engram", manifest_text)
 
         if sys.platform == "win32":
             self._restart_windows()

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -249,9 +249,11 @@ class UpdateChecker:
                 raise UpdateError(f"Archive did not contain an 'engram' directory: {asset['name']}")
             self._verify_extracted(extracted, manifest_text)
 
-            # Atomic promote: only once the new build is fully extracted and verified
-            # does it replace any previously staged build. os.replace() on a directory
-            # is an atomic rename within the same filesystem.
+            # Promote: the verified build replaces any previously staged build.
+            # os.replace() is an atomic rename within the same filesystem, so once it
+            # succeeds the staged dir has either the old build or the new one. (A crash
+            # between the rmtree and os.replace leaves staging without an engram/ dir;
+            # the next run re-downloads, since state never reached READY.)
             final = staging_dir / "engram"
             shutil.rmtree(final, ignore_errors=True)
             os.replace(extracted, final)
@@ -273,6 +275,9 @@ class UpdateChecker:
             await self._broadcast()
 
         except UpdateError as exc:
+            # A rejection here (checksum/integrity failure) is the main guard against
+            # staging a bad build — leave a trace so a support case has something to grep.
+            logger.warning(f"Staged update rejected: {exc}", exc_info=True)
             shutil.rmtree(staging_dir, ignore_errors=True)
             self.state = UpdateStatus.ERROR
             self.error = str(exc)
@@ -476,13 +481,15 @@ class UpdateChecker:
         # Re-verify the staged build is still complete right before the swap. It
         # passed verification at download time, but files can disappear afterwards
         # (AV quarantine, partial deletion). Never swap an incomplete build over a
-        # working install.
-        if self.staging_path is not None:
-            manifest_path = self.staging_path / "engram.manifest.sha256"
-            manifest_text = (
-                manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else None
-            )
-            self._verify_extracted(self.staging_path / "engram", manifest_text)
+        # working install. staging_path is always set once state == READY, so a None
+        # here is a bug, not a "skip verification" case — fail loudly.
+        if self.staging_path is None:
+            raise UpdateError("staging_path is unset despite READY state — refusing to apply.")
+        manifest_path = self.staging_path / "engram.manifest.sha256"
+        manifest_text = (
+            manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else None
+        )
+        self._verify_extracted(self.staging_path / "engram", manifest_text)
 
         if sys.platform == "win32":
             self._restart_windows()

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -87,6 +87,12 @@ if os.path.isdir(static_dir):
 datas += collect_data_files("faster_whisper")
 datas += collect_data_files("ctranslate2")
 
+# TLS CA bundle. httpx/requests load certifi.where() (-> certifi/cacert.pem) for
+# every HTTPS call. Collect it explicitly so the CA bundle can never silently drop
+# out from PyInstaller hook / certifi-version drift — a missing cacert.pem makes
+# ssl.create_default_context() raise FileNotFoundError and kills all networking.
+datas += collect_data_files("certifi")
+
 # Ship the third-party license notice (covers the bundled fpcalc) alongside the
 # binary it describes, satisfying Chromaprint's LGPL redistribution terms.
 _licenses = os.path.join("..", "THIRD_PARTY_LICENSES.md")

--- a/backend/run.py
+++ b/backend/run.py
@@ -16,9 +16,44 @@ opens an endless stream of browser tabs until the machine gives out.
 """
 
 import multiprocessing
+import os
 import socket
 import sys
 import traceback
+
+
+def _selftest() -> int:
+    """Verify the bundled runtime can complete a TLS handshake (`engram --selftest`).
+
+    Catches the packaging defect where certifi's ``cacert.pem`` is absent, which makes
+    ``ssl.create_default_context()`` raise ``FileNotFoundError`` and kills every HTTPS
+    call. Returns 0 on success. A missing/unloadable CA bundle is a build defect
+    (non-zero); a transient network error is tolerated (0) so CI never flakes on it.
+    """
+    import ssl
+
+    import certifi
+
+    ca = certifi.where()
+    if not os.path.exists(ca):
+        print(f"SELFTEST FAIL: CA bundle not bundled at {ca}")
+        return 2
+    try:
+        import httpx
+
+        httpx.get("https://api.github.com", timeout=10.0)
+        print("SELFTEST OK: HTTPS request succeeded with bundled CA bundle")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — classify, then re-decide exit code
+        # A missing/unloadable CA bundle surfaces as FileNotFoundError or ssl.SSLError
+        # (directly or as the __cause__/__context__). That's a build defect -> fail.
+        # Pure connect/timeout errors are tolerated so CI isn't flaky.
+        chain = [exc, exc.__cause__, exc.__context__]
+        if any(isinstance(e, (FileNotFoundError, ssl.SSLError)) for e in chain if e):
+            print(f"SELFTEST FAIL: TLS/CA error: {exc!r}")
+            return 3
+        print(f"SELFTEST WARN: tolerated network error: {exc!r}")
+        return 0
 
 
 def _find_free_port(host: str, preferred: int, max_attempts: int = 20) -> int:
@@ -104,4 +139,8 @@ if __name__ == "__main__":
     # Must run before any multiprocessing work and before main() so that
     # spawn-relaunched worker processes exit here instead of re-running startup.
     multiprocessing.freeze_support()
+    if "--selftest" in sys.argv[1:]:
+        # CI build guard: prove the frozen bundle can do TLS, then exit without
+        # starting the server.
+        sys.exit(_selftest())
     main()

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -324,6 +324,45 @@ def _streaming_client(archive_bytes: bytes, sums_text: str = ""):
     return mock_client
 
 
+def _manifest_client(
+    archive_bytes: bytes, manifest_url: str, manifest_text: str, sums_text: str = ""
+):
+    """Like _streaming_client, but .get routes by URL: manifest_url -> manifest_text,
+    anything else (the checksum file) -> sums_text. Used to exercise the manifest
+    fetch + enforcement path inside _download."""
+
+    def _resp(text):
+        r = MagicMock()
+        r.raise_for_status = MagicMock()
+        r.text = text
+        return r
+
+    async def _get(url, *args, **kwargs):
+        return _resp(manifest_text if url == manifest_url else sums_text)
+
+    class FakeStream:
+        headers = {"content-length": str(len(archive_bytes))}
+
+        async def aiter_bytes(self, chunk_size=65536):
+            yield archive_bytes
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=_get)
+    mock_client.stream = MagicMock(return_value=FakeStream())
+    return mock_client
+
+
 class TestExtractionIntegrity:
     """Atomic extraction + completeness verification (regression: truncated 0.14.0)."""
 
@@ -451,6 +490,58 @@ class TestExtractionIntegrity:
 
         await checker.apply_update()
         assert called["restart"] is True
+
+    async def test_download_fetches_and_enforces_manifest(self, monkeypatch, tmp_path):
+        """A release that ships a manifest: _download fetches it and rejects a build
+        missing a listed file — proving the manifest path is wired end to end."""
+        import io
+        import tarfile
+
+        checker = UpdateChecker()
+        monkeypatch.setattr(checker, "_is_frozen", True)
+        monkeypatch.setattr("app.core.updater.STAGING_BASE", tmp_path)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        # Complete-sentinel archive, but the manifest lists an extra file it lacks.
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            for name, content in (
+                ("engram/engram", b"bin"),
+                ("engram/_internal/base_library.zip", b"z"),
+                ("engram/_internal/certifi/cacert.pem", b"ca"),
+            ):
+                info = tarfile.TarInfo(name=name)
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+        buf.seek(0)
+        archive_bytes = buf.read()
+
+        manifest_url = "https://example.com/engram-linux-x64.manifest.sha256"
+        manifest_text = (
+            "aaaa  engram\n"
+            "bbbb  _internal/base_library.zip\n"
+            "cccc  _internal/certifi/cacert.pem\n"
+            "dddd  _internal/onnxruntime/onnxruntime.dll\n"  # not in the archive
+        )
+        release = {
+            **FAKE_RELEASE,
+            "assets": FAKE_RELEASE["assets"]
+            + [{"name": "engram-linux-x64.manifest.sha256", "browser_download_url": manifest_url}],
+        }
+        mock_client = _manifest_client(archive_bytes, manifest_url, manifest_text)
+
+        with patch("app.core.updater.httpx.AsyncClient", return_value=mock_client):
+            with patch.object(checker, "_broadcast", AsyncMock()):
+                await checker._download(release)
+
+        # The manifest was fetched ...
+        assert any(
+            call.args and call.args[0] == manifest_url for call in mock_client.get.call_args_list
+        )
+        # ... and enforced: the sentinel files all exist, so the only thing that can
+        # fail is the manifest's missing onnxruntime entry -> rejected, never READY.
+        assert checker.state == UpdateStatus.ERROR
+        assert checker.staging_path is None
 
 
 class TestPruneStaging:

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -80,12 +80,18 @@ class TestUpdateCheckerStates:
         import io
         import tarfile
 
+        # A realistic complete onedir layout: launcher + the sentinel files the
+        # extraction-integrity check requires (base_library.zip + certifi/cacert.pem).
         fake_archive = io.BytesIO()
         with tarfile.open(fileobj=fake_archive, mode="w:gz") as tar:
-            content = b"fake binary"
-            info = tarfile.TarInfo(name="engram/engram")
-            info.size = len(content)
-            tar.addfile(info, io.BytesIO(content))
+            for name, content in (
+                ("engram/engram", b"fake binary"),
+                ("engram/_internal/base_library.zip", b"fake zip"),
+                ("engram/_internal/certifi/cacert.pem", b"fake ca bundle"),
+            ):
+                info = tarfile.TarInfo(name=name)
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
         fake_archive.seek(0)
         archive_bytes = fake_archive.read()
 
@@ -118,6 +124,9 @@ class TestUpdateCheckerStates:
         assert checker.state == UpdateStatus.READY
         assert checker.staging_path is not None
         assert checker.staging_path.exists()
+        # Atomic promote left a complete engram/ dir and cleaned up the temp dir.
+        assert (checker.staging_path / "engram" / "engram").exists()
+        assert not (checker.staging_path / ".incoming").exists()
 
     async def test_skipped_version_stays_skipped(self):
         """When GitHub returns a version the user previously skipped, state = SKIPPED."""
@@ -268,6 +277,180 @@ class TestUpdateCheckerStates:
         assert asset is not None
         assert asset["name"].endswith(".zip")
         assert "windows" in asset["name"]
+
+
+def _make_build(root: Path, *, complete: bool = True) -> Path:
+    """Create a fake extracted onedir build at root/engram. Returns the engram dir.
+
+    A complete build has the launcher + base_library.zip + certifi/cacert.pem
+    (the sentinels _verify_extracted requires). complete=False omits cacert.pem to
+    model the truncated 0.14.0 extraction.
+    """
+    eng = root / "engram"
+    (eng / "_internal" / "certifi").mkdir(parents=True, exist_ok=True)
+    (eng / "engram").write_bytes(b"bin")
+    (eng / "_internal" / "base_library.zip").write_bytes(b"z")
+    if complete:
+        (eng / "_internal" / "certifi" / "cacert.pem").write_bytes(b"ca")
+    return eng
+
+
+def _streaming_client(archive_bytes: bytes, sums_text: str = ""):
+    """An httpx.AsyncClient mock: .get returns sums_text, .stream yields archive_bytes."""
+    mock_sums = MagicMock()
+    mock_sums.raise_for_status = MagicMock()
+    mock_sums.text = sums_text
+
+    class FakeStream:
+        headers = {"content-length": str(len(archive_bytes))}
+
+        async def aiter_bytes(self, chunk_size=65536):
+            yield archive_bytes
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def raise_for_status(self):
+            pass
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_sums)
+    mock_client.stream = MagicMock(return_value=FakeStream())
+    return mock_client
+
+
+class TestExtractionIntegrity:
+    """Atomic extraction + completeness verification (regression: truncated 0.14.0)."""
+
+    def test_verify_extracted_ok_with_sentinels(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        eng = _make_build(tmp_path, complete=True)
+        UpdateChecker()._verify_extracted(eng, None)  # must not raise
+
+    def test_verify_extracted_missing_certifi_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        eng = _make_build(tmp_path, complete=False)  # no cacert.pem
+        with pytest.raises(UpdateError, match="incomplete"):
+            UpdateChecker()._verify_extracted(eng, None)
+
+    def test_verify_extracted_manifest_missing_file_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        eng = _make_build(tmp_path, complete=True)
+        # Manifest lists a file (onnxruntime) that wasn't extracted.
+        manifest = (
+            "aaaa  engram\n"
+            "bbbb  _internal/base_library.zip\n"
+            "cccc  _internal/certifi/cacert.pem\n"
+            "dddd  _internal/onnxruntime/onnxruntime.dll\n"
+        )
+        with pytest.raises(UpdateError, match="manifest file"):
+            UpdateChecker()._verify_extracted(eng, manifest)
+
+    def test_verify_extracted_manifest_all_present_ok(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        eng = _make_build(tmp_path, complete=True)
+        manifest = (
+            "aaaa  engram\n"
+            "bbbb  _internal/base_library.zip\n"
+            "cccc *_internal/certifi/cacert.pem\n"  # binary-mode '*' prefix tolerated
+        )
+        UpdateChecker()._verify_extracted(eng, manifest)  # must not raise
+
+    async def test_partial_extraction_does_not_become_ready(self, monkeypatch, tmp_path):
+        """An incomplete extraction must end ERROR (never READY) and promote nothing."""
+        checker = UpdateChecker()
+        monkeypatch.setattr(checker, "_is_frozen", True)
+        monkeypatch.setattr("app.core.updater.STAGING_BASE", tmp_path)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        # Extraction yields a launcher-only tree (no _internal) -> incomplete.
+        def fake_extract(archive_path, dest_dir):
+            eng = dest_dir / "engram"
+            eng.mkdir(parents=True, exist_ok=True)
+            (eng / "engram").write_bytes(b"bin")
+
+        monkeypatch.setattr(checker, "_extract", fake_extract)
+
+        mock_client = _streaming_client(b"archive-bytes")
+        with patch("app.core.updater.httpx.AsyncClient", return_value=mock_client):
+            with patch.object(checker, "_broadcast", AsyncMock()):
+                await checker._download(FAKE_RELEASE)
+
+        assert checker.state == UpdateStatus.ERROR
+        assert checker.staging_path is None
+        # No half-extracted build was promoted under the staging base.
+        assert not any(p.name == "engram" for p in tmp_path.rglob("engram") if p.is_dir())
+
+    async def test_apply_update_reverifies_and_refuses_incomplete(self, monkeypatch, tmp_path):
+        """apply_update re-checks the staged dir and refuses to swap an incomplete build."""
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+        from sqlmodel import SQLModel
+
+        engine = create_async_engine(
+            "sqlite+aiosqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        monkeypatch.setattr("app.core.updater.async_session", factory)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        staged = tmp_path / "staged"
+        _make_build(staged, complete=False)  # missing cacert.pem
+
+        checker = UpdateChecker()
+        checker._is_frozen = True
+        checker.state = UpdateStatus.READY
+        checker.staging_path = staged
+
+        called = {"restart": False}
+        monkeypatch.setattr(checker, "_restart_linux_macos", lambda: called.update(restart=True))
+        monkeypatch.setattr(checker, "_restart_windows", lambda: called.update(restart=True))
+
+        with pytest.raises(UpdateError, match="incomplete"):
+            await checker.apply_update()
+        assert called["restart"] is False
+
+    async def test_apply_update_complete_build_reaches_restart(self, monkeypatch, tmp_path):
+        """A complete staged build passes re-verification and proceeds to restart."""
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
+        from sqlmodel import SQLModel
+
+        engine = create_async_engine(
+            "sqlite+aiosqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        monkeypatch.setattr("app.core.updater.async_session", factory)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        staged = tmp_path / "staged"
+        _make_build(staged, complete=True)
+
+        checker = UpdateChecker()
+        checker._is_frozen = True
+        checker.state = UpdateStatus.READY
+        checker.staging_path = staged
+
+        called = {"restart": False}
+        monkeypatch.setattr(checker, "_restart_linux_macos", lambda: called.update(restart=True))
+
+        await checker.apply_update()
+        assert called["restart"] is True
 
 
 class TestPruneStaging:


### PR DESCRIPTION
## Problem

A user reported "the new exe seems broken" pointing at `~/.engram/update/0.14.0/engram`. Investigation (read-only, from `~/.engram/engram.log` + comparing the staged tree to known-good builds) found:

- The crash was `httpx → ssl.create_default_context() → FileNotFoundError [Errno 2]` on **every** HTTPS call — `certifi/cacert.pem` wasn't on disk.
- The published v0.14.0 release is **fine** (the 189.5 MB zip extracts to a complete ~472 MB / 825-file build). The locally **staged** copy was only 216 MB / **181 files** — a truncated extraction missing certifi plus ~640 other files (frontend `app/static`, `faster_whisper`, `onnxruntime`, fpcalc, the 44 `api-ms-win-*` CRT DLLs, …).
- Root weakness in the auto-updater: it extracted non-atomically with `zipfile.extractall()` straight into the final dir, and the SHA-256 check validated only the downloaded **zip**, never the unpacked **tree**. A half-extraction still reached `state == READY` and was one click away from being `xcopy`-ed over the working install.

`certifi` dropping out is the likely consequence of the **unpinned** `pyinstaller-hooks-contrib` (the certifi hook lives there), and CI never caught it because the smoke test makes no outbound HTTPS request.

## What changed

**Updater robustness** (`backend/app/core/updater.py`)
- Extract into a temp `.incoming/` dir, verify, then `os.replace` **atomically** into `engram/` — a partial extraction can never become the staged build.
- `_verify_extracted()`: required-file **sentinels** (launcher + `_internal/base_library.zip` + `_internal/certifi/cacert.pem`) always, plus a per-release **file manifest** (presence of every listed file) when shipped.
- `apply_update()` **re-verifies** completeness immediately before the swap (covers post-stage loss, e.g. AV quarantine).

**certifi / CI hardening**
- `backend/engram.spec`: `collect_data_files("certifi")` — bundle the CA file explicitly, independent of the PyInstaller hook.
- `.github/workflows/release.yml`: pin `pyinstaller==6.20.0` + `pyinstaller-hooks-contrib==2026.5`; generate and publish per-platform `sha256` manifests; smoke test now asserts `_internal/certifi/cacert.pem` exists and runs `engram --selftest`.
- `backend/run.py`: new `--selftest` flag — a real HTTPS round-trip through the frozen runtime that fails only on TLS/CA errors and tolerates transient network blips.

**Changelog**: `[Unreleased]` entry. (Ships to users as 0.14.1 — a fully certifi-less install can't auto-update, since the update check itself needs HTTPS.)

## Verification

- `uv run pytest tests/unit/test_updater.py tests/integration/test_update_workflow.py` → **28 passed** (7 new integrity tests: partial-extract never READY, manifest/sentinel rejection, apply-time re-verify). ruff clean.
- Built the exe from this branch (pinned PyInstaller): `_internal/certifi/cacert.pem` present (270,954 B); `engram.exe --selftest` → `SELFTEST OK`.
- Ran the built server (isolated temp DB): clean startup, `GET https://api.github.com/.../releases/latest "HTTP/1.1 200 OK"` — the exact call that was failing — with **zero** `FileNotFoundError`.

## Reviewer notes

- The `os.replace` atomic-promote relies on `.incoming/` and `engram/` being on the same filesystem (both under `~/.engram/update/<ver>/`) — they are.
- Manifest verification checks **presence** (the actual failure mode was missing files); hashes are shipped for manual `sha256sum -c` but not re-hashed at runtime to keep apply fast.
- Backward compatible: releases without a manifest fall back to the sentinel check (and the existing minimal-archive unit test still passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
