### PR TITLE
feat(fingerprint): default server URL to api.engramfp.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **The fingerprint network moved to a stable custom domain** — Engram now contributes and identifies against `https://api.engramfp.com` by default, instead of the old `*.workers.dev` address. Existing installs pick up the new address automatically on update (unless you've set a custom server URL in Settings → Data Sharing); the old address keeps serving during the transition, so nothing breaks mid-migration.
+
 ## [0.15.1] - 2026-06-03
 
 _Highlights: a data-loss fix — importing from a watch folder no longer deletes your source folder — plus faster, more accurate episode matching, several import-reliability fixes, and a disc loaded right after an eject is now reliably picked up._

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -16,7 +16,7 @@ from sqlmodel import Field, SQLModel
 # — whose app_config row predates this column and stores NULL — still engage the
 # network. The opt-out toggle (enable_fingerprint_contributions), not a blank
 # URL, is the single source of truth for "do I contribute".
-DEFAULT_FINGERPRINT_SERVER_URL = "https://engram-fp-prod.jonathansakkos.workers.dev"
+DEFAULT_FINGERPRINT_SERVER_URL = "https://api.engramfp.com"
 
 
 class AppConfig(SQLModel, table=True):

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -961,7 +961,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                     <input
                                         id="fingerprintServerUrl"
                                         type="text"
-                                        placeholder="https://engram-fp-prod.jonathansakkos.workers.dev"
+                                        placeholder="https://api.engramfp.com"
                                         value={config.fingerprintServerUrl}
                                         onChange={(e) => handleInputChange('fingerprintServerUrl', e.target.value)}
                                     />


### PR DESCRIPTION
## What

Flips the default fingerprint-server URL from the old name-bearing `https://engram-fp-prod.jonathansakkos.workers.dev` to the owned domain **`https://api.engramfp.com`**. This is the one-line value change the prep PR (#274) set up — the URL lives in a single constant and the tests assert against that constant.

- `backend/app/models/app_config.py`: `DEFAULT_FINGERPRINT_SERVER_URL` → new domain.
- `frontend/src/components/ConfigWizard.tsx`: the server-URL input placeholder, so the maintainer's name leaves the UI too.
- `CHANGELOG.md`: an `[Unreleased] → Changed` note.

Per `docs/superpowers/specs/2026-05-30-depersonalize-fingerprint-server-url-design.md`, historical specs/plans/mockups are intentionally left untouched (the sweep is scoped to live code).

## Server side (already live)

`api.engramfp.com` is a Cloudflare **Custom Domain** on the worker, served by the same D1/R2 as before (engram-fingerprint-server#39). The old `*.workers.dev` host is kept **enabled** (soft sunset) so unmigrated installs keep working.

## Migration / compatibility

- Installs with a **NULL** `fingerprint_server_url` resolve to the constant at call time → pick up the new default automatically on update.
- Installs that **explicitly saved** the old URL keep sending there; the old `*.workers.dev` host stays reachable until they update.
- The SSRF allow-check on `fingerprint_server_url` is unaffected — a new public https host passes.

## Tests

URL-default tests pass against the new constant (constant-relative since #274): `test_app_config_has_fingerprint_server_url`, `test_curator_routes_fallback_through_constant`, `test_uploader_falls_back_to_default_url_when_unset` — 5 passed.

## Not in this PR

- **No version bump / release tag** — handled at release time.
- **No client-side `Deprecation`/`Sunset` header handling** — considered and intentionally omitted: those headers reach almost no one programmatically (old clients don't read them; new clients don't hit the old host), and the NULL-config auto-upgrade + soft sunset already cover the migration.