### PR TITLE
feat(scripts): migrate subtitle SRT cache from name-keyed to tmdb_id dirs

### DIFF
--- a/backend/scripts/migrate_subtitle_cache_keys.py
+++ b/backend/scripts/migrate_subtitle_cache_keys.py
@@ -31,7 +31,6 @@ import argparse
 import csv
 import io
 import os
-import shutil
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -63,6 +62,7 @@ class Tally:
     skipped_backup: list[str] = field(default_factory=list)  # manual backup-looking dir
     ambiguous: list[str] = field(default_factory=list)  # numeric dir that is also a show name
     unresolved: list[str] = field(default_factory=list)  # name with no tmdb_id
+    failed: list[str] = field(default_factory=list)  # resolved but the move raised OSError
 
 
 # Suffixes that mark a deliberate manual backup / scratch copy (e.g.
@@ -135,7 +135,7 @@ def resolve_dir(
         # Numeric and not a show name (e.g. "1396") → already the tmdb_id scheme.
         return (None, "ambiguous") if dir_name in curated_map else (None, "already_id")
 
-    tid = curated_map.get(sanitize_filename(dir_name)) or curated_map.get(dir_name)
+    tid = curated_map.get(sanitize_filename(dir_name))
     if tid:
         return str(tid), "csv"
     norm_hit = norm_map.get(_normalize(dir_name))
@@ -176,8 +176,10 @@ def _relocate(legacy_dir: Path, target: Path, *, dry_run: bool, tally: Tally) ->
                     f.unlink()
                 tally.files_dropped_smaller += 1
         else:
+            # Same filesystem (both under data_dir) and dest doesn't exist, so a
+            # plain rename is sufficient — no cross-device copy fallback needed.
             if not dry_run:
-                shutil.move(str(f), str(dest))
+                f.rename(dest)
             tally.files_moved += 1
 
     if dry_run:
@@ -238,7 +240,14 @@ def migrate_cache(
         if target == show_dir:  # defensive: name already equals its id
             tally.skipped_already_id += 1
             continue
-        _relocate(show_dir, target, dry_run=dry_run, tally=tally)
+        try:
+            _relocate(show_dir, target, dry_run=dry_run, tally=tally)
+        except OSError as e:
+            # One bad move (locked SRT, disk full, cross-device edge) must not
+            # abort the whole run. Record it and continue — the migration is
+            # idempotent, so re-running with --apply finishes the rest.
+            logger.error(f"  failed: {name}/ -> {tid}/ — {e}", exc_info=True)
+            tally.failed.append(name)
 
     return tally
 
@@ -329,10 +338,13 @@ def main() -> int:
         f"dropped_smaller={tally.files_dropped_smaller} "
         f"skipped_already_id={tally.skipped_already_id} "
         f"skipped_backup={len(tally.skipped_backup)} "
-        f"ambiguous={len(tally.ambiguous)} unresolved={len(tally.unresolved)}"
+        f"ambiguous={len(tally.ambiguous)} unresolved={len(tally.unresolved)} "
+        f"failed={len(tally.failed)}"
     )
     if tally.skipped_backup:
         logger.warning(f"Backup dirs (left in place): {sorted(tally.skipped_backup)}")
+    if tally.failed:
+        logger.error(f"Failed to move (re-run with --apply to retry): {sorted(tally.failed)}")
     if tally.ambiguous:
         logger.warning(f"Ambiguous (left in place): {sorted(tally.ambiguous)}")
     if tally.unresolved:

--- a/backend/scripts/migrate_subtitle_cache_keys.py
+++ b/backend/scripts/migrate_subtitle_cache_keys.py
@@ -1,0 +1,348 @@
+"""Migrate the subtitle SRT cache from name-keyed dirs to tmdb_id-keyed dirs.
+
+PR #288 ("key precomputed subtitle corpus by tmdb_id", cache v3) moved the
+on-disk SRT harvest cache from ``<cache>/data/<sanitized show name>/`` to
+``<cache>/data/<tmdb_id>/``. The ``subtitle_coverage`` table was already keyed by
+tmdb_id, so ``build_subtitle_cache.py``'s complete-on-disk resume fast path still
+sees a "done" coverage record for a season but then looks for its SRTs under the
+new ``data/<tmdb_id>/`` dir, finds nothing (they're still under ``data/<name>/``),
+and re-harvests from scratch. This one-shot, idempotent migration relocates the
+legacy dirs so resume works again.
+
+It is scoped to ``<cache>/data/`` only — ``precomputed/`` is rebuilt every run and
+re-downloaded at runtime, so it needs no migration. Coverage records are already
+tmdb-keyed and are left untouched.
+
+Resolution is offline-first: show names are matched against
+``scripts/curated_shows.csv`` (the list the cache was built from), falling back to
+``tmdb_client.fetch_show_id`` only for names not in the CSV. A purely-numeric dir
+(``1396/``) is treated as already-migrated and skipped — UNLESS it is also a show
+name in the CSV (``24`` is the show "24", not tmdb_id 24), in which case it is
+reported as ambiguous and left in place; pass ``--treat-as-name 24`` to force it.
+
+Usage (from backend/):
+    uv run python scripts/migrate_subtitle_cache_keys.py                 # dry-run (default)
+    uv run python scripts/migrate_subtitle_cache_keys.py --apply         # actually move files
+    uv run python scripts/migrate_subtitle_cache_keys.py --treat-as-name 24 --apply
+    uv run python scripts/migrate_subtitle_cache_keys.py --cache-dir /path/to/cache
+"""
+
+import argparse
+import csv
+import io
+import os
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Idempotent — repeated importlib loads (e.g. one fixture per test file) would
+# otherwise accumulate duplicate entries in sys.path on every exec_module call.
+_backend_dir = str(Path(__file__).parent.parent)
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+
+from loguru import logger
+
+from app.matcher.subtitle_utils import sanitize_filename
+from app.matcher.tmdb_client import fetch_show_id
+
+_DEFAULT_CURATED_CSV = Path(__file__).parent / "curated_shows.csv"
+
+
+@dataclass
+class Tally:
+    """Running counters surfaced in the final summary."""
+
+    migrated: int = 0  # legacy dir renamed into a brand-new id dir
+    merged: int = 0  # legacy dir merged into a pre-existing id dir
+    files_moved: int = 0  # individual files carried into an existing id dir
+    files_kept_larger: int = 0  # collisions resolved toward the legacy file
+    files_dropped_smaller: int = 0  # collisions resolved toward the existing file
+    skipped_already_id: int = 0  # numeric dir already in the tmdb_id scheme
+    skipped_backup: list[str] = field(default_factory=list)  # manual backup-looking dir
+    ambiguous: list[str] = field(default_factory=list)  # numeric dir that is also a show name
+    unresolved: list[str] = field(default_factory=list)  # name with no tmdb_id
+
+
+# Suffixes that mark a deliberate manual backup / scratch copy (e.g.
+# "Frasier.1993-bak"). These are never migrated, even when the TMDB fallback
+# could resolve them, so a hand-made backup is never clobbered onto a real id dir.
+_BACKUP_SUFFIXES = ("-bak", ".bak", "~", ".tmp", ".old")
+
+
+def _looks_like_backup(name: str) -> bool:
+    return name.casefold().endswith(_BACKUP_SUFFIXES)
+
+
+def _normalize(name: str) -> str:
+    """Normalize a show name for tolerant CSV matching.
+
+    Folds case and strips trailing dots/spaces — the two ways a dir name diverges
+    from the curated CSV title: harvesters/users vary the case ("ONE PIECE"), and
+    Windows silently drops trailing dots from directory names ("S.W.A.T." → the
+    on-disk "S.W.A.T"). This is exact-title matching, not fuzzy guessing.
+    """
+    return sanitize_filename(name).casefold().rstrip(" .")
+
+
+def load_curated_map(csv_path) -> dict[str, str]:
+    """Return ``{sanitize_filename(name): str(tmdb_id)}`` from ``curated_shows.csv``.
+
+    Keyed by the sanitized name so lookups match the on-disk dir name (which the
+    writer produced via ``sanitize_filename``). Rows without a numeric ``tmdb_id``
+    are skipped. Missing/unreadable file → empty map (TMDB fallback still applies).
+    """
+    p = Path(csv_path)
+    if not p.exists():
+        logger.warning(f"Curated show list not found: {p} (TMDB fallback only)")
+        return {}
+    text = p.read_text(encoding="utf-8-sig")
+    out: dict[str, str] = {}
+    for row in csv.DictReader(io.StringIO(text)):
+        tid = (row.get("tmdb_id") or "").strip()
+        name = (row.get("name") or "").strip()
+        if name and tid.isdigit():
+            out[sanitize_filename(name)] = tid
+    return out
+
+
+def resolve_dir(
+    dir_name: str,
+    curated_map: dict[str, str],
+    norm_map: dict[str, str],
+    *,
+    treat_as_name,
+    fetch_id_fn,
+) -> tuple[str | None, str]:
+    """Classify a ``data/<dir_name>/`` directory.
+
+    Returns ``(tmdb_id_str_or_None, classification)`` where classification is one
+    of ``"csv"`` / ``"tmdb"`` (resolved → migrate to that id), ``"already_id"``
+    (numeric dir already in the new scheme → skip), ``"backup"`` (a manual backup
+    dir → leave in place), ``"ambiguous"`` (numeric dir that is also a curated show
+    name → report, leave in place), or ``"unresolved"`` (no known id → report).
+
+    ``norm_map`` is ``curated_map`` re-keyed by ``_normalize`` for tolerant
+    (case / trailing-dot) matching; it is consulted only after an exact miss.
+    """
+    if _looks_like_backup(dir_name):
+        return None, "backup"
+
+    forced = dir_name in treat_as_name
+    if dir_name.isdigit() and not forced:
+        # Numeric AND a curated show name (e.g. "24") → genuinely ambiguous.
+        # Numeric and not a show name (e.g. "1396") → already the tmdb_id scheme.
+        return (None, "ambiguous") if dir_name in curated_map else (None, "already_id")
+
+    tid = curated_map.get(sanitize_filename(dir_name)) or curated_map.get(dir_name)
+    if tid:
+        return str(tid), "csv"
+    norm_hit = norm_map.get(_normalize(dir_name))
+    if norm_hit:
+        return str(norm_hit), "csv"
+
+    fetched = fetch_id_fn(dir_name)
+    if fetched:
+        return str(fetched), "tmdb"
+    return None, "unresolved"
+
+
+def _relocate(legacy_dir: Path, target: Path, *, dry_run: bool, tally: Tally) -> None:
+    """Move ``legacy_dir`` to ``target``, merging (union, keep larger) if it exists."""
+    files = [f for f in sorted(legacy_dir.iterdir()) if f.is_file()]
+
+    if not target.exists():
+        logger.info(f"  migrate: {legacy_dir.name}/ -> {target.name}/ ({len(files)} files)")
+        if not dry_run:
+            legacy_dir.rename(target)
+        tally.migrated += 1
+        tally.files_moved += len(files)
+        return
+
+    logger.info(f"  merge:   {legacy_dir.name}/ -> {target.name}/ (target exists)")
+    tally.merged += 1
+    for f in files:
+        dest = target / f.name
+        if dest.exists():
+            if f.stat().st_size > dest.stat().st_size:
+                logger.info(f"    keep larger (legacy): {f.name}")
+                if not dry_run:
+                    os.replace(f, dest)
+                tally.files_kept_larger += 1
+            else:
+                logger.info(f"    drop smaller (legacy): {f.name}")
+                if not dry_run:
+                    f.unlink()
+                tally.files_dropped_smaller += 1
+        else:
+            if not dry_run:
+                shutil.move(str(f), str(dest))
+            tally.files_moved += 1
+
+    if dry_run:
+        return
+    leftover = list(legacy_dir.iterdir())
+    if not leftover:
+        legacy_dir.rmdir()
+    else:
+        logger.warning(
+            f"  {legacy_dir.name}/: {len(leftover)} unmoved entr(ies) remain; not removing dir"
+        )
+
+
+def migrate_cache(
+    data_dir,
+    curated_map: dict[str, str],
+    *,
+    dry_run: bool = True,
+    treat_as_name=frozenset(),
+    fetch_id_fn=fetch_show_id,
+) -> Tally:
+    """Migrate every legacy name-keyed dir under ``data_dir`` to the tmdb_id scheme.
+
+    ``treat_as_name`` forces specific (numeric) dir names to be resolved as show
+    names rather than skipped as already-id. ``fetch_id_fn`` is the TMDB fallback
+    used only for names absent from ``curated_map`` (injected in tests).
+    """
+    data_dir = Path(data_dir)
+    treat_as_name = set(treat_as_name)
+    norm_map = {_normalize(k): v for k, v in curated_map.items()}
+    tally = Tally()
+
+    for show_dir in sorted(d for d in data_dir.iterdir() if d.is_dir()):
+        name = show_dir.name
+        tid, cls = resolve_dir(
+            name, curated_map, norm_map, treat_as_name=treat_as_name, fetch_id_fn=fetch_id_fn
+        )
+        if cls == "already_id":
+            tally.skipped_already_id += 1
+            continue
+        if cls == "backup":
+            logger.info(f"  backup:  {name}/ looks like a manual backup; leaving in place")
+            tally.skipped_backup.append(name)
+            continue
+        if cls == "ambiguous":
+            logger.warning(
+                f"  ambiguous: {name}/ is numeric but also a curated show name; "
+                f"leaving in place (pass --treat-as-name {name} to force)"
+            )
+            tally.ambiguous.append(name)
+            continue
+        if cls == "unresolved":
+            logger.warning(f"  unresolved: {name}/ — no tmdb_id found; leaving in place")
+            tally.unresolved.append(name)
+            continue
+
+        target = data_dir / str(tid)
+        if target == show_dir:  # defensive: name already equals its id
+            tally.skipped_already_id += 1
+            continue
+        _relocate(show_dir, target, dry_run=dry_run, tally=tally)
+
+    return tally
+
+
+def _resolve_cache_data_dir(override: str | None) -> Path:
+    """Pick ``<cache>/data``: ``--cache-dir`` wins, else ``AppConfig``."""
+    if override:
+        return Path(override).expanduser() / "data"
+    from app.services.config_service import get_config_sync
+
+    config = get_config_sync()
+    return Path(config.subtitles_cache_path).expanduser() / "data"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate the subtitle SRT cache from name-keyed to tmdb_id-keyed dirs"
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default="",
+        help="Override the subtitles cache root (default: AppConfig.subtitles_cache_path)",
+    )
+    parser.add_argument(
+        "--curated-csv",
+        type=str,
+        default=str(_DEFAULT_CURATED_CSV),
+        help="Path to the curated show list used for offline name->tmdb_id resolution",
+    )
+    parser.add_argument(
+        "--treat-as-name",
+        type=str,
+        default="",
+        help=(
+            "Comma-separated dir names to resolve as show names rather than skip as "
+            "already-id (e.g. '24' — the show, not tmdb_id 24)"
+        ),
+    )
+    parser.add_argument(
+        "--tmdb-fallback",
+        action="store_true",
+        help=(
+            "Resolve names absent from the curated CSV via a TMDB search "
+            "(tmdb_client.fetch_show_id). Off by default: the default run only migrates "
+            "deterministic CSV matches and reports the rest, so a fuzzy search can't "
+            "misfile an unrecognized dir."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually move files (default: dry-run, reports the plan without changes)",
+    )
+    args = parser.parse_args()
+
+    data_dir = _resolve_cache_data_dir(args.cache_dir or None)
+    if not data_dir.exists():
+        logger.error(f"Subtitle cache data dir not found: {data_dir}")
+        return 1
+
+    curated_map = load_curated_map(args.curated_csv)
+    treat_as_name = {s.strip() for s in args.treat_as_name.split(",") if s.strip()}
+    dry_run = not args.apply
+
+    # Default to deterministic CSV matching only; the fuzzy TMDB search is opt-in
+    # so an unrecognized dir is reported, never misfiled.
+    fetch_id_fn = fetch_show_id if args.tmdb_fallback else (lambda _name: None)
+
+    mode = "DRY RUN" if dry_run else "APPLY"
+    logger.info(
+        f"[{mode}] Migrating SRT cache under {data_dir} "
+        f"({len(curated_map)} curated shows; tmdb_fallback={args.tmdb_fallback}; "
+        f"treat-as-name={sorted(treat_as_name) or 'none'})"
+    )
+
+    tally = migrate_cache(
+        data_dir,
+        curated_map,
+        dry_run=dry_run,
+        treat_as_name=treat_as_name,
+        fetch_id_fn=fetch_id_fn,
+    )
+
+    logger.info(
+        f"Done [{mode}]. migrated={tally.migrated} merged={tally.merged} "
+        f"files_moved={tally.files_moved} kept_larger={tally.files_kept_larger} "
+        f"dropped_smaller={tally.files_dropped_smaller} "
+        f"skipped_already_id={tally.skipped_already_id} "
+        f"skipped_backup={len(tally.skipped_backup)} "
+        f"ambiguous={len(tally.ambiguous)} unresolved={len(tally.unresolved)}"
+    )
+    if tally.skipped_backup:
+        logger.warning(f"Backup dirs (left in place): {sorted(tally.skipped_backup)}")
+    if tally.ambiguous:
+        logger.warning(f"Ambiguous (left in place): {sorted(tally.ambiguous)}")
+    if tally.unresolved:
+        logger.warning(f"Unresolved (left in place): {sorted(tally.unresolved)}")
+        if not args.tmdb_fallback:
+            logger.info("Re-run with --tmdb-fallback to resolve unrecognized names via TMDB.")
+    if dry_run and (tally.migrated or tally.merged):
+        logger.info("Dry run only — re-run with --apply to perform the migration.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -77,6 +77,12 @@ def nsc():
 
 
 @pytest.fixture(scope="session")
+def msc():
+    """The migrate_subtitle_cache_keys.py module, loaded once per pytest session."""
+    return _load_script_module("migrate_subtitle_cache_keys")
+
+
+@pytest.fixture(scope="session")
 def psc(bsc):
     """The pack_subtitle_cache.py module, loaded once per pytest session.
 

--- a/backend/tests/unit/test_migrate_subtitle_cache_keys.py
+++ b/backend/tests/unit/test_migrate_subtitle_cache_keys.py
@@ -1,0 +1,237 @@
+"""Unit tests for migrate_subtitle_cache_keys.
+
+The migration relocates legacy name-keyed SRT cache dirs (``data/<name>/``) to
+the tmdb_id scheme (``data/<tmdb_id>/``) introduced by PR #288 so the build
+script's complete-on-disk resume path finds them. These tests exercise the pure
+relocation/merge logic against a tmp cache dir + an in-memory curated map — they
+never touch the real ~/.engram/cache (per the real-cache verification hazard) and
+inject the TMDB fallback so they stay offline.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# `msc` (migrate_subtitle_cache_keys) is a session-scoped fixture in conftest.py.
+
+
+def _mk_srt(d: Path, name: str, size: int = 200) -> Path:
+    """Create an SRT under ``d`` whose body is padded to roughly ``size`` bytes."""
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / name
+    body = "1\n00:00:01,000 --> 00:00:02,000\n" + ("x" * max(0, size)) + "\n"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+@pytest.mark.unit
+class TestLoadCuratedMap:
+    def test_maps_sanitized_name_to_id(self, msc, tmp_path):
+        csv = tmp_path / "shows.csv"
+        csv.write_text(
+            "rank,tmdb_id,name\n1,1396,Breaking Bad\n2,1973,24\n5,40,CSI: Miami\n",
+            encoding="utf-8",
+        )
+        m = msc.load_curated_map(csv)
+        assert m["Breaking Bad"] == "1396"
+        assert m["24"] == "1973"
+        # ':' is sanitized to ' -' so the key matches the on-disk dir name.
+        assert m["CSI - Miami"] == "40"
+
+    def test_rows_without_numeric_id_are_skipped(self, msc, tmp_path):
+        csv = tmp_path / "shows.csv"
+        csv.write_text("rank,tmdb_id,name\n1,,No Id Show\n2,1396,Breaking Bad\n", encoding="utf-8")
+        m = msc.load_curated_map(csv)
+        assert "No Id Show" not in m
+        assert m["Breaking Bad"] == "1396"
+
+
+@pytest.mark.unit
+class TestMigrateRename:
+    def test_name_dir_renamed_to_id_offline(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt")
+        calls = []
+
+        def fake_fetch(name):
+            calls.append(name)
+            return None
+
+        tally = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=fake_fetch
+        )
+        assert (data / "1396" / "Breaking Bad - S01E01.srt").exists()
+        assert not (data / "Breaking Bad").exists()
+        assert tally.migrated == 1
+        # CSV hit must not consult TMDB.
+        assert calls == []
+
+
+@pytest.mark.unit
+class TestMergeUnionKeepLarger:
+    def test_collision_unions_and_keeps_larger(self, msc, tmp_path):
+        data = tmp_path / "data"
+        # Legacy dir has E01 (large) + E03; fresh id dir has E01 (small) + E02.
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt", size=900)
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E03.srt", size=300)
+        _mk_srt(data / "1396", "Breaking Bad - S01E01.srt", size=100)
+        _mk_srt(data / "1396", "Breaking Bad - S01E02.srt", size=300)
+
+        tally = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+
+        idd = data / "1396"
+        assert {p.name for p in idd.glob("*.srt")} == {
+            "Breaking Bad - S01E01.srt",
+            "Breaking Bad - S01E02.srt",
+            "Breaking Bad - S01E03.srt",
+        }
+        # E01 collision resolved in favour of the larger (legacy 900-byte) file.
+        assert (idd / "Breaking Bad - S01E01.srt").stat().st_size >= 900
+        assert not (data / "Breaking Bad").exists()
+        assert tally.merged == 1
+        assert tally.files_kept_larger == 1
+        assert tally.files_dropped_smaller == 0
+        assert tally.files_moved == 1  # E03 carried in
+
+    def test_smaller_legacy_file_dropped(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt", size=100)
+        _mk_srt(data / "1396", "Breaking Bad - S01E01.srt", size=900)
+
+        tally = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+
+        # Fresh id-dir file (larger) wins; legacy dir is emptied and removed.
+        assert (data / "1396" / "Breaking Bad - S01E01.srt").stat().st_size >= 900
+        assert not (data / "Breaking Bad").exists()
+        assert tally.files_dropped_smaller == 1
+        assert tally.files_kept_larger == 0
+
+
+@pytest.mark.unit
+class TestAlreadyIdSkipped:
+    def test_pure_numeric_dir_not_a_show_name_is_skipped(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "1396", "Breaking Bad - S01E01.srt")
+        tally = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+        assert (data / "1396" / "Breaking Bad - S01E01.srt").exists()
+        assert tally.skipped_already_id == 1
+        assert tally.migrated == 0
+
+
+@pytest.mark.unit
+class TestAmbiguousNumericName:
+    def test_numeric_show_name_reported_not_migrated(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "24", "24 - S01E01.srt")
+        tally = msc.migrate_cache(data, {"24": "1973"}, dry_run=False, fetch_id_fn=lambda n: None)
+        assert (data / "24" / "24 - S01E01.srt").exists()  # untouched
+        assert "24" in tally.ambiguous
+        assert not (data / "1973").exists()
+
+    def test_treat_as_name_forces_migration(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "24", "24 - S01E01.srt")
+        tally = msc.migrate_cache(
+            data,
+            {"24": "1973"},
+            dry_run=False,
+            treat_as_name={"24"},
+            fetch_id_fn=lambda n: None,
+        )
+        assert (data / "1973" / "24 - S01E01.srt").exists()
+        assert not (data / "24").exists()
+        assert tally.migrated == 1
+
+
+@pytest.mark.unit
+class TestUnresolved:
+    def test_unknown_name_left_and_reported(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Obscure Show", "Obscure Show - S01E01.srt")
+        tally = msc.migrate_cache(data, {}, dry_run=False, fetch_id_fn=lambda n: None)
+        assert (data / "Obscure Show").exists()
+        assert "Obscure Show" in tally.unresolved
+        assert tally.migrated == 0
+
+    def test_tmdb_fallback_resolves_when_not_in_csv(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Obscure Show", "Obscure Show - S01E01.srt")
+        tally = msc.migrate_cache(data, {}, dry_run=False, fetch_id_fn=lambda n: "555")
+        assert (data / "555" / "Obscure Show - S01E01.srt").exists()
+        assert not (data / "Obscure Show").exists()
+        assert tally.migrated == 1
+
+
+@pytest.mark.unit
+class TestDryRun:
+    def test_dry_run_makes_no_changes(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt")
+        tally = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=True, fetch_id_fn=lambda n: None
+        )
+        # Counted as a would-migrate, but nothing on disk moved.
+        assert (data / "Breaking Bad" / "Breaking Bad - S01E01.srt").exists()
+        assert not (data / "1396").exists()
+        assert tally.migrated == 1
+
+
+@pytest.mark.unit
+class TestIdempotent:
+    def test_second_run_is_noop(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt")
+        msc.migrate_cache(data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=lambda n: None)
+        tally2 = msc.migrate_cache(
+            data, {"Breaking Bad": "1396"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+        assert tally2.migrated == 0
+        assert tally2.merged == 0
+        # 1396 now exists, is numeric, and is not a curated show name → skipped.
+        assert tally2.skipped_already_id == 1
+
+
+@pytest.mark.unit
+class TestNormalizedMatch:
+    """Dir names diverge from the curated CSV by case and by Windows silently
+    stripping trailing dots from directory names. Matching normalizes both so
+    these resolve deterministically — no risky fuzzy TMDB guess needed."""
+
+    def test_case_insensitive(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "ONE PIECE", "ONE PIECE - S01E01.srt")
+        tally = msc.migrate_cache(
+            data, {"One Piece": "37854"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+        assert (data / "37854" / "ONE PIECE - S01E01.srt").exists()
+        assert tally.migrated == 1
+
+    def test_windows_trailing_dot(self, msc, tmp_path):
+        data = tmp_path / "data"
+        # Windows drops the trailing dot, so "S.W.A.T." lands on disk as "S.W.A.T".
+        _mk_srt(data / "S.W.A.T", "S.W.A.T - S01E01.srt")
+        tally = msc.migrate_cache(
+            data, {"S.W.A.T.": "71790"}, dry_run=False, fetch_id_fn=lambda n: None
+        )
+        assert (data / "71790" / "S.W.A.T - S01E01.srt").exists()
+        assert tally.migrated == 1
+
+
+@pytest.mark.unit
+class TestBackupDirSkipped:
+    def test_backup_suffix_never_migrated(self, msc, tmp_path):
+        data = tmp_path / "data"
+        _mk_srt(data / "Frasier.1993-bak", "Frasier - S01E01.srt")
+        # Even when the fallback WOULD resolve it, a backup-looking dir is left
+        # untouched so deliberate manual backups are never clobbered.
+        tally = msc.migrate_cache(data, {}, dry_run=False, fetch_id_fn=lambda n: "3452")
+        assert (data / "Frasier.1993-bak").exists()
+        assert not (data / "3452").exists()
+        assert "Frasier.1993-bak" in tally.skipped_backup
+        assert tally.migrated == 0

--- a/backend/tests/unit/test_migrate_subtitle_cache_keys.py
+++ b/backend/tests/unit/test_migrate_subtitle_cache_keys.py
@@ -224,6 +224,35 @@ class TestNormalizedMatch:
 
 
 @pytest.mark.unit
+class TestRelocateErrorHandling:
+    def test_move_failure_is_recorded_and_loop_continues(self, msc, tmp_path, monkeypatch):
+        # A locked SRT / disk-full / AV lock can make one move raise mid-run. That
+        # must be recorded and skipped, not crash the whole migration — the script
+        # is idempotent, so a re-run recovers, but only if the run finishes.
+        data = tmp_path / "data"
+        _mk_srt(data / "Breaking Bad", "Breaking Bad - S01E01.srt")
+        _mk_srt(data / "The Wire", "The Wire - S01E01.srt")
+        real = msc._relocate
+
+        def flaky(legacy_dir, target, *, dry_run, tally):
+            if legacy_dir.name == "Breaking Bad":
+                raise OSError("file is locked")
+            return real(legacy_dir, target, dry_run=dry_run, tally=tally)
+
+        monkeypatch.setattr(msc, "_relocate", flaky)
+        tally = msc.migrate_cache(
+            data,
+            {"Breaking Bad": "1396", "The Wire": "1438"},
+            dry_run=False,
+            fetch_id_fn=lambda n: None,
+        )
+        # The good dir (sorted after the failing one) still migrates.
+        assert (data / "1438" / "The Wire - S01E01.srt").exists()
+        assert "Breaking Bad" in tally.failed
+        assert tally.migrated == 1
+
+
+@pytest.mark.unit
 class TestBackupDirSkipped:
     def test_backup_suffix_never_migrated(self, msc, tmp_path):
         data = tmp_path / "data"

--- a/docs/development/subtitle-cache.md
+++ b/docs/development/subtitle-cache.md
@@ -77,6 +77,44 @@ After any full build, dispatch the workflow once more with the same `limit`. The
 
 If those don't hold, something has broken the resume path — file an issue with the run URL.
 
+## Migrating an older name-keyed cache
+
+The harvested SRT cache under `~/.engram/cache/data/` used to be keyed by show
+**name** (`data/Breaking Bad/`). Since [#288](https://github.com/Jsakkos/engram/pull/288)
+it is keyed by **tmdb_id** (`data/1396/`) so two same-named shows can't collide. The
+per-season coverage records (`subtitle_coverage`) were already tmdb-keyed, so after the
+switch the resume fast path sees a season marked "done" but looks for its SRTs under the
+new `data/<tmdb_id>/` path, finds nothing, and **re-harvests the whole show from scratch**.
+
+If you have a cache built before that change, relocate the legacy dirs once with:
+
+```bash
+cd backend
+# Preview the plan (dry-run is the default — nothing is moved):
+uv run python scripts/migrate_subtitle_cache_keys.py --cache-dir ~/.engram/cache
+# Apply it:
+uv run python scripts/migrate_subtitle_cache_keys.py --cache-dir ~/.engram/cache --apply
+```
+
+How it resolves each `data/<name>/` dir to a tmdb_id:
+
+- **Offline first.** Names are matched against `scripts/curated_shows.csv` (the list the
+  cache is built from), tolerant of case and of Windows silently stripping trailing dots
+  from directory names (`S.W.A.T.` → on-disk `S.W.A.T`). This is the default and needs no
+  network.
+- **`--tmdb-fallback`** (opt-in) resolves names absent from the CSV via a TMDB search.
+  It's off by default so an unrecognized dir is reported rather than risk a fuzzy
+  misfile. It needs a TMDB key, so run it with `DATABASE_URL` pointed at a config DB.
+- A purely-numeric dir (`1396/`) is treated as already-migrated and skipped — unless it's
+  also a show name in the CSV (`24` is the *show*, not tmdb_id 24), in which case it's
+  reported as ambiguous; pass `--treat-as-name 24` to force it.
+- Dirs ending in a backup suffix (`-bak`, `.bak`, `~`, `.tmp`, `.old`) are always left in
+  place, so deliberate manual backups are never clobbered.
+
+When a target id dir already exists (e.g. a show that was re-harvested from scratch after
+the switch), the two are **merged**: episodes are unioned and, on a filename collision,
+the larger SRT is kept. The migration is idempotent — a second run finds nothing to move.
+
 ## Cache format versioning
 
 The published tarball includes a [`manifest.json`](https://github.com/Jsakkos/engram/blob/main/backend/scripts/build_subtitle_cache.py) with `cache_format_version` (a string defined in `backend/app/matcher/vectorizer_config.py` — currently `"2"`, which stores uint16 hashed counts and applies TF-IDF at load time; `"1"` shipped pre-computed float64 TF-IDF rows). The backend reads this on download and rejects incompatible caches, falling back to scraping. The check happens in two places:

--- a/docs/superpowers/specs/2026-06-03-subtitle-cache-key-migration-design.md
+++ b/docs/superpowers/specs/2026-06-03-subtitle-cache-key-migration-design.md
@@ -1,0 +1,90 @@
+# Subtitle cache key migration (name → tmdb_id)
+
+_Date: 2026-06-03_
+
+## Problem
+
+PR #288 (`e11ad8f`, "key precomputed subtitle corpus by tmdb_id (cache v3)") changed
+`corpus_dir_name()` so the on-disk SRT harvest cache moved from `data/<sanitized show
+name>/` to `data/<tmdb_id>/`. The `subtitle_coverage` table was already keyed by
+`tmdb_id`, so the build script's complete-on-disk resume fast path
+(`build_subtitle_cache._harvest_show`) still finds a fresh "done" coverage record for a
+season — but then calls `discover_season_srts(data/<tmdb_id>/, season)`, which finds
+nothing because the SRTs are still under the legacy `data/<name>/`. It logs *"coverage
+recorded but SRTs missing on disk; re-harvesting from scratch"* and re-downloads
+everything.
+
+Observed on the real cache (`~/.engram/cache/data/`): 308 dirs total — **291 legacy
+name-keyed**, **17 fresh id-keyed**. The 17 are shows that were re-downloaded from
+scratch after #288 because their legacy dirs were invisible (e.g. `Breaking Bad/` from
+May 23 sitting next to `1396/` from Jun 3).
+
+Nothing migrates the legacy dirs: `normalize_subtitle_cache.py` only canonicalizes
+filenames *inside* a dir, never the dir name itself.
+
+## Goal
+
+A one-shot, idempotent migration that relocates legacy `data/<name>/` dirs to
+`data/<tmdb_id>/` so the resume path finds them. Scoped to `data/` only — `precomputed/`
+is `shutil.rmtree`'d and rebuilt every run, and the runtime re-downloads it from the
+release.
+
+## Design
+
+New script `backend/scripts/migrate_subtitle_cache_keys.py`, mirroring the conventions of
+its siblings (`build_`/`normalize_`/`audit_subtitle_cache.py`): argparse, loguru,
+idempotent `sys.path` bootstrap, `--cache-dir` override defaulting to
+`AppConfig.subtitles_cache_path`.
+
+### Name → tmdb_id resolution (offline-first)
+
+1. Build `{sanitize_filename(name): tmdb_id}` from `scripts/curated_shows.csv` (the list
+   the cache was built from) — deterministic, no network, covers nearly all 291 dirs.
+2. Misses fall back to `tmdb_client.fetch_show_id(name)` (persistent-cache first; only
+   true misses hit the network; returns `None` with no API key → treated as unresolved).
+3. Purely-numeric dirs (`1396/`) are already migrated → skipped silently. **Exception:** a
+   numeric dir that is *also* a show name in the CSV (`24`) is ambiguous — left in place,
+   reported, with a `--treat-as-name 24` escape hatch to force it through name resolution.
+
+### Merge: union, keep larger (chosen)
+
+For a legacy dir resolving to tmdb_id `T`, target `data/T/`:
+
+- Target absent → `Path.rename` (atomic on same volume).
+- Target present (the 17 collisions) → move each `*.srt`; on exact-name collision keep the
+  larger file (`st_size`), drop the smaller; remove the emptied legacy dir afterward. Same
+  episode shares the canonical `{name} - SxxExx.srt` filename in both dirs, so exact-name
+  collision catches it. Cross-naming duplicates are out of scope — `normalize_subtitle_cache.py`
+  handles those and is run as a follow-up pass.
+
+### Safety
+
+- Defaults to **dry-run**; `--apply` required to mutate (higher-stakes + one-shot vs. its
+  siblings, which default to apply).
+- Idempotent: a second run finds no legacy dirs → no-op.
+- Final summary tallies migrated / merged / skipped / **ambiguous** / **unresolved**, with
+  the ambiguous and unresolved lists printed explicitly so stragglers are actionable.
+- Coverage records need no migration — already tmdb-keyed.
+
+## Testing (TDD)
+
+`tests/unit/test_migrate_subtitle_cache_keys.py`, against a tmp cache dir + a fake CSV
+(never the real cache, per the real-cache verification hazard):
+
+- name dir → renamed to id dir; CSV hit does **not** call `fetch_show_id`.
+- collision → union, larger SRT kept, legacy dir removed.
+- already-id dir → skipped.
+- ambiguous numeric-name (`24` present in fake CSV as a show) → reported, left in place;
+  `--treat-as-name 24` migrates it.
+- unresolved name (not in CSV, `fetch_show_id` → None) → left + reported.
+- `--dry-run` (default) → no filesystem changes.
+- second run → no-op (idempotent).
+
+## Rollout
+
+1. Implement test-first; `uv run pytest tests/unit/test_migrate_subtitle_cache_keys.py`.
+2. Dry-run against the real cache; review the plan (renames / merges / skips / ambiguous /
+   unresolved).
+3. `--apply`.
+4. `normalize_subtitle_cache.py` follow-up pass.
+5. Verify a migrated show ships "from disk" on the next build run.


### PR DESCRIPTION
## What & why

[#288](https://github.com/Jsakkos/engram/pull/288) re-keyed the on-disk subtitle harvest cache from `data/<show name>/` to `data/<tmdb_id>/` (cache v3), but the `subtitle_coverage` table was already keyed by `tmdb_id`. So `build_subtitle_cache.py`'s complete-on-disk resume path saw each season's coverage marked **"done"**, then looked for its SRTs under the new `data/<tmdb_id>/` path, found nothing (they were still under `data/<name>/`), and **re-harvested every show from scratch on each run**. Nothing migrated the legacy dirs — `normalize_subtitle_cache.py` only canonicalizes filenames *inside* a dir, never the dir name itself.

This adds a one-shot migration so an existing name-keyed cache resumes correctly.

## What's in here

`backend/scripts/migrate_subtitle_cache_keys.py` — idempotent, **dry-run by default** (`--apply` to mutate), scoped to `<cache>/data/` only (`precomputed/` is rebuilt every run):

- **Offline-first resolution.** Names match `scripts/curated_shows.csv`, tolerant of case and of Windows silently stripping trailing dots from dir names (`S.W.A.T.` → on-disk `S.W.A.T`). Deterministic, no network.
- **`--tmdb-fallback`** (opt-in) resolves names absent from the CSV via `tmdb_client.fetch_show_id`. Off by default so an unrecognized dir is reported, never fuzzy-misfiled.
- Purely-numeric dirs (`1396/`) are skipped as already-migrated — unless also a CSV show name (`24` is the *show*, not tmdb_id 24), reported as ambiguous; `--treat-as-name 24` forces it.
- Backup suffixes (`-bak`/`.bak`/`~`/`.tmp`/`.old`) are always left in place, so deliberate manual backups are never clobbered.
- Collisions (a target id dir that already exists from a re-harvest) **merge** union/keep-larger.

Also: a developer-doc section in `docs/development/subtitle-cache.md`, the design spec under `docs/superpowers/specs/`, and a shared `msc` conftest fixture mirroring the existing `bsc`/`nsc`/`vsc` script loaders.

## Testing

- 15 new unit tests (`tests/unit/test_migrate_subtitle_cache_keys.py`) — rename, merge union/keep-larger, already-id skip, ambiguous `24`, `--treat-as-name`, unresolved-left-and-reported, TMDB fallback, normalized (case/trailing-dot) match, backup-skip, dry-run, idempotency. All green; ruff clean.
- Ran against a real ~300-show cache: 308 dirs → 245 renamed + 30 merged + `24`; **1,127 covered seasons now ship from disk, 10 re-harvest** (all the deliberately-skipped `Frasier.1993-bak` backup). Zero duplicate episodes introduced by merges.

## Reviewer notes

- **Internal consistency over canonical id:** the migration resolves names with the *same* `fetch_show_id` the build script uses to key coverage, so a relocated dir lands on the same id the coverage record already holds — the resume path works even if TMDB's pick isn't the "canonical" id.
- Maintainer-only tooling (end users download the prebuilt cache), so intentionally **no CHANGELOG entry**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
