### PR TITLE
fix(dashboard): declutter disc card for same-name discs awaiting re-identify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clearer disc card when two shows share a name** — a disc that matches more than one same-name show (for example the 1993 vs 2023 **Frasier**) is flagged for review before ripping, but its card showed a "Review needed" button that opened an empty review screen — there's nothing to review until the disc is ripped — right next to an identical "Review needed" status badge. The card now hides that dead-end button until the disc actually has ripped tracks, emphasizes the **Wrong title?** action as the thing to click, and adds a short banner explaining the same-name ambiguity and how to resolve it. (#308)
+
 ## [0.15.0] - 2026-06-03
 
 _Highlights: same-name shows (for example the 2023 **Frasier** vs the 1993 original) can now coexist in your TV library, each in its own year/TMDB-tagged folder; the dashboard now warns you up front when no TMDB key is configured; and FFmpeg is now a documented prerequisite with broader Windows auto-detection and inline path validation in the Config Wizard._

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -614,7 +614,7 @@ function MainDashboard() {
                   disc={disc}
                   onCancel={disc.state !== 'completed' && disc.state !== 'error' ? () => cancelJob(disc.id) : undefined}
                   onAdvance={disc.state !== 'completed' && disc.state !== 'error' ? () => advanceJob(disc.id) : undefined}
-                  onReview={disc.needsReview ? () => navigate(reviewPath(disc.id)) : undefined}
+                  onReview={disc.needsReview && (disc.tracks?.length ?? 0) > 0 ? () => navigate(reviewPath(disc.id)) : undefined}
                   onReIdentify={disc.needsReview && disc.title ? () => {
                     const job = jobs.find(j => String(j.id) === disc.id);
                     if (job) setReIdentifyTarget(job);
@@ -947,7 +947,7 @@ function CompactList({
               </span>
               {/* Actions */}
               <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                {disc.needsReview && (
+                {disc.needsReview && (disc.tracks?.length ?? 0) > 0 && (
                   <CompactRowButton color={sv.yellow} onClick={() => onReview(disc.id)}>
                     Review
                   </CompactRowButton>

--- a/frontend/src/app/components/DiscCard.test.tsx
+++ b/frontend/src/app/components/DiscCard.test.tsx
@@ -16,6 +16,7 @@ function makeDisc(overrides: Partial<DiscData> = {}): DiscData {
     progress: 0,
     needsReview: true,
     tracks: [],
+    tracksLoaded: true,
     ...overrides,
   };
 }
@@ -83,5 +84,27 @@ describe('DiscCard — review affordances', () => {
     expect(
       screen.queryByText(/use "wrong title\?" to pick the correct one/i),
     ).not.toBeInTheDocument();
+  });
+
+  it('titles not loaded yet: does not flash the pre-rip banner (title-load race)', () => {
+    // A post-rip review_needed job whose titles haven't been fetched yet looks
+    // identical to a pre-rip disc (tracks=[]). tracksLoaded=false must suppress
+    // the banner so it doesn't flash on page load / WebSocket reconnect.
+    render(
+      <DiscCard
+        disc={makeDisc({
+          tracks: [],
+          tracksLoaded: false,
+          reviewReason: 'some pending reason',
+        })}
+        onReview={undefined}
+        onReIdentify={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/use "wrong title\?" to pick the correct one/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/some pending reason/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/components/DiscCard.test.tsx
+++ b/frontend/src/app/components/DiscCard.test.tsx
@@ -1,0 +1,87 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DiscCard, type DiscData } from './DiscCard';
+
+/** Minimal valid review_needed disc; override only what a test cares about. */
+function makeDisc(overrides: Partial<DiscData> = {}): DiscData {
+  return {
+    id: '1',
+    title: 'Frasier',
+    subtitle: 'TV • FRASIER_S1D2',
+    discLabel: 'FRASIER_S1D2',
+    coverUrl: '/api/jobs/1/poster',
+    mediaType: 'tv',
+    state: 'review_needed',
+    progress: 0,
+    needsReview: true,
+    tracks: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // usePosterImage fetches a poster on mount — stub it so the test stays
+  // hermetic (jsdom has no real network) and logs nothing.
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('DiscCard — review affordances', () => {
+  it('pre-rip review (no tracks): hides the review-queue button, keeps "Wrong title?", and shows the reason banner', () => {
+    render(
+      <DiscCard
+        disc={makeDisc({
+          tracks: [],
+          reviewReason:
+            '"Frasier" has multiple same-name shows on TMDB and the disc label has no year to tell them apart.',
+        })}
+        // App passes onReview=undefined when there are no tracks to review yet.
+        onReview={undefined}
+        onReIdentify={vi.fn()}
+      />,
+    );
+
+    // The dead-end review-queue button is gone (the StateIndicator badge with
+    // the same words is a non-button span, so this asserts the action button).
+    expect(
+      screen.queryByRole('button', { name: /review needed — open review queue/i }),
+    ).not.toBeInTheDocument();
+
+    // The corrective action remains...
+    expect(
+      screen.getByRole('button', { name: /wrong title — re-identify disc/i }),
+    ).toBeInTheDocument();
+
+    // ...and the card explains the ambiguity, pointing the user at "Wrong title?".
+    expect(screen.getByText(/multiple same-name shows on TMDB/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/use "wrong title\?" to pick the correct one/i),
+    ).toBeInTheDocument();
+  });
+
+  it('post-rip review (has tracks): shows the review-queue button and no banner', () => {
+    render(
+      <DiscCard
+        disc={makeDisc({
+          reviewReason: undefined,
+          tracks: [
+            { id: 't1', title: 'Title 0', duration: '22:14', state: 'review', progress: 0 },
+          ],
+        })}
+        onReview={vi.fn()}
+        onReIdentify={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /review needed — open review queue/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/use "wrong title\?" to pick the correct one/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -72,6 +72,9 @@ export interface DiscData {
   startedAt?: string;
   needsReview?: boolean;
   reviewReason?: string;
+  /** Whether this disc's titles have been fetched yet (vs. genuinely empty).
+   *  Guards the pre-rip banner against the title-load race — see reviewPreRip. */
+  tracksLoaded?: boolean;
   conflictStatus?: string;
 }
 
@@ -192,7 +195,10 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
     // A disc that needs review but hasn't ripped yet (no tracks) has nothing to
     // review in the queue — the only useful action is "Wrong title?" (re-identify).
     // Drives both the on-card hint banner and the emphasis on the re-identify button.
-    const reviewPreRip = !!disc.needsReview && totalTrackCount === 0;
+    // `tracksLoaded` gates out the title-load race: titles resolve after the job
+    // list, so a post-rip review_needed job momentarily has tracks=[] on first
+    // render — without this guard the banner/emphasis would flash then vanish.
+    const reviewPreRip = !!disc.needsReview && totalTrackCount === 0 && !!disc.tracksLoaded;
 
     return (
       <motion.div

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -71,6 +71,7 @@ export interface DiscData {
   subtitleError?: string;
   startedAt?: string;
   needsReview?: boolean;
+  reviewReason?: string;
   conflictStatus?: string;
 }
 
@@ -187,6 +188,11 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
     const doneTrackCount =
       disc.tracks?.filter(t => ["matched", "completed"].includes(t.state)).length ?? 0;
     const failedTrackCount = disc.tracks?.filter(t => t.state === "failed").length ?? 0;
+
+    // A disc that needs review but hasn't ripped yet (no tracks) has nothing to
+    // review in the queue — the only useful action is "Wrong title?" (re-identify).
+    // Drives both the on-card hint banner and the emphasis on the re-identify button.
+    const reviewPreRip = !!disc.needsReview && totalTrackCount === 0;
 
     return (
       <motion.div
@@ -373,9 +379,41 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                     onReIdentify={onReIdentify}
                     onAdvance={onAdvance}
                     onReportBug={onReportBug}
+                    emphasizeReIdentify={reviewPreRip}
                   />
                 </div>
               </div>
+
+              {/* Ambiguous / unconfirmed identity, pre-rip — the review queue is
+                  empty until ripping, so point the user at "Wrong title?" instead
+                  and explain why (reuses the backend's review_reason sentence). */}
+              {reviewPreRip && (
+                <div
+                  role="alert"
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    marginBottom: 16,
+                    padding: "10px 12px",
+                    border: `1px solid ${sv.yellow}99`,
+                    borderLeft: `3px solid ${sv.yellow}`,
+                    background: `${sv.yellow}14`,
+                    fontFamily: sv.mono,
+                    fontSize: 12,
+                    lineHeight: 1.45,
+                    letterSpacing: "0.02em",
+                    color: sv.yellow,
+                  }}
+                >
+                  <span aria-hidden style={{ flexShrink: 0 }}>⚠</span>
+                  <span>
+                    {disc.reviewReason ||
+                      "This disc's identity needs confirming before ripping."}{" "}
+                    Use "Wrong title?" to pick the correct one.
+                  </span>
+                </div>
+              )}
 
               {/* No reference subtitles — loud + actionable while the job is still
                   actionable. Hidden once completed (e.g. user assigned manually). */}

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -10,6 +10,11 @@
  *   Cancel       — 30×30 square, icon-only, red    → quiet/destructive
  *   Re-Identify  — 30 tall, icon + 10px label, cyan → tertiary action
  *   Review       — 30 tall, icon + 11px label, yellow → primary callout
+ *
+ * Exception: when a disc needs review but hasn't ripped yet, the Review button
+ * is suppressed (the review queue is empty), so Re-Identify ("Wrong title?")
+ * becomes the only useful action — `emphasizeReIdentify` renders it filled to
+ * promote it to the primary callout in that state.
  */
 
 import { useState, type CSSProperties, type ReactNode, type MouseEvent } from "react";
@@ -27,6 +32,9 @@ interface ActionButtonsProps {
     onReIdentify?: () => void;
     onAdvance?: () => void;
     onReportBug?: () => void;
+    /** Render the "Wrong title?" button filled — it's the primary action when
+     *  the review queue is suppressed pre-rip. */
+    emphasizeReIdentify?: boolean;
 }
 
 // States where Force-advance makes sense (job is actively processing).
@@ -105,9 +113,12 @@ interface ToneButtonProps {
     /** Horizontal padding in px. 0 means render as a square icon-only button. */
     paddingX?: number;
     testId?: string;
+    /** Render the resting state as if hovered (filled bg, stronger border + glow)
+     *  to promote this button to the primary action. */
+    emphasis?: boolean;
 }
 
-function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0, testId }: ToneButtonProps) {
+function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0, testId, emphasis = false }: ToneButtonProps) {
     const [hovered, setHovered] = useState(false);
     const isSquare = paddingX === 0;
     return (
@@ -125,7 +136,7 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0, t
             aria-label={ariaLabel}
             data-testid={testId}
             style={{
-                ...baseStyle(tone, hovered),
+                ...baseStyle(tone, hovered || emphasis),
                 paddingLeft: paddingX,
                 paddingRight: paddingX,
                 width: isSquare ? BUTTON_HEIGHT : undefined,
@@ -137,7 +148,7 @@ function ToneButton({ tone, onClick, title, ariaLabel, children, paddingX = 0, t
     );
 }
 
-export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance, onReportBug }: ActionButtonsProps) {
+export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdentify, onAdvance, onReportBug, emphasizeReIdentify = false }: ActionButtonsProps) {
     const showCancel = !!onCancel && (isHovered || CANCELABLE_STATES.includes(state));
     const showReview = !!onReview && state === "review_needed";
     const showAdvance = !!onAdvance && ACTIVE_STATES.includes(state);
@@ -188,6 +199,7 @@ export function ActionButtons({ state, isHovered, onCancel, onReview, onReIdenti
                     title="Wrong title — re-identify disc"
                     ariaLabel="Wrong title — re-identify disc"
                     paddingX={10}
+                    emphasis={emphasizeReIdentify}
                 >
                     <IcoRetry size={12} />
                     <span style={{ fontSize: 10 }}>Wrong title?</span>

--- a/frontend/src/app/hooks/useDiscFilters.ts
+++ b/frontend/src/app/hooks/useDiscFilters.ts
@@ -22,6 +22,11 @@ export function useDiscFilters(
         return jobs.map(job => ({
             ...transformJobToDiscData(job, titlesMap[job.id] || []),
             needsReview: job.state === 'review_needed',
+            // Distinguishes "titles fetched and genuinely empty" (key present, []),
+            // from "not fetched yet" (key absent). The titles request resolves after
+            // the job list, so without this a post-rip review_needed job briefly has
+            // tracks=[] on first render — enough to flash the pre-rip banner/emphasis.
+            tracksLoaded: titlesMap[job.id] !== undefined,
         }));
     }, [jobs, titlesMap, devMode]);
 

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -67,6 +67,7 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     subtitleStatus: job.subtitle_status || undefined,
     subtitleError: job.subtitle_error_message || undefined,
     conflictStatus: job.conflict_status || undefined,
+    reviewReason: job.review_reason || undefined,
     startedAt: job.created_at
       ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')
       : undefined,


### PR DESCRIPTION
## What & why

A disc that matches more than one same-name show (e.g. the 1993 vs 2023 **Frasier**) is flagged for review **before** ripping. In that state the disc card showed three look-alike boxes:

1. amber **REVIEW NEEDED** — a passive status badge
2. cyan **WRONG TITLE?** — the correct action (opens the Re-Identify modal)
3. red **REVIEW NEEDED** — a button that just navigated to the review queue, which is **empty until the disc is ripped** ("No titles awaiting review")

Box 3 looked like a primary call-to-action but led to a dead screen, and was easily confused with the box 1 badge. This PR removes that confusion and clarifies what to do.

## Changes

- **Hide the review-queue button until the disc has ripped tracks** (both the expanded `DiscCard` and the compact-row view). Gated on `disc.tracks?.length > 0`, mirroring how `onReIdentify` is already conditionally wired. `titlesMap` is fetched for every job on load, so "no tracks" reliably means "not ripped yet" → the review queue has nothing to show.
- **Add an amber hint banner** on the card for pre-rip review states, reusing the existing alert-banner pattern. It surfaces the backend's `review_reason` (the same sentence the Re-Identify modal shows) plus a nudge to use **Wrong title?** — keeping the copy DRY with the backend.
- **Emphasize the "Wrong title?" button** as the primary action in that state via a new filled `ToneButton` variant (`emphasis` renders the resting state as hovered — no new design tokens).
- **Regression test** (`DiscCard.test.tsx`) covering both the pre-rip state (button hidden, banner shown, "Wrong title?" present) and the post-rip state (review button present, no banner — confirms the real review entry point isn't regressed).

The amber status badge is intentionally kept. No backend changes — `review_reason` is already produced and exposed.

## Testing

- `npm run build` (tsc + vite) ✅
- `npm run lint` ✅
- `npm run test:unit` → **107/107 pass** (incl. 2 new)
- Visual check in mock mode (`?mock=true`): the ambiguous Frasier card loses the red nav button and gains the banner + emphasized "Wrong title?"; a `review_needed` disc **with** tracks still shows the review button and no banner.

## Reviewer notes

- The hide gate lives at the `onReview` wiring in `App.tsx` (consistent with `onReIdentify`); `ActionButtons` already guards on `!!onReview`, so no logic change was needed there to remove the button.
- Behavior for any other pre-rip review state (not just same-name) is the same: the dead-end button is suppressed and "Wrong title?" remains the action. This is intentional.
