### PR TITLE
perf(matcher): cache ASR transcripts across candidate seasons (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 origi
 ### Fixed
 
 - **A TV disc named like "Show Season 11 Disc 2" could match the wrong episodes for hours, then fail** — when a disc had no readable volume label, Engram fell back to the drive's display name (e.g. `Supernatural Season 11 Disc 2`), but the parser only recognized a season when the disc number was in parentheses (`(Disc 2)`). A space-separated `Disc 2` left the season undetected, so no subtitles were downloaded for that season and matching fell back to brute-forcing every previously-seen season's subtitles with speech recognition — a run that could churn for many hours scoring the audio against the wrong seasons before failing. Engram now reads the season from these names (with or without parentheses or a dash), so the correct season is detected, its subtitles download, and episodes match on the first pass. (#303)
+- **Matching a disc whose season couldn't be determined was needlessly slow** — when a TV disc's season is unknown, Engram matches the file against every candidate season in turn. Each attempt re-ran speech recognition over the *same* audio from scratch, so a show with many seasons could spend hours re-transcribing identical audio before giving up. Transcriptions are now cached and reused across season attempts, so only the first attempt does the expensive transcription work and the rest are near-instant. (#303)
 
 ## [0.14.1] - 2026-06-02
 

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -886,9 +886,12 @@ class EpisodeMatcher:
         The cache persists across identify_episode() calls (it is NOT cleared in the
         per-call ``finally``), letting the season-unknown path reuse Whisper output
         across candidate seasons. It is shared across concurrent matches on the
-        singleton matcher; distinct-key writes are GIL-safe and keys are
+        singleton matcher; individual dict ops are GIL-safe and keys are
         source-addressed, so concurrent files never read each other's transcripts.
-        On overflow the whole cache is dropped (a rare, cheap reset).
+        On overflow the whole cache is dropped (a rare, cheap reset). The size-check
+        and clear are not atomic, so two concurrent overflows may flush early — at
+        worst a few extra transcriptions, never a wrong or mixed-up result; a lock
+        isn't warranted for a best-effort perf cache.
         """
         if len(self.transcriptions) >= self._max_transcription_cache:
             self.transcriptions.clear()
@@ -1396,7 +1399,12 @@ class EpisodeMatcher:
                             video_file, start_time, duration=chunk_len
                         )
                         temp_files_to_remove.append(audio_path)  # Track for cleanup
-                        text = model.transcribe(audio_path)["text"]
+                        # `or ""` guards a wrapper returning {"text": None}: caching
+                        # None would make this offset a perpetual miss (the `is None`
+                        # guard above would re-transcribe it every season). Matches
+                        # transcribe_full; the `len(text) < 10` check below still skips
+                        # genuinely empty audio.
+                        text = (model.transcribe(audio_path).get("text") or "").strip()
                         self._remember_transcription(chunk_key, text)
 
                     if len(text) < 10:

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -348,6 +348,13 @@ MIN_CONSENSUS_FOR_RATIO = 0.50
 CHUNK_VOTE_FLOOR = 0.06  # below this top-1 cosine, treat the chunk as noise
 CHUNK_VOTE_MARGIN_RATIO = 1.8  # top-1 must lead the runner-up by this ratio to vote
 
+# Upper bound on the per-matcher ASR transcript cache (entries: chunks + full-file
+# transcripts, keyed by source+offset+duration). One season-unknown file needs
+# ~num_points + 1 entries; the bound just stops the long-lived singleton matcher
+# from growing without limit across many files. On overflow the cache is cleared
+# wholesale (cheap, correctness-preserving — keys are source-addressed).
+MAX_TRANSCRIPTION_CACHE = 1024
+
 
 def select_chunk_vote(
     tfidf_results: list[tuple[str, float]],
@@ -827,8 +834,15 @@ class EpisodeMatcher:
         self.subtitle_cache = SubtitleCache()
         # TF-IDF matcher (lazily initialized per season)
         self.tfidf_matcher = None
-        # Cache for extracted audio chunks
+        # Cache for extracted audio chunks (cleared per identify_episode call)
         self.audio_chunks = {}
+        # Cache for ASR transcripts, keyed by (resolved_source, start, duration).
+        # Unlike audio_chunks this PERSISTS across identify_episode calls so the
+        # season-unknown path (one call per candidate season) reuses Whisper output
+        # instead of re-transcribing the same offsets per season. Bounded; see
+        # _remember_transcription.
+        self.transcriptions = {}
+        self._max_transcription_cache = MAX_TRANSCRIPTION_CACHE
         # Store reference files to avoid repeated glob operations
         self.reference_files_cache = {}
         # Precomputed subtitle-vector cache (lazily loaded; False once known-absent)
@@ -856,6 +870,29 @@ class EpisodeMatcher:
         """Hash resolved source path into the filename so concurrent threads don't collide."""
         src_hash = hashlib.sha1(self._resolve_source(mkv_file).encode("utf-8")).hexdigest()[:16]
         return self.temp_dir / f"chunk_{src_hash}_{start_time}_{duration}.wav"
+
+    def _transcription_key(self, mkv_file, start_time, duration) -> tuple:
+        """Cache key for an ASR transcript: resolved source path + offset + duration.
+
+        Same shape as the audio-chunk cache key, so the chunk loop and the full-file
+        fallback share one transcript cache without colliding (chunks start >= 300s
+        with a 30s duration; the full-file pass uses start=0 with the file duration).
+        """
+        return (self._resolve_source(mkv_file), start_time, duration)
+
+    def _remember_transcription(self, key: tuple, text: str) -> None:
+        """Store an ASR transcript, bounding the cache.
+
+        The cache persists across identify_episode() calls (it is NOT cleared in the
+        per-call ``finally``), letting the season-unknown path reuse Whisper output
+        across candidate seasons. It is shared across concurrent matches on the
+        singleton matcher; distinct-key writes are GIL-safe and keys are
+        source-addressed, so concurrent files never read each other's transcripts.
+        On overflow the whole cache is dropped (a rare, cheap reset).
+        """
+        if len(self.transcriptions) >= self._max_transcription_cache:
+            self.transcriptions.clear()
+        self.transcriptions[key] = text
 
     def extract_audio_chunk(self, mkv_file, start_time, duration=None):
         """Extract a chunk of audio from MKV file with caching."""
@@ -1087,10 +1124,16 @@ class EpisodeMatcher:
 
         model_config = {"type": "whisper", "name": self.model_name, "device": self.device}
         try:
-            model = get_cached_model(model_config)
-            audio_path = self.extract_audio_chunk(video_file, start_time=0, duration=duration)
-            result = model.transcribe(audio_path)
-            full = (result.get("text") or "").strip()
+            # Memoized by (source, 0, duration): the full-file fallback fires once per
+            # candidate season when no chunk votes, so without this the season-unknown
+            # path re-transcribes the ENTIRE file per season — the single biggest cost.
+            full_key = self._transcription_key(video_file, 0, duration)
+            full = self.transcriptions.get(full_key)
+            if full is None:
+                model = get_cached_model(model_config)
+                audio_path = self.extract_audio_chunk(video_file, start_time=0, duration=duration)
+                full = (model.transcribe(audio_path).get("text") or "").strip()
+                self._remember_transcription(full_key, full)
         except Exception as e:
             logger.warning(
                 f"transcribe_full: transcription failed for {video_file}: {e}",
@@ -1342,14 +1385,19 @@ class EpisodeMatcher:
                 scan_percent = 10.0 + (i / len(scan_points)) * 80.0
 
                 try:
-                    audio_path = self.extract_audio_chunk(
-                        video_file, start_time, duration=chunk_len
-                    )
-                    temp_files_to_remove.append(audio_path)  # Track for cleanup
-
-                    # Transcribe
-                    result = model.transcribe(audio_path)
-                    text = result["text"]
+                    # Transcribe, memoized by (source, offset, duration). On a hit
+                    # (e.g. a later candidate season re-scanning the same file) we
+                    # skip both ffmpeg extraction and Whisper — only the ~1ms TF-IDF
+                    # match below re-runs.
+                    chunk_key = self._transcription_key(video_file, start_time, chunk_len)
+                    text = self.transcriptions.get(chunk_key)
+                    if text is None:
+                        audio_path = self.extract_audio_chunk(
+                            video_file, start_time, duration=chunk_len
+                        )
+                        temp_files_to_remove.append(audio_path)  # Track for cleanup
+                        text = model.transcribe(audio_path)["text"]
+                        self._remember_transcription(chunk_key, text)
 
                     if len(text) < 10:
                         logger.debug(

--- a/backend/tests/unit/test_episode_identification.py
+++ b/backend/tests/unit/test_episode_identification.py
@@ -723,6 +723,39 @@ class TestTranscriptionCache:
         # Whisper ran once; the second call was served from the transcript cache.
         assert fake_model.transcribe.call_count == 1
 
+    def test_identify_episode_reuses_chunk_transcripts_across_seasons(self, tmp_path):
+        """End-to-end across-seasons win: matching the same file against two
+        seasons transcribes each scan-point offset once, not once per season.
+        """
+        matcher = self._matcher(tmp_path)
+        fake_model = MagicMock()
+        fake_model.transcribe.return_value = {"text": "the quick brown fox jumps over " * 4}
+
+        # Pre-seed a prepared TF-IDF matcher so identify_episode skips the real
+        # rebuild + hashed-query path; only the transcript-cache behaviour is exercised.
+        tfidf = MagicMock()
+        tfidf.is_prepared = True
+        tfidf.reference_signature.return_value = ("precomputed", ("S01E01",))
+        tfidf.match.return_value = [("S01E01", 0.9)]
+        matcher.tfidf_matcher = tfidf
+
+        precomputed = (csr_matrix(np.eye(1)), ["S01E01"], np.ones(1))
+
+        with (
+            patch.object(matcher, "_load_precomputed_season", return_value=precomputed),
+            patch.object(matcher, "extract_audio_chunk", return_value=str(tmp_path / "a.wav")),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=fake_model),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=2000),
+        ):
+            matcher.identify_episode(tmp_path / "file.mkv", tmp_path, 1)
+            after_first = fake_model.transcribe.call_count
+            matcher.identify_episode(tmp_path / "file.mkv", tmp_path, 2)
+            after_second = fake_model.transcribe.call_count
+
+        assert after_first > 0, "first pass must transcribe the scan-point chunks"
+        # Second pass over the SAME file (different season) reused every transcript.
+        assert after_second == after_first
+
     def test_distinct_segments_each_transcribe(self, tmp_path):
         matcher = self._matcher(tmp_path)
         calls = []

--- a/backend/tests/unit/test_episode_identification.py
+++ b/backend/tests/unit/test_episode_identification.py
@@ -686,3 +686,74 @@ class TestMatchFullFileSurfacesTranscript:
         assert result is not None
         assert "transcript" in result
         assert result["transcript"].startswith("long fake transcript")
+
+
+@pytest.mark.unit
+class TestTranscriptionCache:
+    """ASR transcripts are memoized by (source, start, duration) and the cache
+    SURVIVES across identify_episode() calls.
+
+    Background: identify_episode()'s `finally` clears audio_chunks and deletes the
+    chunk WAVs every call, so when the season is unknown and the curator matches a
+    file against several candidate seasons (one identify_episode per season), every
+    season re-extracts AND re-runs Whisper over the exact same audio offsets — the
+    dominant cost behind the multi-hour season-unknown runaway. A persistent
+    transcript cache collapses seasons 2..N to a TF-IDF-only pass.
+    """
+
+    def _matcher(self, tmp_path):
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        return EpisodeMatcher(cache_dir=tmp_path, show_name="Test Show", model_name="tiny")
+
+    def test_transcribe_full_reuses_transcript_across_calls(self, tmp_path):
+        matcher = self._matcher(tmp_path)
+        fake_model = MagicMock()
+        fake_model.transcribe.return_value = {"text": " hello world from the episode " * 10}
+
+        with (
+            patch.object(matcher, "extract_audio_chunk", return_value=str(tmp_path / "a.wav")),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=fake_model),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=1320),
+        ):
+            first = matcher.transcribe_full(tmp_path / "fake.mkv")
+            second = matcher.transcribe_full(tmp_path / "fake.mkv")
+
+        assert first == second
+        # Whisper ran once; the second call was served from the transcript cache.
+        assert fake_model.transcribe.call_count == 1
+
+    def test_distinct_segments_each_transcribe(self, tmp_path):
+        matcher = self._matcher(tmp_path)
+        calls = []
+
+        def compute():
+            calls.append(1)
+            return f"text-{len(calls)}"
+
+        key_a = matcher._transcription_key(tmp_path / "f.mkv", 300, 30)
+        key_b = matcher._transcription_key(tmp_path / "f.mkv", 600, 30)
+        # Same key reuses; different (start) recomputes.
+        assert matcher.transcriptions.get(key_a) is None
+        matcher._remember_transcription(key_a, compute())
+        assert matcher.transcriptions.get(key_a) == "text-1"
+        matcher._remember_transcription(key_b, compute())
+        assert len(calls) == 2
+        assert key_a != key_b
+
+    def test_cache_is_bounded(self, tmp_path):
+        matcher = self._matcher(tmp_path)
+        matcher._max_transcription_cache = 2
+        matcher._remember_transcription(("s", 0, 30), "a")
+        matcher._remember_transcription(("s", 30, 30), "b")
+        # Third insert exceeds the cap -> cache is cleared before storing.
+        matcher._remember_transcription(("s", 60, 30), "c")
+        assert ("s", 60, 30) in matcher.transcriptions
+        assert len(matcher.transcriptions) == 1
+
+    def test_key_is_source_addressed(self, tmp_path):
+        matcher = self._matcher(tmp_path)
+        # Same offset/duration on different source files must not collide.
+        a = matcher._transcription_key("/d/title_t00.mkv", 300, 30)
+        b = matcher._transcription_key("/d/title_t01.mkv", 300, 30)
+        assert a != b


### PR DESCRIPTION
Closes #303

## Summary

Follow-up hardening for #303. The parse fix (#304, merged) stops a well-named disc from landing in the season-unknown path; **this PR makes that path itself efficient** so any disc that genuinely lacks a season can no longer burn hours.

## Problem

When a TV disc's season is unknown, the curator matches the file against **every candidate season in turn** (`_match_across_seasons` → one `identify_episode` per season). But `identify_episode`'s `finally` **clears the audio-chunk cache and deletes the chunk WAVs on every call**, so across the per-season loop:

- Each season **re-extracts and re-transcribes** the exact same audio offsets (the scan points depend only on the file, not the season).
- When no chunk votes — which is *every wrong season* — it falls back to `_match_full_file`, which **re-transcribes the entire file**. That's the single biggest cost (~45 min of audio per season).

For a show with many cached seasons this compounds into a multi-hour run before failing. The TF-IDF match itself is ~1ms; transcription is the whole cost.

## Fix

Add a bounded transcript cache on `EpisodeMatcher`, keyed by `(resolved_source, start, duration)`, that **persists across `identify_episode` calls** (it is *not* cleared in the per-call `finally`). Both transcription sites consult it:

- the chunk loop (`identify_episode`)
- the full-file fallback (`transcribe_full`)

So seasons 2..N skip ffmpeg + Whisper entirely and re-run only the ~1ms TF-IDF match. Net effect: the season-unknown match cost drops from `N_seasons × transcription` to `1 × transcription`.

### Safety

- **Source-addressed key** → concurrent matches on different files never read each other's transcripts (the matcher is a shared singleton).
- **None-guarded** — both sites use `(... .get("text") or "").strip()`, so a `{"text": None}` result caches `""` instead of becoming a perpetual cache miss.
- **Bounded** (`MAX_TRANSCRIPTION_CACHE`, wholesale clear on overflow) so the long-lived singleton can't grow without limit. The size-check + clear aren't atomic, so a concurrent overflow may flush early (a few extra transcriptions, never a wrong result); a lock isn't warranted.
- **No cross-show staleness** — a new show replaces the whole matcher instance.

## Testing

`TestTranscriptionCache`:
- `transcribe_full` called twice → `model.transcribe` runs **once** (the across-seasons win).
- `identify_episode` run for the same file against two seasons → `model.transcribe.call_count` does **not** double (chunk-level cache hit, end-to-end).
- key is source-addressed (no cross-file collision); cache is bounded (clears on overflow).

Full backend unit suite green, `ruff check` clean.

## Note

Scoped to "Layer C" (recycle transcriptions). Two larger follow-ups remain optional: a **combined multi-season corpus** (transcribe once, season falls out of the match) and a **disc-level "determine season from the first track, pin the rest."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
