### PR TITLE
fix(import): retry watch-folder imports after a failed job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Engram will be documented in this file.
 
 ### Fixed
 
+- **The import watch folder stopped re-importing a folder after a single failed attempt** — once any job had been created for a watched folder, that exact folder was blocked from ever being imported again, even if the job had failed (cancelled, or auto-failed when the server restarted mid-job). Because the watch folder is re-scanned on every poll and on every restart, a one-time failure silently wedged the folder: the watcher kept detecting it and immediately skipped it ("Job already exists for staging path …"), so nothing imported. Engram now dedups only against an active or review-pending job for the path, so a previously failed import is retried on the next scan instead of being stuck forever.
 - **Clearer disc card when two shows share a name** — a disc that matches more than one same-name show (for example the 1993 vs 2023 **Frasier**) is flagged for review before ripping, but its card showed a "Review needed" button that opened an empty review screen — there's nothing to review until the disc is ripped — right next to an identical "Review needed" status badge. The card now hides that dead-end button until the disc actually has ripped tracks, emphasizes the **Wrong title?** action as the thing to click, and adds a short banner explaining the same-name ambiguity and how to resolve it. (#308)
 
 ## [0.15.0] - 2026-06-03

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -65,6 +65,11 @@ class JobManager:
         self._analyst = DiscAnalyst()
         self._active_jobs: dict[int, asyncio.Task] = {}
         self._drive_locks: dict[str, asyncio.Lock] = {}
+        # Per staging-path lock guarding create_job_from_staging's check→insert,
+        # mirroring _drive_locks for the disc path. create_job_from_staging is
+        # reachable from both the watch-folder poller and POST /api/staging/import,
+        # so concurrent calls for the same path must not both pass the dedup guard.
+        self._staging_locks: dict[str, asyncio.Lock] = {}
         self._last_job_created_at: dict[str, float] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._timed_cleanup_task: asyncio.Task | None = None
@@ -410,54 +415,63 @@ class JobManager:
         if not volume_label:
             volume_label = staging_dir.name.upper().replace(" ", "_")
 
