### PR TITLE
feat(organizer): disambiguate same-name TV shows in the library folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+_Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 original) can now coexist in your TV library, each in its own year/TMDB-tagged folder; plus FFmpeg is now a documented prerequisite with broader Windows auto-detection and inline path validation in the Config Wizard._
+
 ### Added
 
+- **Same-name TV shows can now coexist in the library** — TV episodes were filed under the bare show name (`Frasier/Season 01/…`), so ripping both the 1993 **Frasier** and the 2023 revival collided in one folder with identical filenames, and the second rip was skipped, overwritten, or bounced to Review. A new optional **Show Folder Format** setting disambiguates the show folder with the first-air year and TMDB id, matching the layout Plex (`Frasier (1993) {tmdb-3452}`) and Jellyfin (`Frasier (1993) [tmdbid-3452]`) parse for reliable matching. It is opt-in and defaults to the current bare-name layout, so existing libraries are untouched — set a format containing `{year}`/`{tmdb_id}` (and optionally add them to the episode filename format) to enable it. (#297)
 - FFmpeg is now documented as a prerequisite, with per-platform install steps (including `winget install Gyan.FFmpeg` on Windows) and a dedicated [Troubleshooting](https://jsakkos.github.io/engram/troubleshooting/) page led by the common "FFmpeg not detected" case.
 - The Config Wizard now validates a manually-entered MakeMKV or FFmpeg path against the backend and shows the detected version inline (or the specific error), so a hand-typed override is no longer saved blind. The FFmpeg "not found" card also links to the download page.
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -291,6 +291,7 @@ class ConfigResponse(BaseModel):
     naming_season_format: str
     naming_episode_format: str
     naming_movie_format: str
+    naming_tv_show_format: str
     # Episode ordering (#200) — global default output ordering
     episode_ordering_preference: str
     # AI identification
@@ -369,6 +370,7 @@ class ConfigUpdate(BaseModel):
     naming_season_format: str | None = None
     naming_episode_format: str | None = None
     naming_movie_format: str | None = None
+    naming_tv_show_format: str | None = None
     # Episode ordering (#200) — global default output ordering
     episode_ordering_preference: str | None = None
     # AI identification
@@ -1141,6 +1143,7 @@ async def get_config() -> ConfigResponse:
         naming_season_format=config.naming_season_format,
         naming_episode_format=config.naming_episode_format,
         naming_movie_format=config.naming_movie_format,
+        naming_tv_show_format=config.naming_tv_show_format,
         # Episode ordering (#200)
         episode_ordering_preference=config.episode_ordering_preference,
         # AI identification
@@ -1246,15 +1249,18 @@ async def update_config(config: ConfigUpdate) -> dict:
 
     # Validate naming format strings before persisting
     from app.core.organizer import (
+        ALLOWED_EPISODE_PLACEHOLDERS,
         ALLOWED_MOVIE_PLACEHOLDERS,
         ALLOWED_TV_PLACEHOLDERS,
+        ALLOWED_TV_SHOW_PLACEHOLDERS,
         validate_naming_format,
     )
 
     format_checks = [
         ("naming_season_format", ALLOWED_TV_PLACEHOLDERS),
-        ("naming_episode_format", ALLOWED_TV_PLACEHOLDERS),
+        ("naming_episode_format", ALLOWED_EPISODE_PLACEHOLDERS),
         ("naming_movie_format", ALLOWED_MOVIE_PLACEHOLDERS),
+        ("naming_tv_show_format", ALLOWED_TV_SHOW_PLACEHOLDERS),
     ]
     for field, allowed in format_checks:
         if field in update_data:

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -77,15 +77,19 @@ def format_movie_folder(fmt: str, title: str, year: int | None) -> str:
 
 
 def _strip_empty_name_groups(name: str) -> str:
-    """Remove empty (), {..-}, [..-] groups left when year/tmdb_id are absent.
+    """Remove empty (), {..-}, [..-] groups left when year/tmdb_id are absent,
+    consuming the whitespace that preceded each removed group so no double space
+    is left behind. Does NOT collapse other internal whitespace — so a bare
+    default format ("{show}") yields a byte-identical folder to pre-feature
+    behavior (e.g. a sanitized "Tom  Jerry" double space is preserved).
 
-    e.g. "Frasier () {tmdb-}" -> "Frasier". A populated tag like "{tmdb-3452}"
-    is preserved (the char before '}' is a digit, not '-').
+    A populated tag like "{tmdb-3452}" is preserved (the char before '}' is a
+    digit, not '-'); genuinely non-empty parens like "(US)" are preserved too.
     """
-    name = re.sub(r"\(\s*\)", "", name)  # empty parens
-    name = re.sub(r"\{[^{}]*-\s*\}", "", name)  # empty Plex tag, e.g. {tmdb-}
-    name = re.sub(r"\[[^\[\]]*-\s*\]", "", name)  # empty Jellyfin tag, e.g. [tmdbid-]
-    return re.sub(r"\s+", " ", name).strip()
+    name = re.sub(r"\s*\(\s*\)", "", name)  # empty parens (+ leading ws)
+    name = re.sub(r"\s*\{[^{}]*-\s*\}", "", name)  # empty Plex tag, e.g. {tmdb-}
+    name = re.sub(r"\s*\[[^\[\]]*-\s*\]", "", name)  # empty Jellyfin tag, e.g. [tmdbid-]
+    return name.strip()
 
 
 def format_tv_show_folder(fmt: str, show: str, year: int | None, tmdb_id: str | int | None) -> str:

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -28,8 +28,12 @@ ALLOWED_MOVIE_PLACEHOLDERS = {"title", "year"}
 
 def format_season_folder(fmt: str, season: int) -> str:
     """Format a season folder name from a config format string."""
+    # format_map (not format(**...)) so a user-supplied format with an unknown
+    # placeholder raises KeyError → caught below → safe fallback. Equivalent to
+    # format(**mapping) but keeps CodeQL's missing-named-argument check from
+    # flagging the intentionally-dynamic, user-controlled format string.
     try:
-        result = fmt.format(season=season)
+        result = fmt.format_map({"season": season})
     except (KeyError, ValueError, IndexError):
         result = f"Season {season:02d}"
     return sanitize_filename(result)
@@ -51,13 +55,18 @@ def format_episode_filename(
     ``()`` left behind is stripped (mirrors ``format_movie_folder``). The default
     format ("{show} - SxxExx") is unaffected.
     """
+    # format_map keeps an unknown placeholder raising KeyError → safe fallback,
+    # while avoiding CodeQL's missing-named-argument false positive on the
+    # user-controlled format string (see format_season_folder).
     try:
-        result = fmt.format(
-            show=show,
-            season=season,
-            episode=episode,
-            year=year or "",
-            tmdb_id=tmdb_id or "",
+        result = fmt.format_map(
+            {
+                "show": show,
+                "season": season,
+                "episode": episode,
+                "year": year or "",
+                "tmdb_id": tmdb_id or "",
+            }
         )
     except (KeyError, ValueError, IndexError):
         result = f"{show} - S{season:02d}E{episode:02d}"
@@ -68,7 +77,7 @@ def format_episode_filename(
 def format_movie_folder(fmt: str, title: str, year: int | None) -> str:
     """Format a movie folder name from a config format string."""
     try:
-        result = fmt.format(title=title, year=year or "")
+        result = fmt.format_map({"title": title, "year": year or ""})
     except (KeyError, ValueError, IndexError):
         result = f"{title} ({year})" if year else title
     # Clean up trailing empty parens if year is None
@@ -104,7 +113,7 @@ def format_tv_show_folder(fmt: str, show: str, year: int | None, tmdb_id: str | 
     if not fmt:
         return sanitize_filename(show)
     try:
-        result = fmt.format(show=show, year=year or "", tmdb_id=tmdb_id or "")
+        result = fmt.format_map({"show": show, "year": year or "", "tmdb_id": tmdb_id or ""})
     except (KeyError, ValueError, IndexError):
         result = show
     return sanitize_filename(_strip_empty_name_groups(result))

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -13,7 +13,12 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Allowed placeholders for naming format strings
-ALLOWED_TV_PLACEHOLDERS = {"show", "season", "episode"}
+ALLOWED_TV_PLACEHOLDERS = {"show", "season", "episode"}  # season folder format
+# Show *folder* format — adds year/tmdb_id for same-name disambiguation
+# (Plex "{tmdb-NNNN}" / Jellyfin "[tmdbid-NNNN]").
+ALLOWED_TV_SHOW_PLACEHOLDERS = {"show", "year", "tmdb_id"}
+# Episode *filename* format — widened so the year can opt into the filename too.
+ALLOWED_EPISODE_PLACEHOLDERS = {"show", "season", "episode", "year", "tmdb_id"}
 ALLOWED_MOVIE_PLACEHOLDERS = {"title", "year"}
 
 
@@ -26,12 +31,34 @@ def format_season_folder(fmt: str, season: int) -> str:
     return sanitize_filename(result)
 
 
-def format_episode_filename(fmt: str, show: str, season: int, episode: int) -> str:
-    """Format an episode filename from a config format string."""
+def format_episode_filename(
+    fmt: str,
+    show: str,
+    season: int,
+    episode: int,
+    *,
+    year: int | None = None,
+    tmdb_id: str | int | None = None,
+) -> str:
+    """Format an episode filename from a config format string.
+
+    ``year``/``tmdb_id`` are optional placeholders ({year}, {tmdb_id}). When the
+    chosen format omits them they are ignored; when year is missing, an empty
+    ``()`` left behind is stripped (mirrors ``format_movie_folder``). The default
+    format ("{show} - SxxExx") is unaffected.
+    """
     try:
-        result = fmt.format(show=show, season=season, episode=episode)
+        result = fmt.format(
+            show=show,
+            season=season,
+            episode=episode,
+            year=year or "",
+            tmdb_id=tmdb_id or "",
+        )
     except (KeyError, ValueError, IndexError):
         result = f"{show} - S{season:02d}E{episode:02d}"
+    result = re.sub(r"\(\s*\)", "", result)
+    result = re.sub(r"\s+", " ", result).strip()
     return sanitize_filename(result)
 
 
@@ -44,6 +71,36 @@ def format_movie_folder(fmt: str, title: str, year: int | None) -> str:
     # Clean up trailing empty parens if year is None
     result = re.sub(r"\s*\(\s*\)\s*$", "", result).strip()
     return sanitize_filename(result)
+
+
+def _strip_empty_name_groups(name: str) -> str:
+    """Remove empty (), {..-}, [..-] groups left when year/tmdb_id are absent.
+
+    e.g. "Frasier () {tmdb-}" -> "Frasier". A populated tag like "{tmdb-3452}"
+    is preserved (the char before '}' is a digit, not '-').
+    """
+    name = re.sub(r"\(\s*\)", "", name)  # empty parens
+    name = re.sub(r"\{[^{}]*-\s*\}", "", name)  # empty Plex tag, e.g. {tmdb-}
+    name = re.sub(r"\[[^\[\]]*-\s*\]", "", name)  # empty Jellyfin tag, e.g. [tmdbid-]
+    return re.sub(r"\s+", " ", name).strip()
+
+
+def format_tv_show_folder(fmt: str, show: str, year: int | None, tmdb_id: str | int | None) -> str:
+    """Format the show *directory* name from a config format string.
+
+    Mirrors ``format_movie_folder`` but adds a ``{tmdb_id}`` placeholder for
+    media-server disambiguation (Plex ``{tmdb-NNNN}`` / Jellyfin ``[tmdbid-NNNN]``).
+    Empty groups are stripped when year/id are missing, so the stable id tag never
+    degrades to ``Frasier {tmdb-}``. A falsy/empty ``fmt`` (e.g. an existing DB that
+    backfilled '') falls back to the bare show name == current behavior.
+    """
+    if not fmt:
+        return sanitize_filename(show)
+    try:
+        result = fmt.format(show=show, year=year or "", tmdb_id=tmdb_id or "")
+    except (KeyError, ValueError, IndexError):
+        result = show
+    return sanitize_filename(_strip_empty_name_groups(result))
 
 
 def validate_naming_format(fmt: str, allowed: set[str]) -> str | None:

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -427,10 +427,10 @@ def organize_tv_episode(
     library_path: Path | None = None,
     conflict_resolution: str = "ask",
     *,
+    year: int | None = None,
     tmdb_id: str | None = None,
     ordering: str = "aired",
     episode_group_id: str | None = None,
-    year: int | None = None,
 ) -> dict:
     """Organize a ripped TV episode into the library.
 
@@ -550,7 +550,7 @@ def organize_tv_extras(
     title_index: int | None = None,
     *,
     year: int | None = None,
-    tmdb_id: str | int | None = None,
+    tmdb_id: str | None = None,
 ) -> dict:
     """Organize a ripped TV extra/bonus content into the library Extras folder.
 
@@ -562,6 +562,10 @@ def organize_tv_extras(
         disc_number: Disc number for multi-disc sets (default: 1)
         extra_index: Index of this extra on the disc (default: 1)
         title_index: MakeMKV title index for unique naming (e.g., t03)
+        year: First-air year for show-folder disambiguation (e.g. Frasier 1993 vs 2023).
+            Only affects the folder when ``naming_tv_show_format`` includes ``{year}``.
+        tmdb_id: Show's TMDB id for show-folder disambiguation. Only affects the folder
+            when ``naming_tv_show_format`` includes ``{tmdb_id}``.
 
     Returns:
         dict with 'success', 'final_path', 'error' keys

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -64,8 +64,8 @@ def format_episode_filename(
                 "show": show,
                 "season": season,
                 "episode": episode,
-                "year": year or "",
-                "tmdb_id": tmdb_id or "",
+                "year": year if year is not None else "",
+                "tmdb_id": tmdb_id if tmdb_id is not None else "",
             }
         )
     except (KeyError, ValueError, IndexError):
@@ -107,13 +107,21 @@ def format_tv_show_folder(fmt: str, show: str, year: int | None, tmdb_id: str | 
     Mirrors ``format_movie_folder`` but adds a ``{tmdb_id}`` placeholder for
     media-server disambiguation (Plex ``{tmdb-NNNN}`` / Jellyfin ``[tmdbid-NNNN]``).
     Empty groups are stripped when year/id are missing, so the stable id tag never
-    degrades to ``Frasier {tmdb-}``. A falsy/empty ``fmt`` (e.g. an existing DB that
-    backfilled '') falls back to the bare show name == current behavior.
+    degrades to ``Frasier {tmdb-}``. A falsy/empty/whitespace-only ``fmt`` (e.g. an
+    existing DB that backfilled '') falls back to the bare show name == current
+    behavior — a whitespace-only format must NOT collapse the show-folder level.
     """
+    fmt = (fmt or "").strip()
     if not fmt:
         return sanitize_filename(show)
     try:
-        result = fmt.format_map({"show": show, "year": year or "", "tmdb_id": tmdb_id or ""})
+        result = fmt.format_map(
+            {
+                "show": show,
+                "year": year if year is not None else "",
+                "tmdb_id": tmdb_id if tmdb_id is not None else "",
+            }
+        )
     except (KeyError, ValueError, IndexError):
         result = show
     return sanitize_filename(_strip_empty_name_groups(result))
@@ -671,19 +679,24 @@ class TVOrganizer:
         self,
         files: list[tuple[Path, str]],
         show_name: str,
+        *,
+        year: int | None = None,
+        tmdb_id: str | None = None,
     ) -> list[dict]:
         """Organize multiple TV episodes.
 
         Args:
             files: List of (file_path, episode_code) tuples
             show_name: Name of the TV show
+            year: First-air year for show-folder disambiguation (threaded to organize).
+            tmdb_id: Show's TMDB id for show-folder disambiguation.
 
         Returns:
             List of result dicts for each file
         """
         results = []
         for source_file, episode_code in files:
-            result = self.organize(source_file, show_name, episode_code)
+            result = self.organize(source_file, show_name, episode_code, year=year, tmdb_id=tmdb_id)
             results.append(result)
         return results
 

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -13,7 +13,11 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Allowed placeholders for naming format strings
-ALLOWED_TV_PLACEHOLDERS = {"show", "season", "episode"}  # season folder format
+ALLOWED_TV_PLACEHOLDERS = {
+    "show",
+    "season",
+    "episode",
+}  # season folder (episode validation uses ALLOWED_EPISODE_PLACEHOLDERS once routes are wired)
 # Show *folder* format — adds year/tmdb_id for same-name disambiguation
 # (Plex "{tmdb-NNNN}" / Jellyfin "[tmdbid-NNNN]").
 ALLOWED_TV_SHOW_PLACEHOLDERS = {"show", "year", "tmdb_id"}
@@ -57,8 +61,7 @@ def format_episode_filename(
         )
     except (KeyError, ValueError, IndexError):
         result = f"{show} - S{season:02d}E{episode:02d}"
-    result = re.sub(r"\(\s*\)", "", result)
-    result = re.sub(r"\s+", " ", result).strip()
+    result = _strip_empty_name_groups(result)
     return sanitize_filename(result)
 
 

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -430,6 +430,7 @@ def organize_tv_episode(
     tmdb_id: str | None = None,
     ordering: str = "aired",
     episode_group_id: str | None = None,
+    year: int | None = None,
 ) -> dict:
     """Organize a ripped TV episode into the library.
 
@@ -447,6 +448,9 @@ def organize_tv_episode(
             canonical (#200).
         episode_group_id: Resolved TMDB group id for ``ordering`` (unused here;
             accepted so callers can pass the resolver's full result for audit).
+        year: First-air year used for same-name show disambiguation in the folder
+            name (e.g. Frasier 1993 vs 2023). Only affects the show folder when
+            the configured ``naming_tv_show_format`` includes ``{year}``.
 
     Returns:
         dict with 'success', 'final_path', 'error' keys
@@ -495,15 +499,22 @@ def organize_tv_episode(
 
     # Clean and sanitize names
     clean_show = sanitize_filename(show_name.strip())
+    show_folder = format_tv_show_folder(cfg.naming_tv_show_format, clean_show, year, tmdb_id)
     season_folder = format_season_folder(cfg.naming_season_format, out_season)
     ep_stem = format_episode_filename(
-        cfg.naming_episode_format, clean_show, out_season, out_episode
+        cfg.naming_episode_format,
+        clean_show,
+        out_season,
+        out_episode,
+        year=year,
+        tmdb_id=tmdb_id,
     )
     filename = f"{ep_stem}.mkv"
 
-    # Build destination path
+    # Build destination path. The show folder may carry year/tmdb-id so same-name
+    # shows (Frasier 1993 vs 2023) coexist; default "{show}" == bare clean_show.
     library_path = Path(library_path)
-    dest_dir = library_path / clean_show / season_folder
+    dest_dir = library_path / show_folder / season_folder
     dest_file = dest_dir / filename
 
     logger.info(f"Organizing TV episode: {source_file.name} -> {dest_file}")
@@ -537,6 +548,9 @@ def organize_tv_extras(
     disc_number: int = 1,
     extra_index: int = 1,
     title_index: int | None = None,
+    *,
+    year: int | None = None,
+    tmdb_id: str | int | None = None,
 ) -> dict:
     """Organize a ripped TV extra/bonus content into the library Extras folder.
 
@@ -571,6 +585,9 @@ def organize_tv_extras(
 
     # Clean and sanitize names
     clean_show = sanitize_filename(show_name.strip())
+    # Use the SAME disambiguated show folder as organize_tv_episode so an extra
+    # and its episodes land under one show folder (TV-organize-paths-sync hazard).
+    show_folder = format_tv_show_folder(cfg.naming_tv_show_format, clean_show, year, tmdb_id)
     season_folder = format_season_folder(cfg.naming_season_format, season)
 
     if title_index is not None:
@@ -580,7 +597,7 @@ def organize_tv_extras(
 
     # Build destination path
     library_path = Path(library_path)
-    dest_dir = library_path / clean_show / season_folder / "Extras"
+    dest_dir = library_path / show_folder / season_folder / "Extras"
     dest_file = dest_dir / extra_name
 
     logger.info(f"Organizing TV extra: {source_file.name} -> {dest_file}")
@@ -615,12 +632,13 @@ class TVOrganizer:
         tmdb_id: str | None = None,
         ordering: str = "aired",
         episode_group_id: str | None = None,
+        year: int | None = None,
     ) -> dict:
         """Organize a TV episode from staging to library.
 
-        Forwards the output-ordering controls to organize_tv_episode so the
-        library-mode path (no explicit library_path) also honors the chosen
-        ordering. episode_code stays canonical; only the filename is projected.
+        Forwards the output-ordering controls AND show disambiguation (year/tmdb_id)
+        to organize_tv_episode so the library-mode path (no explicit library_path)
+        also honors them. episode_code stays canonical; only the filename is projected.
         """
         return organize_tv_episode(
             source_file,
@@ -629,6 +647,7 @@ class TVOrganizer:
             tmdb_id=tmdb_id,
             ordering=ordering,
             episode_group_id=episode_group_id,
+            year=year,
         )
 
     def organize_batch(

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -109,6 +109,15 @@ class AppConfig(SQLModel, table=True):
     naming_season_format: str = "Season {season:02d}"
     naming_episode_format: str = "{show} - S{season:02d}E{episode:02d}"
     naming_movie_format: str = "{title} ({year})"
+    # Show *folder* format. Default "{show}" == today's bare-name behavior so
+    # existing libraries are untouched. server_default ensures EXISTING DBs get
+    # "{show}" (not the _add_missing_columns String fallback of '') when the
+    # column is added. Opt into disambiguation with e.g.
+    # "{show} ({year}) {{tmdb-{tmdb_id}}}" (Plex) or
+    # "{show} ({year}) [tmdbid-{tmdb_id}]" (Jellyfin).
+    naming_tv_show_format: str = Field(
+        default="{show}", sa_column_kwargs={"server_default": text("'{show}'")}
+    )
 
     # Episode ordering (#200) — global default output ordering for TV libraries.
     # "aired" keeps TMDB's canonical numbering (== the fingerprint-network key,

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -63,6 +63,10 @@ class DiscJob(SQLModel, table=True):
     )
     tmdb_id: int | None = Field(default=None)
     tmdb_name: str | None = Field(default=None)
+    # First-air year for the resolved show; persisted at identify time so the
+    # organizer can build a disambiguated library folder (Frasier 1993 vs 2023)
+    # deterministically and offline. Nullable — degrades to id-only/bare folder.
+    tmdb_year: int | None = Field(default=None)
     # Same-name TMDB collision candidates (JSON list of {tmdb_id, name, year,
     # popularity}). Recorded at identify time whenever >=2 same-name shows exist
     # (e.g. Frasier 1993 #3452 vs 2023 revival #195241) so the downstream

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -813,6 +813,7 @@ class FinalizationCoordinator:
             # Canonical (aired) for the common case; projected to the filename only.
             ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
             _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+            _tmdb_year = job.tmdb_year
 
             # Organize all MATCHED winners
             extra_index = 1
@@ -844,6 +845,8 @@ class FinalizationCoordinator:
                         disc_number=job.disc_number or 1,
                         extra_index=extra_index,
                         title_index=t.title_index,
+                        tmdb_id=_tmdb_id_str,
+                        year=_tmdb_year,
                     )
                 elif _lib_path:
                     org_result = await asyncio.to_thread(
@@ -855,6 +858,7 @@ class FinalizationCoordinator:
                         tmdb_id=_tmdb_id_str,
                         ordering=ordering,
                         episode_group_id=ordering_group_id,
+                        year=_tmdb_year,
                     )
                 else:
                     org_result = await asyncio.to_thread(
@@ -865,6 +869,7 @@ class FinalizationCoordinator:
                         tmdb_id=_tmdb_id_str,
                         ordering=ordering,
                         episode_group_id=ordering_group_id,
+                        year=_tmdb_year,
                     )
 
                 # Classification is independent of the file move: a failed extra
@@ -1172,6 +1177,7 @@ class FinalizationCoordinator:
         # Resolve output ordering once for this sweep (#200); filename-only projection.
         ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
         _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+        _tmdb_year = job.tmdb_year
 
         success_count = 0
         conflict_count = 0
@@ -1197,6 +1203,8 @@ class FinalizationCoordinator:
                             disc_number=job.disc_number or 1,
                             extra_index=extra_index,
                             title_index=disc_title.title_index,
+                            tmdb_id=_tmdb_id_str,
+                            year=_tmdb_year,
                         )
                         extra_index += 1
                     else:
@@ -1210,6 +1218,7 @@ class FinalizationCoordinator:
                                 tmdb_id=_tmdb_id_str,
                                 ordering=ordering,
                                 episode_group_id=ordering_group_id,
+                                year=_tmdb_year,
                             )
                         else:
                             org_result = await asyncio.to_thread(
@@ -1220,6 +1229,7 @@ class FinalizationCoordinator:
                                 tmdb_id=_tmdb_id_str,
                                 ordering=ordering,
                                 episode_group_id=ordering_group_id,
+                                year=_tmdb_year,
                             )
                     if org_result["success"]:
                         success_count += 1
@@ -1358,6 +1368,7 @@ class FinalizationCoordinator:
             # Resolve output ordering once for this sweep (#200); filename-only projection.
             ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
             _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+            _tmdb_year = job.tmdb_year
 
             success_count = 0
             conflict_count = 0
@@ -1383,6 +1394,8 @@ class FinalizationCoordinator:
                         disc_number=job.disc_number or 1,
                         extra_index=extra_index,
                         title_index=disc_title.title_index,
+                        tmdb_id=_tmdb_id_str,
+                        year=_tmdb_year,
                     )
                     extra_index += 1
                 else:
@@ -1396,6 +1409,7 @@ class FinalizationCoordinator:
                             tmdb_id=_tmdb_id_str,
                             ordering=ordering,
                             episode_group_id=ordering_group_id,
+                            year=_tmdb_year,
                         )
                     else:
                         org_result = await asyncio.to_thread(
@@ -1406,6 +1420,7 @@ class FinalizationCoordinator:
                             tmdb_id=_tmdb_id_str,
                             ordering=ordering,
                             episode_group_id=ordering_group_id,
+                            year=_tmdb_year,
                         )
 
                 if org_result["success"]:

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -79,7 +79,7 @@ def _resolve_show_year(tmdb_id: int | None, signal=None) -> int | None:
     None when unknown — the organizer then degrades to an id-only/bare folder.
     Sync (blocking on the fallback) — call via ``asyncio.to_thread``.
     """
-    if not tmdb_id:
+    if tmdb_id is None:
         return None
     cands = getattr(signal, "all_candidates", None) if signal else None
     for c in cands or []:

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -79,7 +79,9 @@ def _resolve_show_year(tmdb_id: int | None, signal=None) -> int | None:
     None when unknown — the organizer then degrades to an id-only/bare folder.
     Sync (blocking on the fallback) — call via ``asyncio.to_thread``.
     """
-    if tmdb_id is None:
+    # Falsy guard (not ``is None``) so a 0/empty id short-circuits instead of
+    # making a pointless fetch_show_details(0) call for a non-existent id.
+    if not tmdb_id:
         return None
     cands = getattr(signal, "all_candidates", None) if signal else None
     for c in cands or []:
@@ -862,6 +864,8 @@ class IdentificationCoordinator:
             job.candidates_json = None
 
             # Optionally re-run TMDB lookup with corrected title
+            _old_tmdb_id = job.tmdb_id
+            _old_year = job.tmdb_year
             _signal = None
             if tmdb_id is not None:
                 job.tmdb_id = tmdb_id
@@ -881,12 +885,20 @@ class IdentificationCoordinator:
                 except Exception:
                     logger.warning(
                         f"Job {job_id}: TMDB re-lookup failed for '{title}', "
-                        f"continuing with user-provided title"
+                        f"continuing with user-provided title",
+                        exc_info=True,
                     )
 
             # Re-derive the year for the (possibly changed) show so the library
-            # folder stays correct after re-identification.
-            job.tmdb_year = await asyncio.to_thread(_resolve_show_year, job.tmdb_id, _signal)
+            # folder stays correct after re-identification. Preserve a previously
+            # resolved year ONLY when the show identity is unchanged and the
+            # (cache-miss + offline) lookup fails — so a transient TMDB outage
+            # can't blank a good year, but a stale year isn't carried across an
+            # identity change to a different show.
+            _year = await asyncio.to_thread(_resolve_show_year, job.tmdb_id, _signal)
+            if _year is None and job.tmdb_id == _old_tmdb_id:
+                _year = _old_year
+            job.tmdb_year = _year
 
             if has_ripped:
                 # Post-rip: go to MATCHING to re-run episode matching

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -71,6 +71,32 @@ def _candidates_json_from_signal(signal) -> str | None:
     return json.dumps(cands) if cands else None
 
 
+def _resolve_show_year(tmdb_id: int | None, signal=None) -> int | None:
+    """First-air year for a show, for library-folder disambiguation.
+
+    No-network fast path: same-name candidates already carry a 'year' string
+    (Frasier 1993 vs 2023). Universal fallback: cached TMDB details. Returns
+    None when unknown — the organizer then degrades to an id-only/bare folder.
+    Sync (blocking on the fallback) — call via ``asyncio.to_thread``.
+    """
+    if not tmdb_id:
+        return None
+    cands = getattr(signal, "all_candidates", None) if signal else None
+    for c in cands or []:
+        if c.get("tmdb_id") == tmdb_id:
+            y = (c.get("year") or "").strip()
+            if y.isdigit():
+                return int(y)
+    from app.matcher.tmdb_client import fetch_show_details
+
+    details = fetch_show_details(tmdb_id)
+    if details:
+        fa = (details.get("first_air_date") or "")[:4]
+        if fa.isdigit():
+            return int(fa)
+    return None
+
+
 class IdentificationCoordinator:
     """Coordinates disc identification: scanning, classification, and metadata lookup."""
 
@@ -200,6 +226,9 @@ class IdentificationCoordinator:
                 job.tmdb_id = analysis.tmdb_id
                 job.tmdb_name = analysis.tmdb_name
                 job.candidates_json = _candidates_json_from_signal(tmdb_signal)
+                job.tmdb_year = await asyncio.to_thread(
+                    _resolve_show_year, analysis.tmdb_id, tmdb_signal
+                )
                 job.is_ambiguous_movie = analysis.is_ambiguous_movie
                 if analysis.play_all_title_indices:
                     job.play_all_indices_json = json.dumps(analysis.play_all_title_indices)
@@ -554,8 +583,10 @@ class IdentificationCoordinator:
                 job.classification_source = analysis.classification_source or "staging_import"
                 job.tmdb_id = analysis.tmdb_id
                 job.tmdb_name = analysis.tmdb_name
-                job.candidates_json = _candidates_json_from_signal(
-                    getattr(analysis, "_tmdb_signal", None)
+                _signal = getattr(analysis, "_tmdb_signal", None)
+                job.candidates_json = _candidates_json_from_signal(_signal)
+                job.tmdb_year = await asyncio.to_thread(
+                    _resolve_show_year, analysis.tmdb_id, _signal
                 )
                 job.is_ambiguous_movie = analysis.is_ambiguous_movie
                 if analysis.play_all_title_indices:
@@ -831,6 +862,7 @@ class IdentificationCoordinator:
             job.candidates_json = None
 
             # Optionally re-run TMDB lookup with corrected title
+            _signal = None
             if tmdb_id is not None:
                 job.tmdb_id = tmdb_id
             else:
@@ -841,16 +873,20 @@ class IdentificationCoordinator:
 
                     config = await get_config()
                     if config.tmdb_api_key:
-                        signal = classify_from_tmdb(title, config.tmdb_api_key)
-                        if signal and signal.tmdb_id:
-                            job.tmdb_id = signal.tmdb_id
-                            if signal.tmdb_name:
-                                job.detected_title = signal.tmdb_name
+                        _signal = classify_from_tmdb(title, config.tmdb_api_key)
+                        if _signal and _signal.tmdb_id:
+                            job.tmdb_id = _signal.tmdb_id
+                            if _signal.tmdb_name:
+                                job.detected_title = _signal.tmdb_name
                 except Exception:
                     logger.warning(
                         f"Job {job_id}: TMDB re-lookup failed for '{title}', "
                         f"continuing with user-provided title"
                     )
+
+            # Re-derive the year for the (possibly changed) show so the library
+            # folder stays correct after re-identification.
+            job.tmdb_year = await asyncio.to_thread(_resolve_show_year, job.tmdb_id, _signal)
 
             if has_ripped:
                 # Post-rip: go to MATCHING to re-run episode matching

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1133,6 +1133,8 @@ class MatchingCoordinator:
             job.disc_number,
             extra_index,
             title.title_index,
+            tmdb_id=str(job.tmdb_id) if job.tmdb_id else None,
+            year=job.tmdb_year,
         )
         if org_result["success"]:
             title.state = TitleState.COMPLETED

--- a/backend/migrations/versions/c5e9a1b3d7f2_add_disc_jobs_tmdb_year.py
+++ b/backend/migrations/versions/c5e9a1b3d7f2_add_disc_jobs_tmdb_year.py
@@ -1,0 +1,35 @@
+"""add disc_jobs.tmdb_year
+
+Persists the resolved show's first-air year on a job so the organizer can build
+a disambiguated library folder (e.g. Frasier 1993 #3452 vs the 2023 revival
+#195241) deterministically and offline. Resolved at identify time from the
+same-name candidates (no extra network) or a cached TMDB details lookup. Mirrors
+the database.py reconciler path used by frozen builds (which skip Alembic) — the
+two must stay in agreement.
+
+Revision ID: c5e9a1b3d7f2
+Revises: c4d8e1f0a2b3
+Create Date: 2026-06-02 12:50:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c5e9a1b3d7f2"
+down_revision: str | Sequence[str] | None = "c4d8e1f0a2b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("tmdb_year", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("tmdb_year")

--- a/backend/tests/integration/test_re_identify.py
+++ b/backend/tests/integration/test_re_identify.py
@@ -138,6 +138,61 @@ async def test_re_identify_clears_stale_candidates(client):
         assert refreshed.candidates_json is None  # stale twins cleared
 
 
+async def _create_reident_year_job(tmdb_id=3452, tmdb_year=1993):
+    async with async_session() as session:
+        job = DiscJob(
+            volume_label="FRASIER_S1D1",
+            drive_id="E:",
+            state=JobState.REVIEW_NEEDED,
+            content_type=ContentType.TV,
+            detected_title="Frasier",
+            detected_season=1,
+            tmdb_id=tmdb_id,
+            tmdb_year=tmdb_year,
+            needs_review=True,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job.id
+
+
+@pytest.mark.asyncio
+async def test_re_identify_preserves_year_on_tmdb_outage_same_show(client):
+    """A transient TMDB outage during re-identify must not blank a known year.
+
+    User re-picks the SAME show id while fetch_show_details is unreachable; the
+    previously-resolved tmdb_year must survive so the disambiguated library
+    folder (Frasier (1993) {tmdb-3452}) doesn't collapse to the bare name.
+    """
+    job_id = await _create_reident_year_job(tmdb_id=3452, tmdb_year=1993)
+
+    coordinator = IdentificationCoordinator(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+    with patch("app.matcher.tmdb_client.fetch_show_details", return_value=None):
+        await coordinator.re_identify(job_id, "Frasier", "tv", season=1, tmdb_id=3452)
+
+    async with async_session() as session:
+        refreshed = await session.get(DiscJob, job_id)
+        assert refreshed.tmdb_id == 3452
+        assert refreshed.tmdb_year == 1993  # preserved across the outage
+
+
+@pytest.mark.asyncio
+async def test_re_identify_drops_stale_year_on_identity_change(client):
+    """Changing the show id (and the new year can't resolve) must NOT carry the
+    old show's year over — that would mislabel the new show's folder."""
+    job_id = await _create_reident_year_job(tmdb_id=3452, tmdb_year=1993)
+
+    coordinator = IdentificationCoordinator(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+    with patch("app.matcher.tmdb_client.fetch_show_details", return_value=None):
+        await coordinator.re_identify(job_id, "Frasier", "tv", season=1, tmdb_id=195241)
+
+    async with async_session() as session:
+        refreshed = await session.get(DiscJob, job_id)
+        assert refreshed.tmdb_id == 195241
+        assert refreshed.tmdb_year is None  # stale 1993 not carried across the change
+
+
 @pytest.mark.asyncio
 async def test_re_identify_rejects_wrong_state(client):
     """Re-identify should return 400 for jobs not in REVIEW_NEEDED state."""

--- a/backend/tests/pipeline/test_organization_paths.py
+++ b/backend/tests/pipeline/test_organization_paths.py
@@ -208,3 +208,52 @@ class TestMovieExtrasMapping:
         assert result["success"]
         dest_names = {dest.name for dest in result["extras_mapping"].values()}
         assert dest_names == {"Extra 1.mkv", "Extra 2.mkv"}
+
+
+@pytest.mark.pipeline
+class TestTVSameNameCoexistence:
+    """Same-name shows coexist when disambiguation is enabled; default unchanged."""
+
+    @staticmethod
+    def _patch_cfg(**over):
+        from unittest.mock import patch
+
+        from app.models.app_config import AppConfig
+
+        return patch(
+            "app.services.config_service.get_config_sync",
+            return_value=AppConfig(**over),
+        )
+
+    def test_frasier_twins_coexist(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            a = tmp_path / "staging" / "a.mkv"
+            a.parent.mkdir(parents=True, exist_ok=True)
+            a.write_bytes(b"x" * 1024)
+            r1 = organize_tv_episode(
+                a, "Frasier", "S01E01", library_path=lib, tmdb_id="3452", year=1993
+            )
+            b = tmp_path / "staging" / "b.mkv"
+            b.write_bytes(b"x" * 1024)
+            r2 = organize_tv_episode(
+                b, "Frasier", "S01E01", library_path=lib, tmdb_id="195241", year=2023
+            )
+        assert r1["success"] and r2["success"]
+        assert r1["final_path"].parent.parent.name == "Frasier (1993) {tmdb-3452}"
+        assert r2["final_path"].parent.parent.name == "Frasier (2023) {tmdb-195241}"
+        assert r1["final_path"] != r2["final_path"]
+
+    def test_default_format_unchanged_bare_folder(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg():  # default naming_tv_show_format == "{show}"
+            s = tmp_path / "staging" / "c.mkv"
+            s.parent.mkdir(parents=True, exist_ok=True)
+            s.write_bytes(b"x" * 1024)
+            r = organize_tv_episode(
+                s, "Frasier", "S01E01", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"].parent.parent.name == "Frasier"
+        assert r["final_path"].name == "Frasier - S01E01.mkv"

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -144,6 +144,36 @@ class TestHandleExtras:
             assert title.is_extra is True
             assert json.loads(title.match_details)["organize_error"] == "boom"
 
+    async def test_keep_policy_threads_tmdb_id_and_year(self, monkeypatch, tmp_path):
+        """When job carries tmdb_id + tmdb_year, organize_tv_extras must receive them
+        as kwargs — otherwise match-time extras land in the bare show folder instead
+        of the disambiguated one (e.g. "Frasier/..." vs "Frasier (1993) {tmdb-3452}/...").
+        """
+        _patch_config(monkeypatch, "keep")
+        import app.core.organizer as org
+
+        mock_org = Mock(return_value={"success": True, "final_path": "/lib/tv/Show/Extras/x.mkv"})
+        monkeypatch.setattr(org, "organize_tv_extras", mock_org)
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await _seed(session)
+            # Simulate a job that has been identified with a specific TMDB entry.
+            job.tmdb_id = 3452
+            job.tmdb_year = 1993
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            await coord._handle_extras(
+                job.id, title.id, title, job, tmp_path / "x.mkv", 10.0, [22, 44], session
+            )
+
+        mock_org.assert_called_once()
+        kwargs = mock_org.call_args.kwargs
+        assert kwargs["tmdb_id"] == "3452", (
+            f"expected tmdb_id='3452', got {kwargs.get('tmdb_id')!r}"
+        )
+        assert kwargs["year"] == 1993, f"expected year=1993, got {kwargs.get('year')!r}"
+
 
 @pytest.mark.unit
 class TestRematchSingleTitle:

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -324,6 +324,13 @@ class TestNamingHelpers:
         fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
         assert format_tv_show_folder(fmt, "Frasier", None, "3452") == "Frasier {tmdb-3452}"
 
+    def test_show_folder_whitespace_only_format_falls_back_to_bare(self):
+        # A whitespace-only format must NOT collapse the show-folder level
+        # (would file every show flat under the TV root).
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("   ", "Frasier", 1993, "3452") == "Frasier"
+
     def test_show_folder_jellyfin_missing_id_strips_tag(self):
         from app.core.organizer import format_tv_show_folder
 

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -347,6 +347,13 @@ class TestNamingHelpers:
 
         assert format_tv_show_folder("", "Frasier", 1993, "3452") == "Frasier"
 
+    def test_show_folder_default_preserves_internal_double_space(self):
+        # Default "{show}" must be byte-identical to pre-feature behavior: a show
+        # name that sanitizes to a double space is NOT collapsed (no silent reloc).
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("{show}", "Tom  Jerry", 1993, "3452") == "Tom  Jerry"
+
     def test_episode_filename_with_year(self):
         from app.core.organizer import format_episode_filename
 

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -476,7 +476,7 @@ class TestTVDisambiguation:
                 s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=None
             )
         assert r["success"]
-        assert "Frasier {tmdb-3452}" in str(r["final_path"])
+        assert r["final_path"] == lib / "Frasier {tmdb-3452}" / "Season 01" / "Frasier - S01E02.mkv"
         assert "()" not in str(r["final_path"])
 
     def test_episode_filename_year_opt_in(self, tmp_path):

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -11,6 +11,7 @@ from app.core.organizer import (
     clean_movie_name,
     organize_movie,
     organize_tv_episode,
+    organize_tv_extras,
     sanitize_filename,
 )
 
@@ -421,3 +422,100 @@ class TestNamingHelpers:
         )
         # Unknown placeholder still rejected.
         assert validate_naming_format("{bogus}", ALLOWED_TV_SHOW_PLACEHOLDERS) is not None
+
+
+class TestTVDisambiguation:
+    """End-to-end folder building with the disambiguating format."""
+
+    @staticmethod
+    def _patch_cfg(**over):
+        from app.models.app_config import AppConfig
+
+        return patch(
+            "app.services.config_service.get_config_sync",
+            return_value=AppConfig(**over),
+        )
+
+    def test_same_name_twins_land_in_distinct_folders(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            s1 = tmp_path / "a.mkv"
+            s1.write_bytes(b"x")
+            r1 = organize_tv_episode(
+                s1, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+            s2 = tmp_path / "b.mkv"
+            s2.write_bytes(b"x")
+            r2 = organize_tv_episode(
+                s2, "Frasier", "S01E02", library_path=lib, tmdb_id="195241", year=2023
+            )
+        assert r1["success"] and r2["success"]
+        assert "Frasier (1993) {tmdb-3452}" in str(r1["final_path"])
+        assert "Frasier (2023) {tmdb-195241}" in str(r2["final_path"])
+        assert r1["final_path"] != r2["final_path"]
+
+    def test_default_format_keeps_bare_folder(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg():  # naming_tv_show_format defaults to "{show}"
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"] == lib / "Frasier" / "Season 01" / "Frasier - S01E02.mkv"
+
+    def test_missing_year_keeps_id_no_empty_parens(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=None
+            )
+        assert r["success"]
+        assert "Frasier {tmdb-3452}" in str(r["final_path"])
+        assert "()" not in str(r["final_path"])
+
+    def test_episode_filename_year_opt_in(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg(
+            naming_tv_show_format="{show} ({year}) {{tmdb-{tmdb_id}}}",
+            naming_episode_format="{show} ({year}) - S{season:02d}E{episode:02d}",
+        ):
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"].name == "Frasier (1993) - S01E02.mkv"
+
+    def test_extras_share_show_folder_with_episode(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            ep = tmp_path / "e.mkv"
+            ep.write_bytes(b"x")
+            r_ep = organize_tv_episode(
+                ep, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+            ex = tmp_path / "x.mkv"
+            ex.write_bytes(b"x")
+            r_ex = organize_tv_extras(
+                ex,
+                "Frasier",
+                season=1,
+                library_path=lib,
+                disc_number=1,
+                title_index=3,
+                tmdb_id="3452",
+                year=1993,
+            )
+        assert r_ep["success"] and r_ex["success"]
+        show_dir = str(lib / "Frasier (1993) {tmdb-3452}")
+        assert str(r_ep["final_path"]).startswith(show_dir)
+        assert str(r_ex["final_path"]).startswith(show_dir)
+        assert "Extras" in str(r_ex["final_path"])

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -335,7 +335,7 @@ class TestNamingHelpers:
         fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
         assert format_tv_show_folder(fmt, "Frasier", None, None) == "Frasier"
 
-    def test_show_folder_default_is_bare(self):
+    def test_show_folder_show_only_format_ignores_extras(self):
         from app.core.organizer import format_tv_show_folder
 
         assert format_tv_show_folder("{show}", "Frasier", 1993, "3452") == "Frasier"
@@ -366,6 +366,30 @@ class TestNamingHelpers:
         from app.core.organizer import format_episode_filename
 
         out = format_episode_filename("{show} - S{season:02d}E{episode:02d}", "Frasier", 1, 2)
+        assert out == "Frasier - S01E02"
+
+    def test_episode_filename_plex_tag_with_id(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} {{tmdb-{tmdb_id}}} - S{season:02d}E{episode:02d}",
+            "Frasier",
+            1,
+            2,
+            tmdb_id="3452",
+        )
+        assert out == "Frasier {tmdb-3452} - S01E02"
+
+    def test_episode_filename_plex_tag_missing_id_stripped(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} {{tmdb-{tmdb_id}}} - S{season:02d}E{episode:02d}",
+            "Frasier",
+            1,
+            2,
+            tmdb_id=None,
+        )
         assert out == "Frasier - S01E02"
 
     def test_placeholder_sets_validate(self):

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -297,3 +297,103 @@ class TestTVOrderingProjection:
                 ordering="dvd",
             )
         assert result["final_path"].name == "Firefly - S01E11.mkv"
+
+
+class TestNamingHelpers:
+    """format_tv_show_folder, widened placeholders, episode-filename year."""
+
+    def test_show_folder_plex_full(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", 1993, "3452") == "Frasier (1993) {tmdb-3452}"
+
+    def test_show_folder_jellyfin_full(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) [tmdbid-{tmdb_id}]"
+        assert (
+            format_tv_show_folder(fmt, "Frasier", 2023, "195241")
+            == "Frasier (2023) [tmdbid-195241]"
+        )
+
+    def test_show_folder_missing_year_keeps_id(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", None, "3452") == "Frasier {tmdb-3452}"
+
+    def test_show_folder_jellyfin_missing_id_strips_tag(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) [tmdbid-{tmdb_id}]"
+        assert format_tv_show_folder(fmt, "Frasier", 1993, None) == "Frasier (1993)"
+
+    def test_show_folder_missing_both_is_bare(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", None, None) == "Frasier"
+
+    def test_show_folder_default_is_bare(self):
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("{show}", "Frasier", 1993, "3452") == "Frasier"
+
+    def test_show_folder_empty_format_falls_back_to_bare(self):
+        # Existing DBs may have backfilled '' for this column; degrade, don't break.
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("", "Frasier", 1993, "3452") == "Frasier"
+
+    def test_episode_filename_with_year(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} ({year}) - S{season:02d}E{episode:02d}", "Frasier", 1, 2, year=1993
+        )
+        assert out == "Frasier (1993) - S01E02"
+
+    def test_episode_filename_year_missing_strips_parens(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} ({year}) - S{season:02d}E{episode:02d}", "Frasier", 1, 2, year=None
+        )
+        assert out == "Frasier - S01E02"
+
+    def test_episode_filename_default_unchanged(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename("{show} - S{season:02d}E{episode:02d}", "Frasier", 1, 2)
+        assert out == "Frasier - S01E02"
+
+    def test_placeholder_sets_validate(self):
+        from app.core.organizer import (
+            ALLOWED_EPISODE_PLACEHOLDERS,
+            ALLOWED_TV_SHOW_PLACEHOLDERS,
+            validate_naming_format,
+        )
+
+        assert ALLOWED_TV_SHOW_PLACEHOLDERS == {"show", "year", "tmdb_id"}
+        assert {"year", "tmdb_id"} <= ALLOWED_EPISODE_PLACEHOLDERS
+        assert (
+            validate_naming_format(
+                "{show} ({year}) {{tmdb-{tmdb_id}}}", ALLOWED_TV_SHOW_PLACEHOLDERS
+            )
+            is None
+        )
+        assert (
+            validate_naming_format(
+                "{show} ({year}) [tmdbid-{tmdb_id}]", ALLOWED_TV_SHOW_PLACEHOLDERS
+            )
+            is None
+        )
+        assert (
+            validate_naming_format(
+                "{show} ({year}) - S{season:02d}E{episode:02d}", ALLOWED_EPISODE_PLACEHOLDERS
+            )
+            is None
+        )
+        # Unknown placeholder still rejected.
+        assert validate_naming_format("{bogus}", ALLOWED_TV_SHOW_PLACEHOLDERS) is not None

--- a/backend/tests/unit/test_resolve_show_year.py
+++ b/backend/tests/unit/test_resolve_show_year.py
@@ -1,0 +1,43 @@
+"""Unit tests for identification year resolution."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.services.identification_coordinator import _resolve_show_year
+
+
+def test_none_tmdb_id_returns_none():
+    assert _resolve_show_year(None) is None
+
+
+def test_fast_path_reads_year_from_candidates():
+    sig = SimpleNamespace(
+        all_candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 50.0},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 30.0},
+        ]
+    )
+    assert _resolve_show_year(3452, sig) == 1993
+    assert _resolve_show_year(195241, sig) == 2023
+
+
+def test_fallback_to_tmdb_details_when_no_candidates():
+    with patch(
+        "app.matcher.tmdb_client.fetch_show_details",
+        return_value={"first_air_date": "1993-09-16"},
+    ):
+        assert _resolve_show_year(3452, None) == 1993
+
+
+def test_returns_none_when_details_missing():
+    with patch("app.matcher.tmdb_client.fetch_show_details", return_value=None):
+        assert _resolve_show_year(3452, None) is None
+
+
+def test_candidate_year_blank_falls_through_to_details():
+    sig = SimpleNamespace(all_candidates=[{"tmdb_id": 3452, "year": ""}])
+    with patch(
+        "app.matcher.tmdb_client.fetch_show_details",
+        return_value={"first_air_date": "1993-09-16"},
+    ):
+        assert _resolve_show_year(3452, sig) == 1993

--- a/backend/tests/unit/test_resolve_show_year.py
+++ b/backend/tests/unit/test_resolve_show_year.py
@@ -10,6 +10,13 @@ def test_none_tmdb_id_returns_none():
     assert _resolve_show_year(None) is None
 
 
+def test_zero_tmdb_id_short_circuits_without_network():
+    # Falsy id (0) short-circuits — no pointless fetch_show_details(0) call.
+    with patch("app.matcher.tmdb_client.fetch_show_details") as m:
+        assert _resolve_show_year(0, None) is None
+        m.assert_not_called()
+
+
 def test_fast_path_reads_year_from_candidates():
     sig = SimpleNamespace(
         all_candidates=[

--- a/docs/superpowers/plans/2026-06-02-tv-library-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-02-tv-library-disambiguation.md
@@ -1,0 +1,1654 @@
+# TV Library Disambiguation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give TV library organization the same year/tmdb-id folder disambiguation movies already get, so same-name shows (Frasier 1993 #3452 vs the 2023 revival #195241) coexist on disk instead of colliding.
+
+**Architecture:** A new opt-in config format string (`naming_tv_show_format`, default `"{show}"` = current behavior) drives a `format_tv_show_folder` helper that both `organize_tv_episode` and `organize_tv_extras` use to build the show directory. The first-air year is persisted on `DiscJob.tmdb_year` at identification time (no-network fast path via the existing `candidates_json`, cached-TMDB fallback) and threaded to the organizer alongside the already-threaded `tmdb_id`. Three finalization call sites are updated in lockstep.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLModel/SQLite, pytest; React 18 + TypeScript (ConfigWizard). Backend commands use `uv run`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md`
+
+**Working dir note:** All paths are repo-relative. Run backend commands from `backend/`, frontend from `frontend/`. This branch is a worktree; edit only within it.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `backend/app/core/organizer.py` | Naming/format helpers + TV organize functions | Add placeholder sets, `_strip_empty_name_groups`, `format_tv_show_folder`; extend `format_episode_filename`; thread `year`/`tmdb_id` through `organize_tv_episode`, `organize_tv_extras`, `TVOrganizer.organize` |
+| `backend/app/models/app_config.py` | Persisted config | Add `naming_tv_show_format` (with `server_default`) |
+| `backend/app/api/routes.py` | Config REST + validation | Add field to `ConfigResponse`, GET constructor, `ConfigUpdate`, and the format-validation table |
+| `backend/app/models/disc_job.py` | Job state | Add `tmdb_year` column |
+| `backend/app/services/identification_coordinator.py` | Identify → persist metadata | Add `_resolve_show_year`; set `job.tmdb_year` at 3 sites |
+| `backend/app/services/finalization_coordinator.py` | Organize matched titles | Pass `year`/`tmdb_id` at 3 TV-organize sites |
+| `frontend/src/components/ConfigWizard.tsx` | Settings UI | Add Show Folder Format field (interface, defaults, read/write, input) |
+| `backend/tests/unit/test_organizer.py` | Organizer unit tests | New helper + disambiguation tests |
+| `backend/tests/unit/test_resolve_show_year.py` | Year-resolver unit test | New file |
+| `backend/tests/pipeline/test_organization_paths.py` | Pipeline path tests | Coexistence test + default-unchanged guard |
+
+---
+
+## Task 1: Organizer naming helpers + placeholder sets
+
+**Files:**
+- Modify: `backend/app/core/organizer.py:15-17` (placeholder sets), `:29-35` (`format_episode_filename`), after `:46` (new helpers)
+- Test: `backend/tests/unit/test_organizer.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_organizer.py`:
+
+```python
+class TestNamingHelpers:
+    """format_tv_show_folder, widened placeholders, episode-filename year."""
+
+    def test_show_folder_plex_full(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", 1993, "3452") == "Frasier (1993) {tmdb-3452}"
+
+    def test_show_folder_jellyfin_full(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) [tmdbid-{tmdb_id}]"
+        assert (
+            format_tv_show_folder(fmt, "Frasier", 2023, "195241")
+            == "Frasier (2023) [tmdbid-195241]"
+        )
+
+    def test_show_folder_missing_year_keeps_id(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", None, "3452") == "Frasier {tmdb-3452}"
+
+    def test_show_folder_jellyfin_missing_id_strips_tag(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) [tmdbid-{tmdb_id}]"
+        assert format_tv_show_folder(fmt, "Frasier", 1993, None) == "Frasier (1993)"
+
+    def test_show_folder_missing_both_is_bare(self):
+        from app.core.organizer import format_tv_show_folder
+
+        fmt = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        assert format_tv_show_folder(fmt, "Frasier", None, None) == "Frasier"
+
+    def test_show_folder_default_is_bare(self):
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("{show}", "Frasier", 1993, "3452") == "Frasier"
+
+    def test_show_folder_empty_format_falls_back_to_bare(self):
+        # Existing DBs may have backfilled '' for this column; degrade, don't break.
+        from app.core.organizer import format_tv_show_folder
+
+        assert format_tv_show_folder("", "Frasier", 1993, "3452") == "Frasier"
+
+    def test_episode_filename_with_year(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} ({year}) - S{season:02d}E{episode:02d}", "Frasier", 1, 2, year=1993
+        )
+        assert out == "Frasier (1993) - S01E02"
+
+    def test_episode_filename_year_missing_strips_parens(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename(
+            "{show} ({year}) - S{season:02d}E{episode:02d}", "Frasier", 1, 2, year=None
+        )
+        assert out == "Frasier - S01E02"
+
+    def test_episode_filename_default_unchanged(self):
+        from app.core.organizer import format_episode_filename
+
+        out = format_episode_filename("{show} - S{season:02d}E{episode:02d}", "Frasier", 1, 2)
+        assert out == "Frasier - S01E02"
+
+    def test_placeholder_sets_validate(self):
+        from app.core.organizer import (
+            ALLOWED_EPISODE_PLACEHOLDERS,
+            ALLOWED_TV_SHOW_PLACEHOLDERS,
+            validate_naming_format,
+        )
+
+        assert ALLOWED_TV_SHOW_PLACEHOLDERS == {"show", "year", "tmdb_id"}
+        assert {"year", "tmdb_id"} <= ALLOWED_EPISODE_PLACEHOLDERS
+        assert (
+            validate_naming_format(
+                "{show} ({year}) {{tmdb-{tmdb_id}}}", ALLOWED_TV_SHOW_PLACEHOLDERS
+            )
+            is None
+        )
+        assert (
+            validate_naming_format(
+                "{show} ({year}) [tmdbid-{tmdb_id}]", ALLOWED_TV_SHOW_PLACEHOLDERS
+            )
+            is None
+        )
+        assert (
+            validate_naming_format(
+                "{show} ({year}) - S{season:02d}E{episode:02d}", ALLOWED_EPISODE_PLACEHOLDERS
+            )
+            is None
+        )
+        # Unknown placeholder still rejected.
+        assert validate_naming_format("{bogus}", ALLOWED_TV_SHOW_PLACEHOLDERS) is not None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_organizer.py::TestNamingHelpers -q`
+Expected: FAIL with `ImportError: cannot import name 'format_tv_show_folder'` (and `ALLOWED_TV_SHOW_PLACEHOLDERS`).
+
+- [ ] **Step 3: Add the placeholder sets**
+
+In `backend/app/core/organizer.py`, replace lines 15-17:
+
+```python
+# Allowed placeholders for naming format strings
+ALLOWED_TV_PLACEHOLDERS = {"show", "season", "episode"}
+ALLOWED_MOVIE_PLACEHOLDERS = {"title", "year"}
+```
+
+with:
+
+```python
+# Allowed placeholders for naming format strings
+ALLOWED_TV_PLACEHOLDERS = {"show", "season", "episode"}  # season folder format
+# Show *folder* format — adds year/tmdb_id for same-name disambiguation
+# (Plex "{tmdb-NNNN}" / Jellyfin "[tmdbid-NNNN]").
+ALLOWED_TV_SHOW_PLACEHOLDERS = {"show", "year", "tmdb_id"}
+# Episode *filename* format — widened so the year can opt into the filename too.
+ALLOWED_EPISODE_PLACEHOLDERS = {"show", "season", "episode", "year", "tmdb_id"}
+ALLOWED_MOVIE_PLACEHOLDERS = {"title", "year"}
+```
+
+- [ ] **Step 4: Extend `format_episode_filename`**
+
+Replace lines 29-35:
+
+```python
+def format_episode_filename(fmt: str, show: str, season: int, episode: int) -> str:
+    """Format an episode filename from a config format string."""
+    try:
+        result = fmt.format(show=show, season=season, episode=episode)
+    except (KeyError, ValueError, IndexError):
+        result = f"{show} - S{season:02d}E{episode:02d}"
+    return sanitize_filename(result)
+```
+
+with:
+
+```python
+def format_episode_filename(
+    fmt: str,
+    show: str,
+    season: int,
+    episode: int,
+    *,
+    year: int | None = None,
+    tmdb_id: str | int | None = None,
+) -> str:
+    """Format an episode filename from a config format string.
+
+    ``year``/``tmdb_id`` are optional placeholders ({year}, {tmdb_id}). When the
+    chosen format omits them they are ignored; when year is missing, an empty
+    ``()`` left behind is stripped (mirrors ``format_movie_folder``). The default
+    format ("{show} - SxxExx") is unaffected.
+    """
+    try:
+        result = fmt.format(
+            show=show,
+            season=season,
+            episode=episode,
+            year=year or "",
+            tmdb_id=tmdb_id or "",
+        )
+    except (KeyError, ValueError, IndexError):
+        result = f"{show} - S{season:02d}E{episode:02d}"
+    result = re.sub(r"\(\s*\)", "", result)
+    result = re.sub(r"\s+", " ", result).strip()
+    return sanitize_filename(result)
+```
+
+- [ ] **Step 5: Add `_strip_empty_name_groups` and `format_tv_show_folder`**
+
+Insert after `format_movie_folder` (after line 46, before `def validate_naming_format`):
+
+```python
+def _strip_empty_name_groups(name: str) -> str:
+    """Remove empty (), {..-}, [..-] groups left when year/tmdb_id are absent.
+
+    e.g. "Frasier () {tmdb-}" -> "Frasier". A populated tag like "{tmdb-3452}"
+    is preserved (the char before '}' is a digit, not '-').
+    """
+    name = re.sub(r"\(\s*\)", "", name)  # empty parens
+    name = re.sub(r"\{[^{}]*-\s*\}", "", name)  # empty Plex tag, e.g. {tmdb-}
+    name = re.sub(r"\[[^\[\]]*-\s*\]", "", name)  # empty Jellyfin tag, e.g. [tmdbid-]
+    return re.sub(r"\s+", " ", name).strip()
+
+
+def format_tv_show_folder(
+    fmt: str, show: str, year: int | None, tmdb_id: str | int | None
+) -> str:
+    """Format the show *directory* name from a config format string.
+
+    Mirrors ``format_movie_folder`` but adds a ``{tmdb_id}`` placeholder for
+    media-server disambiguation (Plex ``{tmdb-NNNN}`` / Jellyfin ``[tmdbid-NNNN]``).
+    Empty groups are stripped when year/id are missing, so the stable id tag never
+    degrades to ``Frasier {tmdb-}``. A falsy/empty ``fmt`` (e.g. an existing DB that
+    backfilled '') falls back to the bare show name == current behavior.
+    """
+    if not fmt:
+        return sanitize_filename(show)
+    try:
+        result = fmt.format(show=show, year=year or "", tmdb_id=tmdb_id or "")
+    except (KeyError, ValueError, IndexError):
+        result = show
+    return sanitize_filename(_strip_empty_name_groups(result))
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_organizer.py::TestNamingHelpers -q`
+Expected: PASS (all 11 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/core/organizer.py backend/tests/unit/test_organizer.py
+git commit -m "feat(organizer): add format_tv_show_folder + year/tmdb_id placeholders"
+```
+
+---
+
+## Task 2: Add `naming_tv_show_format` config field (model)
+
+**Files:**
+- Modify: `backend/app/models/app_config.py:108-111`
+
+- [ ] **Step 1: Add the field with a server_default**
+
+In `backend/app/models/app_config.py`, replace lines 108-111:
+
+```python
+    # Naming conventions (Python format strings)
+    naming_season_format: str = "Season {season:02d}"
+    naming_episode_format: str = "{show} - S{season:02d}E{episode:02d}"
+    naming_movie_format: str = "{title} ({year})"
+```
+
+with:
+
+```python
+    # Naming conventions (Python format strings)
+    naming_season_format: str = "Season {season:02d}"
+    naming_episode_format: str = "{show} - S{season:02d}E{episode:02d}"
+    naming_movie_format: str = "{title} ({year})"
+    # Show *folder* format. Default "{show}" == today's bare-name behavior so
+    # existing libraries are untouched. server_default ensures EXISTING DBs get
+    # "{show}" (not the _add_missing_columns String fallback of '') when the
+    # column is added. Opt into disambiguation with e.g.
+    # "{show} ({year}) {{tmdb-{tmdb_id}}}" (Plex) or
+    # "{show} ({year}) [tmdbid-{tmdb_id}]" (Jellyfin).
+    naming_tv_show_format: str = Field(
+        default="{show}", sa_column_kwargs={"server_default": text("'{show}'")}
+    )
+```
+
+> `Field` and `text` are already imported in this file (used by `episode_ordering_preference` at line ~118). Confirm with: `grep -nE "^from sqlmodel|import text|from sqlalchemy" backend/app/models/app_config.py`.
+
+- [ ] **Step 2: Verify the model imports and default cleanly**
+
+Run: `uv run python -c "from app.models.app_config import AppConfig; c=AppConfig(); print(repr(c.naming_tv_show_format))"`
+Expected: `'{show}'`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/models/app_config.py
+git commit -m "feat(config): add naming_tv_show_format (default {show}, server_default)"
+```
+
+---
+
+## Task 3: Thread year/tmdb_id through the TV organize functions
+
+**Files:**
+- Modify: `backend/app/core/organizer.py` — `organize_tv_episode` (~363-447), `organize_tv_extras` (~472-523), `TVOrganizer.organize` (~549-572)
+- Test: `backend/tests/unit/test_organizer.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_organizer.py`:
+
+```python
+class TestTVDisambiguation:
+    """End-to-end folder building with the disambiguating format."""
+
+    @staticmethod
+    def _patch_cfg(**over):
+        from app.models.app_config import AppConfig
+
+        return patch(
+            "app.services.config_service.get_config_sync",
+            return_value=AppConfig(**over),
+        )
+
+    def test_same_name_twins_land_in_distinct_folders(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            s1 = tmp_path / "a.mkv"
+            s1.write_bytes(b"x")
+            r1 = organize_tv_episode(
+                s1, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+            s2 = tmp_path / "b.mkv"
+            s2.write_bytes(b"x")
+            r2 = organize_tv_episode(
+                s2, "Frasier", "S01E02", library_path=lib, tmdb_id="195241", year=2023
+            )
+        assert r1["success"] and r2["success"]
+        assert "Frasier (1993) {tmdb-3452}" in str(r1["final_path"])
+        assert "Frasier (2023) {tmdb-195241}" in str(r2["final_path"])
+        assert r1["final_path"] != r2["final_path"]
+
+    def test_default_format_keeps_bare_folder(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg():  # naming_tv_show_format defaults to "{show}"
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"] == lib / "Frasier" / "Season 01" / "Frasier - S01E02.mkv"
+
+    def test_missing_year_keeps_id_no_empty_parens(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=None
+            )
+        assert r["success"]
+        assert "Frasier {tmdb-3452}" in str(r["final_path"])
+        assert "()" not in str(r["final_path"])
+
+    def test_episode_filename_year_opt_in(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg(
+            naming_tv_show_format="{show} ({year}) {{tmdb-{tmdb_id}}}",
+            naming_episode_format="{show} ({year}) - S{season:02d}E{episode:02d}",
+        ):
+            s = tmp_path / "a.mkv"
+            s.write_bytes(b"x")
+            r = organize_tv_episode(
+                s, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"].name == "Frasier (1993) - S01E02.mkv"
+
+    def test_extras_share_show_folder_with_episode(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            ep = tmp_path / "e.mkv"
+            ep.write_bytes(b"x")
+            r_ep = organize_tv_episode(
+                ep, "Frasier", "S01E02", library_path=lib, tmdb_id="3452", year=1993
+            )
+            ex = tmp_path / "x.mkv"
+            ex.write_bytes(b"x")
+            r_ex = organize_tv_extras(
+                ex,
+                "Frasier",
+                season=1,
+                library_path=lib,
+                disc_number=1,
+                title_index=3,
+                tmdb_id="3452",
+                year=1993,
+            )
+        assert r_ep["success"] and r_ex["success"]
+        show_dir = str(lib / "Frasier (1993) {tmdb-3452}")
+        assert str(r_ep["final_path"]).startswith(show_dir)
+        assert str(r_ex["final_path"]).startswith(show_dir)
+        assert "Extras" in str(r_ex["final_path"])
+```
+
+> `organize_tv_extras` is not yet imported in this test file — add it to the top-of-file import: `from app.core.organizer import (clean_movie_name, organize_movie, organize_tv_episode, organize_tv_extras, sanitize_filename)` (it currently imports `organize_tv_episode` and `sanitize_filename`). `patch` is already imported.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_organizer.py::TestTVDisambiguation -q`
+Expected: FAIL — `organize_tv_episode() got an unexpected keyword argument 'year'`.
+
+- [ ] **Step 3: Update `organize_tv_episode`**
+
+In `backend/app/core/organizer.py`, change the signature (lines 369-372). Replace:
+
+```python
+    *,
+    tmdb_id: str | None = None,
+    ordering: str = "aired",
+    episode_group_id: str | None = None,
+) -> dict:
+```
+
+with:
+
+```python
+    *,
+    tmdb_id: str | None = None,
+    ordering: str = "aired",
+    episode_group_id: str | None = None,
+    year: int | None = None,
+) -> dict:
+```
+
+Then replace the folder/filename build block (lines 436-447):
+
+```python
+    # Clean and sanitize names
+    clean_show = sanitize_filename(show_name.strip())
+    season_folder = format_season_folder(cfg.naming_season_format, out_season)
+    ep_stem = format_episode_filename(
+        cfg.naming_episode_format, clean_show, out_season, out_episode
+    )
+    filename = f"{ep_stem}.mkv"
+
+    # Build destination path
+    library_path = Path(library_path)
+    dest_dir = library_path / clean_show / season_folder
+    dest_file = dest_dir / filename
+```
+
+with:
+
+```python
+    # Clean and sanitize names
+    clean_show = sanitize_filename(show_name.strip())
+    show_folder = format_tv_show_folder(cfg.naming_tv_show_format, clean_show, year, tmdb_id)
+    season_folder = format_season_folder(cfg.naming_season_format, out_season)
+    ep_stem = format_episode_filename(
+        cfg.naming_episode_format,
+        clean_show,
+        out_season,
+        out_episode,
+        year=year,
+        tmdb_id=tmdb_id,
+    )
+    filename = f"{ep_stem}.mkv"
+
+    # Build destination path. The show folder may carry year/tmdb-id so same-name
+    # shows (Frasier 1993 vs 2023) coexist; default "{show}" == bare clean_show.
+    library_path = Path(library_path)
+    dest_dir = library_path / show_folder / season_folder
+    dest_file = dest_dir / filename
+```
+
+- [ ] **Step 4: Update `organize_tv_extras`**
+
+Replace the signature (lines 472-480):
+
+```python
+def organize_tv_extras(
+    source_file: Path,
+    show_name: str,
+    season: int,
+    library_path: Path | None = None,
+    disc_number: int = 1,
+    extra_index: int = 1,
+    title_index: int | None = None,
+) -> dict:
+```
+
+with:
+
+```python
+def organize_tv_extras(
+    source_file: Path,
+    show_name: str,
+    season: int,
+    library_path: Path | None = None,
+    disc_number: int = 1,
+    extra_index: int = 1,
+    title_index: int | None = None,
+    *,
+    year: int | None = None,
+    tmdb_id: str | int | None = None,
+) -> dict:
+```
+
+Then replace the folder build (lines 512-523):
+
+```python
+    # Clean and sanitize names
+    clean_show = sanitize_filename(show_name.strip())
+    season_folder = format_season_folder(cfg.naming_season_format, season)
+
+    if title_index is not None:
+        extra_name = f"{clean_show} Disc {disc_number} Extra t{title_index:02d}.mkv"
+    else:
+        extra_name = f"{clean_show} Disc {disc_number} Extra {extra_index}.mkv"
+
+    # Build destination path
+    library_path = Path(library_path)
+    dest_dir = library_path / clean_show / season_folder / "Extras"
+    dest_file = dest_dir / extra_name
+```
+
+with:
+
+```python
+    # Clean and sanitize names
+    clean_show = sanitize_filename(show_name.strip())
+    # Use the SAME disambiguated show folder as organize_tv_episode so an extra
+    # and its episodes land under one show folder (TV-organize-paths-sync hazard).
+    show_folder = format_tv_show_folder(cfg.naming_tv_show_format, clean_show, year, tmdb_id)
+    season_folder = format_season_folder(cfg.naming_season_format, season)
+
+    if title_index is not None:
+        extra_name = f"{clean_show} Disc {disc_number} Extra t{title_index:02d}.mkv"
+    else:
+        extra_name = f"{clean_show} Disc {disc_number} Extra {extra_index}.mkv"
+
+    # Build destination path
+    library_path = Path(library_path)
+    dest_dir = library_path / show_folder / season_folder / "Extras"
+    dest_file = dest_dir / extra_name
+```
+
+- [ ] **Step 5: Update `TVOrganizer.organize` to forward `year`**
+
+Replace the method signature and body (lines 549-572). Replace:
+
+```python
+    def organize(
+        self,
+        source_file: Path,
+        show_name: str,
+        episode_code: str,
+        *,
+        tmdb_id: str | None = None,
+        ordering: str = "aired",
+        episode_group_id: str | None = None,
+    ) -> dict:
+        """Organize a TV episode from staging to library.
+
+        Forwards the output-ordering controls to organize_tv_episode so the
+        library-mode path (no explicit library_path) also honors the chosen
+        ordering. episode_code stays canonical; only the filename is projected.
+        """
+        return organize_tv_episode(
+            source_file,
+            show_name,
+            episode_code,
+            tmdb_id=tmdb_id,
+            ordering=ordering,
+            episode_group_id=episode_group_id,
+        )
+```
+
+with:
+
+```python
+    def organize(
+        self,
+        source_file: Path,
+        show_name: str,
+        episode_code: str,
+        *,
+        tmdb_id: str | None = None,
+        ordering: str = "aired",
+        episode_group_id: str | None = None,
+        year: int | None = None,
+    ) -> dict:
+        """Organize a TV episode from staging to library.
+
+        Forwards the output-ordering controls AND show disambiguation (year/tmdb_id)
+        to organize_tv_episode so the library-mode path (no explicit library_path)
+        also honors them. episode_code stays canonical; only the filename is projected.
+        """
+        return organize_tv_episode(
+            source_file,
+            show_name,
+            episode_code,
+            tmdb_id=tmdb_id,
+            ordering=ordering,
+            episode_group_id=episode_group_id,
+            year=year,
+        )
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_organizer.py -q`
+Expected: PASS (TestTVDisambiguation + all pre-existing organizer tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/core/organizer.py backend/tests/unit/test_organizer.py
+git commit -m "feat(organizer): build disambiguated TV show folder from year/tmdb_id"
+```
+
+---
+
+## Task 4: Config three-way sync + validation (routes.py)
+
+**Files:**
+- Modify: `backend/app/api/routes.py:291-293` (`ConfigResponse`), `:369-371` (`ConfigUpdate`), `:1141-1143` (GET constructor), `:1248-1258` (validation imports + table)
+
+- [ ] **Step 1: Add to `ConfigResponse`**
+
+In `backend/app/api/routes.py`, replace lines 291-293:
+
+```python
+    naming_season_format: str
+    naming_episode_format: str
+    naming_movie_format: str
+```
+
+with:
+
+```python
+    naming_season_format: str
+    naming_episode_format: str
+    naming_movie_format: str
+    naming_tv_show_format: str
+```
+
+- [ ] **Step 2: Add to `ConfigUpdate`**
+
+Replace lines 369-371:
+
+```python
+    naming_season_format: str | None = None
+    naming_episode_format: str | None = None
+    naming_movie_format: str | None = None
+```
+
+with:
+
+```python
+    naming_season_format: str | None = None
+    naming_episode_format: str | None = None
+    naming_movie_format: str | None = None
+    naming_tv_show_format: str | None = None
+```
+
+- [ ] **Step 3: Add to the GET-config constructor**
+
+Replace lines 1141-1143:
+
+```python
+        naming_season_format=config.naming_season_format,
+        naming_episode_format=config.naming_episode_format,
+        naming_movie_format=config.naming_movie_format,
+```
+
+with:
+
+```python
+        naming_season_format=config.naming_season_format,
+        naming_episode_format=config.naming_episode_format,
+        naming_movie_format=config.naming_movie_format,
+        naming_tv_show_format=config.naming_tv_show_format,
+```
+
+- [ ] **Step 4: Update the validation imports + table**
+
+Replace lines 1248-1258:
+
+```python
+    from app.core.organizer import (
+        ALLOWED_MOVIE_PLACEHOLDERS,
+        ALLOWED_TV_PLACEHOLDERS,
+        validate_naming_format,
+    )
+
+    format_checks = [
+        ("naming_season_format", ALLOWED_TV_PLACEHOLDERS),
+        ("naming_episode_format", ALLOWED_TV_PLACEHOLDERS),
+        ("naming_movie_format", ALLOWED_MOVIE_PLACEHOLDERS),
+    ]
+```
+
+with:
+
+```python
+    from app.core.organizer import (
+        ALLOWED_EPISODE_PLACEHOLDERS,
+        ALLOWED_MOVIE_PLACEHOLDERS,
+        ALLOWED_TV_PLACEHOLDERS,
+        ALLOWED_TV_SHOW_PLACEHOLDERS,
+        validate_naming_format,
+    )
+
+    format_checks = [
+        ("naming_season_format", ALLOWED_TV_PLACEHOLDERS),
+        ("naming_episode_format", ALLOWED_EPISODE_PLACEHOLDERS),
+        ("naming_movie_format", ALLOWED_MOVIE_PLACEHOLDERS),
+        ("naming_tv_show_format", ALLOWED_TV_SHOW_PLACEHOLDERS),
+    ]
+```
+
+- [ ] **Step 5: Verify the config round-trips through PUT → GET**
+
+Run:
+
+```bash
+uv run python -c "
+import asyncio
+from httpx import ASGITransport, AsyncClient
+from app.main import app
+from app.database import init_db
+
+async def main():
+    await init_db()
+    t = ASGITransport(app=app)
+    async with AsyncClient(transport=t, base_url='http://test') as ac:
+        plex = '{show} ({year}) {{tmdb-{tmdb_id}}}'
+        r = await ac.put('/api/config', json={'naming_tv_show_format': plex})
+        print('PUT', r.status_code)
+        g = await ac.get('/api/config')
+        print('GET value:', g.json().get('naming_tv_show_format'))
+        bad = await ac.put('/api/config', json={'naming_tv_show_format': '{bogus}'})
+        print('BAD status:', bad.status_code)
+
+asyncio.run(main())
+"
+```
+
+Expected: `PUT 200`, `GET value: {show} ({year}) {{tmdb-{tmdb_id}}}` (the stored value keeps
+its doubled braces — it is the raw format string, not the rendered folder name), `BAD status: 400`.
+(This proves the three-way sync — model ↔ ConfigUpdate ↔ ConfigResponse — and validation.)
+
+> **Note:** this writes to the worktree's `backend/engram.db`. That's fine — it only changes a naming format. If the DB lacks the `app_config` table, `init_db()` creates it (worktree-empty-DB hazard).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/routes.py
+git commit -m "feat(config): wire naming_tv_show_format through REST + validation"
+```
+
+---
+
+## Task 5: Persist `tmdb_year` + resolver helper
+
+**Files:**
+- Modify: `backend/app/models/disc_job.py:64-65` (add column)
+- Modify: `backend/app/services/identification_coordinator.py` — add `_resolve_show_year` (near `_candidates_json_from_signal`, ~line 71); set `job.tmdb_year` at `:200-202`, `:555-559`, `:828-848`
+- Test: `backend/tests/unit/test_resolve_show_year.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_resolve_show_year.py`:
+
+```python
+"""Unit tests for identification year resolution."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.services.identification_coordinator import _resolve_show_year
+
+
+def test_none_tmdb_id_returns_none():
+    assert _resolve_show_year(None) is None
+
+
+def test_fast_path_reads_year_from_candidates():
+    sig = SimpleNamespace(
+        all_candidates=[
+            {"tmdb_id": 3452, "name": "Frasier", "year": "1993", "popularity": 50.0},
+            {"tmdb_id": 195241, "name": "Frasier", "year": "2023", "popularity": 30.0},
+        ]
+    )
+    assert _resolve_show_year(3452, sig) == 1993
+    assert _resolve_show_year(195241, sig) == 2023
+
+
+def test_fallback_to_tmdb_details_when_no_candidates():
+    with patch(
+        "app.matcher.tmdb_client.fetch_show_details",
+        return_value={"first_air_date": "1993-09-16"},
+    ):
+        assert _resolve_show_year(3452, None) == 1993
+
+
+def test_returns_none_when_details_missing():
+    with patch("app.matcher.tmdb_client.fetch_show_details", return_value=None):
+        assert _resolve_show_year(3452, None) is None
+
+
+def test_candidate_year_blank_falls_through_to_details():
+    sig = SimpleNamespace(all_candidates=[{"tmdb_id": 3452, "year": ""}])
+    with patch(
+        "app.matcher.tmdb_client.fetch_show_details",
+        return_value={"first_air_date": "1993-09-16"},
+    ):
+        assert _resolve_show_year(3452, sig) == 1993
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_resolve_show_year.py -q`
+Expected: FAIL — `ImportError: cannot import name '_resolve_show_year'`.
+
+- [ ] **Step 3: Add the `tmdb_year` column**
+
+In `backend/app/models/disc_job.py`, replace lines 64-65:
+
+```python
+    tmdb_id: int | None = Field(default=None)
+    tmdb_name: str | None = Field(default=None)
+```
+
+with:
+
+```python
+    tmdb_id: int | None = Field(default=None)
+    tmdb_name: str | None = Field(default=None)
+    # First-air year for the resolved show; persisted at identify time so the
+    # organizer can build a disambiguated library folder (Frasier 1993 vs 2023)
+    # deterministically and offline. Nullable — degrades to id-only/bare folder.
+    tmdb_year: int | None = Field(default=None)
+```
+
+- [ ] **Step 4: Add the `_resolve_show_year` helper**
+
+In `backend/app/services/identification_coordinator.py`, add after `_candidates_json_from_signal` (after line 71, before `class IdentificationCoordinator`):
+
+```python
+def _resolve_show_year(tmdb_id: int | None, signal=None) -> int | None:
+    """First-air year for a show, for library-folder disambiguation.
+
+    No-network fast path: same-name candidates already carry a 'year' string
+    (Frasier 1993 vs 2023). Universal fallback: cached TMDB details. Returns
+    None when unknown — the organizer then degrades to an id-only/bare folder.
+    Sync (blocking on the fallback) — call via ``asyncio.to_thread``.
+    """
+    if not tmdb_id:
+        return None
+    cands = getattr(signal, "all_candidates", None) if signal else None
+    for c in cands or []:
+        if c.get("tmdb_id") == tmdb_id:
+            y = (c.get("year") or "").strip()
+            if y.isdigit():
+                return int(y)
+    from app.matcher.tmdb_client import fetch_show_details
+
+    details = fetch_show_details(tmdb_id)
+    if details:
+        fa = (details.get("first_air_date") or "")[:4]
+        if fa.isdigit():
+            return int(fa)
+    return None
+```
+
+> Confirm `import asyncio` is present at the top of this file: `grep -n "^import asyncio" backend/app/services/identification_coordinator.py`. It is used elsewhere in the file; if absent, add it.
+
+- [ ] **Step 5: Set `job.tmdb_year` at the main identify site**
+
+Replace lines 200-202:
+
+```python
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.candidates_json = _candidates_json_from_signal(tmdb_signal)
+```
+
+with:
+
+```python
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.candidates_json = _candidates_json_from_signal(tmdb_signal)
+                job.tmdb_year = await asyncio.to_thread(
+                    _resolve_show_year, analysis.tmdb_id, tmdb_signal
+                )
+```
+
+- [ ] **Step 6: Set `job.tmdb_year` at the staging-import site**
+
+Replace lines 555-559:
+
+```python
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                job.candidates_json = _candidates_json_from_signal(
+                    getattr(analysis, "_tmdb_signal", None)
+                )
+```
+
+with:
+
+```python
+                job.tmdb_id = analysis.tmdb_id
+                job.tmdb_name = analysis.tmdb_name
+                _signal = getattr(analysis, "_tmdb_signal", None)
+                job.candidates_json = _candidates_json_from_signal(_signal)
+                job.tmdb_year = await asyncio.to_thread(
+                    _resolve_show_year, analysis.tmdb_id, _signal
+                )
+```
+
+- [ ] **Step 7: Set `job.tmdb_year` at the re-identify site**
+
+Replace lines 828-848:
+
+```python
+            # Optionally re-run TMDB lookup with corrected title
+            if tmdb_id is not None:
+                job.tmdb_id = tmdb_id
+            else:
+                # Try TMDB search with the corrected title
+                try:
+                    from app.core.tmdb_classifier import classify_from_tmdb
+                    from app.services.config_service import get_config
+
+                    config = await get_config()
+                    if config.tmdb_api_key:
+                        signal = classify_from_tmdb(title, config.tmdb_api_key)
+                        if signal and signal.tmdb_id:
+                            job.tmdb_id = signal.tmdb_id
+                            if signal.tmdb_name:
+                                job.detected_title = signal.tmdb_name
+                except Exception:
+                    logger.warning(
+                        f"Job {job_id}: TMDB re-lookup failed for '{title}', "
+                        f"continuing with user-provided title"
+                    )
+```
+
+with:
+
+```python
+            # Optionally re-run TMDB lookup with corrected title
+            _signal = None
+            if tmdb_id is not None:
+                job.tmdb_id = tmdb_id
+            else:
+                # Try TMDB search with the corrected title
+                try:
+                    from app.core.tmdb_classifier import classify_from_tmdb
+                    from app.services.config_service import get_config
+
+                    config = await get_config()
+                    if config.tmdb_api_key:
+                        _signal = classify_from_tmdb(title, config.tmdb_api_key)
+                        if _signal and _signal.tmdb_id:
+                            job.tmdb_id = _signal.tmdb_id
+                            if _signal.tmdb_name:
+                                job.detected_title = _signal.tmdb_name
+                except Exception:
+                    logger.warning(
+                        f"Job {job_id}: TMDB re-lookup failed for '{title}', "
+                        f"continuing with user-provided title"
+                    )
+
+            # Re-derive the year for the (possibly changed) show so the library
+            # folder stays correct after re-identification.
+            job.tmdb_year = await asyncio.to_thread(_resolve_show_year, job.tmdb_id, _signal)
+```
+
+- [ ] **Step 8: Run the resolver test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_resolve_show_year.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 9: Verify the column is added cleanly on an existing DB**
+
+Run:
+
+```bash
+uv run python -c "
+import asyncio
+from app.database import init_db, async_session
+from sqlalchemy import text
+
+async def main():
+    await init_db()
+    async with async_session() as s:
+        rows = (await s.execute(text('PRAGMA table_info(disc_jobs)'))).fetchall()
+        cols = [r[1] for r in rows]
+        print('tmdb_year present:', 'tmdb_year' in cols)
+
+asyncio.run(main())
+"
+```
+
+Expected: `tmdb_year present: True`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend/app/models/disc_job.py backend/app/services/identification_coordinator.py backend/tests/unit/test_resolve_show_year.py
+git commit -m "feat(identify): persist tmdb_year (candidates fast-path + TMDB fallback)"
+```
+
+---
+
+## Task 6: Thread year/tmdb_id at the three finalization call sites
+
+**Files:**
+- Modify: `backend/app/services/finalization_coordinator.py` — `finalize_disc_job` (preamble :815, extras :839, episode :850, tv_organizer :861); `_finalize_tv_if_resolved` (preamble :1174, extras :1192, episode :1205, tv_organizer :1216); `process_matched_titles` (preamble :1360, extras :1378, episode :1391, tv_organizer :1402)
+
+> All three sites share an identical shape. For each: add `_tmdb_year = job.tmdb_year` beside the existing `_tmdb_id_str = …` line, then add `year=_tmdb_year` to the episode + tv_organizer calls and `tmdb_id=_tmdb_id_str, year=_tmdb_year` to the extras call.
+
+- [ ] **Step 1: `finalize_disc_job` — preamble (line 815)**
+
+> The bare `_tmdb_id_str = …` line is identical at sites 1 and 3 (same 12-space indent), so each preamble edit below includes its surrounding comment/`resolve_show_ordering` line to be a UNIQUE match. Site 1 is distinguished by its two-line comment; sites 2 and 3 differ by indentation (8 vs 12 spaces).
+
+Replace (note the site-1 comment wording, "Resolve the show's output ordering…"):
+
+```python
+            # Resolve the show's output ordering once for this sweep (#200).
+            # Canonical (aired) for the common case; projected to the filename only.
+            ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+            _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+```
+
+with:
+
+```python
+            # Resolve the show's output ordering once for this sweep (#200).
+            # Canonical (aired) for the common case; projected to the filename only.
+            ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+            _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+            _tmdb_year = job.tmdb_year
+```
+
+- [ ] **Step 2: `finalize_disc_job` — extras call (line 838-847)**
+
+Replace:
+
+```python
+                    org_result = await asyncio.to_thread(
+                        organize_tv_extras,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        job.detected_season or 1,
+                        library_path=_lib_path,
+                        disc_number=job.disc_number or 1,
+                        extra_index=extra_index,
+                        title_index=t.title_index,
+                    )
+```
+
+with:
+
+```python
+                    org_result = await asyncio.to_thread(
+                        organize_tv_extras,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        job.detected_season or 1,
+                        library_path=_lib_path,
+                        disc_number=job.disc_number or 1,
+                        extra_index=extra_index,
+                        title_index=t.title_index,
+                        tmdb_id=_tmdb_id_str,
+                        year=_tmdb_year,
+                    )
+```
+
+- [ ] **Step 3: `finalize_disc_job` — episode + tv_organizer calls (lines 849-868)**
+
+Replace:
+
+```python
+                elif _lib_path:
+                    org_result = await asyncio.to_thread(
+                        organize_tv_episode,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        t.matched_episode,
+                        _lib_path,
+                        tmdb_id=_tmdb_id_str,
+                        ordering=ordering,
+                        episode_group_id=ordering_group_id,
+                    )
+                else:
+                    org_result = await asyncio.to_thread(
+                        tv_organizer.organize,
+                        source_file,
+                        job.detected_title,
+                        t.matched_episode,
+                        tmdb_id=_tmdb_id_str,
+                        ordering=ordering,
+                        episode_group_id=ordering_group_id,
+                    )
+```
+
+with:
+
+```python
+                elif _lib_path:
+                    org_result = await asyncio.to_thread(
+                        organize_tv_episode,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        t.matched_episode,
+                        _lib_path,
+                        tmdb_id=_tmdb_id_str,
+                        ordering=ordering,
+                        episode_group_id=ordering_group_id,
+                        year=_tmdb_year,
+                    )
+                else:
+                    org_result = await asyncio.to_thread(
+                        tv_organizer.organize,
+                        source_file,
+                        job.detected_title,
+                        t.matched_episode,
+                        tmdb_id=_tmdb_id_str,
+                        ordering=ordering,
+                        episode_group_id=ordering_group_id,
+                        year=_tmdb_year,
+                    )
+```
+
+- [ ] **Step 4: `_finalize_tv_if_resolved` — preamble (line 1174)**
+
+Replace (8-space indent — this is the only site at this indentation):
+
+```python
+        # Resolve output ordering once for this sweep (#200); filename-only projection.
+        ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+        _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+```
+
+with:
+
+```python
+        # Resolve output ordering once for this sweep (#200); filename-only projection.
+        ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+        _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+        _tmdb_year = job.tmdb_year
+```
+
+- [ ] **Step 5: `_finalize_tv_if_resolved` — extras call (lines 1191-1200)**
+
+Replace:
+
+```python
+                        org_result = await asyncio.to_thread(
+                            organize_tv_extras,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            job.detected_season or 1,
+                            library_path=_lib_path,
+                            disc_number=job.disc_number or 1,
+                            extra_index=extra_index,
+                            title_index=disc_title.title_index,
+                        )
+```
+
+with:
+
+```python
+                        org_result = await asyncio.to_thread(
+                            organize_tv_extras,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            job.detected_season or 1,
+                            library_path=_lib_path,
+                            disc_number=job.disc_number or 1,
+                            extra_index=extra_index,
+                            title_index=disc_title.title_index,
+                            tmdb_id=_tmdb_id_str,
+                            year=_tmdb_year,
+                        )
+```
+
+- [ ] **Step 6: `_finalize_tv_if_resolved` — episode + tv_organizer calls (lines 1203-1223)**
+
+Replace:
+
+```python
+                        if _lib_path:
+                            org_result = await asyncio.to_thread(
+                                organize_tv_episode,
+                                source_file,
+                                job.detected_title or job.volume_label,
+                                disc_title.matched_episode,
+                                _lib_path,
+                                tmdb_id=_tmdb_id_str,
+                                ordering=ordering,
+                                episode_group_id=ordering_group_id,
+                            )
+                        else:
+                            org_result = await asyncio.to_thread(
+                                tv_organizer.organize,
+                                source_file,
+                                job.detected_title or job.volume_label,
+                                disc_title.matched_episode,
+                                tmdb_id=_tmdb_id_str,
+                                ordering=ordering,
+                                episode_group_id=ordering_group_id,
+                            )
+```
+
+with:
+
+```python
+                        if _lib_path:
+                            org_result = await asyncio.to_thread(
+                                organize_tv_episode,
+                                source_file,
+                                job.detected_title or job.volume_label,
+                                disc_title.matched_episode,
+                                _lib_path,
+                                tmdb_id=_tmdb_id_str,
+                                ordering=ordering,
+                                episode_group_id=ordering_group_id,
+                                year=_tmdb_year,
+                            )
+                        else:
+                            org_result = await asyncio.to_thread(
+                                tv_organizer.organize,
+                                source_file,
+                                job.detected_title or job.volume_label,
+                                disc_title.matched_episode,
+                                tmdb_id=_tmdb_id_str,
+                                ordering=ordering,
+                                episode_group_id=ordering_group_id,
+                                year=_tmdb_year,
+                            )
+```
+
+- [ ] **Step 7: `process_matched_titles` — preamble (line 1360)**
+
+Replace (12-space indent + the "filename-only projection" comment — distinguishes it from site 1, whose comment differs):
+
+```python
+            # Resolve output ordering once for this sweep (#200); filename-only projection.
+            ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+            _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+```
+
+with:
+
+```python
+            # Resolve output ordering once for this sweep (#200); filename-only projection.
+            ordering, ordering_group_id = await resolve_show_ordering(job.tmdb_id, session)
+            _tmdb_id_str = str(job.tmdb_id) if job.tmdb_id else None
+            _tmdb_year = job.tmdb_year
+```
+
+- [ ] **Step 8: `process_matched_titles` — extras call (lines 1377-1386)**
+
+Replace:
+
+```python
+                    org_result = await asyncio.to_thread(
+                        organize_tv_extras,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        job.detected_season or 1,
+                        library_path=_lib_path,
+                        disc_number=job.disc_number or 1,
+                        extra_index=extra_index,
+                        title_index=disc_title.title_index,
+                    )
+```
+
+with:
+
+```python
+                    org_result = await asyncio.to_thread(
+                        organize_tv_extras,
+                        source_file,
+                        job.detected_title or job.volume_label,
+                        job.detected_season or 1,
+                        library_path=_lib_path,
+                        disc_number=job.disc_number or 1,
+                        extra_index=extra_index,
+                        title_index=disc_title.title_index,
+                        tmdb_id=_tmdb_id_str,
+                        year=_tmdb_year,
+                    )
+```
+
+- [ ] **Step 9: `process_matched_titles` — episode + tv_organizer calls (lines 1389-1409)**
+
+Replace:
+
+```python
+                    if _lib_path:
+                        org_result = await asyncio.to_thread(
+                            organize_tv_episode,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                            _lib_path,
+                            tmdb_id=_tmdb_id_str,
+                            ordering=ordering,
+                            episode_group_id=ordering_group_id,
+                        )
+                    else:
+                        org_result = await asyncio.to_thread(
+                            tv_organizer.organize,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                            tmdb_id=_tmdb_id_str,
+                            ordering=ordering,
+                            episode_group_id=ordering_group_id,
+                        )
+```
+
+with:
+
+```python
+                    if _lib_path:
+                        org_result = await asyncio.to_thread(
+                            organize_tv_episode,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                            _lib_path,
+                            tmdb_id=_tmdb_id_str,
+                            ordering=ordering,
+                            episode_group_id=ordering_group_id,
+                            year=_tmdb_year,
+                        )
+                    else:
+                        org_result = await asyncio.to_thread(
+                            tv_organizer.organize,
+                            source_file,
+                            job.detected_title or job.volume_label,
+                            disc_title.matched_episode,
+                            tmdb_id=_tmdb_id_str,
+                            ordering=ordering,
+                            episode_group_id=ordering_group_id,
+                            year=_tmdb_year,
+                        )
+```
+
+- [ ] **Step 10: Verify it imports and existing finalization tests pass**
+
+Run: `uv run python -c "import app.services.finalization_coordinator"`
+Expected: no error.
+
+Run: `uv run pytest tests/pipeline/ tests/integration/ -q -k "tv or organiz or finaliz or extra"`
+Expected: PASS (no regressions). If a pre-existing unrelated failure appears (`test_movie_ambiguous_rip_first_workflow` is a known flaky staging-cleanup race per project memory), note it and continue.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/app/services/finalization_coordinator.py
+git commit -m "feat(finalization): pass year+tmdb_id to all 3 TV-organize sites"
+```
+
+---
+
+## Task 7: ConfigWizard — Show Folder Format field
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx:70-72` (interface), `:139-141` (defaults), `:234-236` (read), `:374-376` (write), after `:1368` (input)
+
+- [ ] **Step 1: Add to the config interface**
+
+In `frontend/src/components/ConfigWizard.tsx`, replace lines 70-72:
+
+```tsx
+    namingSeasonFormat: string;
+    namingEpisodeFormat: string;
+    namingMovieFormat: string;
+```
+
+with:
+
+```tsx
+    namingSeasonFormat: string;
+    namingEpisodeFormat: string;
+    namingMovieFormat: string;
+    namingTvShowFormat: string;
+```
+
+- [ ] **Step 2: Add to the defaults object**
+
+Replace lines 139-141:
+
+```tsx
+        namingSeasonFormat: 'Season {season:02d}',
+        namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
+        namingMovieFormat: '{title} ({year})',
+```
+
+with:
+
+```tsx
+        namingSeasonFormat: 'Season {season:02d}',
+        namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
+        namingMovieFormat: '{title} ({year})',
+        namingTvShowFormat: '{show}',
+```
+
+- [ ] **Step 3: Add to the read mapping (GET → state)**
+
+Replace lines 234-236:
+
+```tsx
+                    namingSeasonFormat: data.naming_season_format || 'Season {season:02d}',
+                    namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
+                    namingMovieFormat: data.naming_movie_format || '{title} ({year})',
+```
+
+with:
+
+```tsx
+                    namingSeasonFormat: data.naming_season_format || 'Season {season:02d}',
+                    namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
+                    namingMovieFormat: data.naming_movie_format || '{title} ({year})',
+                    namingTvShowFormat: data.naming_tv_show_format || '{show}',
+```
+
+- [ ] **Step 4: Add to the write mapping (state → PUT)**
+
+Replace lines 374-376:
+
+```tsx
+                    naming_season_format: config.namingSeasonFormat,
+                    naming_episode_format: config.namingEpisodeFormat,
+                    naming_movie_format: config.namingMovieFormat,
+```
+
+with:
+
+```tsx
+                    naming_season_format: config.namingSeasonFormat,
+                    naming_episode_format: config.namingEpisodeFormat,
+                    naming_movie_format: config.namingMovieFormat,
+                    naming_tv_show_format: config.namingTvShowFormat,
+```
+
+- [ ] **Step 5: Add the input field (always visible, opt-in)**
+
+Replace the closing of the Naming Convention form-group + hint (lines 1365-1368):
+
+```tsx
+                            <span className="form-hint">
+                                Preview: TV/{config.namingSeasonFormat.replace('{season:02d}', '01').replace('{season:d}', '1')}/{config.namingEpisodeFormat.replace('{show}', 'Breaking Bad').replace('{season:02d}', '01').replace('{season:d}', '1').replace('{episode:02d}', '05').replace('{episode:d}', '5')}.mkv
+                            </span>
+                        </div>
+```
+
+with:
+
+```tsx
+                            <span className="form-hint">
+                                Preview: TV/{config.namingSeasonFormat.replace('{season:02d}', '01').replace('{season:d}', '1')}/{config.namingEpisodeFormat.replace('{show}', 'Breaking Bad').replace('{season:02d}', '01').replace('{season:d}', '1').replace('{episode:02d}', '05').replace('{episode:d}', '5')}.mkv
+                            </span>
+                        </div>
+
+                        <div className="form-group">
+                            <label htmlFor="namingTvShowFormat">Show Folder Format</label>
+                            <input
+                                id="namingTvShowFormat"
+                                type="text"
+                                value={config.namingTvShowFormat}
+                                onChange={(e) => handleInputChange('namingTvShowFormat', e.target.value)}
+                                placeholder="{show}"
+                            />
+                            <span className="form-hint">
+                                Placeholders: {'{show}'}, {'{year}'}, {'{tmdb_id}'}. Default{' '}
+                                {'{show}'} keeps your current folders. To let same-name shows
+                                coexist (e.g. Frasier 1993 vs 2023), use Plex{' '}
+                                &quot;{'{show} ({year}) {{tmdb-{tmdb_id}}}'}&quot; or Jellyfin{' '}
+                                &quot;{'{show} ({year}) [tmdbid-{tmdb_id}]'}&quot;.
+                            </span>
+                        </div>
+```
+
+- [ ] **Step 6: Verify the frontend builds and lints**
+
+Run (from `frontend/`): `npm run build && npm run lint`
+Expected: build succeeds (TypeScript happy with the new `namingTvShowFormat` key), lint clean.
+
+> Worktree note (project memory): `frontend/node_modules` may be absent — run `npm install` first if build fails on missing deps. If `package-lock.json` changes, `git checkout` it before committing (it rewrites a stale lock).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/ConfigWizard.tsx
+git commit -m "feat(ui): add Show Folder Format setting to ConfigWizard"
+```
+
+---
+
+## Task 8: Pipeline org-path tests — coexistence + default guard
+
+**Files:**
+- Modify: `backend/tests/pipeline/test_organization_paths.py`
+
+- [ ] **Step 1: Write the failing/guard tests**
+
+Append to `backend/tests/pipeline/test_organization_paths.py`:
+
+```python
+@pytest.mark.pipeline
+class TestTVSameNameCoexistence:
+    """Same-name shows coexist when disambiguation is enabled; default unchanged."""
+
+    @staticmethod
+    def _patch_cfg(**over):
+        from unittest.mock import patch
+
+        from app.models.app_config import AppConfig
+
+        return patch(
+            "app.services.config_service.get_config_sync",
+            return_value=AppConfig(**over),
+        )
+
+    def test_frasier_twins_coexist(self, tmp_path):
+        lib = tmp_path / "tv"
+        plex = "{show} ({year}) {{tmdb-{tmdb_id}}}"
+        with self._patch_cfg(naming_tv_show_format=plex):
+            a = tmp_path / "staging" / "a.mkv"
+            a.parent.mkdir(parents=True, exist_ok=True)
+            a.write_bytes(b"x" * 1024)
+            r1 = organize_tv_episode(
+                a, "Frasier", "S01E01", library_path=lib, tmdb_id="3452", year=1993
+            )
+            b = tmp_path / "staging" / "b.mkv"
+            b.write_bytes(b"x" * 1024)
+            r2 = organize_tv_episode(
+                b, "Frasier", "S01E01", library_path=lib, tmdb_id="195241", year=2023
+            )
+        assert r1["success"] and r2["success"]
+        assert r1["final_path"].parent.parent.name == "Frasier (1993) {tmdb-3452}"
+        assert r2["final_path"].parent.parent.name == "Frasier (2023) {tmdb-195241}"
+        assert r1["final_path"] != r2["final_path"]
+
+    def test_default_format_unchanged_bare_folder(self, tmp_path):
+        lib = tmp_path / "tv"
+        with self._patch_cfg():  # default naming_tv_show_format == "{show}"
+            s = tmp_path / "staging" / "c.mkv"
+            s.parent.mkdir(parents=True, exist_ok=True)
+            s.write_bytes(b"x" * 1024)
+            r = organize_tv_episode(
+                s, "Frasier", "S01E01", library_path=lib, tmdb_id="3452", year=1993
+            )
+        assert r["success"]
+        assert r["final_path"].parent.parent.name == "Frasier"
+        assert r["final_path"].name == "Frasier - S01E01.mkv"
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `uv run pytest tests/pipeline/test_organization_paths.py::TestTVSameNameCoexistence -q`
+Expected: PASS (both tests).
+
+- [ ] **Step 3: Run the full pipeline org-path file (regression)**
+
+Run: `uv run pytest tests/pipeline/test_organization_paths.py -q`
+Expected: PASS (existing Picard/Arrested-Dev tests still green — they rely on `get_config_sync` defaults, so the worktree DB must have an `app_config` row; if they error with "no such table"/missing column, run `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first per the worktree-DB hazard).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/pipeline/test_organization_paths.py
+git commit -m "test(pipeline): same-name TV coexistence + default-folder guard"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint the backend**
+
+Run (from `backend/`): `uv run ruff check .`
+Expected: `All checks passed!` (fix any new warnings in the touched files).
+
+- [ ] **Step 2: Run the full touched-area backend suites**
+
+Run:
+
+```bash
+uv run pytest tests/unit/test_organizer.py tests/unit/test_resolve_show_year.py tests/pipeline/test_organization_paths.py -q
+uv run pytest tests/integration/ -q -k "tv or organiz or finaliz or extra or workflow"
+```
+
+Expected: PASS. The only acceptable failure is the documented pre-existing flaky `test_movie_ambiguous_rip_first_workflow` (staging-cleanup race) — confirm any failure is exactly that and unrelated to this change.
+
+- [ ] **Step 3: Frontend build + lint**
+
+Run (from `frontend/`): `npm run build && npm run lint`
+Expected: both succeed.
+
+- [ ] **Step 4: Final commit (if any verification fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore: lint/test fixes for TV disambiguation"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Out of scope (do NOT implement here)
+
+- Runtime SRT scrape cache `~/.engram/cache/data/<show_name>/` is still name-keyed — separately tracked follow-up.
+- Migrating/relocating users' existing bare `Frasier/` libraries — intentionally not done (opt-in default avoids touching them).
+- Exposing `tmdb_year` in WebSocket/REST job payloads — it is internal organize-time metadata only.

--- a/docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md
@@ -114,15 +114,44 @@ tmdb_year: int | None = Field(default=None)
 Auto-migrated for existing/end-user DBs by `database.py` `_add_missing_columns` (frozen builds
 skip Alembic — the reconciler is what reaches users; see memory note on frozen-build migrations).
 
-Population:
-- Add `year: int | None` to `DiscAnalysisResult` (`analyst.py:96`). The Analyst sets it from the
-  chosen candidate's `first_air_date` (the `TmdbSignal.candidates`/`all_candidates` dicts already
-  carry `year`, classifier.py:201), with `fetch_show_details(tmdb_id)["first_air_date"][:4]` as
-  the fallback for the unambiguous single-match path.
-- Persist `job.tmdb_year = analysis.year` at the same sites that set `tmdb_id`/`tmdb_name`
-  (`identification_coordinator.py` ~156, ~465, and the DiscDB-signal path ~697/~708 where year is
-  resolved from the signal/details).
-- Re-identify already computes `tmdb_year` (`routes.py:1854`); also write it onto the job there.
+Population — a single helper in `identification_coordinator.py`, no analyst/classifier changes:
+
+```python
+def _resolve_show_year(tmdb_id: int | None, signal=None) -> int | None:
+    """First-air year for a show. No-network fast path via same-name candidates
+    (each carries a 'year' string), else cached TMDB details."""
+    if not tmdb_id:
+        return None
+    cands = getattr(signal, "all_candidates", None) if signal else None
+    for c in cands or []:
+        if c.get("tmdb_id") == tmdb_id:
+            y = (c.get("year") or "").strip()
+            if y.isdigit():
+                return int(y)
+    from app.matcher.tmdb_client import fetch_show_details
+    details = fetch_show_details(tmdb_id)
+    if details:
+        fa = (details.get("first_air_date") or "")[:4]
+        if fa.isdigit():
+            return int(fa)
+    return None
+```
+
+Call it (wrapped in `asyncio.to_thread`, since `fetch_show_details` blocks) right after each
+`job.tmdb_id = …` assignment:
+- main identify flow — `identification_coordinator.py:200` (signal = local `tmdb_signal`)
+- staging-import flow — `:555` (signal = `getattr(analysis, "_tmdb_signal", None)`)
+- re-identify / name-correction — `:830` (manual id, no signal → details fallback) and `:841`
+  (re-search `signal`). This is the path `POST /jobs/{id}/re-identify` →
+  `job_manager.re_identify_job` reaches, so re-identify is covered here — **no routes.py change**.
+
+> **Correction (vs. earlier draft):** `candidates_json` *does* exist — it was added by the
+> #287/#288 same-name-collision work and persists `{tmdb_id, name, year, popularity}` for every
+> same-name twin (classifier.py builds the dict at ~199-203; `identification_coordinator` sets the
+> column at `:202` / `:557`). So the Frasier case resolves its year with **zero extra network** via
+> the fast path. No `DiscAnalysisResult`/Analyst/classifier change is needed. (The earlier draft's
+> claim that `candidates_json` didn't exist and that re-identify lived in `routes.py:1854` was based
+> on a stale checkout; `routes.py:1851` is the unrelated bootstrap-library response builder.)
 
 Reading directly off the persisted `job.tmdb_year` at organize time means **no per-sweep TMDB
 fetch** and a stable folder name.
@@ -163,13 +192,13 @@ gains `tmdb_id`. `TVOrganizer.organize` forwards `year` (and `tmdb_id`, already 
 
 ### 4. finalization_coordinator — three call sites in sync
 
-All three TV-organize sites pass `year=job.tmdb_year`; the two `organize_tv_extras` calls also
-gain `tmdb_id=` so the Extras folder matches the episode folder:
-- auto-flow `finalize_disc_job` (~727 extras, ~741 episode, ~752 `tv_organizer.organize`)
-- `process_matched_titles` (~1083 extras, ~1096 episode, ~1107 `tv_organizer.organize`)
-- `_finalize_tv_if_resolved` review path (~1269 extras, ~1282 episode, ~1293 `tv_organizer.organize`)
+All three TV-organize sites pass `year=_tmdb_year`; the two `organize_tv_extras` calls also gain
+`tmdb_id=_tmdb_id_str` so the Extras folder matches the episode folder. Worktree line numbers:
+- auto-flow `finalize_disc_job` — preamble `:814-815`; extras `:839`, episode `:850`, `tv_organizer.organize` `:861`
+- `_finalize_tv_if_resolved` review path — preamble `:1173-1174`; extras `:1192`, episode `:1205`, `tv_organizer.organize` `:1216`
+- `process_matched_titles` — preamble `:1359-1360`; extras `:1378`, episode `:1391`, `tv_organizer.organize` `:1402`
 
-(`_tmdb_id_str` is already computed per sweep at these sites; add the analogous `job.tmdb_year` read.)
+(`_tmdb_id_str` is already computed at each preamble; add `_tmdb_year = job.tmdb_year` beside it.)
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md
@@ -1,0 +1,197 @@
+# TV library disambiguation for same-name shows
+
+**Date:** 2026-06-01
+**Status:** Approved (design) — pending implementation plan
+**Branch:** `claude/vibrant-sinoussi-f510bc`
+**Related:** PR #287 / #288 (matcher-side same-name fixes), `project_show_identity_collision`, `project_tv_organize_paths_sync`
+
+## Problem
+
+TV library organization keys the destination on the **bare show name only**, so two shows
+that share a title collide on disk. The canonical case is *Frasier* 1993 (`tmdb_id=3452`) vs.
+the 2023 revival (`tmdb_id=195241`): both land in `<library>/Frasier/Season 1/` with identical
+filenames (`Frasier - S01E02.mkv`). The second rip then hits `resolve_conflict` and is
+skipped / overwritten / prompted per `conflict_resolution_default`. The two shows cannot
+coexist, and nothing in the path records which is which.
+
+Movies already solve this: `format_movie_folder` (organizer.py:38) emits `Title (Year)` and
+strips a trailing empty `()` when the year is unknown. `organize_tv_episode` already *receives*
+`tmdb_id` but uses it only for episode-ordering projection (organizer.py:429), never for naming.
+
+Surfaced during live verification of PR #287/#288. This work is **library-side coexistence /
+naming only** — it is independent of episode *matching*.
+
+## Goal
+
+Give TV the same disambiguation movies get, targeting the convention Plex/Jellyfin parse:
+
+```
+<library>/Frasier (1993) {tmdb-3452}/Season 1/Frasier (1993) - S01E02.mkv      (Plex)
+<library>/Frasier (1993) [tmdbid-3452]/Season 1/Frasier (1993) - S01E02.mkv    (Jellyfin)
+```
+
+The format is configurable via the existing `naming_*` config fields, defaulting to **preserve
+today's behavior** so no existing library is silently relocated.
+
+## Media-server compatibility (researched)
+
+- **Series identity lives on the FOLDER, not the filename.** Both Plex and Jellyfin match the
+  series from the folder's provider-id tag and the episode from the `SxxExx` token. A year in
+  the filename is ignored by both — Jellyfin's own docs use `Alias (2001) - S01E01`, Plex's use
+  `Alias - S01E01`. Both render fine in both servers.
+- **The id-tag syntax differs and there is no single string that satisfies both:**
+  - Plex: `{tmdb-3452}` (curly braces, `tmdb-`)
+  - Jellyfin: `[tmdbid-3452]` (square brackets, `tmdbid-`)
+  This is precisely why the format is **configurable + opt-in**: the user picks the syntax for
+  their server. The id tag belongs **only on the folder**, never the filename.
+- Sources: Plex "Naming and Organizing Your TV Show Files"; Jellyfin "Metadata Provider Identifiers".
+
+## Decisions (confirmed with user)
+
+1. **Opt-in default.** New `naming_tv_show_format` defaults to `"{show}"` — byte-for-byte
+   identical to today. Disambiguation turns on only when the user changes the format. No
+   migration relocates existing libraries.
+2. **Persist the year.** Add `DiscJob.tmdb_year`, set at identification time (and on
+   re-identify). Deterministic and offline-safe; the folder name stays stable across rips even
+   if TMDB is unreachable on a later disc.
+3. **Year in the filename too**, opt-in via `naming_episode_format` (default unchanged). Matches
+   the GOAL and is server-neutral.
+
+## Design
+
+### 1. Config: new show-folder format + widened episode placeholders
+
+`AppConfig` (`models/app_config.py`):
+
+```python
+naming_tv_show_format: str = "{show}"   # default == current behavior (bare show folder)
+# existing:
+naming_season_format:   str = "Season {season:02d}"
+naming_episode_format:  str = "{show} - S{season:02d}E{episode:02d}"
+naming_movie_format:    str = "{title} ({year})"
+```
+
+Placeholder sets (`organizer.py`):
+
+```python
+ALLOWED_TV_PLACEHOLDERS      = {"show", "season", "episode"}     # season format (unchanged)
+ALLOWED_TV_SHOW_PLACEHOLDERS = {"show", "year", "tmdb_id"}        # NEW: show folder
+ALLOWED_EPISODE_PLACEHOLDERS = {"show", "season", "episode", "year", "tmdb_id"}  # NEW: widened
+ALLOWED_MOVIE_PLACEHOLDERS   = {"title", "year"}                 # unchanged
+```
+
+- Season format keeps validating against `ALLOWED_TV_PLACEHOLDERS` (no year/id — meaningless there).
+- Episode format validates against the widened `ALLOWED_EPISODE_PLACEHOLDERS`. Default string
+  unchanged → year in filename is strictly opt-in.
+
+**Config three-way-sync hazard** (`project_config_field_three_way_sync`): the new field MUST be
+added to all of:
+- `AppConfig` model (above)
+- `ConfigResponse` + the GET-config constructor that builds it (`routes.py` ~285, ~1132)
+- `ConfigUpdate` (`routes.py` ~362) + the naming-format validation table (`routes.py` ~1245,
+  pairing `naming_tv_show_format` → `ALLOWED_TV_SHOW_PLACEHOLDERS`, and updating the
+  `naming_episode_format` pairing to `ALLOWED_EPISODE_PLACEHOLDERS`)
+- `ConfigWizard.tsx` read (~234) + write (~374) mappings
+
+**Recommended formats (documented for users):**
+
+| Server | `naming_tv_show_format` | `naming_episode_format` |
+|---|---|---|
+| Plex | `{show} ({year}) {{tmdb-{tmdb_id}}}` | `{show} ({year}) - S{season:02d}E{episode:02d}` |
+| Jellyfin | `{show} ({year}) [tmdbid-{tmdb_id}]` | `{show} ({year}) - S{season:02d}E{episode:02d}` |
+
+> **Brace escaping gotcha:** to emit a literal `{tmdb-3452}` via `str.format`, the format string
+> needs **doubled** braces: `{{tmdb-{tmdb_id}}}`. Jellyfin's `[tmdbid-{tmdb_id}]` needs no escaping.
+
+### 2. Persist the first-air year
+
+`DiscJob` (`models/disc_job.py`), next to `tmdb_id`/`tmdb_name`:
+
+```python
+tmdb_year: int | None = Field(default=None)
+```
+
+Auto-migrated for existing/end-user DBs by `database.py` `_add_missing_columns` (frozen builds
+skip Alembic — the reconciler is what reaches users; see memory note on frozen-build migrations).
+
+Population:
+- Add `year: int | None` to `DiscAnalysisResult` (`analyst.py:96`). The Analyst sets it from the
+  chosen candidate's `first_air_date` (the `TmdbSignal.candidates`/`all_candidates` dicts already
+  carry `year`, classifier.py:201), with `fetch_show_details(tmdb_id)["first_air_date"][:4]` as
+  the fallback for the unambiguous single-match path.
+- Persist `job.tmdb_year = analysis.year` at the same sites that set `tmdb_id`/`tmdb_name`
+  (`identification_coordinator.py` ~156, ~465, and the DiscDB-signal path ~697/~708 where year is
+  resolved from the signal/details).
+- Re-identify already computes `tmdb_year` (`routes.py:1854`); also write it onto the job there.
+
+Reading directly off the persisted `job.tmdb_year` at organize time means **no per-sweep TMDB
+fetch** and a stable folder name.
+
+### 3. organizer.py — disambiguated folder + filename
+
+New helper, mirroring `format_movie_folder`:
+
+```python
+def format_tv_show_folder(fmt: str, show: str, year: int | None, tmdb_id: str | int | None) -> str:
+    """Format the show *directory* name. Strips empty (), {..-}, [..-] groups
+    when year/tmdb_id are missing, then collapses whitespace. Sanitized."""
+```
+
+Graceful-strip helper removes, after formatting with empty strings for missing values:
+- empty parens `\(\s*\)`
+- empty Plex tag `\{[^{}]*-\s*\}`  (e.g. `{tmdb-}`)
+- empty Jellyfin tag `\[[^\[\]]*-\s*\]`  (e.g. `[tmdbid-]`)
+
+then `re.sub(r"\s+", " ", x).strip()`. Degradation ladder:
+- year + id → `Frasier (1993) {tmdb-3452}`
+- id only (no year) → `Frasier {tmdb-3452}`  ← still disambiguated; id is the stable token
+- neither → `Frasier`  ← bare name == current behavior
+
+`format_episode_filename` gains `year`/`tmdb_id` params and the same empty-`()` strip, so an
+opt-in episode format yields `Frasier (1993) - S01E02` (year missing → `Frasier - S01E02`).
+
+`organize_tv_episode` and `organize_tv_extras` BOTH compute the show directory via
+`format_tv_show_folder(cfg.naming_tv_show_format, show, year, tmdb_id)` — a single source of
+truth so episodes and their `Extras/` always share one folder (the
+`project_tv_organize_paths_sync` hazard). Both gain a `year` param; `organize_tv_extras` also
+gains `tmdb_id`. `TVOrganizer.organize` forwards `year` (and `tmdb_id`, already present) to
+`organize_tv_episode`.
+
+- Extras **folder** is disambiguated (required, so extras sit under the same show folder).
+- Extras **filename** stays `"{clean_show} Disc N Extra ..."` — non-colliding inside the now-unique
+  folder; left as-is to keep the change focused.
+
+### 4. finalization_coordinator — three call sites in sync
+
+All three TV-organize sites pass `year=job.tmdb_year`; the two `organize_tv_extras` calls also
+gain `tmdb_id=` so the Extras folder matches the episode folder:
+- auto-flow `finalize_disc_job` (~727 extras, ~741 episode, ~752 `tv_organizer.organize`)
+- `process_matched_titles` (~1083 extras, ~1096 episode, ~1107 `tv_organizer.organize`)
+- `_finalize_tv_if_resolved` review path (~1269 extras, ~1282 episode, ~1293 `tv_organizer.organize`)
+
+(`_tmdb_id_str` is already computed per sweep at these sites; add the analogous `job.tmdb_year` read.)
+
+## Testing
+
+**organizer unit tests** (`tests/unit/`):
+- Same-name twins (3452 vs 195241) with a disambiguating format → distinct folders, no conflict.
+- Missing year → `Frasier {tmdb-3452}` (no empty parens); missing year **and** id → bare `Frasier`.
+- Filename year strip: opt-in episode format with missing year → `Frasier - S01E02` (no `()`).
+- Plex `{{tmdb-{tmdb_id}}}` and Jellyfin `[tmdbid-{tmdb_id}]` formats both render correctly.
+- Default `"{show}"` reproduces today's exact path (regression guard).
+- `organize_tv_extras` lands under the SAME disambiguated folder as `organize_tv_episode`.
+
+**pipeline org-path tests** (`tests/pipeline/test_organization_paths.py`): update expectations;
+add a same-name-twins coexistence case.
+
+**Validation/commands:** `uv run ruff check .`; organizer + finalization + pipeline suites.
+(Worktree note from memory: pipeline org-path tests need `init_db()` against the worktree DB.)
+
+## Out of scope (noted only)
+
+- Runtime SRT scrape cache `~/.engram/cache/data/<show_name>/` is still **name-keyed** (only the
+  precomputed corpus was re-keyed by `tmdb_id` in #288), so same-name shows still collide there.
+  Separately tracked follow-up — not fixed here.
+- Episode **matching** of same-name shows (PR #287/#288 territory) — unchanged.
+- Migrating/relocating users' existing bare `Frasier/` libraries — intentionally not done
+  (opt-in default avoids touching them).

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -70,6 +70,7 @@ interface ConfigData {
     namingSeasonFormat: string;
     namingEpisodeFormat: string;
     namingMovieFormat: string;
+    namingTvShowFormat: string;
     discdbEnabled: boolean;
     enableFingerprintContributions: boolean;
     fingerprintServerUrl: string;
@@ -139,6 +140,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         namingSeasonFormat: 'Season {season:02d}',
         namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
         namingMovieFormat: '{title} ({year})',
+        namingTvShowFormat: '{show}',
         discdbEnabled: true,
         enableFingerprintContributions: true,
         fingerprintServerUrl: '',
@@ -244,6 +246,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     namingSeasonFormat: data.naming_season_format || 'Season {season:02d}',
                     namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
                     namingMovieFormat: data.naming_movie_format || '{title} ({year})',
+                    namingTvShowFormat: data.naming_tv_show_format || '{show}',
                     discdbEnabled: data.discdb_enabled ?? true,
                     enableFingerprintContributions: data.enable_fingerprint_contributions ?? true,
                     fingerprintServerUrl: data.fingerprint_server_url || '',
@@ -384,6 +387,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     naming_season_format: config.namingSeasonFormat,
                     naming_episode_format: config.namingEpisodeFormat,
                     naming_movie_format: config.namingMovieFormat,
+                    naming_tv_show_format: config.namingTvShowFormat,
                     discdb_enabled: config.discdbEnabled,
                     enable_fingerprint_contributions: config.enableFingerprintContributions,
                     fingerprint_server_url: config.fingerprintServerUrl || null,
@@ -1449,6 +1453,24 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             />
                             <span className="form-hint">
                                 Preview: TV/{config.namingSeasonFormat.replace('{season:02d}', '01').replace('{season:d}', '1')}/{config.namingEpisodeFormat.replace('{show}', 'Breaking Bad').replace('{season:02d}', '01').replace('{season:d}', '1').replace('{episode:02d}', '05').replace('{episode:d}', '5')}.mkv
+                            </span>
+                        </div>
+
+                        <div className="form-group">
+                            <label htmlFor="namingTvShowFormat">Show Folder Format</label>
+                            <input
+                                id="namingTvShowFormat"
+                                type="text"
+                                value={config.namingTvShowFormat}
+                                onChange={(e) => handleInputChange('namingTvShowFormat', e.target.value)}
+                                placeholder="{show}"
+                            />
+                            <span className="form-hint">
+                                Placeholders: {'{show}'}, {'{year}'}, {'{tmdb_id}'}. Default{' '}
+                                {'{show}'} keeps your current folders. To let same-name shows
+                                coexist (e.g. Frasier 1993 vs 2023), use Plex{' '}
+                                &quot;{'{show} ({year}) {{tmdb-{tmdb_id}}}'}&quot; or Jellyfin{' '}
+                                &quot;{'{show} ({year}) [tmdbid-{tmdb_id}]'}&quot;.
                             </span>
                         </div>
 


### PR DESCRIPTION
## Summary

Gives TV library organization the same year + TMDB-id folder disambiguation that movies already have, so two shows that share a title (e.g. **Frasier** 1993 `#3452` vs the 2023 revival `#195241`) can coexist on disk instead of colliding in one `Frasier/` folder. Surfaced during live verification of #287/#288.

**Opt-in and migration-safe:** a new `naming_tv_show_format` config defaults to `"{show}"` — byte-for-byte identical to today's behavior. No existing library is touched. Users opt in by setting a format with `{year}`/`{tmdb_id}` placeholders, targeting the convention Plex/Jellyfin parse:

- Plex: `{show} ({year}) {{tmdb-{tmdb_id}}}` → `Frasier (1993) {tmdb-3452}/Season 01/Frasier (1993) - S01E02.mkv`
- Jellyfin: `{show} ({year}) [tmdbid-{tmdb_id}]` → `Frasier (1993) [tmdbid-3452]/…`

(The provider-id tag lives on the **folder** only — the year-in-filename is optional and opt-in via `naming_episode_format`, which now also accepts `{year}`/`{tmdb_id}`.)

## What changed

- **Config** — new `naming_tv_show_format` field (`AppConfig`, default `"{show}"` with a `server_default` so existing DBs backfill `{show}` rather than the empty-string `_add_missing_columns` fallback). Wired through the full three-way sync: `ConfigResponse` + GET constructor + `ConfigUpdate` + the validation table (new `ALLOWED_TV_SHOW_PLACEHOLDERS`; `naming_episode_format` widened to `ALLOWED_EPISODE_PLACEHOLDERS`), and a "Show Folder Format" field in `ConfigWizard`.
- **Organizer** — new `format_tv_show_folder()` (mirrors `format_movie_folder`, adds a `{tmdb_id}` placeholder and strips empty `()`/`{…-}`/`[…-]` groups so a missing year degrades cleanly to `Frasier {tmdb-3452}`, never `Frasier () {tmdb-}`). Both `organize_tv_episode` and `organize_tv_extras` build the show folder from this single helper, so an episode and its `Extras/` always share one folder.
- **Year source** — new `DiscJob.tmdb_year` column (+ Alembic migration `c5e9a1b3d7f2`, chained off the current head), persisted at identify time via `_resolve_show_year()`: a zero-network fast path off the existing `candidates_json` twins, falling back to cached TMDB details. Set at all three identification sites (main, staging-import, re-identify).
- **All organize call sites threaded** — the 3 in `finalization_coordinator` (`finalize_disc_job`, `_finalize_tv_if_resolved`, `process_matched_titles`) **and** the match-time `matching_coordinator._handle_extras` "keep"-policy path now pass `year`/`tmdb_id`, so extras land under the same disambiguated folder as episodes.

## Reviewer notes

- **Default behavior is unchanged.** With `naming_tv_show_format="{show}"`, paths are identical to before (regression tests assert the exact path, including preserving a sanitized double-space title so no silent relocation).
- **`{{tmdb-{tmdb_id}}}` brace escaping** is intentional — `str.format` needs doubled braces to emit a literal `{tmdb-3452}`. `sanitize_filename` leaves `{}`/`[]`/`()` intact, so the tag survives.
- **`tmdb_year` is internal** organize-time metadata — deliberately not exposed in REST/WS job payloads.
- **Out of scope (separately tracked):** the runtime SRT scrape cache `~/.engram/cache/data/<show_name>/` is still name-keyed; relocating users' existing bare `Frasier/` libraries is intentionally not done (opt-in default avoids it).
- Design spec + implementation plan: `docs/superpowers/specs/2026-06-01-tv-library-disambiguation-design.md`, `docs/superpowers/plans/2026-06-02-tv-library-disambiguation.md`.

## Test Plan

- [x] `uv run ruff check .` — clean
- [x] Backend unit/pipeline — 82 pass (`test_organizer.py`, `test_resolve_show_year.py`, `test_matching_coordinator.py`, `test_organization_paths.py`); same-name twins land in distinct folders, missing-year/id degrade with no empty `()`/`{tmdb-}`, default format unchanged, extras share the episode's show folder
- [x] Backend integration (`-k "tv or organiz or finaliz or extra or workflow"`) — 49 pass
- [x] `uv run alembic heads` — single head `c5e9a1b3d7f2`; `init_db()` adds the column cleanly
- [x] Config round-trip — `PUT`/`GET /api/config` carries `naming_tv_show_format`; invalid placeholder → 400
- [x] Frontend `npm run build` + `npm run lint` — clean
- [ ] (reviewer) sanity-check a real rip of two same-name discs under a disambiguating format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
