### PR TITLE
fix(matching): asymmetric duration window so long episodes aren't misfiled as extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A disc's longest episode could be misfiled as an "extra"** — before matching a TV track, Engram checks its length against the episode runtimes TMDB lists for the season, and a track that's too far off is set aside as bonus content without ever being matched. That length window was symmetric (±5 minutes), but DVD/Blu-ray episodes run *longer* than TMDB's listed runtime — the disc includes the "previously on" recap, full end credits, and "next time" preview — so a season's longest episode could overshoot the window and be dropped into Extras even though its shorter siblings on the same disc matched fine (seen with **Gilmore Girls** S1, where the ~50-minute "Rory's Dance" was filed as an extra next to its ~46–48-minute neighbors). The window is now lenient on the long side (up to 5 minutes short, 10 minutes over), so a long-but-real episode is still transcribed and matched.
+
 ## [0.15.2] - 2026-06-04
 
 _Highlights: the community fingerprint network moved to a stable custom domain (`api.engramfp.com`); existing installs migrate automatically on update with no interruption._

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -31,6 +31,32 @@ logger = logging.getLogger(__name__)
 STRICT_SCAN_POINTS = 25
 STRICT_MIN_VOTES = 4
 
+# Duration pre-filter tolerances (minutes). DVD/Blu-ray episode tracks run LONGER
+# than TMDB's nominal runtime: the physical track includes the "previously on"
+# recap, full end credits, and "next time" preview that the broadcast-slot runtime
+# figure omits. So the accept window is asymmetric — tight below an episode runtime,
+# lenient above it — mirroring analyst.py's movie tolerances. A symmetric window
+# centered on TMDB's underestimate wrongly rejected the season's longest real
+# episodes (Gilmore Girls S01E09 "Rory's Dance": disc 49.8min vs TMDB 44min) and
+# dumped them to Extras un-transcribed (bug report job 41).
+EPISODE_DURATION_UNDER_TOLERANCE_MIN = 5
+EPISODE_DURATION_OVER_TOLERANCE_MIN = 10
+
+
+def _duration_matches_episode_runtime(title_minutes: float, runtimes: list[int]) -> bool:
+    """True if a track's duration is plausibly an episode for this season.
+
+    Asymmetric window: a track may fall up to ``UNDER`` minutes short of an episode
+    runtime or run up to ``OVER`` minutes past it (DVD recap + credits padding).
+    """
+    return any(
+        (rt - EPISODE_DURATION_UNDER_TOLERANCE_MIN)
+        <= title_minutes
+        <= (rt + EPISODE_DURATION_OVER_TOLERANCE_MIN)
+        for rt in runtimes
+    )
+
+
 # Module-level cache for fpcalc detection results.
 # `detect_fpcalc()` is deterministic within a process (the binary doesn't appear
 # or disappear mid-run), but each invocation runs up to 6 subprocess probes with
@@ -634,9 +660,7 @@ class MatchingCoordinator:
                     runtimes = await self._episode_runtimes_for_job(job)
                     if runtimes and title.duration_seconds:
                         title_minutes = title.duration_seconds / 60
-                        tolerance = 5  # minutes
-                        matches_any = any(abs(title_minutes - rt) <= tolerance for rt in runtimes)
-                        if not matches_any:
+                        if not _duration_matches_episode_runtime(title_minutes, runtimes):
                             handled = await self._handle_extras(
                                 job_id,
                                 title_id,
@@ -1079,7 +1103,9 @@ class MatchingCoordinator:
         """Handle extras based on policy. Returns True if title was handled."""
         logger.info(
             f"[MATCH] Title {title_id} (Job {job_id}): duration {title_minutes:.0f}min "
-            f"doesn't match any episode runtime {runtimes} (±5min). "
+            f"doesn't match any episode runtime {runtimes} "
+            f"(window -{EPISODE_DURATION_UNDER_TOLERANCE_MIN}/"
+            f"+{EPISODE_DURATION_OVER_TOLERANCE_MIN}min). "
             f"Detected as extra."
         )
 

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -17,7 +17,11 @@ from app.api.websocket import manager as ws_manager
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.job_state_machine import JobStateMachine
-from app.services.matching_coordinator import MatchingCoordinator, episode_curator
+from app.services.matching_coordinator import (
+    MatchingCoordinator,
+    _duration_matches_episode_runtime,
+    episode_curator,
+)
 from tests.unit.conftest import _unit_session_factory
 
 
@@ -173,6 +177,54 @@ class TestHandleExtras:
             f"expected tmdb_id='3452', got {kwargs.get('tmdb_id')!r}"
         )
         assert kwargs["year"] == 1993, f"expected year=1993, got {kwargs.get('year')!r}"
