### PR TITLE
chore(ci): fix Dependabot auto-merge + ignore Vite major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    ignore:
+      # Vite major bumps are a coordinated, dev-only upgrade (vite +
+      # @vitejs/plugin-react + @tailwindcss/vite must move together) that
+      # Dependabot can't do atomically — it raises a vite-only PR that fails
+      # `npm ci` with ERESOLVE. Keep majors off; do the upgrade deliberately.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/backend"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,19 +13,14 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve patch and minor updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # No approval step: branch protection on `main` requires no approving
+      # review, and `gh pr review --approve` fails outright with "GitHub Actions
+      # is not permitted to approve pull requests" — which used to abort this
+      # job and stop auto-merge from ever being enabled for minor/patch bumps.
       - name: Enable auto-merge for patch and minor updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
## Why

Ten Dependabot PRs piled up open. Root cause: the `dependabot-auto-merge.yml` workflow's **approve step crashes** with `GitHub Actions is not permitted to approve pull requests`, which aborts the job *before* `gh pr merge --auto` runs — so minor/patch bumps never auto-merged. Branch protection on `main` requires **no approving review**, so the step is both unnecessary and harmful.

## What

- **Remove the broken `gh pr review --approve` step**; keep `gh pr merge --auto --squash`. Minor/patch Dependabot PRs will auto-merge again.
- **Bump `dependabot/fetch-metadata` 2 → 3** in the same file — **supersedes #218** (which only made this one-line change and conflicts with this PR).
- **Ignore Vite *major* bumps** in `dependabot.yml`. Vite 8 is a coordinated, dev-only upgrade (`vite` + `@vitejs/plugin-react@6` + `@tailwindcss/vite@4.3.0` must move together); Dependabot raises a vite-only PR that fails `npm ci` with `ERESOLVE` (that's #220). The upgrade should be done deliberately as its own PR.

## Follow-up (handled separately, not in this PR)

- Merge the 4 green GitHub-Actions PRs (#312, #313, #314, #315).
- Rebase + merge the 4 safe npm PRs (#219, #221, #222, #223).
- Close #218 (superseded here) and #220 (deferred via the ignore above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)