### PR TITLE
chore: release v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-06-04
+
+_Highlights: the community fingerprint network moved to a stable custom domain (`api.engramfp.com`); existing installs migrate automatically on update with no interruption._
+
 ### Changed
 
-- **The fingerprint network moved to a stable custom domain** — Engram now contributes and identifies against `https://api.engramfp.com` by default, instead of the old `*.workers.dev` address. Existing installs pick up the new address automatically on update (unless you've set a custom server URL in Settings → Data Sharing); the old address keeps serving during the transition, so nothing breaks mid-migration.
+- **The fingerprint network moved to a stable custom domain** — Engram now contributes and identifies against `https://api.engramfp.com` by default, instead of the old `*.workers.dev` address. Existing installs pick up the new address automatically on update (unless you've set a custom server URL in Settings → Data Sharing); the old address keeps serving during the transition, so nothing breaks mid-migration. (#319)
 
 ## [0.15.1] - 2026-06-03
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.15.1"
+version = "0.15.2"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.15.1"
+version = "0.15.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.15.1",
+    "version": "0.15.2",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.15.2

Cuts the `v0.15.2` release following #319 (the only change merged since `v0.15.1`).

### Changes
- Bump version `0.15.1 → 0.15.2` in `backend/pyproject.toml` and `frontend/package.json`.
- Promote the `[Unreleased]` changelog entry into a curated `## [0.15.2] - 2026-06-04` section with a leading `_Highlights: …_` summary (this becomes the release-notes body).

### Why patch, not minor
The sole change (#319) swaps the default fingerprint-server URL to the `api.engramfp.com` custom domain. It's behavior-preserving and auto-migrating (NULL-config installs resolve the new default on update; the old `*.workers.dev` host stays live during the soft sunset), so it's released as a patch.

### Contributors
No external-contributor roster changes — #319 is by the repo owner, so `CONTRIBUTORS.md` is unchanged.

### Release-notes preview
`changelog-version-check` passes and `extract_changelog.py --version 0.15.2` produces:

> _Highlights: the community fingerprint network moved to a stable custom domain (`api.engramfp.com`); existing installs migrate automatically on update with no interruption._
>
> ### Changed
> - **The fingerprint network moved to a stable custom domain** — … (#319)

After squash-merge, `tag-release.yml` tags `v0.15.2` from `main` and `release.yml` builds the binaries and publishes the release with the extracted notes.

https://claude.ai/code/session_014zjaPxm4x1X5hnKcbUSxuT

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjaPxm4x1X5hnKcbUSxuT)_