### PR TITLE
feat(ffmpeg): document prerequisite, validate manual paths, broaden Windows detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- FFmpeg is now documented as a prerequisite, with per-platform install steps (including `winget install Gyan.FFmpeg` on Windows) and a dedicated [Troubleshooting](https://jsakkos.github.io/engram/troubleshooting/) page led by the common "FFmpeg not detected" case.
+- The Config Wizard now validates a manually-entered MakeMKV or FFmpeg path against the backend and shows the detected version inline (or the specific error), so a hand-typed override is no longer saved blind. The FFmpeg "not found" card also links to the download page.
+
+### Changed
+
+- Windows FFmpeg auto-detection now also searches the Chocolatey, scoop, winget (`Gyan.FFmpeg`), and user-home install locations, so a freshly-installed FFmpeg is found even when it isn't yet on the running process's `PATH`. The in-app install hint now names the exact winget package.
+
 ## [0.14.1] - 2026-06-02
 
 _Highlights: a hardening fix for the in-app auto-updater — it can no longer install an incomplete or corrupted download over your working copy, and builds now always include the TLS certificate bundle whose absence silently broke all networking in some 0.14.0 installs._

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ On all platforms, Engram supports a **staging folder workflow**: drop a folder o
 ## Prerequisites
 
 - [MakeMKV](https://www.makemkv.com/) with a valid license
+- [FFmpeg](https://ffmpeg.org/download.html) for episode matching (audio fingerprinting). Engram auto-detects it on your `PATH` — see [installing FFmpeg](docs/getting-started/installation.md#installing-ffmpeg), or [Troubleshooting](docs/troubleshooting.md#ffmpeg-not-detected-windows) if it isn't found
 - A TMDB API Read Access Token (v4) from [TMDB](https://www.themoviedb.org/settings/api)
 - If running from source: Python 3.11–3.13 with [uv](https://docs.astral.sh/uv/), and Node.js 24 (Python 3.14 is not yet supported — some ML dependencies have no 3.14 wheels)
 
@@ -83,6 +84,8 @@ No Python or Node.js required — the Config Wizard opens in your browser on fir
 | macOS | `engram-macos-arm64.tar.gz` | `./engram/engram` |
 
 On macOS, download `engram-macos-arm64.tar.gz`. It runs natively on Apple Silicon (M1/M2/M3/M4) and transparently on Intel Macs via Rosetta 2. macOS has no automatic optical-drive detection — use the staging-folder workflow (see [Linux / macOS setup](docs/guide/linux-setup.md)).
+
+> **FFmpeg is required for episode matching.** Engram auto-detects it on your `PATH` (Windows: `winget install Gyan.FFmpeg`, then restart Engram). If the Config Wizard reports FFmpeg missing, see [installing FFmpeg](docs/getting-started/installation.md#installing-ffmpeg) and [Troubleshooting](docs/troubleshooting.md#ffmpeg-not-detected-windows).
 
 ### Option B: From source (all platforms)
 
@@ -162,7 +165,7 @@ See the [configuration guide](docs/getting-started/configuration.md) for the ful
 
 Full documentation is published at **[jsakkos.github.io/engram](https://jsakkos.github.io/engram/)**.
 
-- **Getting started** — [Installation](docs/getting-started/installation.md) · [Configuration](docs/getting-started/configuration.md) · [Simulation](docs/getting-started/simulation.md)
+- **Getting started** — [Installation](docs/getting-started/installation.md) · [Configuration](docs/getting-started/configuration.md) · [Simulation](docs/getting-started/simulation.md) · [Troubleshooting](docs/troubleshooting.md)
 - **User guide** — [Dashboard](docs/guide/dashboard.md) · [Review Queue](docs/guide/review-queue.md) · [Job History](docs/guide/history.md) · [Linux / macOS setup](docs/guide/linux-setup.md)
 - **Architecture** — [Overview](docs/architecture/overview.md) · [State Machine](docs/architecture/state-machine.md) · [WebSocket Protocol](docs/architecture/websocket.md)
 - **API reference** — [REST Endpoints](docs/api/rest.md) · [Data Models](docs/api/models.md)

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -90,17 +90,63 @@ def _get_makemkv_search_paths() -> list[str]:
 
 
 def _get_ffmpeg_search_paths() -> list[str]:
-    """Return platform-specific common FFmpeg installation paths."""
-    if sys.platform == "win32":
+    """Return platform-specific common FFmpeg installation paths.
+
+    On Windows this covers manual extracts (``C:\\ffmpeg\\bin``) plus the
+    install layouts of the common package managers (Chocolatey, scoop) and a
+    user-home extract. These often aren't on the *running* process's PATH —
+    e.g. PATH was updated after Engram launched, so a restart-less install is
+    invisible to ``shutil.which`` — yet the binary is sitting in a predictable
+    spot. winget's version-stamped layout needs globbing and is handled
+    separately by ``_iter_winget_ffmpeg_paths``.
+    """
+    if sys.platform != "win32":
         return [
-            r"C:\tools\ffmpeg\bin\ffmpeg.exe",
-            r"C:\ffmpeg\bin\ffmpeg.exe",
-            r"C:\Program Files\ffmpeg\bin\ffmpeg.exe",
+            "/usr/bin/ffmpeg",
+            "/usr/local/bin/ffmpeg",
         ]
-    return [
-        "/usr/bin/ffmpeg",
-        "/usr/local/bin/ffmpeg",
+
+    paths = [
+        r"C:\tools\ffmpeg\bin\ffmpeg.exe",
+        r"C:\ffmpeg\bin\ffmpeg.exe",
+        r"C:\Program Files\ffmpeg\bin\ffmpeg.exe",
+        # Chocolatey drops a shim here; its bin dir is usually (but not always) on PATH.
+        r"C:\ProgramData\chocolatey\bin\ffmpeg.exe",
     ]
+    userprofile = os.environ.get("USERPROFILE")
+    if userprofile:
+        home = Path(userprofile)
+        paths.extend(
+            [
+                # scoop (per-user): shim + the real binary under the app dir
+                str(home / "scoop" / "shims" / "ffmpeg.exe"),
+                str(home / "scoop" / "apps" / "ffmpeg" / "current" / "bin" / "ffmpeg.exe"),
+                # common manual extract under the home directory
+                str(home / "ffmpeg" / "bin" / "ffmpeg.exe"),
+            ]
+        )
+    return paths
+
+
+def _iter_winget_ffmpeg_paths() -> list[str]:
+    """Resolve FFmpeg installed via ``winget install Gyan.FFmpeg``.
+
+    winget is the install hint Engram shows in the Config Wizard, but it lays
+    the build down under a version-stamped path —
+    ``%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\Gyan.FFmpeg_*\\ffmpeg-*\\bin\\ffmpeg.exe``
+    — that can't be hardcoded, so glob for it. Returns an empty list off
+    Windows, when ``LOCALAPPDATA`` is unset, or when nothing matches.
+    """
+    if sys.platform != "win32":
+        return []
+    local_appdata = os.environ.get("LOCALAPPDATA")
+    if not local_appdata:
+        return []
+    packages = Path(local_appdata) / "Microsoft" / "WinGet" / "Packages"
+    try:
+        return [str(p) for p in packages.glob("Gyan.FFmpeg*/**/bin/ffmpeg.exe")]
+    except OSError:
+        return []
 
 
 _VERSION_NOT_DETECTABLE = "MakeMKV (version not detectable)"
@@ -345,8 +391,10 @@ def detect_ffmpeg() -> ToolDetectionResult:
         if result.found:
             return result
 
-    # 2. Check platform-specific common locations
-    for path_str in _get_ffmpeg_search_paths():
+    # 2. Check platform-specific common locations (package managers, manual
+    #    extracts, and winget's version-stamped layout). Each candidate is still
+    #    verified by _validate_ffmpeg_binary before it's accepted.
+    for path_str in (*_get_ffmpeg_search_paths(), *_iter_winget_ffmpeg_paths()):
         if Path(path_str).is_file():
             logger.info(f"Found FFmpeg at: {path_str}")
             result = _validate_ffmpeg_binary(path_str)

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -236,6 +236,11 @@ def _validate_makemkv_binary(path_str: str) -> ToolDetectionResult:
 
 def _validate_ffmpeg_binary(path_str: str) -> ToolDetectionResult:
     """Validate an FFmpeg binary and extract version info."""
+    # Self-guard the subprocess sink: never execute a path whose basename isn't a
+    # known FFmpeg executable, independent of the caller (py/command-line-injection).
+    # Mirrors _validate_makemkv_binary and the endpoint-level guard.
+    if not executable_basename_allowed(path_str, _FFMPEG_EXE_NAMES):
+        return ToolDetectionResult(found=False, error="Not a valid FFmpeg executable")
     try:
         result = subprocess.run(
             [path_str, "-version"],

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -766,11 +766,15 @@ class TestSearchPaths:
         ):
             ff = validation._get_ffmpeg_search_paths()
 
-        joined = "\n".join(ff).lower()
+        # pathlib joins with "\" on Windows but "/" on the Linux CI runner, so
+        # normalise separators before comparing — the production guard only ever
+        # runs this branch on Windows.
+        normalized = [p.replace("\\", "/").lower() for p in ff]
+        joined = "\n".join(normalized)
         assert "chocolatey" in joined
         assert "scoop" in joined
         # The user-home extract is built from the expanded USERPROFILE.
-        assert any(p.lower() == r"c:\users\tester\ffmpeg\bin\ffmpeg.exe" for p in ff)
+        assert "c:/users/tester/ffmpeg/bin/ffmpeg.exe" in normalized
 
     def test_windows_ffmpeg_paths_without_userprofile(self):
         """Missing USERPROFILE degrades to the machine-wide paths, no crash."""

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -756,6 +756,110 @@ class TestSearchPaths:
         assert any("makemkvcon64.exe" in p for p in mk)
         assert any("ffmpeg.exe" in p for p in ff)
 
+    def test_windows_ffmpeg_includes_package_manager_paths(self):
+        """Windows FFmpeg search covers Chocolatey + scoop + a home extract."""
+        from app.api import validation
+
+        with (
+            patch.object(validation.sys, "platform", "win32"),
+            patch.dict(validation.os.environ, {"USERPROFILE": r"C:\Users\tester"}, clear=False),
+        ):
+            ff = validation._get_ffmpeg_search_paths()
+
+        joined = "\n".join(ff).lower()
+        assert "chocolatey" in joined
+        assert "scoop" in joined
+        # The user-home extract is built from the expanded USERPROFILE.
+        assert any(p.lower() == r"c:\users\tester\ffmpeg\bin\ffmpeg.exe" for p in ff)
+
+    def test_windows_ffmpeg_paths_without_userprofile(self):
+        """Missing USERPROFILE degrades to the machine-wide paths, no crash."""
+        from app.api import validation
+
+        with (
+            patch.object(validation.sys, "platform", "win32"),
+            patch.dict(validation.os.environ, {}, clear=True),
+        ):
+            ff = validation._get_ffmpeg_search_paths()
+        assert any("ffmpeg.exe" in p for p in ff)
+        # No per-user paths get appended when USERPROFILE is absent.
+        assert not any("scoop" in p.lower() for p in ff)
+
+
+class TestWingetFfmpegDetection:
+    """winget's version-stamped FFmpeg layout is resolved via globbing.
+
+    ``winget install Gyan.FFmpeg`` (the in-app install hint) unpacks the build
+    under ``%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages\\Gyan.FFmpeg_*\\ffmpeg-*\\bin``.
+    That path is version-stamped, so it can't be hardcoded like the other
+    search paths — it has to be globbed.
+    """
+
+    @staticmethod
+    def _make_winget_layout(root: Path) -> Path:
+        bin_dir = (
+            root
+            / "Microsoft"
+            / "WinGet"
+            / "Packages"
+            / "Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe"
+            / "ffmpeg-8.1.1-full_build"
+            / "bin"
+        )
+        bin_dir.mkdir(parents=True)
+        exe = bin_dir / "ffmpeg.exe"
+        exe.write_text("")
+        return exe
+
+    def test_winget_glob_resolves_versioned_path(self, tmp_path):
+        from app.api import validation
+
+        exe = self._make_winget_layout(tmp_path)
+        with (
+            patch.object(validation.sys, "platform", "win32"),
+            patch.dict(validation.os.environ, {"LOCALAPPDATA": str(tmp_path)}, clear=False),
+        ):
+            matches = validation._iter_winget_ffmpeg_paths()
+        assert str(exe) in matches
+
+    def test_winget_glob_empty_when_no_localappdata(self):
+        from app.api import validation
+
+        with (
+            patch.object(validation.sys, "platform", "win32"),
+            patch.dict(validation.os.environ, {}, clear=True),
+        ):
+            assert validation._iter_winget_ffmpeg_paths() == []
+
+    def test_winget_glob_empty_off_windows(self):
+        from app.api import validation
+
+        with patch.object(validation.sys, "platform", "linux"):
+            assert validation._iter_winget_ffmpeg_paths() == []
+
+    def test_detect_ffmpeg_finds_winget_install(self, tmp_path):
+        """detect_ffmpeg resolves a winget binary when PATH + fixed paths miss it."""
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult
+
+        exe = self._make_winget_layout(tmp_path)
+        with (
+            patch.object(validation.sys, "platform", "win32"),
+            patch.object(validation.shutil, "which", return_value=None),
+            patch.object(validation, "_get_ffmpeg_search_paths", return_value=[]),
+            patch.dict(validation.os.environ, {"LOCALAPPDATA": str(tmp_path)}, clear=False),
+            patch.object(
+                validation,
+                "_validate_ffmpeg_binary",
+                return_value=ToolDetectionResult(
+                    found=True, path=str(exe), version="ffmpeg version 8.1.1"
+                ),
+            ),
+        ):
+            result = validation.detect_ffmpeg()
+        assert result.found is True
+        assert result.version == "ffmpeg version 8.1.1"
+
 
 class TestValidateMakemkvEndpoint:
     """The /validate/makemkv endpoint's existence + relabel branches."""

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -638,6 +638,17 @@ class TestFfmpegBinaryValidation:
         assert result.found is False
         assert "Execution failed" in result.error
 
+    def test_refuses_non_ffmpeg_path(self):
+        """The binary validator self-guards: a non-FFmpeg basename never reaches subprocess."""
+        from app.api.validation import _validate_ffmpeg_binary
+
+        with patch("app.api.validation.subprocess.run") as mock_run:
+            result = _validate_ffmpeg_binary("/usr/bin/python3")
+
+        assert result.found is False
+        assert "FFmpeg executable" in result.error
+        mock_run.assert_not_called()
+
 
 class TestToolDetection:
     """Auto-detection across PATH and common install locations."""

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - [MakeMKV](https://www.makemkv.com/) with a valid license key
+- [FFmpeg](https://ffmpeg.org/download.html) for episode matching (audio fingerprinting) — see [Installing FFmpeg](#installing-ffmpeg)
 - A [TMDB Read Access Token](https://www.themoviedb.org/settings/api) (v4 auth) for media metadata and poster art
 - If running from source: **Python 3.11+** with [uv](https://docs.astral.sh/uv/), and **Node.js 24**
 
@@ -30,6 +31,44 @@ On Fedora/RHEL:
 ```bash
 sudo dnf install ffmpeg eject
 # Install MakeMKV from https://www.makemkv.com/
+```
+
+## Installing FFmpeg
+
+Engram uses FFmpeg for episode matching — audio fingerprinting and the speech-recognition fallback both decode audio with it. On first launch Engram auto-detects FFmpeg on your `PATH` and in common install locations; if it can't find it, install it as below and restart Engram.
+
+!!! note "The version doesn't matter"
+    Engram only needs to be able to run FFmpeg — any recent build works. A "not detected" result almost always means FFmpeg isn't on your `PATH`, not that the version is wrong.
+
+### Windows
+
+The simplest option is [winget](https://learn.microsoft.com/windows/package-manager/winget/):
+
+```powershell
+winget install Gyan.FFmpeg
+```
+
+Then **fully close and reopen Engram** so it picks up the updated `PATH` — a running process keeps the `PATH` it started with.
+
+Prefer a manual install? Download a build from [gyan.dev](https://www.gyan.dev/ffmpeg/builds/) or [BtbN](https://github.com/BtbN/FFmpeg-Builds/releases), extract it, and do **one** of:
+
+- Add the extracted `...\bin` folder to your **system PATH** (Settings → *Edit the system environment variables* → *Environment Variables*), then restart Engram.
+- Drop `ffmpeg.exe` at `C:\ffmpeg\bin\ffmpeg.exe` — one of the locations Engram scans automatically.
+- Point Engram at it directly: in the Config Wizard (or **Settings → Tools**), use **Override path manually** and enter the full path to `ffmpeg.exe`. The path is validated immediately and shows the detected version.
+
+Still not detected? See [Troubleshooting → FFmpeg not detected (Windows)](../troubleshooting.md#ffmpeg-not-detected-windows).
+
+### Linux / macOS
+
+```bash
+# Debian/Ubuntu
+sudo apt install ffmpeg
+
+# Fedora
+sudo dnf install ffmpeg
+
+# macOS (Homebrew)
+brew install ffmpeg
 ```
 
 ## Option A: Standalone Executable (Windows)
@@ -98,7 +137,7 @@ Once both servers are running:
 
 1. The browser should show the Engram dashboard at `localhost:5173`.
 2. The Config Wizard will prompt you to configure MakeMKV path, library paths, and your TMDB token.
-3. Engram will auto-detect MakeMKV and FFmpeg if they are on your system PATH.
+3. Engram will auto-detect MakeMKV and FFmpeg if they are on your system PATH. If FFmpeg isn't detected, see [Installing FFmpeg](#installing-ffmpeg) or [Troubleshooting](../troubleshooting.md#ffmpeg-not-detected-windows).
 
 !!! tip "No physical disc drive?"
     You can test the full workflow without hardware using simulation mode.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+Common setup and runtime issues, and how to resolve them. If something here doesn't cover your problem, open an [issue](https://github.com/Jsakkos/engram/issues) — a [diagnostics bundle](#diagnostics-bundle) makes it much easier to help.
+
+## FFmpeg not detected (Windows)
+
+Engram needs FFmpeg for episode matching (audio fingerprinting and the speech-recognition fallback). If the Config Wizard's **Tools** step shows *"FFmpeg not found"* even though you installed it, it's almost always because FFmpeg isn't on your `PATH` — **not** because of the version. Engram doesn't care which FFmpeg version you have; it only needs to be able to run it.
+
+Work through these in order:
+
+**1. Confirm FFmpeg actually runs.** Open a **new** PowerShell or Command Prompt window and run:
+
+```powershell
+ffmpeg -version
+```
+
+- If you see version output, FFmpeg is on your `PATH` — skip to step 2.
+- If you see *"'ffmpeg' is not recognized…"*, FFmpeg is installed but not on your `PATH`. Go to step 3.
+
+**2. Restart Engram.** A running program keeps the `PATH` it was launched with. If you installed FFmpeg (or edited your `PATH`) while Engram was open, **fully close and reopen Engram** so it sees the change, then click **Re-scan** in the Config Wizard.
+
+**3. Put FFmpeg where Engram can find it.** Pick whichever is easiest:
+
+- **Install with winget** (recommended) and restart Engram:
+
+  ```powershell
+  winget install Gyan.FFmpeg
+  ```
+
+- **Add it to your PATH:** extract your FFmpeg download, then add the `...\bin` folder (the one containing `ffmpeg.exe`) to your system `PATH` via *Settings → Edit the system environment variables → Environment Variables*. Restart Engram afterward.
+
+- **Drop it in a scanned location:** copy `ffmpeg.exe` to `C:\ffmpeg\bin\ffmpeg.exe`. Engram scans this path (and the Chocolatey / scoop / winget install locations) automatically — no `PATH` change needed.
+
+- **Point Engram at it directly:** in the Config Wizard (or **Settings → Tools**), click **Override path manually** and enter the **full path to `ffmpeg.exe`** — for example `C:\Users\You\Downloads\ffmpeg\bin\ffmpeg.exe`. Enter the path to the **`.exe` file itself**, not the folder it lives in. The path is validated immediately and shows the detected version on success.
+
+See [Installing FFmpeg](getting-started/installation.md#installing-ffmpeg) for download links.
+
+### FFmpeg on Linux / macOS
+
+Install it with your package manager (`sudo apt install ffmpeg`, `sudo dnf install ffmpeg`, or `brew install ffmpeg`). See the [Linux / macOS setup guide](guide/linux-setup.md#ffmpeg-not-found) for details.
+
+## MakeMKV not detected
+
+MakeMKV is required for disc ripping. If the Config Wizard can't find it, install it from [makemkv.com](https://www.makemkv.com/) and, if it still isn't detected, use **Override path manually** to point at `makemkvcon64.exe` (typically under `C:\Program Files (x86)\MakeMKV\`). On Linux, see [Linux / macOS setup](guide/linux-setup.md). Don't forget to enter your MakeMKV license key in the wizard.
+
+## TMDB token not working
+
+The TMDB field expects a **Read Access Token** (v4 auth) — the long string starting with `eyJ…` — not the shorter v3 "API Key". The wizard validates it as you type. See [Configuration](getting-started/configuration.md) for where to find it.
+
+## Diagnostics bundle
+
+When reporting a problem, attach a diagnostics bundle so the logs and environment come with it. From the dashboard, open a job's detail view and download its diagnostic `.zip`, or fetch the overall report from `GET /api/diagnostics/report`. Secrets (API keys, tokens) are redacted automatically.

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { QRCodeSVG } from 'qrcode.react';
 import { FEATURES } from '../config/constants';
@@ -175,6 +175,10 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [pathValidation, setPathValidation] = useState<
         Partial<Record<keyof ConfigData, {status: 'idle' | 'validating' | 'valid' | 'invalid', version?: string, error?: string}>>
     >({});
+    // Monotonic per-field request counter. Each edit/validate bumps it; a response
+    // is applied only if its id is still current, so a slow earlier response can't
+    // overwrite a newer one (or clobber the user's in-progress edits).
+    const pathValidationSeq = useRef<Partial<Record<keyof ConfigData, number>>>({});
     // #243: first-run gate — require a validated TMDB token (or explicit skip) before leaving the TMDB step.
     const [tmdbContinueAnyway, setTmdbContinueAnyway] = useState(false);
     const [tmdbGatePrompted, setTmdbGatePrompted] = useState(false);
@@ -455,6 +459,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
             return;
         }
         const endpoint = toolName === 'MakeMKV' ? '/api/validate/makemkv' : '/api/validate/ffmpeg';
+        const requestId = (pathValidationSeq.current[configField] ?? 0) + 1;
+        pathValidationSeq.current[configField] = requestId;
+        const isStale = () => pathValidationSeq.current[configField] !== requestId;
         setPathValidation(prev => ({ ...prev, [configField]: { status: 'validating' } }));
         try {
             const response = await fetch(endpoint, {
@@ -462,6 +469,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path }),
             });
+            if (isStale()) return; // a newer request for this field superseded us
             const result = await response.json();
             if (result.valid) {
                 setPathValidation(prev => ({
@@ -475,6 +483,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                 }));
             }
         } catch {
+            if (isStale()) return;
             setPathValidation(prev => ({
                 ...prev,
                 [configField]: { status: 'invalid', error: 'Failed to reach validation endpoint' },
@@ -552,13 +561,18 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                             value={config[configField] as string}
                             onChange={(e) => {
                                 handleInputChange(configField, e.target.value);
-                                // Editing invalidates the previous result; re-check on blur.
+                                // Editing invalidates the previous result and any in-flight
+                                // validation; re-check on blur.
+                                pathValidationSeq.current[configField] =
+                                    (pathValidationSeq.current[configField] ?? 0) + 1;
                                 setPathValidation(prev => ({ ...prev, [configField]: { status: 'idle' } }));
                             }}
                             onBlur={(e) => validateToolPath(toolName, configField, e.target.value)}
                             placeholder={
                                 toolName === 'FFmpeg'
-                                    ? 'C:\\Users\\You\\ffmpeg\\bin\\ffmpeg.exe'
+                                    ? (toolDetection?.platform === 'win32'
+                                        ? 'C:\\Users\\You\\ffmpeg\\bin\\ffmpeg.exe'
+                                        : '/usr/local/bin/ffmpeg')
                                     : `Path to ${toolName.toLowerCase()} executable`
                             }
                         />

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -169,6 +169,12 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
     const [showFfmpegOverride, setShowFfmpegOverride] = useState(false);
     const [savedKeys, setSavedKeys] = useState<{makemkv: boolean, tmdb: boolean, opensubtitles: boolean, ai: boolean}>({makemkv: false, tmdb: false, opensubtitles: false, ai: false});
     const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid', error?: string}>({status: 'idle'});
+    // Inline validation for manually-entered tool paths (MakeMKV/FFmpeg), keyed by
+    // the config field. Without this, a hand-typed override was saved blind — no
+    // confirmation it actually points at a working binary.
+    const [pathValidation, setPathValidation] = useState<
+        Partial<Record<keyof ConfigData, {status: 'idle' | 'validating' | 'valid' | 'invalid', version?: string, error?: string}>>
+    >({});
     // #243: first-run gate — require a validated TMDB token (or explicit skip) before leaving the TMDB step.
     const [tmdbContinueAnyway, setTmdbContinueAnyway] = useState(false);
     const [tmdbGatePrompted, setTmdbGatePrompted] = useState(false);
@@ -436,6 +442,46 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
         }
     };
 
+    // Validate a manually-entered tool path against the backend, which actually
+    // runs the binary. Picks the endpoint by tool; an empty path resets to idle.
+    const validateToolPath = async (
+        toolName: string,
+        configField: keyof ConfigData,
+        rawPath: string,
+    ) => {
+        const path = rawPath.trim();
+        if (!path) {
+            setPathValidation(prev => ({ ...prev, [configField]: { status: 'idle' } }));
+            return;
+        }
+        const endpoint = toolName === 'MakeMKV' ? '/api/validate/makemkv' : '/api/validate/ffmpeg';
+        setPathValidation(prev => ({ ...prev, [configField]: { status: 'validating' } }));
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path }),
+            });
+            const result = await response.json();
+            if (result.valid) {
+                setPathValidation(prev => ({
+                    ...prev,
+                    [configField]: { status: 'valid', version: result.version },
+                }));
+            } else {
+                setPathValidation(prev => ({
+                    ...prev,
+                    [configField]: { status: 'invalid', error: result.error || 'Validation failed' },
+                }));
+            }
+        } catch {
+            setPathValidation(prev => ({
+                ...prev,
+                [configField]: { status: 'invalid', error: 'Failed to reach validation endpoint' },
+            }));
+        }
+    };
+
     const renderToolStatus = (
         tool: ToolDetectionResult | undefined,
         toolName: string,
@@ -504,9 +550,34 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                         <input
                             type="text"
                             value={config[configField] as string}
-                            onChange={(e) => handleInputChange(configField, e.target.value)}
-                            placeholder={`Path to ${toolName.toLowerCase()} executable`}
+                            onChange={(e) => {
+                                handleInputChange(configField, e.target.value);
+                                // Editing invalidates the previous result; re-check on blur.
+                                setPathValidation(prev => ({ ...prev, [configField]: { status: 'idle' } }));
+                            }}
+                            onBlur={(e) => validateToolPath(toolName, configField, e.target.value)}
+                            placeholder={
+                                toolName === 'FFmpeg'
+                                    ? 'C:\\Users\\You\\ffmpeg\\bin\\ffmpeg.exe'
+                                    : `Path to ${toolName.toLowerCase()} executable`
+                            }
                         />
+                        <span className="form-hint">
+                            Point to the {toolName} executable file itself, not the folder it lives in.
+                        </span>
+                        {pathValidation[configField]?.status === 'validating' && (
+                            <span style={{ fontSize: '0.85rem' }}>Checking…</span>
+                        )}
+                        {pathValidation[configField]?.status === 'valid' && (
+                            <span style={{ color: '#22c55e', fontSize: '0.85rem' }}>
+                                ✓ {pathValidation[configField]?.version || 'Valid'}
+                            </span>
+                        )}
+                        {pathValidation[configField]?.status === 'invalid' && (
+                            <span style={{ color: '#ef4444', fontSize: '0.85rem' }}>
+                                ✗ {pathValidation[configField]?.error}
+                            </span>
+                        )}
                     </div>
                 )}
             </div>
@@ -634,7 +705,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                     ? 'Download installer from makemkv.com'
                     : 'sudo apt install makemkv-bin makemkv-oss';
                 const ffmpegInstallHint = isWindows
-                    ? 'winget install ffmpeg'
+                    ? 'winget install Gyan.FFmpeg'
                     : 'sudo apt install ffmpeg';
 
                 return (
@@ -659,7 +730,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 toolDetection?.ffmpeg,
                                 'FFmpeg',
                                 ffmpegInstallHint,
-                                null,
+                                'https://ffmpeg.org/download.html',
                                 showFfmpegOverride,
                                 setShowFfmpegOverride,
                                 'ffmpegPath',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - Review Queue: guide/review-queue.md
     - Job History: guide/history.md
     - LLM Episode Matcher: guide/llm-episode-matcher.md
+  - Troubleshooting: troubleshooting.md
   - Deployment:
     - Docker (Linux): deployment/docker.md
   - Architecture:


### PR DESCRIPTION
## Why

A Windows user reported FFmpeg **"not detected"** even though they had installed it (v8.1.1). Two gaps surfaced:

1. FFmpeg was a **real but undocumented prerequisite** (only mentioned in the Linux/macOS notes).
2. Detection only checks `PATH` then three hardcoded folders, and the Config Wizard's manual-path override saved input without validating it.

The version is a red herring — `_validate_ffmpeg_binary` does no version parsing; it just runs `ffmpeg -version` and checks the exit code. The real cause is FFmpeg not being on `PATH` — or being installed *after* Engram launched, so the running process holds a stale `PATH`.

## What changed

**Docs**
- FFmpeg added to **Prerequisites** in `README.md` and `docs/getting-started/installation.md`, with a new **Installing FFmpeg** section (winget, manual extract → PATH / scanned location / manual override, Linux/macOS).
- New `docs/troubleshooting.md` led by *"FFmpeg not detected (Windows)"* — confirm `ffmpeg -version` in a fresh shell → restart Engram → fix PATH / drop in a scanned location / use the manual override. Wired into the mkdocs nav; linked from the README quick start and installation pages.
- `CHANGELOG.md` `[Unreleased]` entries.

**Frontend** (`ConfigWizard.tsx`)
- The manual tool-path override now validates against `/api/validate/{makemkv,ffmpeg}` on blur and shows the detected version (✓) or the specific error (✗) inline, instead of saving the path unchecked. Because the render function is shared, this fixes both tools.
- The FFmpeg "not found" card gets a download link; clearer placeholder + a "point at `ffmpeg.exe`, not the folder" hint; the install hint now names the exact winget package (`Gyan.FFmpeg`).

**Backend** (`validation.py`)
- Windows FFmpeg auto-detection also searches Chocolatey, scoop, a user-home extract, and globs winget's version-stamped `Gyan.FFmpeg` layout — so a fresh install is found even before it's on the running process's `PATH`. Each candidate is still validated before use.

## Verification
- **Backend:** `pytest tests/unit/test_validation.py` → 70 passed (6 new); ruff lint + format clean.
- **Frontend:** `npm run build` (tsc + vite) and `npm run lint` clean.
- **Docs:** `mkdocs build --strict` introduces **no new warnings** from these files (the 31 pre-existing strict-mode warnings are all from `docs/development/brand.md`, unrelated to this change).

## Notes for reviewers
- No live click-through of the wizard validation was run (would require starting the servers); it's covered by tsc + eslint + the already-tested backend endpoint.
- The pre-existing `docs/development/brand.md` strict-build warnings are out of scope here (flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
