### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-06-02
+
+_Highlights: a hardening fix for the in-app auto-updater — it can no longer install an incomplete or corrupted download over your working copy, and builds now always include the TLS certificate bundle whose absence silently broke all networking in some 0.14.0 installs._
+
 ### Fixed
 
-- **The auto-updater could stage and apply an incomplete build, breaking the app** — if an update's extraction was interrupted (or files were removed afterward, e.g. by antivirus), Engram could leave a half-unpacked build that still looked "ready to install": the integrity check only validated the downloaded archive, never the unpacked files. Applying it would copy a broken build over your working install — in one case a build missing its TLS certificate bundle, which silently breaks every network request (update checks, TMDB, subtitle downloads). The updater now unpacks to a temporary location and only swaps it into place once the build is verified complete (against a per-release file manifest plus required-file sentinels), then re-checks completeness one more time immediately before applying — so a truncated or tampered update is refused instead of installed. As extra safeguards the TLS certificate bundle is now always bundled, the build toolchain is pinned, and the release smoke test fails if a build can't complete an HTTPS request.
+- **The auto-updater could stage and apply an incomplete build, breaking the app** — if an update's extraction was interrupted (or files were removed afterward, e.g. by antivirus), Engram could leave a half-unpacked build that still looked "ready to install": the integrity check only validated the downloaded archive, never the unpacked files. Applying it would copy a broken build over your working install — in one case a build missing its TLS certificate bundle, which silently breaks every network request (update checks, TMDB, subtitle downloads). The updater now unpacks to a temporary location and only swaps it into place once the build is verified complete (against a per-release file manifest plus required-file sentinels), then re-checks completeness one more time immediately before applying — and if that final check fails it drops the staged update instead of leaving a dead "ready to install" offer. As extra safeguards the TLS certificate bundle is now always bundled, the build toolchain is pinned, and the release smoke test fails if a build can't complete an HTTPS request. (#296, #298)
 
 ## [0.14.0] - 2026-06-02
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -249,11 +249,12 @@ class UpdateChecker:
                 raise UpdateError(f"Archive did not contain an 'engram' directory: {asset['name']}")
             self._verify_extracted(extracted, manifest_text)
 
-            # Promote: the verified build replaces any previously staged build.
-            # os.replace() is an atomic rename within the same filesystem, so once it
-            # succeeds the staged dir has either the old build or the new one. (A crash
-            # between the rmtree and os.replace leaves staging without an engram/ dir;
-            # the next run re-downloads, since state never reached READY.)
+            # Promote the verified build. On POSIX os.replace() is an atomic rename(2);
+            # on Windows it uses MoveFileEx, which is not POSIX-atomic. Either way there
+            # is a brief window after rmtree(final) and before os.replace() where neither
+            # dir exists — a crash there leaves staging without an engram/ dir (apply
+            # refuses, the next run re-downloads, since state never reached READY). The
+            # live install is never touched, so the consequence is tolerable.
             final = staging_dir / "engram"
             shutil.rmtree(final, ignore_errors=True)
             os.replace(extracted, final)
@@ -489,7 +490,18 @@ class UpdateChecker:
         manifest_text = (
             manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else None
         )
-        self._verify_extracted(self.staging_path / "engram", manifest_text)
+        try:
+            self._verify_extracted(self.staging_path / "engram", manifest_text)
+        except UpdateError as exc:
+            # The build was complete at download time but isn't now (e.g. AV quarantine).
+            # Drop out of READY and clear the staged path so the UI stops offering a
+            # broken update and a fresh download is required, then re-raise for the API.
+            logger.warning(f"Pre-apply verification failed: {exc}", exc_info=True)
+            self.state = UpdateStatus.ERROR
+            self.error = "Staged build is incomplete (possibly quarantined); re-download required."
+            self.staging_path = None
+            await self._broadcast()
+            raise
 
         if sys.platform == "win32":
             self._restart_windows()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.14.0"
+version = "0.14.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -458,6 +458,10 @@ class TestExtractionIntegrity:
         with pytest.raises(UpdateError, match="incomplete"):
             await checker.apply_update()
         assert called["restart"] is False
+        # A failed pre-apply re-verify must drop out of READY and clear the staged
+        # path, so the UI stops offering a broken update and retries don't loop.
+        assert checker.state == UpdateStatus.ERROR
+        assert checker.staging_path is None
 
     async def test_apply_update_complete_build_reaches_restart(self, monkeypatch, tmp_path):
         """A complete staged build passes re-verification and proceeds to restart."""

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.14.0"
+version = "0.14.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.14.0",
+    "version": "0.14.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Release PR for **v0.14.1**. Squash-merging this (title starts with `chore: release v`) triggers `tag-release.yml` → tags `v0.14.1` from `backend/pyproject.toml` → dispatches the build/publish workflows.

## What's in it

This release ships the auto-updater hardening from #296. **This branch is stacked on #296, so its diff includes that fix** — merging this PR ships the fix *and* cuts 0.14.1 in one squash. Close #296 as included here (or merge #296 first and rebase this).

**Release bump (this PR's own changes):**
- Version `0.14.0 → 0.14.1` in all 6 self-version spots: `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and both fields in `frontend/package-lock.json` (the `^0.14.0` React peer ranges are left untouched).
- `CHANGELOG.md`: moved the `[Unreleased]` entry into `## [0.14.1] - 2026-06-02` with a `_Highlights:_` line.

**Fix being released (from #296):**
- Updater now extracts to a temp dir and atomically promotes only after verifying the unpacked tree is complete (per-release manifest + required-file sentinels), and re-verifies immediately before applying — a truncated/corrupt build can no longer overwrite a working install.
- certifi CA bundle always bundled (`engram.spec`); PyInstaller toolchain pinned; release smoke test asserts `cacert.pem` + runs `engram --selftest` (real HTTPS round-trip).

## Pre-merge checks

- `backend/scripts/extract_changelog.py --version 0.14.1 --check` → `ok` (the CI `changelog-version-check` gate).
- 28 updater tests pass; built exe verified end-to-end (`cacert.pem` bundled, `--selftest` OK, live `api.github.com 200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
