### PR TITLE
fix(analyst): parse season from "Show Season N Disc M" disc names (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ _Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 origi
 
 - Windows FFmpeg auto-detection now also searches the Chocolatey, scoop, winget (`Gyan.FFmpeg`), and user-home install locations, so a freshly-installed FFmpeg is found even when it isn't yet on the running process's `PATH`. The in-app install hint now names the exact winget package.
 
+### Fixed
+
+- **A TV disc named like "Show Season 11 Disc 2" could match the wrong episodes for hours, then fail** — when a disc had no readable volume label, Engram fell back to the drive's display name (e.g. `Supernatural Season 11 Disc 2`), but the parser only recognized a season when the disc number was in parentheses (`(Disc 2)`). A space-separated `Disc 2` left the season undetected, so no subtitles were downloaded for that season and matching fell back to brute-forcing every previously-seen season's subtitles with speech recognition — a run that could churn for many hours scoring the audio against the wrong seasons before failing. Engram now reads the season from these names (with or without parentheses or a dash), so the correct season is detected, its subtitles download, and episodes match on the first pass. (#303)
+
 ## [0.14.1] - 2026-06-02
 
 _Highlights: a hardening fix for the in-app auto-updater — it can no longer install an incomplete or corrupted download over your working copy, and builds now always include the TLS certificate bundle whose absence silently broke all networking in some 0.14.0 installs._

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -849,8 +849,13 @@ class DiscAnalyst:
         name = disc_name.strip()
         season: int | None = None
 
-        # Strip trailing " (Disc N)" or " (Disk N)"
-        name = re.sub(r"\s*\(Dis[ck]\s*\d+\)\s*$", "", name, flags=re.IGNORECASE).strip()
+        # Strip a trailing disc indicator with OR without parentheses/dash:
+        # "(Disc 1)", "Disc 1", "- Disc 1", "Disk 1", "Disc1". Without this, a
+        # space-separated "Disc N" survives and leaves "Season N" mid-string,
+        # so the end-anchored season patterns below never match (issue #303).
+        name = re.sub(
+            r"\s*[-–]?\s*\(?\s*Dis[ck]\s*\d+\s*\)?\s*$", "", name, flags=re.IGNORECASE
+        ).strip()
 
         # Extract "- Season N" or "Season N" suffix
         m = re.search(r"\s*[-–]\s*Season\s+(\d+)\s*$", name, re.IGNORECASE)

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -839,7 +839,12 @@ class DiscAnalyst:
         MakeMKV provides disc names like:
           "Star Trek: Strange New Worlds - Season 3 (Disc 1)"
           "The Office - Season 2"
+          "Supernatural Season 11 Disc 2"   # space- or dash-separated disc, no parens
           "Inception"
+
+        The trailing disc indicator is accepted with or without parentheses or a
+        dash ("(Disc 1)", "Disc 1", "- Disc 1"), so the season is recovered even
+        when it sits ahead of a bare "Disc N" suffix.
 
         Returns (show_title, season), either may be None if not found.
         """

--- a/backend/tests/unit/test_disc_name_identification.py
+++ b/backend/tests/unit/test_disc_name_identification.py
@@ -91,6 +91,8 @@ def test_parse_disc_info_no_cinfo_returns_empty_string():
         # suffix must be stripped so the trailing "Season N" is recognized.
         ("Supernatural Season 11 Disc 2", "Supernatural", 11),
         ("The Office Season 2 Disc 4", "The Office", 2),
+        # Dash-separated disc indicator (also supported, per the regex comment).
+        ("Supernatural Season 11 - Disc 2", "Supernatural", 11),
         # Disc-only name: clean the title, no season.
         ("Firefly Disc 1", "Firefly", None),
         ("", None, None),

--- a/backend/tests/unit/test_disc_name_identification.py
+++ b/backend/tests/unit/test_disc_name_identification.py
@@ -87,6 +87,12 @@ def test_parse_disc_info_no_cinfo_returns_empty_string():
         ("Arrested Development Season 4", "Arrested Development", 4),
         ("Inception", "Inception", None),
         ("Star Trek: Strange New Worlds - Season 3", "Star Trek: Strange New Worlds", 3),
+        # Space-separated "Disc N" without parentheses (issue #303): the disc
+        # suffix must be stripped so the trailing "Season N" is recognized.
+        ("Supernatural Season 11 Disc 2", "Supernatural", 11),
+        ("The Office Season 2 Disc 4", "The Office", 2),
+        # Disc-only name: clean the title, no season.
+        ("Firefly Disc 1", "Firefly", None),
         ("", None, None),
         ("  ", None, None),
     ],


### PR DESCRIPTION
## Summary

Fixes the root cause of #303: a TV disc named like **"Supernatural Season 11 Disc 2"** matched the wrong seasons for ~12 hours, then failed in matching. (Auto-close is wired on the follow-up perf PR #305.)

## Root cause

The disc had no readable filesystem volume label, so identification fell back to MakeMKV's DINFO disc name (`"Supernatural Season 11 Disc 2"`). `DiscAnalyst._parse_disc_name()` failed to extract the season because of two compounding regex flaws:

1. The trailing-disc stripper required **parentheses** — `re.sub(r"\s*\(Dis[ck]\s*\d+\)\s*$", ...)` — so a space-separated `Disc 2` (no parens) was **not** stripped.
2. The season patterns are **end-anchored** (`...Season\s+(\d+)\s*$`) — with `Disc 2` still trailing, `Season 11` sat mid-string and never matched.

Result: `_parse_disc_name("Supernatural Season 11 Disc 2")` → `("Supernatural Season 11 Disc 2", None)` — season lost, show name garbled.

### Why it cascaded into a 12-hour failure

With `detected_season = None`:

- **Subtitle download was skipped** — it's gated on `job.detected_season` being truthy, so Season 11 references were never fetched.
- **Matching brute-forced every cached season** — `match_single_file` routed to `_match_across_seasons`, which runs the full Whisper + TF-IDF matcher once per *previously-cached* season (1–10 from earlier discs). Season 11 audio scored ~0.02 cosine against each wrong season (the `top S03E06=0.029` log lines are one season-3 iteration), churning for hours before failing.

## Fix

Broaden the trailing-disc stripper in `_parse_disc_name` to match `Disc N` / `Disk N` **with or without** parentheses or a leading dash, so the unchanged end-anchored `Season N` extraction sees `Season 11` at the end. This also cleans the show name (drops the embedded season/disc), fixing a secondary garbled-name problem.

| disc_name | before | after |
|---|---|---|
| `Supernatural Season 11 Disc 2` | `('Supernatural Season 11 Disc 2', None)` | `('Supernatural', 11)` |
| `The Office Season 2 Disc 4` | `('The Office Season 2 Disc 4', None)` | `('The Office', 2)` |
| `Supernatural Season 11 - Disc 2` | `('Supernatural Season 11 - Disc 2', None)` | `('Supernatural', 11)` |
| `Firefly Disc 1` | `('Firefly Disc 1', None)` | `('Firefly', None)` |
| `Star Trek: Strange New Worlds - Season 3 (Disc 1)` | `(..., 3)` | unchanged `(..., 3)` |
| `The Office - Season 2` / `Inception` / `Supernatural Season 11` | correct | unchanged |

## Testing

- Added parametrized cases to `test_parse_disc_name` for the no-parens `Show Season N Disc M`, the dash-separated `Show Season N - Disc M`, and bare `Show Disc N` forms (written red-first).
- Expanded the `_parse_disc_name` docstring to show the space/dash-separated variants.
- Full backend unit suite green; `ruff check` clean.

## Follow-up

The underlying **unknown-season Whisper runaway** is hardened separately in #305 (transcriptions are cached and reused across candidate seasons, so the fallback can no longer churn for hours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
