### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
-_Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 original) can now coexist in your TV library, each in its own year/TMDB-tagged folder; plus FFmpeg is now a documented prerequisite with broader Windows auto-detection and inline path validation in the Config Wizard._
+## [0.15.0] - 2026-06-02
+
+_Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 original) can now coexist in your TV library, each in its own year/TMDB-tagged folder; the dashboard now warns you up front when no TMDB key is configured; and FFmpeg is now a documented prerequisite with broader Windows auto-detection and inline path validation in the Config Wizard._
 
 ### Added
 
 - **Same-name TV shows can now coexist in the library** — TV episodes were filed under the bare show name (`Frasier/Season 01/…`), so ripping both the 1993 **Frasier** and the 2023 revival collided in one folder with identical filenames, and the second rip was skipped, overwritten, or bounced to Review. A new optional **Show Folder Format** setting disambiguates the show folder with the first-air year and TMDB id, matching the layout Plex (`Frasier (1993) {tmdb-3452}`) and Jellyfin (`Frasier (1993) [tmdbid-3452]`) parse for reliable matching. It is opt-in and defaults to the current bare-name layout, so existing libraries are untouched — set a format containing `{year}`/`{tmdb_id}` (and optionally add them to the episode filename format) to enable it. (#297)
+- **The dashboard now warns you when TMDB isn't configured** — without a TMDB Read Access Token, discs can't be identified, but previously the only symptom was matches quietly failing. The dashboard now shows a dismissible banner — with a one-click link to open Settings — whenever no TMDB key is set, plus an inline notice on each active job card. Both clear automatically the moment a token is saved, with no page reload. (#294)
 - FFmpeg is now documented as a prerequisite, with per-platform install steps (including `winget install Gyan.FFmpeg` on Windows) and a dedicated [Troubleshooting](https://jsakkos.github.io/engram/troubleshooting/) page led by the common "FFmpeg not detected" case.
 - The Config Wizard now validates a manually-entered MakeMKV or FFmpeg path against the backend and shows the detected version inline (or the specific error), so a hand-typed override is no longer saved blind. The FFmpeg "not found" card also links to the download page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
-## [0.15.0] - 2026-06-02
+## [0.15.0] - 2026-06-03
 
 _Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 original) can now coexist in your TV library, each in its own year/TMDB-tagged folder; the dashboard now warns you up front when no TMDB key is configured; and FFmpeg is now a documented prerequisite with broader Windows auto-detection and inline path validation in the Config Wizard._
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.14.1"
+__version__ = "0.15.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.14.1"
+version = "0.15.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.14.1"
+version = "0.15.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engram-frontend",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engram-frontend",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "dependencies": {
         "@popperjs/core": "2.11.8",
         "@radix-ui/react-accordion": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.14.1",
+    "version": "0.15.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.15.0

Minor release — this `[Unreleased]` window contains new features, so it's a `0.X.0` bump per the version convention.

Bumps `0.14.1 → 0.15.0` across all six version locations (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and both `frontend/package-lock.json` self-version fields) and moves `[Unreleased]` into a dated `## [0.15.0] - 2026-06-02` section.

### What's in this release

**Added**
- **Same-name TV shows can coexist in the library** via the new opt-in Show Folder Format setting (year/TMDB-tagged folders, Plex/Jellyfin layouts) (#297)
- **Dashboard warns when TMDB isn't configured** — dismissible banner + per-job inline alert that clear automatically once a token is saved (#294)
- **FFmpeg documented as a prerequisite**; Config Wizard now validates a manually-entered MakeMKV/FFmpeg path and shows the detected version inline (#300)

**Changed**
- Broader Windows FFmpeg auto-detection (Chocolatey / scoop / winget / user-home) (#300)

**Fixed**
- A TV disc named like "Show Season 11 Disc 2" no longer leaves the season undetected (which previously caused hours of wrong-season ASR brute-forcing) (#303)
- ASR transcripts are cached and reused across candidate seasons instead of re-transcribing identical audio per attempt (#303)

> Note: #294 was merged earlier but never got a `CHANGELOG` entry — this PR adds its user-facing entry so it appears in the published notes.

### Verification
- `extract_changelog.py --version 0.15.0 --check` → `ok` (the `changelog-version-check` CI gate)
- Release-notes preview rendered correctly via `extract_changelog.py --version 0.15.0`
- All six version files confirmed at `0.15.0`; only those six files + `CHANGELOG.md` changed

On squash-merge, `tag-release.yml` matches the `chore: release v` title, tags `v0.15.0`, and dispatches `release.yml` (Win/Linux/macOS-arm64 binaries + GitHub release) and `docker.yml` (GHCR image) with the extracted notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
