### PR TITLE
test(jobs): drop misleading concurrent-job dedup stubs

### DIFF
--- a/backend/tests/pipeline/test_concurrent_jobs.py
+++ b/backend/tests/pipeline/test_concurrent_jobs.py
@@ -1,7 +1,17 @@
-"""Test that a job in REVIEW_NEEDED does not block other jobs.
+"""State-machine-level checks for the concurrent-job model.
 
-Verifies the concurrency model: jobs on different drives can run
-simultaneously, and a review-blocked job doesn't prevent new processing.
+Verifies (via the JobStateMachine transition tables) that jobs on different
+drives can run simultaneously and that REVIEW_NEEDED is neither a blocking nor
+a terminal state.
+
+The authoritative behavior of the per-drive, per-volume_label job-creation
+dedup guard (``JobManager._create_job_for_disc``) — which disc-required states
+block regardless of label, which post-eject states (MATCHING/ORGANIZING) block
+only a same-label re-insert, and which states never block — is exercised
+directly, with in-memory DB isolation, in
+``tests/unit/test_job_manager.py::TestCreateJobForDiscDedup``. Pipeline tests
+have no DB isolation (see ``tests/pipeline/conftest.py``), so they must not call
+``_create_job_for_disc`` against the real ``engram.db``.
 """
 
 import pytest
@@ -27,32 +37,10 @@ class TestReviewDoesNotBlock:
         valid_next = JobStateMachine.VALID_TRANSITIONS.get(JobState.REVIEW_NEEDED, set())
         assert JobState.RIPPING in valid_next or JobState.IDENTIFYING in valid_next
 
-    def test_drive_blocking_excludes_review_state(self):
-        """The JobManager blocks new jobs on the SAME drive only for active states.
-
-        REVIEW_NEEDED should be excluded from the blocking check so a different
-        drive can start a new job even while one drive's job awaits review.
-
-        This tests the design assumption documented in job_manager.py's
-        _create_job_for_disc method.
-        """
-        # REVIEW_NEEDED should be treated specially — it blocks the SAME drive
-        # from starting a new job (disc is still in the drive), but does NOT
-        # block other drives from processing.
-        # The key test: verify that REVIEW_NEEDED is a distinct state from
-        # RIPPING/MATCHING which would indicate the drive is in active use.
-        active_processing_states = {
-            JobState.IDENTIFYING,
-            JobState.RIPPING,
-            JobState.MATCHING,
-            JobState.ORGANIZING,
-        }
-        assert JobState.REVIEW_NEEDED not in active_processing_states
-
 
 @pytest.mark.pipeline
 class TestConcurrentJobScenario:
-    """Document the expected concurrent job behavior for the review+new job case."""
+    """Concurrent jobs on different drives are independent in the state model."""
 
     def test_different_drives_are_independent(self):
         """Two jobs on different drives (E: and F:) should not interfere.
@@ -69,14 +57,3 @@ class TestConcurrentJobScenario:
         # because they're on different drives
         assert JobState.IDENTIFYING in JobStateMachine.VALID_TRANSITIONS[JobState.IDLE]
         assert len(JobStateMachine.VALID_TRANSITIONS[JobState.REVIEW_NEEDED]) > 0
-
-    def test_same_drive_review_blocks_new_insert(self):
-        """A job in REVIEW_NEEDED on drive E: should block a NEW insert on E:.
-
-        The disc is still physically in the drive during review, so another
-        disc can't be inserted on the same drive.
-        """
-        # This is by physical design — can't have two discs in one drive.
-        # The JobManager checks for active jobs on the same drive_id
-        # before creating a new one. REVIEW_NEEDED IS active (disc is in drive).
-        assert True  # Verified by integration tests


### PR DESCRIPTION
## What

Removes two stale/misleading tests from `backend/tests/pipeline/test_concurrent_jobs.py` that exercised the per-drive job-creation dedup guard (`JobManager._create_job_for_disc`) but asserted nothing real:

1. **`test_same_drive_review_blocks_new_insert`** — an `assert True` no-op whose docstring claimed a `REVIEW_NEEDED` job blocks a same-drive re-insert. That is the **opposite** of the actual behavior: `_create_job_for_disc` excludes `REVIEW_NEEDED` from the blocking set, so a new insert during review is **not** blocked.
2. **`test_drive_blocking_excludes_review_state`** — only asserted a locally-built `{IDENTIFYING, RIPPING, MATCHING, ORGANIZING}` set, never calling `JobManager`. Its "RIPPING/MATCHING … drive is in active use" comment also went stale after #323 made `MATCHING`/`ORGANIZING` block only a *same-`volume_label`* re-insert (ripping ejects the disc + calls `notify_ejected()` before the `RIPPING→MATCHING` transition).

## Why remove rather than rewrite

The authoritative, DB-isolated coverage of `_create_job_for_disc`'s real per-drive / per-`volume_label` dedup behavior already lives in `tests/unit/test_job_manager.py::TestCreateJobForDiscDedup` (added in #323):
- disc-required states `[IDLE, IDENTIFYING, RIPPING]` block a new disc regardless of label;
- `MATCHING`/`ORGANIZING` block only a same-label re-insert, but allow a different-label disc to start a new job;
- `REVIEW_NEEDED`/`FAILED`/`COMPLETED` never block.

`tests/pipeline/` has **no** DB isolation (its `conftest.py` only provides analyst snapshot fixtures; the root `tests/conftest.py` only isolates the TMDB cache). Reproducing these scenarios here would either hit the real `engram.db` (the "Integration test DB hazard") or just duplicate the unit suite with no added integration coverage — so the per-label behavior stays owned by the isolated unit tests.

The genuine `JobStateMachine` transition tests in this file are kept, and the module docstring now points readers to `TestCreateJobForDiscDedup` so the gap isn't re-filled with new stubs.

## Verification

```
cd backend
uv run pytest tests/pipeline/test_concurrent_jobs.py tests/unit/test_job_manager.py::TestCreateJobForDiscDedup -v   # 14 passed
uv run ruff check .   # All checks passed!
uv run ruff format .  # unchanged
```

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
