### PR TITLE
ci: streamline CI for release-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_AFTER: ${{ github.sha }}
         run: |
-          title="${PR_TITLE:-$HEAD_MSG}"
+          # Clamp to the first line: head_commit.message carries the full body,
+          # and `grep '^'` matches the start of EVERY line, so a body line that
+          # begins `chore: release v` could false-positive. We only want to key
+          # on the commit subject (PR titles are already single-line).
+          title=$(printf '%s' "${PR_TITLE:-$HEAD_MSG}" | head -n1)
           echo "event=$EVENT_NAME title=$title"
           is_release=false
           if printf '%s' "$title" | grep -qE '^chore: release v[0-9]'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,63 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # Decide whether this is a release-only change (a `chore: release vX.Y.Z` PR
+  # that touches nothing but version strings + CHANGELOG.md). When it is, the
+  # heavy behavioral jobs below are skipped — the released code was already
+  # validated when its source PRs merged, and release.yml does the real binary
+  # validation. The detection keys on a release SIGNAL (title + a strict file
+  # allowlist), NEVER on paths alone, so a Renovate/Dependabot lock-file bump
+  # (which also touches uv.lock / package-lock.json but is titled `build(deps):`)
+  # still runs the full suite. See docs/superpowers/specs for the design.
+  detect-release:
+    name: Detect Release
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.detect.outputs.is_release }}
+      os_matrix: ${{ steps.detect.outputs.os_matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need base history for the changed-file diff
+      - id: detect
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          title="${PR_TITLE:-$HEAD_MSG}"
+          echo "event=$EVENT_NAME title=$title"
+          is_release=false
+          if printf '%s' "$title" | grep -qE '^chore: release v[0-9]'; then
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              base="$PR_BASE_SHA"; head="$PR_HEAD_SHA"
+            else
+              base="$PUSH_BEFORE"; head="$PUSH_AFTER"
+            fi
+            changed=$(git diff --name-only "$base" "$head" 2>/dev/null || true)
+            echo "changed files:"; printf '%s\n' "$changed"
+            allow='^(backend/pyproject\.toml|backend/app/__init__\.py|backend/uv\.lock|frontend/package\.json|frontend/package-lock\.json|CHANGELOG\.md)$'
+            # release-only iff there IS a diff AND no changed file is outside the allowlist
+            if [ -n "$changed" ] && ! printf '%s\n' "$changed" | grep -qvE "$allow"; then
+              is_release=true
+            else
+              echo "Title says release but diff is empty or includes non-allowlisted files — running full CI."
+            fi
+          fi
+          if [ "$is_release" = "true" ]; then
+            os_matrix='["ubuntu-latest"]'
+          else
+            os_matrix='["ubuntu-latest","windows-latest"]'
+          fi
+          echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
+          echo "os_matrix=$os_matrix" >> "$GITHUB_OUTPUT"
+          echo "RESULT is_release=$is_release os_matrix=$os_matrix"
+
   changelog-version-check:
     name: Changelog Version Check
     runs-on: ubuntu-latest
@@ -57,10 +114,13 @@ jobs:
 
   backend-test-unit:
     name: Backend Tests (unit)
+    # Kept on release PRs as the unit smoke, but ubuntu-only there: the dynamic
+    # matrix drops the (slow) Windows leg for a version-only change.
+    needs: [detect-release]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(needs.detect-release.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -117,7 +177,8 @@ jobs:
   backend-test-integration:
     name: Backend Tests (integration)
     runs-on: ubuntu-latest
-    needs: [backend-test-unit]
+    needs: [detect-release, backend-test-unit]
+    if: needs.detect-release.outputs.is_release != 'true'
     defaults:
       run:
         working-directory: backend
@@ -163,7 +224,8 @@ jobs:
   backend-coverage:
     name: Backend Coverage
     runs-on: ubuntu-latest
-    needs: [backend-test-unit, backend-test-integration]
+    needs: [detect-release, backend-test-unit, backend-test-integration]
+    if: needs.detect-release.outputs.is_release != 'true'
     defaults:
       run:
         working-directory: backend
@@ -253,6 +315,8 @@ jobs:
     name: Dependency Resolution (Python ${{ matrix.python }}, ${{ matrix.os }})
     # Reproduces the macOS source-install path so a too-new interpreter or a
     # missing platform wheel (e.g. onnxruntime) is caught before a user hits it.
+    needs: [detect-release]
+    if: needs.detect-release.outputs.is_release != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -278,6 +342,8 @@ jobs:
     # onnxruntime has no cp314 wheel, so the requires-python upper bound must
     # keep uv off Python 3.14. If this job starts failing because uv sync
     # *succeeded* on 3.14, raise the cap and refresh this guard.
+    needs: [detect-release]
+    if: needs.detect-release.outputs.is_release != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -307,6 +373,8 @@ jobs:
 
   alembic-check:
     name: Alembic Migration Sanity
+    needs: [detect-release]
+    if: needs.detect-release.outputs.is_release != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -373,6 +441,8 @@ jobs:
 
   frontend-test-unit:
     name: Frontend Unit Tests
+    needs: [detect-release]
+    if: needs.detect-release.outputs.is_release != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -396,7 +466,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [frontend-lint-build]
+    needs: [detect-release, frontend-lint-build]
+    if: needs.detect-release.outputs.is_release != 'true'
     defaults:
       run:
         working-directory: frontend
@@ -456,3 +527,47 @@ jobs:
         with:
           name: playwright-traces
           path: frontend/test-results/
+
+  # Single required status check for branch protection. `needs:` every granular
+  # job and reports one pass/fail, so the individual jobs can be made
+  # non-required (and freely skipped on release PRs) without leaving a required
+  # context stuck in "Expected — waiting" → PR BLOCKED. Uses `always()` so it
+  # runs even when upstream jobs were skipped or failed. A *skipped* job is
+  # acceptable (intentionally skipped on a release-only change); only a
+  # *failed/cancelled* job fails the gate.
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - detect-release
+      - changelog-version-check
+      - backend-lint
+      - backend-test-unit
+      - backend-test-integration
+      - backend-coverage
+      - backend-smoke
+      - dependency-resolution
+      - dependency-resolution-py314-guard
+      - alembic-check
+      - frontend-lint-build
+      - frontend-test-unit
+      - e2e-tests
+    steps:
+      - name: Gate on needed jobs (skipped is OK, failed/cancelled is not)
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          printf '%s\n' "$NEEDS_JSON"
+          bad=$(printf '%s' "$NEEDS_JSON" | python3 -c '
+          import json, sys
+          needs = json.load(sys.stdin)
+          bad = [k for k, v in needs.items() if v.get("result") in ("failure", "cancelled")]
+          print(",".join(bad))
+          ')
+          if [ -n "$bad" ]; then
+            echo "CI Gate FAILED — failed/cancelled jobs: $bad"
+            exit 1
+          fi
+          echo "CI Gate PASSED."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,15 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Skip on a release-only change (`chore: release vX.Y.Z` PR or its merge
+    # commit): the tree is identical to already-scanned main except version
+    # strings + CHANGELOG. Not a required check, so a title-only guard is safe.
+    # The weekly scheduled scan and all normal PRs/pushes are unaffected.
+    if: >-
+      !(
+        (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v')) ||
+        (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v'))
+      )
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,12 @@ jobs:
   docker:
     name: Build and publish image
     runs-on: ubuntu-latest
+    # Skip the redundant PR-time image build for a release-only PR. The real
+    # release image is built when tag-release.yml dispatches this workflow on the
+    # tag (workflow_dispatch / tag push), which is not a pull_request event and so
+    # is unaffected. Normal PRs and tag builds still build as before.
+    if: >-
+      !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v'))
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/superpowers/plans/2026-06-02-streamline-release-ci.md
+++ b/docs/superpowers/plans/2026-06-02-streamline-release-ci.md
@@ -139,6 +139,16 @@ If anything looks wrong between steps 2 and 3, the legacy contexts still exist a
 still report on normal PRs, so leaving protection on the 9 contexts (i.e. not
 running step 3) is a safe no-op fallback while the workflow change bakes.
 
+> **⚠️ Flip-window hazard — do NOT open a release PR between step 2 (merge) and
+> step 3 (PATCH).** In that window, branch protection still requires the 9 legacy
+> contexts, but a release-only PR (`is_release=true`) drops the Windows unit leg
+> via the dynamic matrix, so `Backend Tests (unit) (windows-latest)` never reports
+> → the release PR is permanently BLOCKED until the PATCH lands. Mitigation: run
+> step 3 **immediately** after merge (the agent/maintainer owns this), and don't
+> cut a release until `gh api .../required_status_checks` shows only `CI Gate`.
+> The repo is currently solo (no other contributors opening PRs), so the window is
+> safe in practice — this warning guards the "forgot to flip" scenario.
+
 ## Rollback story
 
 - **Protection only:** run the rollback PATCH (restores the 9 contexts).

--- a/docs/superpowers/plans/2026-06-02-streamline-release-ci.md
+++ b/docs/superpowers/plans/2026-06-02-streamline-release-ci.md
@@ -1,0 +1,156 @@
+# Streamline Release-PR CI — Implementation & Rollout Plan
+
+**Date:** 2026-06-02
+**Branch:** `chore/streamline-release-ci`
+**Design:** [`docs/superpowers/specs/2026-06-02-streamline-release-ci-design.md`](../specs/2026-06-02-streamline-release-ci-design.md)
+
+## Goal
+
+Reduce a `chore: release vX.Y.Z` PR to the checks it actually needs, without
+breaking branch protection and without weakening `release.yml`.
+
+## Detection mechanism
+
+New `detect-release` job in `ci.yml` outputs `is_release` and `os_matrix`.
+`is_release=true` **iff** the title (`pull_request.title`, or `head_commit.message`
+on push) matches `^chore: release v[0-9]` **AND** every changed file (git diff vs
+base, `fetch-depth: 0`) is in the allowlist:
+
+```
+backend/pyproject.toml
+backend/app/__init__.py
+backend/uv.lock
+frontend/package.json
+frontend/package-lock.json
+CHANGELOG.md
+```
+
+Title is the necessary signal (a Renovate/Dependabot lock-file bump touches
+`uv.lock`/`package-lock.json` but is titled `build(deps):`, so it stays
+`false` → full CI). The allowlist is the belt-and-suspenders guard (a "release"
+PR that also edited source → `false` → full CI).
+
+Dry-run verification (all pass — see PR description / session log):
+
+| Scenario | Title | Files | `is_release` |
+|---|---|---|---|
+| normal code PR | `fix: …` | source files | `false` |
+| dependency bump | `build(deps): …` | `uv.lock` | `false` |
+| release-only | `chore: release v0.15.0` | version set + CHANGELOG | `true` |
+| release + source | `chore: release v0.15.0` | + `extractor.py` | `false` |
+| release, empty diff | `chore: release v0.15.0` | — | `false` |
+| release merge commit | `chore: release v0.15.0 (#299)` | version + CHANGELOG | `true` |
+| lookalike | `chore: release validation tweaks` | source | `false` |
+
+## Required-check strategy: single `CI Gate` aggregator
+
+New `ci-gate` job (`name: CI Gate`, `if: always()`) `needs:` every granular job
+and fails iff any has `result` ∈ {`failure`,`cancelled`}; `skipped`/`success`
+pass. Branch protection is flipped from the 9 granular contexts to the single
+`CI Gate`. This is what makes skipping the heavy jobs safe — a *required* check
+that never reports would block the PR forever; an aggregator always reports.
+
+Side benefit: `changelog-version-check` (previously not required) now feeds the
+gate, so a missing changelog section blocks a release PR.
+
+## Jobs skipped vs kept on a release-only PR
+
+**Kept (the cheap safety net):**
+- `changelog-version-check` — the release-specific gate
+- `backend-lint`
+- `backend-test-unit` — ubuntu-only via dynamic matrix (`os_matrix`)
+- `backend-smoke` — import + boot probe
+- `frontend-lint-build` — validates the bumped `package.json` builds
+
+**Skipped (`if: needs.detect-release.outputs.is_release != 'true'`):**
+- `backend-test-unit` Windows leg (dropped from the matrix, not gated)
+- `backend-test-integration`
+- `backend-coverage`
+- `dependency-resolution` (6-job matrix)
+- `dependency-resolution-py314-guard`
+- `alembic-check`
+- `frontend-test-unit`
+- `e2e-tests`
+
+A custom `if:` without a status function is implicitly ANDed with `success()`,
+so these gates also preserve the normal "don't run if a needed job failed"
+behavior. Only `ci-gate` uses `always()`.
+
+**Non-required workflows trimmed (title-only guard, can't block):**
+- `codeql.yml` `analyze` — skipped on release PR and release push (weekly cron +
+  normal PRs untouched).
+- `docker.yml` `docker` — skips only the `pull_request` image build on release
+  PRs. Tag/`workflow_dispatch` builds (the real release image) untouched.
+
+**Not touched:** `release.yml`, `tag-release.yml`, `publish.yml`,
+`download-stats.yml`, `docs.yml`, `dependabot-auto-merge.yml`.
+
+## Branch-protection changes
+
+Apply via the dedicated `required_status_checks` sub-resource (PATCH, not a full
+PUT) so the other protections (linear history, conversation resolution,
+force-push block, `strict: true`) are preserved.
+
+**Apply (after this PR merges):**
+
+```bash
+gh api -X PATCH repos/Jsakkos/engram/branches/main/protection/required_status_checks \
+  --input ci-gate-required.json
+```
+`ci-gate-required.json`:
+```json
+{"strict": true, "checks": [{"context": "CI Gate"}]}
+```
+
+**Rollback:**
+
+```bash
+gh api -X PATCH repos/Jsakkos/engram/branches/main/protection/required_status_checks \
+  --input ci-gate-rollback.json
+```
+`ci-gate-rollback.json`:
+```json
+{"strict": true, "checks": [
+  {"context": "Backend Lint"},
+  {"context": "Backend Tests (unit) (ubuntu-latest)"},
+  {"context": "Backend Tests (unit) (windows-latest)"},
+  {"context": "Backend Tests (integration)"},
+  {"context": "Backend Smoke Test"},
+  {"context": "Alembic Migration Sanity"},
+  {"context": "Frontend Lint & Build"},
+  {"context": "Frontend Unit Tests"},
+  {"context": "E2E Tests"}
+]}
+```
+
+## Rollout order (cannot self-block)
+
+1. This PR is a **normal** PR → `is_release=false` → full CI → produces all 9
+   legacy contexts **and** the new `CI Gate` context → mergeable under the
+   current (9-context) protection. (Does not require flipping protection first.)
+2. Squash-merge.
+3. **Immediately** run the apply PATCH above → `CI Gate` becomes the sole required
+   context.
+4. The next `chore: release` PR: heavy jobs skip, `CI Gate` stays green, PR is
+   mergeable (not BLOCKED). `tag-release.yml` → `release.yml` then does the real
+   3-platform binary validation on merge.
+
+If anything looks wrong between steps 2 and 3, the legacy contexts still exist and
+still report on normal PRs, so leaving protection on the 9 contexts (i.e. not
+running step 3) is a safe no-op fallback while the workflow change bakes.
+
+## Rollback story
+
+- **Protection only:** run the rollback PATCH (restores the 9 contexts).
+- **Workflows:** `git revert` the implementation commit. Safe to do independently —
+  the legacy job names are unchanged, so they keep reporting; only `detect-release`
+  and `ci-gate` disappear. If protection was already flipped to `CI Gate`, run the
+  rollback PATCH too (since `CI Gate` would no longer be produced after a revert).
+
+## Verification
+
+- `act` not installed → validated by: (1) PyYAML parse of all three workflows
+  (pass, 14/1/1 jobs); (2) shell dry-run of `detect-release` across the 7
+  scenarios above (all correct); (3) live on this PR — confirm all granular jobs
+  run + `CI Gate` is green; (4) post-merge, confirm a `chore: release` PR skips the
+  heavy jobs while `CI Gate` stays green and the PR is mergeable.

--- a/docs/superpowers/specs/2026-06-02-streamline-release-ci-design.md
+++ b/docs/superpowers/specs/2026-06-02-streamline-release-ci-design.md
@@ -1,0 +1,324 @@
+# Streamline Release-PR CI — Design
+
+**Date:** 2026-06-02
+**Status:** Approved (design); implementation pending
+**Branch:** `chore/streamline-release-ci`
+
+## Problem
+
+A release PR (titled `chore: release vX.Y.Z`) changes only version strings and
+`CHANGELOG.md`, yet it currently triggers the full behavioral CI pipeline:
+Playwright E2E (3 browsers), the 6-job `dependency-resolution` matrix, backend
+integration + coverage, frontend unit tests, CodeQL-on-PR, and a Docker PR image
+build — plus a duplicate full `ci.yml` run on the push to `main` after merge.
+
+The released *code* was already validated when its source PRs merged. The release
+tree differs from last-green `main` only in version strings + changelog, so almost
+all of that work is redundant for a release-only change. We want to reduce a
+release PR to the checks it actually needs — **without breaking branch protection**.
+
+## The two hard constraints
+
+### 1. Branch protection / required checks (the "green but BLOCKED" trap)
+
+`main` requires these **9 named status checks** (verified via
+`gh api repos/Jsakkos/engram/branches/main/protection`), with `strict: true`
+(up-to-date branch required), squash-only, force-push blocked, conversation
+resolution required:
+
+```
+Backend Lint
+Backend Tests (unit) (ubuntu-latest)
+Backend Tests (unit) (windows-latest)
+Backend Tests (integration)
+Backend Smoke Test
+Alembic Migration Sanity
+Frontend Lint & Build
+Frontend Unit Tests
+E2E Tests
+```
+
+Note the names are **job display names**, and the matrix legs append
+`(ubuntu-latest)` / `(windows-latest)`. Notably, `Changelog Version Check`,
+`Backend Coverage`, `Dependency Resolution …`, and the py314 guard are **not**
+required.
+
+A *required* status check that never reports (because its job was skipped at the
+job level, or its whole workflow was filtered out) sits in "Expected — waiting"
+forever → the PR is **permanently BLOCKED**. So we cannot simply add
+`if:`-skips to the nine required jobs and leave branch protection as-is.
+
+**Resolution — single aggregator required check.** Introduce one `CI Gate` job
+that `needs:` every granular job and reports a single pass/fail. Flip branch
+protection to require **only** `CI Gate`. The granular jobs become individually
+non-required, so skipping any of them is safe. The aggregator is release-aware:
+a *skipped* upstream job is acceptable (it was intentionally skipped), only a
+*failed/cancelled* upstream job fails the gate. This also declutters normal PRs.
+
+### 2. Lock-file ambiguity (release vs dependency bump)
+
+A release bump **and** a Renovate/Dependabot dependency bump both touch
+`backend/uv.lock` and `frontend/package-lock.json`. So "is this release-only?"
+must key on a **release signal**, never on paths alone — otherwise a real
+dependency bump would skip its own tests.
+
+**Resolution — title signal AND strict file allowlist.** `is_release` is true
+**iff**:
+- the title (`pull_request.title`, or `head_commit.message` on push) starts with
+  `chore: release v`, **AND**
+- every changed file (git diff vs base) is in the allowlist:
+  `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`,
+  `frontend/package.json`, `frontend/package-lock.json`, `CHANGELOG.md`.
+
+The title is the *necessary* signal (mirrors `tag-release.yml`'s existing
+`contains(head_commit.message, 'chore: release v')` convention). The allowlist is
+the belt-and-suspenders guard: a "release" PR that also edited source code fails
+the allowlist and runs full CI. A dependency bump is titled `build(deps): …`, so
+it never matches the title signal even though it touches the lock files.
+
+## Architecture
+
+All changes are additive to `ci.yml`, plus title-only skip guards on two
+non-required workflows. **`release.yml` and `tag-release.yml` are not touched.**
+
+### `ci.yml` — new `detect-release` job
+
+```yaml
+detect-release:
+  name: Detect Release
+  runs-on: ubuntu-latest
+  outputs:
+    is_release: ${{ steps.detect.outputs.is_release }}
+    os_matrix: ${{ steps.detect.outputs.os_matrix }}
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0   # need base history for the changed-file diff
+    - id: detect
+      shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        HEAD_MSG: ${{ github.event.head_commit.message }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PUSH_BEFORE: ${{ github.event.before }}
+        PUSH_AFTER: ${{ github.sha }}
+      run: |
+        title="${PR_TITLE:-$HEAD_MSG}"
+        echo "event=$EVENT_NAME title=$title"
+        is_release=false
+        if printf '%s' "$title" | grep -qE '^chore: release v[0-9]'; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="$PR_BASE_SHA"; head="$PR_HEAD_SHA"
+          else
+            base="$PUSH_BEFORE"; head="$PUSH_AFTER"
+          fi
+          changed=$(git diff --name-only "$base" "$head" 2>/dev/null || true)
+          echo "changed files:"; printf '%s\n' "$changed"
+          allow='^(backend/pyproject\.toml|backend/app/__init__\.py|backend/uv\.lock|frontend/package\.json|frontend/package-lock\.json|CHANGELOG\.md)$'
+          # release-only iff there is a diff AND no changed file falls outside the allowlist
+          if [ -n "$changed" ] && ! printf '%s\n' "$changed" | grep -qvE "$allow"; then
+            is_release=true
+          else
+            echo "Title says release but diff is empty or includes non-allowlisted files — full CI."
+          fi
+        fi
+        if [ "$is_release" = "true" ]; then
+          os_matrix='["ubuntu-latest"]'
+        else
+          os_matrix='["ubuntu-latest","windows-latest"]'
+        fi
+        echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
+        echo "os_matrix=$os_matrix" >> "$GITHUB_OUTPUT"
+        echo "RESULT is_release=$is_release os_matrix=$os_matrix"
+```
+
+### `ci.yml` — new `ci-gate` aggregator
+
+```yaml
+ci-gate:
+  name: CI Gate
+  runs-on: ubuntu-latest
+  if: always()
+  needs:
+    - detect-release
+    - changelog-version-check
+    - backend-lint
+    - backend-test-unit
+    - backend-test-integration
+    - backend-coverage
+    - backend-smoke
+    - dependency-resolution
+    - dependency-resolution-py314-guard
+    - alembic-check
+    - frontend-lint-build
+    - frontend-test-unit
+    - e2e-tests
+  steps:
+    - name: Gate on needed jobs (skipped is OK, failed/cancelled is not)
+      shell: bash
+      env:
+        NEEDS_JSON: ${{ toJSON(needs) }}
+      run: |
+        printf '%s\n' "$NEEDS_JSON"
+        bad=$(printf '%s' "$NEEDS_JSON" | python3 -c '
+        import json,sys
+        needs=json.load(sys.stdin)
+        bad=[k for k,v in needs.items() if v.get("result") in ("failure","cancelled")]
+        print(",".join(bad))
+        ')
+        if [ -n "$bad" ]; then
+          echo "CI Gate FAILED — failed/cancelled jobs: $bad"
+          exit 1
+        fi
+        echo "CI Gate PASSED."
+```
+
+### `ci.yml` — per-job behavior on a release-only PR
+
+| Job | On release-only PR |
+|---|---|
+| `changelog-version-check` | **runs** (no gate) — the release-specific gate |
+| `backend-lint` | **runs** (no gate) |
+| `backend-test-unit` | **runs**, dynamic matrix → ubuntu-only (`needs: [detect-release]`, `matrix.os: ${{ fromJSON(needs.detect-release.outputs.os_matrix) }}`) |
+| `backend-smoke` | **runs** (no gate) — import + boot probe |
+| `frontend-lint-build` | **runs** (no gate) — validates the bumped `package.json` builds |
+| `backend-test-integration` | **skipped** (`if: needs.detect-release.outputs.is_release != 'true'`, add `detect-release` to `needs`) |
+| `backend-coverage` | **skipped** (same gate) |
+| `dependency-resolution` | **skipped** (same gate) |
+| `dependency-resolution-py314-guard` | **skipped** (same gate) |
+| `alembic-check` | **skipped** (same gate) |
+| `frontend-test-unit` | **skipped** (same gate) |
+| `e2e-tests` | **skipped** (same gate) |
+
+Gating mechanics: a custom `if:` *without* a status-check function is implicitly
+ANDed with `success()`. So `if: needs.detect-release.outputs.is_release != 'true'`
+keeps the "skip on release" behavior *and* the normal "don't run if a needed job
+failed" behavior — no explicit `&& success()` required. The `ci-gate` job is the
+exception: it uses `if: always()` precisely so it still runs when upstream jobs
+were skipped or failed.
+
+Side effect (intended improvement): `changelog-version-check` — currently *not* a
+required context — now feeds `CI Gate`, so a missing changelog section fails the
+gate and blocks the release PR.
+
+### `codeql.yml` — skip `analyze` on release (non-required, title-only)
+
+```yaml
+analyze:
+  ...
+  if: >-
+    !(
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v')) ||
+      (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v'))
+    )
+```
+
+Weekly `schedule` scan and normal PRs/pushes are unaffected. CodeQL is not a
+required check, so a title-only guard (no allowlist) is acceptable — a mis-skip
+only means one missing non-required scan, never a block.
+
+### `docker.yml` — skip the PR image build on release PRs (non-required, title-only)
+
+```yaml
+docker:
+  ...
+  if: >-
+    !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v'))
+```
+
+This skips **only** the `pull_request` image build for release PRs. The real
+release image is built when `tag-release.yml` dispatches `docker.yml` on the tag
+(`workflow_dispatch` / tag ref) — that path is `event_name != 'pull_request'`, so
+it is untouched. Normal PRs and tag builds are unaffected.
+
+### Branch protection flip (applied post-merge by maintainer/agent with admin)
+
+Rollout order that cannot self-block:
+
+1. Open this change as a **normal** PR. `is_release=false` → full CI runs →
+   produces all 9 legacy contexts **and** the new `CI Gate` context → mergeable
+   under the *current* (9-context) protection.
+2. Squash-merge.
+3. Immediately PATCH the required-checks sub-resource to require **only**
+   `CI Gate` (keeping `strict: true`):
+
+   ```bash
+   gh api -X PATCH repos/Jsakkos/engram/branches/main/protection/required_status_checks \
+     --input ci-gate-required.json
+   # ci-gate-required.json: {"strict": true, "checks": [{"context": "CI Gate"}]}
+   ```
+
+Using the dedicated `required_status_checks` sub-resource (not a full-protection
+PUT) avoids clobbering the other protections (linear history, conversation
+resolution, force-push block).
+
+**Rollback** — restore the 9 contexts:
+
+```bash
+gh api -X PATCH repos/Jsakkos/engram/branches/main/protection/required_status_checks \
+  --input ci-gate-rollback.json
+```
+```json
+{"strict": true, "checks": [
+  {"context": "Backend Lint"},
+  {"context": "Backend Tests (unit) (ubuntu-latest)"},
+  {"context": "Backend Tests (unit) (windows-latest)"},
+  {"context": "Backend Tests (integration)"},
+  {"context": "Backend Smoke Test"},
+  {"context": "Alembic Migration Sanity"},
+  {"context": "Frontend Lint & Build"},
+  {"context": "Frontend Unit Tests"},
+  {"context": "E2E Tests"}
+]}
+```
+
+(If the workflow changes themselves need reverting, also revert the `ci.yml` /
+`codeql.yml` / `docker.yml` commit. Reverting the commit alone, without the
+protection rollback, is safe because the legacy job names still exist and would
+report — but the protection would then list `CI Gate` which still reports too.)
+
+## Interactions verified
+
+- **Dependabot auto-merge** (`dependabot-auto-merge.yml`): a deps PR is titled
+  `build(deps): …` → `is_release=false` → full CI → `CI Gate` reflects real
+  results → auto-merge waits for `CI Gate` and proceeds normally. No change to
+  that workflow.
+- **`tag-release.yml` → `release.yml` / `docker.yml`**: untouched. On the release
+  push to `main`, `tag-release.yml` still tags and dispatches the 3-platform
+  binary build (certifi assertion, `engram --selftest`, sha256 manifests) and the
+  GHCR image. This is the real release validation and is unchanged.
+- **`docs.yml`**: runs on push to `main`, rebuilds the docs site (incl. the new
+  CHANGELOG section). Desired; untouched; non-required.
+- **Push-to-`main` duplicate `ci.yml` run**: the release squash commit message
+  starts with `chore: release v`, so `detect-release` returns `is_release=true`
+  on that push too → the heavy jobs skip on the duplicate run as well. Cheap nets
+  (lint/unit-ubuntu/smoke/changelog/frontend-build) still run.
+
+## What still validates a release
+
+`CI Gate` (the sole required check) ← `changelog-version-check` + `backend-lint` +
+`backend-test-unit (ubuntu)` + `backend-smoke` + `frontend-lint-build`. Then on
+merge: `tag-release.yml` → `release.yml` (3-platform binaries, certifi CA-bundle
+assertion, `engram --selftest` TLS round-trip, per-platform sha256 manifests,
+pinned PyInstaller) — the actual release gate, deliberately left intact.
+
+## Validation plan
+
+`act` is not installed locally. Validation is by:
+1. **YAML lint / parse** of the three edited workflows.
+2. **Reasoning dry-run** of `detect-release` against three scenarios:
+   normal code PR (full CI), dependency-bump PR (full CI), release-only PR
+   (heavy jobs skipped, `CI Gate` green).
+3. **Live confirmation** on the PR itself: a normal PR must show all granular
+   jobs running plus a green `CI Gate`. Optionally, a throwaway release-shaped
+   PR (or inspecting the post-merge `chore: release` PR) confirms the heavy jobs
+   skip while `CI Gate` stays green and the PR is mergeable (not BLOCKED).
+
+## Out of scope
+
+- Reducing CI on *normal* PRs (only release-only changes are streamlined).
+- Touching `release.yml` / `tag-release.yml` / `publish.yml` / `download-stats.yml`.
+- Changing `strict: true`, conversation-resolution, or any non-status-check
+  protection.


### PR DESCRIPTION
## What & why

A release PR (`chore: release vX.Y.Z`) only changes version strings + `CHANGELOG.md`, yet it currently triggers the **full** behavioral pipeline: Playwright E2E (×3 browsers), the 6-job `dependency-resolution` matrix, backend integration + coverage, frontend unit tests, CodeQL-on-PR, a Docker PR image build — plus a duplicate full `ci.yml` run on the push to `main` after merge. The released *code* was already validated when its source PRs merged; the release tree differs from last-green `main` only in version strings + changelog.

This streamlines a release-only PR down to a cheap safety net, while the real release validation (`release.yml`: 3-platform binaries, certifi CA-bundle assertion, `engram --selftest`, sha256 manifests) is **left completely untouched**.

Design: [`docs/superpowers/specs/2026-06-02-streamline-release-ci-design.md`](https://github.com/Jsakkos/engram/blob/chore/streamline-release-ci/docs/superpowers/specs/2026-06-02-streamline-release-ci-design.md) · Plan/rollout: [`docs/superpowers/plans/2026-06-02-streamline-release-ci.md`](https://github.com/Jsakkos/engram/blob/chore/streamline-release-ci/docs/superpowers/plans/2026-06-02-streamline-release-ci.md)

## How it works

**`detect-release` job** — `is_release=true` iff the title matches `^chore: release v[0-9]` **AND** every changed file is in the allowlist (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json`, `CHANGELOG.md`).

- The **title** is the necessary signal — a Renovate/Dependabot lock-file bump touches `uv.lock`/`package-lock.json` too, but is titled `build(deps):`, so it still runs full CI. (The lock-file-ambiguity trap.)
- The **allowlist** is the belt-and-suspenders guard — a "release" PR that also edited source falls back to full CI.

**`CI Gate` aggregator** — a single job that `needs:` every granular job, `if: always()`, and fails only if some needed job **failed/cancelled** (a *skipped* job passes). This becomes the **sole required status check**, which is what makes skipping the heavy jobs safe: a *required* check that never reports would leave the PR stuck "Expected — waiting" → **BLOCKED** forever. An aggregator always reports.

### Kept vs skipped on a release-only PR

| Kept (safety net) | Skipped (redundant) |
|---|---|
| `changelog-version-check` | Windows unit leg (dynamic matrix) |
| `backend-lint` | `backend-test-integration` |
| `backend-test-unit` (ubuntu-only) | `backend-coverage` |
| `backend-smoke` | `dependency-resolution` (×6) + py314 guard |
| `frontend-lint-build` | `alembic-check`, `frontend-test-unit`, `e2e-tests` |

Non-required trims (title-only guard, can't block): `codeql.yml` analyze and the `docker.yml` **PR-time** image build skip on release PRs. The tag-dispatched release image and weekly CodeQL scan are untouched.

`changelog-version-check` (previously *not* a required context) now feeds `CI Gate` → a missing changelog section blocks a release PR. Nice side benefit.

## ⚠️ Required follow-up: branch protection

This scheme requires flipping branch protection from the 9 granular contexts to the single `CI Gate` **after this PR merges** (this PR is a normal PR → runs full CI → produces all 9 legacy contexts + `CI Gate`, so it merges under current rules). Exact apply/rollback `gh api` commands are in the plan doc. **I will apply this immediately after merge** (sub-resource PATCH, preserves linear-history / conversation-resolution / `strict:true`).

## Verification

`act` isn't installed, so:
- ✅ PyYAML parse of all three edited workflows (14 / 1 / 1 jobs).
- ✅ Shell dry-run of `detect-release` across 7 scenarios — normal PR, two dependency bumps, release-only, release+source, empty-diff, merge-commit `(#299)` form, and a lookalike title — all classify correctly.
- Live on this PR: confirm all granular jobs run + `CI Gate` green.
- Post-merge: confirm a `chore: release` PR skips the heavy jobs, `CI Gate` stays green, PR mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