-        async with async_session() as session:
-            # Guard: don't create a duplicate job for the same staging directory.
-            # A watch folder is re-detected on every poll and every server
-            # restart, so a *terminal-failed* prior job (cancelled, or auto-failed
-            # by restart recovery) must NOT permanently wedge re-import — only an
-            # active or review-pending job should dedup. Use .first() because a
-            # path may now accumulate multiple FAILED rows across retries.
-            existing = await session.execute(
-                sa_select(DiscJob).where(
-                    DiscJob.staging_path == str(staging_dir),
-                    DiscJob.state != JobState.FAILED,
+        # Hold a per-path lock across the dedup check and insert so two concurrent
+        # callers (poller + API, or two API calls) for the same path can't both
+        # pass the guard and insert duplicate jobs — mirrors _drive_locks on the
+        # disc path. Widened slightly by this dedup change: retries of a path with
+        # only FAILED rows now reach the check→insert that the guard used to short.
+        if str(staging_dir) not in self._staging_locks:
+            self._staging_locks[str(staging_dir)] = asyncio.Lock()
+
+        async with self._staging_locks[str(staging_dir)]:
+            async with async_session() as session:
+                # Guard: don't create a duplicate job for the same staging directory.
+                # A watch folder is re-detected on every poll and every server
+                # restart, so a *terminal-failed* prior job (cancelled, or auto-failed
+                # by restart recovery) must NOT permanently wedge re-import — only an
+                # active or review-pending job should dedup. Use .first() because a
+                # path may now accumulate multiple FAILED rows across retries.
+                existing = await session.execute(
+                    sa_select(DiscJob).where(
+                        DiscJob.staging_path == str(staging_dir),
+                        DiscJob.state != JobState.FAILED,
+                    )
                 )
-            )
-            if existing.scalars().first() is not None:
-                safe_path = str(staging_dir).replace("\n", "").replace("\r", "")
-                logger.info("Job already exists for staging path %s, skipping", safe_path)
-                return -1
+                if existing.scalars().first() is not None:
+                    safe_path = str(staging_dir).replace("\n", "").replace("\r", "")
+                    logger.info("Job already exists for staging path %s, skipping", safe_path)
+                    return -1
 
-            job = DiscJob(
-                drive_id=drive_id,
-                volume_label=volume_label,
-                staging_path=str(staging_dir),
-                state=JobState.IDENTIFYING,
-                destination_mode=destination_mode,
-            )
+                job = DiscJob(
+                    drive_id=drive_id,
+                    volume_label=volume_label,
+                    staging_path=str(staging_dir),
+                    state=JobState.IDENTIFYING,
+                    destination_mode=destination_mode,
+                )
 
-            if content_type in ("tv", "movie"):
-                job.content_type = ContentType(content_type)
-            if detected_title:
-                job.detected_title = detected_title
-            if detected_season is not None:
-                job.detected_season = detected_season
+                if content_type in ("tv", "movie"):
+                    job.content_type = ContentType(content_type)
+                if detected_title:
+                    job.detected_title = detected_title
+                if detected_season is not None:
+                    job.detected_season = detected_season
 
-            session.add(job)
-            await session.commit()
-            await session.refresh(job)
+                session.add(job)
+                await session.commit()
+                await session.refresh(job)
 
-            job_id = job.id
-            safe_path = str(staging_path).replace("\n", "").replace("\r", "")
-            safe_label = str(volume_label).replace("\n", "").replace("\r", "")
-            logger.info(
-                "Created %s job %s from %s (label: %s, destination: %s)",
-                "import" if drive_id == "import" else "staging",
-                job_id,
-                safe_path,
-                safe_label,
-                destination_mode,
-            )
+                job_id = job.id
+                safe_path = str(staging_path).replace("\n", "").replace("\r", "")
+                safe_label = str(volume_label).replace("\n", "").replace("\r", "")
+                logger.info(
+                    "Created %s job %s from %s (label: %s, destination: %s)",
+                    "import" if drive_id == "import" else "staging",
+                    job_id,
+                    safe_path,
+                    safe_label,
+                    destination_mode,
+                )
 
         await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -411,11 +411,19 @@ class JobManager:
             volume_label = staging_dir.name.upper().replace(" ", "_")
 
         async with async_session() as session:
-            # Guard: don't create a duplicate job for the same staging directory
+            # Guard: don't create a duplicate job for the same staging directory.
+            # A watch folder is re-detected on every poll and every server
+            # restart, so a *terminal-failed* prior job (cancelled, or auto-failed
+            # by restart recovery) must NOT permanently wedge re-import — only an
+            # active or review-pending job should dedup. Use .first() because a
+            # path may now accumulate multiple FAILED rows across retries.
             existing = await session.execute(
-                sa_select(DiscJob).where(DiscJob.staging_path == str(staging_dir))
+                sa_select(DiscJob).where(
+                    DiscJob.staging_path == str(staging_dir),
+                    DiscJob.state != JobState.FAILED,
+                )
             )
-            if existing.scalar_one_or_none():
+            if existing.scalars().first() is not None:
                 safe_path = str(staging_dir).replace("\n", "").replace("\r", "")
                 logger.info("Job already exists for staging path %s, skipping", safe_path)
                 return -1

--- a/backend/tests/unit/test_create_job_from_staging_dedup.py
+++ b/backend/tests/unit/test_create_job_from_staging_dedup.py
@@ -1,0 +1,88 @@
+"""Unit tests for the dedup guard in JobManager.create_job_from_staging.
+
+The import watch folder re-detects the same directory on every poll and on
+every server restart. A prior *terminal-failed* job for that path must NOT
+permanently block re-import (regression: jobs left FAILED by a cancel or a
+server-restart recovery silently wedged the watch folder). A still-active or
+review-pending job for the path must still be deduped so a polling watcher
+cannot spawn duplicate jobs.
+"""
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models import DiscJob, JobState
+
+# app.services.job_manager is name-shadowed by the singleton in the package
+# __init__, so `from app.services import job_manager` yields the instance, not
+# the module. Resolve the real module the same way conftest does.
+jm_mod = importlib.import_module("app.services.job_manager")
+job_manager = jm_mod.job_manager
+
+
+async def _insert_job(staging_path: str, state: JobState) -> int:
+    """Insert a DiscJob for a given staging_path/state into the in-memory DB."""
+    async with jm_mod.async_session() as session:
+        job = DiscJob(
+            drive_id="import",
+            volume_label="SEINFELD",
+            staging_path=staging_path,
+            state=state,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job.id
+
+
+@pytest.fixture
+def stub_pipeline(monkeypatch):
+    """Prevent create_job_from_staging from spawning the real pipeline/broadcast."""
+    monkeypatch.setattr(job_manager._identification, "identify_from_staging", AsyncMock())
+    monkeypatch.setattr(jm_mod.event_broadcaster, "broadcast_drive_inserted", AsyncMock())
+
+
+async def _drain(job_id: int) -> None:
+    """Await and clear the background task create_job_from_staging spawned."""
+    task = job_manager._active_jobs.pop(job_id, None)
+    if task is not None:
+        await task
+
+
+class TestCreateJobFromStagingDedup:
+    async def test_failed_job_does_not_block_reimport(self, stub_pipeline):
+        """A FAILED job for the path must not prevent a fresh import job."""
+        path = r"X:\media\rips\Seinfeld"
+        failed_id = await _insert_job(path, JobState.FAILED)
+
+        new_id = await job_manager.create_job_from_staging(
+            staging_path=path, volume_label="SEINFELD", drive_id="import"
+        )
+
+        assert new_id != -1, "FAILED job wrongly blocked re-import"
+        assert new_id != failed_id
+        await _drain(new_id)
+
+    async def test_active_job_still_blocks_reimport(self, stub_pipeline):
+        """A non-terminal (in-flight) job for the path must still be deduped."""
+        path = r"X:\media\rips\True Detective\Season 1"
+        await _insert_job(path, JobState.IDENTIFYING)
+
+        result = await job_manager.create_job_from_staging(
+            staging_path=path, volume_label="SEASON_1", drive_id="import"
+        )
+
+        assert result == -1, "active job should still dedup to prevent duplicates"
+
+    async def test_review_needed_job_still_blocks_reimport(self, stub_pipeline):
+        """A REVIEW_NEEDED job must still dedup (files remain in the watch folder)."""
+        path = r"X:\media\rips\Deadwood"
+        await _insert_job(path, JobState.REVIEW_NEEDED)
+
+        result = await job_manager.create_job_from_staging(
+            staging_path=path, volume_label="DEADWOOD", drive_id="import"
+        )
+
+        assert result == -1, "review-pending job should still dedup"

--- a/backend/tests/unit/test_create_job_from_staging_dedup.py
+++ b/backend/tests/unit/test_create_job_from_staging_dedup.py
@@ -48,10 +48,12 @@ def stub_pipeline(monkeypatch):
 async def _drain(job_id: int) -> None:
     """Await and clear the background task create_job_from_staging spawned."""
     task = job_manager._active_jobs.pop(job_id, None)
-    if task is not None:
-        # gather() (not a bare `await task`) so the await is a call expression —
-        # avoids CodeQL py/ineffectual-statement misflagging the bare await.
-        await asyncio.gather(task)
+    # Assert rather than skip silently: if _active_jobs is ever renamed this
+    # helper would become a no-op (leaked task) while the test still passed.
+    assert task is not None, f"no active task tracked for job {job_id}"
+    # gather() (not a bare `await task`) so the await is a call expression —
+    # avoids CodeQL py/ineffectual-statement misflagging the bare await.
+    await asyncio.gather(task)
 
 
 class TestCreateJobFromStagingDedup:
@@ -89,3 +91,21 @@ class TestCreateJobFromStagingDedup:
         )
 
         assert result == -1, "review-pending job should still dedup"
+
+    async def test_completed_job_still_blocks_reimport(self, stub_pipeline):
+        """A COMPLETED job must still dedup.
+
+        Unlike the disc path (which excludes COMPLETED), a watch folder is polled
+        continuously, so a completed import must not re-spawn a duplicate job while
+        its files still sit in the watch folder. This is a deliberate policy — the
+        guard blocks every state except FAILED — and this test pins it so a future
+        change that mirrors the disc filter can't silently regress it.
+        """
+        path = r"X:\media\rips\Sopranos"
+        await _insert_job(path, JobState.COMPLETED)
+
+        result = await job_manager.create_job_from_staging(
+            staging_path=path, volume_label="SOPRANOS", drive_id="import"
+        )
+
+        assert result == -1, "completed import should still dedup"

--- a/backend/tests/unit/test_create_job_from_staging_dedup.py
+++ b/backend/tests/unit/test_create_job_from_staging_dedup.py
@@ -8,6 +8,7 @@ review-pending job for the path must still be deduped so a polling watcher
 cannot spawn duplicate jobs.
 """
 
+import asyncio
 import importlib
 from unittest.mock import AsyncMock
 
@@ -48,7 +49,9 @@ async def _drain(job_id: int) -> None:
     """Await and clear the background task create_job_from_staging spawned."""
     task = job_manager._active_jobs.pop(job_id, None)
     if task is not None:
-        await task
+        # gather() (not a bare `await task`) so the await is a call expression —
+        # avoids CodeQL py/ineffectual-statement misflagging the bare await.
+        await asyncio.gather(task)
 
 
 class TestCreateJobFromStagingDedup:


### PR DESCRIPTION
## Problem

On a live run, the **import watch folder** silently stopped importing. The watcher itself was fine — it detected every folder and fired `staging_ready` on each poll — but no job was ever created. The backend log showed the symptom on every scan:

```
Watcher: Seinfeld is stable (5 MKV files) — triggering import (source=import)
Staging event: staging_ready dir=X:\media\rips\Seinfeld label=SEINFELD source=import
Job already exists for staging path X:\media\rips\Seinfeld, skipping   ← dies here
```

## Root cause

`JobManager.create_job_from_staging` deduped against **any** prior job for the staging path, regardless of state:

```python
sa_select(DiscJob).where(DiscJob.staging_path == str(staging_dir))
```

A watch folder is re-scanned on every poll and on every server restart. Once a job for a path reached a terminal `FAILED` state — by a user cancel, or by the restart-recovery watchdog auto-failing an in-flight job — that `FAILED` row blocked the path **forever**. In the affected DB, every import path had exactly such a `FAILED` row (`"Cancelled by user"` / `"Server restarted while job was in matching state"`).

This is an asymmetry: the disc path (`_create_job_for_disc`) already excludes terminal states (`state.not_in([COMPLETED, FAILED, REVIEW_NEEDED])`) so discs retry after failure — the import path did not.

## Fix

Dedup only against a **non-`FAILED`** job for the path:

```python
sa_select(DiscJob).where(
    DiscJob.staging_path == str(staging_dir),
    DiscJob.state != JobState.FAILED,
)
```

`!= FAILED` (rather than copying the disc path's `not_in([...])`) is deliberate: a polled watch folder differs from a one-shot disc insert. Excluding `REVIEW_NEEDED`/`COMPLETED` would let the 2-second poll spawn duplicate jobs for a folder whose files still sit there awaiting review. Blocking everything *except* `FAILED` is the precise behavior — failed imports retry, in-flight / review-pending / completed imports still dedup. The existence check moves to `.scalars().first()` since a path can now accrue multiple `FAILED` rows across retries.

## Tests

New `backend/tests/unit/test_create_job_from_staging_dedup.py`:
- `test_failed_job_does_not_block_reimport` — RED reproduced the exact live log line, GREEN after the fix.
- `test_active_job_still_blocks_reimport` / `test_review_needed_job_still_blocks_reimport` — lock in the no-duplicate behavior for in-flight and review-pending jobs.

Full unit suite: **1659 passed**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