+
+
+# Real TMDB Season 1 runtimes from the job-41 bundle (max 44, min 39).
+GILMORE_S1 = [44, 43, 43, 43, 42, 44, 44, 44, 44, 42, 44, 42, 39, 44, 43, 44, 44, 44, 42, 43, 43]
+
+
+@pytest.mark.unit
+class TestDurationMatchesEpisodeRuntime:
+    """The duration pre-filter accepts a track as an episode candidate only if its
+    runtime is close to a TMDB episode runtime. The window is ASYMMETRIC: DVD/BD
+    tracks run longer than TMDB's nominal runtime (recap + full credits + "next
+    time" preview), so we are tight below an episode runtime and lenient above it.
+
+    Regression for bug report job 41 (Gilmore Girls S1 Disc 3): E09 "Rory's Dance"
+    ran 2990s (49.8min) vs TMDB's 44min and the old symmetric ±5 window (ceiling
+    49min) dumped it to Extras un-transcribed while its 46-48min siblings matched.
+    """
+
+    def test_long_episode_is_not_an_extra(self):
+        # E09 "Rory's Dance": 2990s = 49.83min. Must clear the gate (the bug).
+        assert _duration_matches_episode_runtime(2990 / 60, GILMORE_S1) is True
+
+    def test_sibling_episodes_match(self):
+        # E10/E11/E12 on the same disc (these matched correctly in the field).
+        for seconds in (2896, 2866, 2763):
+            assert _duration_matches_episode_runtime(seconds / 60, GILMORE_S1) is True
+
+    def test_play_all_track_is_an_extra(self):
+        # t00: 11515s = 191.9min — the concatenated "Play All" track stays an extra.
+        assert _duration_matches_episode_runtime(11515 / 60, GILMORE_S1) is False
+
+    def test_short_featurette_is_an_extra(self):
+        # A 10-min track is well below any episode runtime → still an extra.
+        assert _duration_matches_episode_runtime(10.0, [22, 44]) is False
+
+    def test_upper_bound_is_inclusive(self):
+        # Exactly runtime + 10 (over-tolerance) is accepted; just past it is not.
+        assert _duration_matches_episode_runtime(54.0, [44]) is True
+        assert _duration_matches_episode_runtime(54.01, [44]) is False
+
+    def test_lower_bound_is_inclusive(self):
+        # Exactly runtime - 5 (under-tolerance) is accepted; just under it is not.
+        assert _duration_matches_episode_runtime(39.0, [44]) is True
+        assert _duration_matches_episode_runtime(38.99, [44]) is False
+
+    def test_empty_runtimes_never_matches(self):
+        # No runtimes → the pre-filter caller skips entirely; the predicate is False.
+        assert _duration_matches_episode_runtime(45.0, []) is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why

A disc's longest episode could be silently misfiled as an **extra**.

Before matching a TV track, Engram's duration pre-filter (`MatchingCoordinator.match_single_file`) checks the track length against the TMDB per-episode runtimes for the season. A track outside the window is hard-sorted to `Extras/` via `_handle_extras` and **never transcribed**. That window was **symmetric (±5 min)** — but DVD/Blu-ray episodes run *longer* than TMDB's nominal broadcast runtime (the disc includes the "previously on" recap, full end credits, and "next time" preview). So a season's longest episode can overshoot the ceiling and get dropped into Extras even though its shorter siblings on the same disc match fine.

**Reproduced from bug report job 41** (Gilmore Girls S1 Disc 3, episodes E09–E12):

| Track | Duration | Result (before) |
|---|---|---|
| t00 | 191.9 min | Play-All → Extra (correct) |
| **t01** | **49.83 min** | **→ Extra (WRONG — this is E09 "Rory's Dance")** |
| t02 | 48.27 min | matched S01E10 @ 0.92 |
| t03 | 47.77 min | matched S01E11 @ 0.94 |
| t04 | 46.05 min | matched S01E12 @ 0.92 |

TMDB reported S1 runtimes maxing at **44 min**, so the accept ceiling was `44 + 5 = 49 min`. E09 at **49.83 min** missed by ~50 seconds. TMDB isn't wrong — `44` is the nominal broadcast figure; the physical track is genuinely longer. The defect is a symmetric window centered on a value that systematically *underestimates* disc length.

## Change

- Replace the inline symmetric `±5` check with a pure, unit-tested helper `_duration_matches_episode_runtime` using an **asymmetric window: 5 min under / 10 min over** any episode runtime — mirroring the existing movie tolerances in `analyst.py` (`MOVIE_RUNTIME_TOLERANCE_MIN` / `MOVIE_EXTENDED_ALLOWANCE_MIN`).
- Update the now-stale `(±5min)` log string to reflect the asymmetric window.
- Add `TestDurationMatchesEpisodeRuntime` (7 cases) seeded with the real job-41 runtimes.

**Effect:** E09 (49.83 min) now clears the `[39, 54]` window, gets transcribed, and files as `…/Gilmore Girls/Season 1/Gilmore Girls - S01E09.mkv`. The 192-min play-all and short featurettes are still flagged as extras.

## Why it's safe

The pre-filter is a coarse compute-saver, not the correctness guard. The real guard is downstream: any match below the **0.7** confidence floor is routed to REVIEW, never auto-filed (`matching_coordinator.py` ~884-893, whose comment already anticipates "a bonus track that slipped past the duration pre-filter"). So loosening the gate costs at worst some transcription time on a genuine extra — which then lands in review anyway.

## Testing

- `uv run pytest tests/unit/test_matching_coordinator.py` — new `TestDurationMatchesEpisodeRuntime` added (RED→GREEN verified); existing `TestHandleExtras` + `TestEpisodeRuntimesShowIdentity` unaffected.
- `uv run pytest tests/unit/` — **1677 passed**.
- `ruff check` + `ruff format --check` — clean.

## Notes for reviewers

- The over-tolerance (10 min) is a hardcoded constant, not configurable — deliberately, to avoid the AppConfig three-way-sync surface. Easy to revisit if libraries need per-show tuning.
- **Recovering already-misfiled content** (e.g. the existing E09 file) is out of scope here — `JobState.COMPLETED` is terminal and the review queue only surfaces `review_needed` jobs, so there's no in-app re-review of a finished job today. For job 41 it's a one-file manual rename. A guarded "reopen completed job for re-review" capability is tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
