### PR TITLE
feat(matching): parallel ASR transcription + honest dashboard concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Episode matching now transcribes multiple tracks in parallel** — the dashboard could show several tracks as "Matching" at once while only one actually made progress and the CPU sat mostly idle. The speech-recognition model was running one transcription at a time no matter what, so the **Max Concurrent Matches** setting didn't really do anything. That setting now drives how many episodes are transcribed simultaneously (on CPU or GPU), automatically clamped to your hardware (CPU cores, or a GPU limit) so it can't oversubscribe and slow things down. A small **ASR badge** on the dashboard shows the active backend — e.g. `ASR: CUDA · float16 · 4w` or `ASR: CPU · int8 · 8w`. (#336)
+
+### Changed
+
+- **The dashboard's "Matching" count is now honest** — tracks waiting for a transcription slot now show **QUEUED** and flip to **MATCHING** only when a real worker actually starts on them, so the number of tracks shown as "Matching" reflects what's genuinely transcribing rather than overstating progress. The **Max Concurrent Matches** setting takes effect after a backend restart (noted in Settings). (#336)
+
 ## [0.15.4] - 2026-06-04
 
 _Highlights: a fixes-only release — large multi-season imports no longer dump episodes into "Needs Review" while they wait for a match slot, the review page's "Re-match" is now visible and advisory (it never silently files a track), and every ripped track now shows consistently how its episode was identified._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3594,6 +3594,24 @@ async def get_update_status():
     return update_checker.get_status()
 
 
+@router.get("/asr-status")
+async def get_asr_status():
+    """Resolved ASR backend for the dashboard badge (read-only, no secrets)."""
+    from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
+    from app.services.config_service import get_config as _get_app_config
+
+    config = await _get_app_config()
+    runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+    return {
+        "device": runtime.device,
+        "compute_type": runtime.compute_type,
+        "model": "small",  # current hardcoded matcher default (EpisodeMatcher.model_name)
+        "workers": runtime.workers,
+        "cpu_threads": runtime.cpu_threads,
+        "max_concurrent_matches": config.max_concurrent_matches,
+    }
+
+
 @router.post("/updates/skip")
 async def skip_update_version(body: SkipVersionRequest):
     """Persist user's choice to skip a specific version."""

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -103,6 +103,7 @@ class EpisodeCurator:
                 cache_dir=self._cache_dir,
                 show_name=canonical_name,
                 min_confidence=self.LOW_CONFIDENCE_THRESHOLD,
+                requested_workers=(config.max_concurrent_matches if config else 1),
                 expected_tmdb_id=tmdb_id,
             )
             self._initialized = True

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -228,15 +228,15 @@ class FasterWhisperModel(ASRModel):
             )
 
             try:
-                _kwargs = {
+                model_kwargs = {
                     "device": self.device,
                     "compute_type": compute_type,
                     "download_root": None,  # Use default cache location
                     "num_workers": runtime.workers,
                 }
                 if runtime.cpu_threads is not None:
-                    _kwargs["cpu_threads"] = runtime.cpu_threads
-                self._model = WhisperModel(self.model_name, **_kwargs)
+                    model_kwargs["cpu_threads"] = runtime.cpu_threads
+                self._model = WhisperModel(self.model_name, **model_kwargs)
 
                 # Eagerly transcribe 1s of silence to surface missing CUDA
                 # DLL errors here instead of on the first real transcription.
@@ -269,6 +269,11 @@ class FasterWhisperModel(ASRModel):
                         download_root=None,
                         num_workers=cpu_runtime.workers,
                         cpu_threads=cpu_runtime.cpu_threads,
+                    )
+                    # Stored under the CPU key, not the stale CUDA key computed above.
+                    cache_key = (
+                        f"faster_whisper_{self.model_name}_{self.device}"
+                        f"_w{cpu_runtime.workers}_t{cpu_runtime.cpu_threads}"
                     )
                 else:
                     raise
@@ -472,9 +477,11 @@ def get_cached_model(model_config: dict) -> ASRModel:
     Returns:
         ASRModel instance (loaded and ready for use)
     """
+    device = model_config.get("device") or detect_asr_device()
+    runtime = resolve_asr_runtime(device, model_config.get("requested_workers", 1))
     cache_key = (
         f"{model_config.get('type', '')}_{model_config.get('name', '')}"
-        f"_{model_config.get('device', 'auto')}_w{model_config.get('requested_workers', 1)}"
+        f"_{device}_w{runtime.workers}_t{runtime.cpu_threads}"
     )
 
     if cache_key not in _model_cache:

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -9,6 +9,7 @@ import abc
 import hashlib
 import os
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -22,8 +23,12 @@ from rapidfuzz import fuzz
 
 from app.matcher.srt_utils import clean_text
 
-# Cache for loaded models to avoid reloading
+# Cache for loaded models to avoid reloading. Guarded by _model_cache_lock so that
+# concurrent matching threads (N semaphore slots → N asyncio.to_thread workers) don't
+# each build their own model on a cold cache — without the lock, N threads race past the
+# membership check and construct N models with N workers each (N² threads).
 _model_cache = {}
+_model_cache_lock = threading.Lock()
 
 # Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
 GPU_WORKER_CAP = 4
@@ -484,12 +489,16 @@ def get_cached_model(model_config: dict) -> ASRModel:
         f"_{device}_w{runtime.workers}_t{runtime.cpu_threads}"
     )
 
-    if cache_key not in _model_cache:
-        model = create_asr_model(model_config)
-        model.load()  # Load immediately for caching
-        _model_cache[cache_key] = model
+    # Hold the lock across check-create-store so exactly one thread builds the shared
+    # model per cache_key; the rest block, then reuse it. First-load contention is the
+    # whole point — it's what makes "one shared model with N workers" actually one model.
+    with _model_cache_lock:
+        if cache_key not in _model_cache:
+            model = create_asr_model(model_config)
+            model.load()  # Load immediately for caching
+            _model_cache[cache_key] = model
 
-    return _model_cache[cache_key]
+        return _model_cache[cache_key]
 
 
 def clear_model_cache():

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -25,9 +25,8 @@ from app.matcher.srt_utils import clean_text
 # Cache for loaded models to avoid reloading
 _model_cache = {}
 
-GPU_WORKER_CAP = (
-    4  # Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
-)
+# Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
+GPU_WORKER_CAP = 4
 
 
 @dataclass(frozen=True)
@@ -53,7 +52,7 @@ def detect_asr_device() -> str:
         return "cpu"
 
 
-def resolve_asr_runtime(device: str, requested_workers: int) -> AsrRuntime:
+def resolve_asr_runtime(device: str, requested_workers: int | None) -> AsrRuntime:
     """Resolve (workers, cpu_threads) from a requested worker count, clamped to hardware.
 
     CPU: workers clamp to physical cores; cpu_threads = cores // workers so the total

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -9,11 +9,13 @@ import abc
 import hashlib
 import os
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import ctranslate2
 import librosa
 import numpy as np
+import psutil
 import soundfile as sf
 from loguru import logger
 from rapidfuzz import fuzz
@@ -22,6 +24,54 @@ from app.matcher.srt_utils import clean_text
 
 # Cache for loaded models to avoid reloading
 _model_cache = {}
+
+GPU_WORKER_CAP = (
+    4  # Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
+)
+
+
+@dataclass(frozen=True)
+class AsrRuntime:
+    """Resolved ASR execution parameters — the single source of truth for sizing.
+
+    Consumed by the shared WhisperModel (num_workers/cpu_threads), the JobManager
+    match semaphore (workers == admission slots, so the dashboard cannot overstate
+    MATCHING), and the /api/asr-status endpoint.
+    """
+
+    device: str  # "cuda" | "cpu"
+    compute_type: str  # "float16" (cuda) | "int8" (cpu)
+    workers: int
+    cpu_threads: int | None  # None on GPU (not applicable)
+
+
+def detect_asr_device() -> str:
+    """Return 'cuda' when a CUDA device is visible to ctranslate2, else 'cpu'."""
+    try:
+        return "cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu"
+    except Exception:  # noqa: BLE001 — any probe failure means no usable GPU
+        return "cpu"
+
+
+def resolve_asr_runtime(device: str, requested_workers: int) -> AsrRuntime:
+    """Resolve (workers, cpu_threads) from a requested worker count, clamped to hardware.
+
+    CPU: workers clamp to physical cores; cpu_threads = cores // workers so the total
+    thread count stays ~= cores (avoids the oversubscription that makes naive
+    parallelism slower). GPU: workers clamp to GPU_WORKER_CAP; cpu_threads is N/A.
+    """
+    requested = max(1, int(requested_workers or 1))
+    if device == "cuda":
+        return AsrRuntime(
+            device="cuda",
+            compute_type="float16",
+            workers=min(requested, GPU_WORKER_CAP),
+            cpu_threads=None,
+        )
+    cores = psutil.cpu_count(logical=False) or psutil.cpu_count(logical=True) or 1
+    workers = max(1, min(requested, cores))
+    cpu_threads = max(1, cores // workers)
+    return AsrRuntime(device="cpu", compute_type="int8", workers=workers, cpu_threads=cpu_threads)
 
 
 class ASRModel(abc.ABC):

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -169,16 +169,22 @@ class FasterWhisperModel(ASRModel):
         "large-v3": {"params": "1550M", "vram": "~10GB", "speed": "slowest"},
     }
 
-    def __init__(self, model_name: str = "small", device: str | None = None):
+    def __init__(
+        self, model_name: str = "small", device: str | None = None, requested_workers: int = 1
+    ):
         """
         Initialize Faster Whisper model.
 
         Args:
             model_name: Whisper model size (tiny, base, small, medium, large-v3)
             device: Device to run on ('cpu', 'cuda', or None for auto-detect)
+            requested_workers: Desired parallel ASR workers; resolve_asr_runtime
+                clamps this to hardware at load time.
         """
         if model_name.startswith("openai/whisper-"):
             model_name = model_name.replace("openai/whisper-", "")
+
+        self.requested_workers = max(1, int(requested_workers or 1))
 
         # Ensure NVIDIA libraries are in PATH for Windows CUDA support
         if device == "cuda" or (device is None and ctranslate2.get_cuda_device_count() > 0):
@@ -200,7 +206,11 @@ class FasterWhisperModel(ASRModel):
         if self.is_loaded:
             return
 
-        cache_key = f"faster_whisper_{self.model_name}_{self.device}"
+        runtime = resolve_asr_runtime(self.device, self.requested_workers)
+        cache_key = (
+            f"faster_whisper_{self.model_name}_{self.device}"
+            f"_w{runtime.workers}_t{runtime.cpu_threads}"
+        )
 
         if cache_key in _model_cache:
             self._model = _model_cache[cache_key]
@@ -218,12 +228,15 @@ class FasterWhisperModel(ASRModel):
             )
 
             try:
-                self._model = WhisperModel(
-                    self.model_name,
-                    device=self.device,
-                    compute_type=compute_type,
-                    download_root=None,  # Use default cache location
-                )
+                _kwargs = {
+                    "device": self.device,
+                    "compute_type": compute_type,
+                    "download_root": None,  # Use default cache location
+                    "num_workers": runtime.workers,
+                }
+                if runtime.cpu_threads is not None:
+                    _kwargs["cpu_threads"] = runtime.cpu_threads
+                self._model = WhisperModel(self.model_name, **_kwargs)
 
                 # Eagerly transcribe 1s of silence to surface missing CUDA
                 # DLL errors here instead of on the first real transcription.
@@ -248,11 +261,14 @@ class FasterWhisperModel(ASRModel):
                     )
                     self.device = "cpu"
                     compute_type = "int8"
+                    cpu_runtime = resolve_asr_runtime("cpu", self.requested_workers)
                     self._model = WhisperModel(
                         self.model_name,
                         device=self.device,
                         compute_type=compute_type,
                         download_root=None,
+                        num_workers=cpu_runtime.workers,
+                        cpu_threads=cpu_runtime.cpu_threads,
                     )
                 else:
                     raise
@@ -423,6 +439,7 @@ def create_asr_model(model_config: dict) -> ASRModel:
     model_type = model_config.get("type", "").lower()
     model_name = model_config.get("name", "")
     device = model_config.get("device")
+    requested_workers = model_config.get("requested_workers", 1)
 
     # Handle whisper and faster-whisper types
     if model_type in ("whisper", "faster-whisper", "openai-whisper"):
@@ -430,14 +447,14 @@ def create_asr_model(model_config: dict) -> ASRModel:
             model_name = "small"
 
         logger.info(f"Creating Faster Whisper model: {model_name}")
-        return FasterWhisperModel(model_name, device)
+        return FasterWhisperModel(model_name, device, requested_workers=requested_workers)
 
     # Legacy parakeet support - redirect to whisper
     elif model_type == "parakeet":
         logger.warning(
             "Parakeet models are no longer supported. Using Whisper 'small' model instead."
         )
-        return FasterWhisperModel("small", device)
+        return FasterWhisperModel("small", device, requested_workers=requested_workers)
 
     else:
         raise ValueError(
@@ -455,7 +472,10 @@ def get_cached_model(model_config: dict) -> ASRModel:
     Returns:
         ASRModel instance (loaded and ready for use)
     """
-    cache_key = f"{model_config.get('type', '')}_{model_config.get('name', '')}_{model_config.get('device', 'auto')}"
+    cache_key = (
+        f"{model_config.get('type', '')}_{model_config.get('name', '')}"
+        f"_{model_config.get('device', 'auto')}_w{model_config.get('requested_workers', 1)}"
+    )
 
     if cache_key not in _model_cache:
         model = create_asr_model(model_config)

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -828,6 +828,7 @@ class EpisodeMatcher:
         match_threshold=0.10,
         confidence_accept_floor=CONFIDENCE_ACCEPT_FLOOR,
         model_name="small",
+        requested_workers=1,
         expected_tmdb_id=None,
     ):
         self.cache_dir = Path(cache_dir)
@@ -839,6 +840,7 @@ class EpisodeMatcher:
             90  # Minimal skip for title cards; ranked voting handles intro noise
         )
         self.model_name = model_name
+        self.requested_workers = max(1, int(requested_workers or 1))
         self.device = device or ("cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu")
         self.temp_dir = Path(tempfile.gettempdir()) / "whisper_chunks"
         self.temp_dir.mkdir(exist_ok=True)
@@ -1124,6 +1126,15 @@ class EpisodeMatcher:
         self.reference_files_cache[cache_key] = reference_files
         return reference_files
 
+    def _model_config(self) -> dict:
+        """Single source for the ASR model_config dict (keeps both call sites DRY)."""
+        return {
+            "type": "whisper",
+            "name": self.model_name,
+            "device": self.device,
+            "requested_workers": self.requested_workers,
+        }
+
     def transcribe_full(self, video_file) -> str | None:
         """Whisper-transcribe the entire video file, returning the cleaned text.
 
@@ -1140,7 +1151,7 @@ class EpisodeMatcher:
             )
             return None
 
-        model_config = {"type": "whisper", "name": self.model_name, "device": self.device}
+        model_config = self._model_config()
         try:
             # Memoized by (source, 0, duration): the full-file fallback fires once per
             # candidate season when no chunk votes, so without this the season-unknown
@@ -1358,11 +1369,7 @@ class EpisodeMatcher:
                 if point < video_duration - chunk_len:
                     scan_points.append(point)
 
-            model_config = {
-                "type": "whisper",
-                "name": self.model_name,
-                "device": self.device,
-            }
+            model_config = self._model_config()
             model = get_cached_model(model_config)
 
             # Rebuild the cached matcher when the reference set changes — a stale

--- a/backend/app/matcher/test_episode_identification.py
+++ b/backend/app/matcher/test_episode_identification.py
@@ -198,3 +198,28 @@ class TestEpisodeMatcherConfiguration:
         )
 
         assert matcher.use_ranked_voting is True
+
+
+class TestEpisodeMatcherWorkers:
+    def test_model_config_includes_requested_workers(self):
+        from pathlib import Path
+
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        matcher = EpisodeMatcher(
+            cache_dir=Path.home() / ".engram" / "cache",
+            show_name="Test Show",
+            requested_workers=5,
+        )
+        cfg = matcher._model_config()
+        assert cfg["requested_workers"] == 5
+        assert cfg["type"] == "whisper"
+        assert cfg["name"] == matcher.model_name
+
+    def test_requested_workers_defaults_to_one(self):
+        from pathlib import Path
+
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        matcher = EpisodeMatcher(cache_dir=Path.home() / ".engram" / "cache", show_name="Test Show")
+        assert matcher._model_config()["requested_workers"] == 1

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -171,14 +171,12 @@ class JobManager:
         config = await get_config()
         await ensure_paths_exist(config)
 
-        # Initialize matching concurrency limiter
-        concurrency = max(1, config.max_concurrent_matches)
-        if concurrency != config.max_concurrent_matches:
-            logger.warning(
-                f"Invalid max_concurrent_matches={config.max_concurrent_matches} "
-                f"in config, using {concurrency}"
-            )
-        self._matching.init_semaphore(concurrency)
+        # Initialize matching concurrency limiter from REAL ASR capacity, so the
+        # dashboard's MATCHING count can't exceed what can actually be transcribing.
+        from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
+
+        _asr_runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+        self._matching.init_semaphore(_asr_runtime.workers)
 
         # Start timed staging cleanup if policy is "after_days"
         if config.staging_cleanup_policy == "after_days":
@@ -204,7 +202,11 @@ class JobManager:
         if config.watchdog_enabled:
             self._watchdog_task = asyncio.create_task(self._watchdog_loop())
 
-        logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
+        logger.info(
+            f"Job manager started (asr_device={_asr_runtime.device}, "
+            f"asr_workers={_asr_runtime.workers}, cpu_threads={_asr_runtime.cpu_threads}, "
+            f"requested={config.max_concurrent_matches})"
+        )
 
     async def _cleanup_stale_jobs(self) -> None:
         """Mark stale jobs as FAILED on startup."""

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -358,3 +358,26 @@ class TestErrorHandling:
         list_resp = await client.get("/api/jobs")
         job_ids = [j["id"] for j in list_resp.json()]
         assert job.id not in job_ids
+
+
+# ---------------------------------------------------------------------------
+# ASR Status
+# ---------------------------------------------------------------------------
+
+
+class TestAsrStatusEndpoint:
+    async def test_asr_status_reports_cpu_runtime(self, client):
+        from unittest.mock import patch
+
+        with (
+            patch("app.matcher.asr_models.detect_asr_device", return_value="cpu"),
+            patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
+        ):
+            resp = await client.get("/api/asr-status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["device"] == "cpu"
+        assert body["compute_type"] == "int8"
+        assert body["workers"] >= 1
+        assert "max_concurrent_matches" in body
+        assert "model" in body

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -70,3 +70,49 @@ class TestResolveAsrRuntimeGpu:
         assert rt.workers == 2
         assert rt.cpu_threads is None
         assert rt.compute_type == "float16"
+
+
+class TestModelConstruction:
+    """FasterWhisperModel must pass num_workers/cpu_threads and key the cache by them."""
+
+    def _fake_whisper(self):
+        """A WhisperModel stand-in that records constructor kwargs."""
+        calls = []
+
+        class FakeWhisperModel:
+            def __init__(self, model_name, **kwargs):
+                calls.append({"model_name": model_name, **kwargs})
+
+        return FakeWhisperModel, calls
+
+    def test_cpu_model_gets_num_workers_and_cpu_threads(self):
+        import app.matcher.asr_models as m
+
+        m._model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        with (
+            patch("faster_whisper.WhisperModel", Fake),
+            patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
+        ):
+            model = m.FasterWhisperModel("small", device="cpu", requested_workers=4)
+            model.load()
+        assert calls[0]["num_workers"] == 4
+        assert calls[0]["cpu_threads"] == 2  # 8 // 4
+
+    def test_cache_key_varies_by_requested_workers(self):
+        import app.matcher.asr_models as m
+
+        m._model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        with (
+            patch("faster_whisper.WhisperModel", Fake),
+            patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
+        ):
+            m.get_cached_model(
+                {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 2}
+            )
+            m.get_cached_model(
+                {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 4}
+            )
+        # Two distinct worker counts -> two distinct constructions, not a stale reuse.
+        assert len(calls) == 2

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -1,0 +1,54 @@
+"""Unit tests for ASR runtime sizing (resolve_asr_runtime / detect_asr_device)."""
+
+from unittest.mock import patch
+
+from app.matcher.asr_models import (
+    GPU_WORKER_CAP,
+    AsrRuntime,
+    resolve_asr_runtime,
+)
+
+
+class TestResolveAsrRuntimeCpu:
+    def test_divides_threads_so_total_matches_cores(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=16):
+            rt = resolve_asr_runtime("cpu", requested_workers=4)
+        assert rt == AsrRuntime(device="cpu", compute_type="int8", workers=4, cpu_threads=4)
+
+    def test_clamps_workers_to_physical_cores(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+            rt = resolve_asr_runtime("cpu", requested_workers=32)
+        assert rt.workers == 8
+        assert rt.cpu_threads == 1  # 8 // 8
+
+    def test_floor_division_never_yields_zero_threads(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=6):
+            rt = resolve_asr_runtime("cpu", requested_workers=6)
+        assert rt.workers == 6
+        assert rt.cpu_threads == 1  # max(1, 6 // 6)
+
+    def test_requested_below_one_becomes_one(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+            rt = resolve_asr_runtime("cpu", requested_workers=0)
+        assert rt.workers == 1
+        assert rt.cpu_threads == 8
+
+    def test_missing_core_count_falls_back_to_one(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=None):
+            rt = resolve_asr_runtime("cpu", requested_workers=4)
+        assert rt.workers == 1
+        assert rt.cpu_threads == 1
+
+
+class TestResolveAsrRuntimeGpu:
+    def test_caps_workers_at_gpu_cap(self):
+        rt = resolve_asr_runtime("cuda", requested_workers=8)
+        assert rt == AsrRuntime(
+            device="cuda", compute_type="float16", workers=GPU_WORKER_CAP, cpu_threads=None
+        )
+
+    def test_below_cap_is_passed_through(self):
+        rt = resolve_asr_runtime("cuda", requested_workers=2)
+        assert rt.workers == 2
+        assert rt.cpu_threads is None
+        assert rt.compute_type == "float16"

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -1,5 +1,6 @@
 """Unit tests for ASR runtime sizing (resolve_asr_runtime / detect_asr_device)."""
 
+import threading
 from unittest.mock import patch
 
 from app.matcher.asr_models import (
@@ -131,3 +132,27 @@ class TestModelConstruction:
             model.load()
         assert calls[0]["num_workers"] == 3
         assert "cpu_threads" not in calls[0]  # GPU path must not pass cpu_threads
+
+    def test_concurrent_get_cached_model_constructs_once(self):
+        # N threads racing on a cold cache must build exactly ONE shared model, not N
+        # (the _model_cache_lock guards the check-create-store). Without the lock this
+        # would usually construct several models, each with N workers (N**2 threads).
+        _model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        cfg = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 2}
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()  # release all threads together to maximize the race window
+            get_cached_model(cfg)
+
+        with (
+            patch("faster_whisper.WhisperModel", Fake),
+            patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        assert len(calls) == 1

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -83,6 +83,10 @@ class TestModelConstruction:
             def __init__(self, model_name, **kwargs):
                 calls.append({"model_name": model_name, **kwargs})
 
+            def transcribe(self, *args, **kwargs):
+                # CUDA self-verification calls next(model.transcribe(...)[0], None)
+                return iter([]), None
+
         return FakeWhisperModel, calls
 
     def test_cpu_model_gets_num_workers_and_cpu_threads(self):
@@ -116,3 +120,17 @@ class TestModelConstruction:
             )
         # Two distinct worker counts -> two distinct constructions, not a stale reuse.
         assert len(calls) == 2
+
+    def test_gpu_model_passes_workers_and_omits_cpu_threads(self):
+        import app.matcher.asr_models as m
+
+        m._model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        with (
+            patch("faster_whisper.WhisperModel", Fake),
+            patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=1),
+        ):
+            model = m.FasterWhisperModel("small", device="cuda", requested_workers=3)
+            model.load()
+        assert calls[0]["num_workers"] == 3
+        assert "cpu_threads" not in calls[0]  # GPU path must not pass cpu_threads

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -5,8 +5,26 @@ from unittest.mock import patch
 from app.matcher.asr_models import (
     GPU_WORKER_CAP,
     AsrRuntime,
+    detect_asr_device,
     resolve_asr_runtime,
 )
+
+
+class TestDetectAsrDevice:
+    def test_returns_cuda_when_device_present(self):
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=1):
+            assert detect_asr_device() == "cuda"
+
+    def test_returns_cpu_when_no_device(self):
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=0):
+            assert detect_asr_device() == "cpu"
+
+    def test_returns_cpu_when_probe_raises(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_cuda_device_count",
+            side_effect=RuntimeError("no cuda runtime"),
+        ):
+            assert detect_asr_device() == "cpu"
 
 
 class TestResolveAsrRuntimeCpu:

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 from app.matcher.asr_models import (
     GPU_WORKER_CAP,
     AsrRuntime,
+    FasterWhisperModel,
+    _model_cache,
     detect_asr_device,
+    get_cached_model,
     resolve_asr_runtime,
 )
 
@@ -90,47 +93,41 @@ class TestModelConstruction:
         return FakeWhisperModel, calls
 
     def test_cpu_model_gets_num_workers_and_cpu_threads(self):
-        import app.matcher.asr_models as m
-
-        m._model_cache.clear()
+        _model_cache.clear()
         Fake, calls = self._fake_whisper()
         with (
             patch("faster_whisper.WhisperModel", Fake),
             patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
         ):
-            model = m.FasterWhisperModel("small", device="cpu", requested_workers=4)
+            model = FasterWhisperModel("small", device="cpu", requested_workers=4)
             model.load()
         assert calls[0]["num_workers"] == 4
         assert calls[0]["cpu_threads"] == 2  # 8 // 4
 
     def test_cache_key_varies_by_requested_workers(self):
-        import app.matcher.asr_models as m
-
-        m._model_cache.clear()
+        _model_cache.clear()
         Fake, calls = self._fake_whisper()
         with (
             patch("faster_whisper.WhisperModel", Fake),
             patch("app.matcher.asr_models.psutil.cpu_count", return_value=8),
         ):
-            m.get_cached_model(
+            get_cached_model(
                 {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 2}
             )
-            m.get_cached_model(
+            get_cached_model(
                 {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 4}
             )
         # Two distinct worker counts -> two distinct constructions, not a stale reuse.
         assert len(calls) == 2
 
     def test_gpu_model_passes_workers_and_omits_cpu_threads(self):
-        import app.matcher.asr_models as m
-
-        m._model_cache.clear()
+        _model_cache.clear()
         Fake, calls = self._fake_whisper()
         with (
             patch("faster_whisper.WhisperModel", Fake),
             patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=1),
         ):
-            model = m.FasterWhisperModel("small", device="cuda", requested_workers=3)
+            model = FasterWhisperModel("small", device="cuda", requested_workers=3)
             model.load()
         assert calls[0]["num_workers"] == 3
         assert "cpu_threads" not in calls[0]  # GPU path must not pass cpu_threads

--- a/backend/tests/unit/test_curator.py
+++ b/backend/tests/unit/test_curator.py
@@ -353,7 +353,10 @@ class TestEnsureInitialized:
             ),
             patch(
                 "app.services.config_service.get_config_sync",
-                return_value=SimpleNamespace(subtitles_cache_path=str(tmp_path / "cache")),
+                return_value=SimpleNamespace(
+                    subtitles_cache_path=str(tmp_path / "cache"),
+                    max_concurrent_matches=2,
+                ),
             ),
         ):
             ok = curator._ensure_initialized("Show")

--- a/backend/tests/unit/test_curator_tmdb_id.py
+++ b/backend/tests/unit/test_curator_tmdb_id.py
@@ -9,7 +9,7 @@ def test_ensure_initialized_uses_known_id_and_skips_fetch_show_id():
     captured = {}
 
     class FakeMatcher:
-        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None):
+        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None, **kwargs):
             captured["expected_tmdb_id"] = expected_tmdb_id
             captured["show_name"] = show_name
 
@@ -41,7 +41,7 @@ def test_ensure_initialized_rebuilds_when_tmdb_id_changes():
     captured = {}
 
     class FakeMatcher:
-        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None):
+        def __init__(self, cache_dir, show_name, min_confidence, expected_tmdb_id=None, **kwargs):
             captured["expected_tmdb_id"] = expected_tmdb_id
 
     cfg = MagicMock()

--- a/backend/tests/unit/test_curator_workers.py
+++ b/backend/tests/unit/test_curator_workers.py
@@ -1,0 +1,22 @@
+"""The curator forwards config.max_concurrent_matches as the matcher's requested_workers."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_ensure_initialized_passes_concurrency_as_workers():
+    from app.core.curator import EpisodeCurator
+
+    fake_config = MagicMock()
+    fake_config.subtitles_cache_path = None
+    fake_config.max_concurrent_matches = 7
+
+    with (
+        patch("app.matcher.episode_identification.EpisodeMatcher") as MockMatcher,
+        patch("app.services.config_service.get_config_sync", return_value=fake_config),
+        patch("app.matcher.tmdb_client.fetch_show_id", return_value=None),
+        patch("app.matcher.tmdb_client.fetch_show_details", return_value=None),
+    ):
+        curator = EpisodeCurator()
+        curator._ensure_initialized("Test Show")
+
+    assert MockMatcher.call_args.kwargs["requested_workers"] == 7

--- a/backend/tests/unit/test_semaphore_sizing.py
+++ b/backend/tests/unit/test_semaphore_sizing.py
@@ -1,0 +1,25 @@
+"""The match semaphore is sized to resolved ASR workers, not the raw config value."""
+
+from unittest.mock import patch
+
+from app.matcher.asr_models import resolve_asr_runtime
+from app.services.matching_coordinator import MatchingCoordinator
+
+
+def test_semaphore_value_equals_resolved_workers_cpu():
+    # 16 cores, requested 4 -> 4 workers -> 4 admission slots.
+    with patch("app.matcher.asr_models.psutil.cpu_count", return_value=16):
+        runtime = resolve_asr_runtime("cpu", requested_workers=4)
+    coord = MatchingCoordinator.__new__(MatchingCoordinator)  # no full __init__ needed
+    coord._match_semaphore = None
+    coord.init_semaphore(runtime.workers)
+    assert coord._match_semaphore._value == 4
+
+
+def test_semaphore_clamped_when_request_exceeds_cores():
+    with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+        runtime = resolve_asr_runtime("cpu", requested_workers=32)
+    coord = MatchingCoordinator.__new__(MatchingCoordinator)
+    coord._match_semaphore = None
+    coord.init_semaphore(runtime.workers)
+    assert coord._match_semaphore._value == 8  # clamped to cores

--- a/docs/superpowers/plans/2026-06-04-parallel-asr-matching-visibility.md
+++ b/docs/superpowers/plans/2026-06-04-parallel-asr-matching-visibility.md
@@ -1,0 +1,906 @@
+# Parallel ASR Matching + Honest Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the shared Whisper model real parallelism via faster-whisper `num_workers`, tie the match-admission semaphore to that real capacity so the dashboard stops overstating `MATCHING`, and surface the active ASR backend.
+
+**Architecture:** A single pure helper (`resolve_asr_runtime`) in the ASR model layer computes `(workers, cpu_threads)` from the detected device and the requested worker count (`config.max_concurrent_matches`), clamped to hardware. That one value flows to three consumers: the shared `WhisperModel` (parallel inference), the `asyncio.Semaphore` in `JobManager` (honest admission), and a new `GET /api/asr-status` endpoint (a read-only dashboard badge).
+
+**Tech Stack:** Python 3.11, FastAPI, faster-whisper / ctranslate2, psutil, pytest/pytest-asyncio; React + TypeScript + Vite frontend.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-parallel-asr-matching-visibility.md`
+
+---
+
+## File Structure
+
+**Backend**
+- `backend/app/matcher/asr_models.py` — add `AsrRuntime`, `GPU_WORKER_CAP`, `detect_asr_device()`, `resolve_asr_runtime()`; thread `requested_workers` into `FasterWhisperModel` and both `_model_cache` keys (Tasks 1, 2).
+- `backend/app/matcher/episode_identification.py` — `EpisodeMatcher` carries `requested_workers` into a shared `_model_config()` helper (Task 3).
+- `backend/app/core/curator.py` — pass `config.max_concurrent_matches` into `EpisodeMatcher` (Task 4).
+- `backend/app/services/job_manager.py` — size the semaphore from `resolve_asr_runtime(...).workers` (Task 5).
+- `backend/app/api/routes.py` — `GET /api/asr-status` (Task 6).
+- `backend/tests/unit/test_asr_runtime.py` — new test module (Tasks 1, 2).
+- `backend/tests/unit/test_api_routes.py` — extend for the new endpoint (Task 6).
+
+**Frontend**
+- `frontend/src/app/components/AsrStatusBadge.tsx` — new self-contained badge (Task 7).
+- `frontend/src/app/App.tsx` — mount the badge (Task 7).
+- `frontend/src/components/ConfigWizard.tsx` — honest hint text + input bound (Task 8).
+
+---
+
+## Task 1: ASR runtime sizing helpers (pure, fully unit-tested)
+
+**Files:**
+- Modify: `backend/app/matcher/asr_models.py` (top-of-file imports + new module-level helpers)
+- Test: `backend/tests/unit/test_asr_runtime.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_asr_runtime.py`:
+
+```python
+"""Unit tests for ASR runtime sizing (resolve_asr_runtime / detect_asr_device)."""
+
+from unittest.mock import patch
+
+from app.matcher.asr_models import (
+    GPU_WORKER_CAP,
+    AsrRuntime,
+    resolve_asr_runtime,
+)
+
+
+class TestResolveAsrRuntimeCpu:
+    def test_divides_threads_so_total_matches_cores(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=16):
+            rt = resolve_asr_runtime("cpu", requested_workers=4)
+        assert rt == AsrRuntime(device="cpu", compute_type="int8", workers=4, cpu_threads=4)
+
+    def test_clamps_workers_to_physical_cores(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+            rt = resolve_asr_runtime("cpu", requested_workers=32)
+        assert rt.workers == 8
+        assert rt.cpu_threads == 1  # 8 // 8
+
+    def test_floor_division_never_yields_zero_threads(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=6):
+            rt = resolve_asr_runtime("cpu", requested_workers=6)
+        assert rt.workers == 6
+        assert rt.cpu_threads == 1  # max(1, 6 // 6)
+
+    def test_requested_below_one_becomes_one(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+            rt = resolve_asr_runtime("cpu", requested_workers=0)
+        assert rt.workers == 1
+        assert rt.cpu_threads == 8
+
+    def test_missing_core_count_falls_back_to_one(self):
+        with patch("app.matcher.asr_models.psutil.cpu_count", return_value=None):
+            rt = resolve_asr_runtime("cpu", requested_workers=4)
+        assert rt.workers == 1
+        assert rt.cpu_threads == 1
+
+
+class TestResolveAsrRuntimeGpu:
+    def test_caps_workers_at_gpu_cap(self):
+        rt = resolve_asr_runtime("cuda", requested_workers=8)
+        assert rt == AsrRuntime(
+            device="cuda", compute_type="float16", workers=GPU_WORKER_CAP, cpu_threads=None
+        )
+
+    def test_below_cap_is_passed_through(self):
+        rt = resolve_asr_runtime("cuda", requested_workers=2)
+        assert rt.workers == 2
+        assert rt.cpu_threads is None
+        assert rt.compute_type == "float16"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_asr_runtime.py -v`
+Expected: FAIL — `ImportError: cannot import name 'GPU_WORKER_CAP'` (helpers not defined yet).
+
+- [ ] **Step 3: Add the imports and helpers**
+
+In `backend/app/matcher/asr_models.py`, add to the existing top-of-file imports (the module already imports `ctranslate2`; add these two):
+
+```python
+import psutil
+from dataclasses import dataclass
+```
+
+Then add these module-level definitions near the top of the file, after the imports and the `_model_cache = {}` line:
+
+```python
+GPU_WORKER_CAP = 4  # Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
+
+
+@dataclass(frozen=True)
+class AsrRuntime:
+    """Resolved ASR execution parameters — the single source of truth for sizing.
+
+    Consumed by the shared WhisperModel (num_workers/cpu_threads), the JobManager
+    match semaphore (workers == admission slots, so the dashboard cannot overstate
+    MATCHING), and the /api/asr-status endpoint.
+    """
+
+    device: str  # "cuda" | "cpu"
+    compute_type: str  # "float16" (cuda) | "int8" (cpu)
+    workers: int
+    cpu_threads: int | None  # None on GPU (not applicable)
+
+
+def detect_asr_device() -> str:
+    """Return 'cuda' when a CUDA device is visible to ctranslate2, else 'cpu'."""
+    try:
+        return "cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu"
+    except Exception:  # noqa: BLE001 — any probe failure means no usable GPU
+        return "cpu"
+
+
+def resolve_asr_runtime(device: str, requested_workers: int) -> AsrRuntime:
+    """Resolve (workers, cpu_threads) from a requested worker count, clamped to hardware.
+
+    CPU: workers clamp to physical cores; cpu_threads = cores // workers so the total
+    thread count stays ~= cores (avoids the oversubscription that makes naive
+    parallelism slower). GPU: workers clamp to GPU_WORKER_CAP; cpu_threads is N/A.
+    """
+    requested = max(1, int(requested_workers or 1))
+    if device == "cuda":
+        return AsrRuntime(
+            device="cuda",
+            compute_type="float16",
+            workers=min(requested, GPU_WORKER_CAP),
+            cpu_threads=None,
+        )
+    cores = psutil.cpu_count(logical=False) or psutil.cpu_count(logical=True) or 1
+    workers = max(1, min(requested, cores))
+    cpu_threads = max(1, cores // workers)
+    return AsrRuntime(
+        device="cpu", compute_type="int8", workers=workers, cpu_threads=cpu_threads
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_asr_runtime.py -v`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/matcher/asr_models.py tests/unit/test_asr_runtime.py
+git add backend/app/matcher/asr_models.py backend/tests/unit/test_asr_runtime.py
+git commit -m "feat(asr): add resolve_asr_runtime hardware-clamped sizing helper"
+```
+
+---
+
+## Task 2: Pass workers/threads to the shared model + fix cache keys
+
+**Files:**
+- Modify: `backend/app/matcher/asr_models.py` — `FasterWhisperModel.__init__` (123-138), `load()` (149-220), `create_asr_model` (360-396), `get_cached_model` (399-416)
+- Test: `backend/tests/unit/test_asr_runtime.py` (add a class)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_asr_runtime.py`:
+
+```python
+class TestModelConstruction:
+    """FasterWhisperModel must pass num_workers/cpu_threads and key the cache by them."""
+
+    def _fake_whisper(self):
+        """A WhisperModel stand-in that records constructor kwargs."""
+        calls = []
+
+        class FakeWhisperModel:
+            def __init__(self, model_name, **kwargs):
+                calls.append({"model_name": model_name, **kwargs})
+
+        return FakeWhisperModel, calls
+
+    def test_cpu_model_gets_num_workers_and_cpu_threads(self):
+        import app.matcher.asr_models as m
+
+        m._model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        with patch("faster_whisper.WhisperModel", Fake), patch(
+            "app.matcher.asr_models.psutil.cpu_count", return_value=8
+        ):
+            model = m.FasterWhisperModel("small", device="cpu", requested_workers=4)
+            model.load()
+        assert calls[0]["num_workers"] == 4
+        assert calls[0]["cpu_threads"] == 2  # 8 // 4
+
+    def test_cache_key_varies_by_requested_workers(self):
+        import app.matcher.asr_models as m
+
+        m._model_cache.clear()
+        Fake, calls = self._fake_whisper()
+        with patch("faster_whisper.WhisperModel", Fake), patch(
+            "app.matcher.asr_models.psutil.cpu_count", return_value=8
+        ):
+            m.get_cached_model({"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 2})
+            m.get_cached_model({"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 4})
+        # Two distinct worker counts -> two distinct constructions, not a stale reuse.
+        assert len(calls) == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_asr_runtime.py::TestModelConstruction -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'requested_workers'`.
+
+- [ ] **Step 3: Implement — `FasterWhisperModel.__init__`**
+
+Replace the existing `__init__` (lines 123-138) with:
+
+```python
+    def __init__(
+        self, model_name: str = "small", device: str | None = None, requested_workers: int = 1
+    ):
+        """
+        Initialize Faster Whisper model.
+
+        Args:
+            model_name: Whisper model size (tiny, base, small, medium, large-v3)
+            device: Device to run on ('cpu', 'cuda', or None for auto-detect)
+            requested_workers: Desired parallel ASR workers; resolve_asr_runtime
+                clamps this to hardware at load time.
+        """
+        if model_name.startswith("openai/whisper-"):
+            model_name = model_name.replace("openai/whisper-", "")
+
+        self.requested_workers = max(1, int(requested_workers or 1))
+
+        # Ensure NVIDIA libraries are in PATH for Windows CUDA support
+        if device == "cuda" or (device is None and ctranslate2.get_cuda_device_count() > 0):
+            _ensure_nvidia_libraries()
+
+        super().__init__(model_name, device)
+```
+
+- [ ] **Step 4: Implement — `load()` cache key + WhisperModel kwargs**
+
+In `load()`, replace the cache_key line (154):
+
+```python
+        cache_key = f"faster_whisper_{self.model_name}_{self.device}"
+```
+
+with:
+
+```python
+        runtime = resolve_asr_runtime(self.device, self.requested_workers)
+        cache_key = (
+            f"faster_whisper_{self.model_name}_{self.device}"
+            f"_w{runtime.workers}_t{runtime.cpu_threads}"
+        )
+```
+
+Replace the primary `WhisperModel(...)` construction (lines 172-177):
+
+```python
+                self._model = WhisperModel(
+                    self.model_name,
+                    device=self.device,
+                    compute_type=compute_type,
+                    download_root=None,  # Use default cache location
+                )
+```
+
+with (adds num_workers always; cpu_threads only when applicable):
+
+```python
+                _kwargs = {
+                    "device": self.device,
+                    "compute_type": compute_type,
+                    "download_root": None,  # Use default cache location
+                    "num_workers": runtime.workers,
+                }
+                if runtime.cpu_threads is not None:
+                    _kwargs["cpu_threads"] = runtime.cpu_threads
+                self._model = WhisperModel(self.model_name, **_kwargs)
+```
+
+Replace the CUDA-to-CPU fallback construction (lines 200-207) so the fallback re-resolves for CPU:
+
+```python
+                    self.device = "cpu"
+                    compute_type = "int8"
+                    cpu_runtime = resolve_asr_runtime("cpu", self.requested_workers)
+                    self._model = WhisperModel(
+                        self.model_name,
+                        device=self.device,
+                        compute_type=compute_type,
+                        download_root=None,
+                        num_workers=cpu_runtime.workers,
+                        cpu_threads=cpu_runtime.cpu_threads,
+                    )
+```
+
+- [ ] **Step 5: Implement — `create_asr_model` forwards `requested_workers`**
+
+In `create_asr_model`, after `device = model_config.get("device")` (line 376) add:
+
+```python
+    requested_workers = model_config.get("requested_workers", 1)
+```
+
+and update both `FasterWhisperModel(...)` calls (lines 384 and 391) to pass it:
+
+```python
+        return FasterWhisperModel(model_name, device, requested_workers=requested_workers)
+```
+```python
+        return FasterWhisperModel("small", device, requested_workers=requested_workers)
+```
+
+- [ ] **Step 6: Implement — `get_cached_model` cache key**
+
+In `get_cached_model`, replace the cache_key line (409):
+
+```python
+    cache_key = f"{model_config.get('type', '')}_{model_config.get('name', '')}_{model_config.get('device', 'auto')}"
+```
+
+with:
+
+```python
+    cache_key = (
+        f"{model_config.get('type', '')}_{model_config.get('name', '')}"
+        f"_{model_config.get('device', 'auto')}_w{model_config.get('requested_workers', 1)}"
+    )
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_asr_runtime.py -v`
+Expected: PASS (all tests, including `TestModelConstruction`).
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/matcher/asr_models.py tests/unit/test_asr_runtime.py
+git add backend/app/matcher/asr_models.py backend/tests/unit/test_asr_runtime.py
+git commit -m "feat(asr): give the shared Whisper model num_workers/cpu_threads"
+```
+
+---
+
+## Task 3: `EpisodeMatcher` carries `requested_workers` into model config
+
+**Files:**
+- Modify: `backend/app/matcher/episode_identification.py` — `EpisodeMatcher.__init__` (820-844), `transcribe_full` model_config (1143), `identify_episode` model_config (1361-1365)
+- Test: `backend/app/matcher/test_episode_identification.py` (add a test alongside the existing `TestEpisodeMatcherConfiguration`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/app/matcher/test_episode_identification.py`:
+
+```python
+class TestEpisodeMatcherWorkers:
+    def test_model_config_includes_requested_workers(self):
+        from pathlib import Path
+
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        matcher = EpisodeMatcher(
+            cache_dir=Path.home() / ".engram" / "cache",
+            show_name="Test Show",
+            requested_workers=5,
+        )
+        cfg = matcher._model_config()
+        assert cfg["requested_workers"] == 5
+        assert cfg["type"] == "whisper"
+        assert cfg["name"] == matcher.model_name
+
+    def test_requested_workers_defaults_to_one(self):
+        from pathlib import Path
+
+        from app.matcher.episode_identification import EpisodeMatcher
+
+        matcher = EpisodeMatcher(
+            cache_dir=Path.home() / ".engram" / "cache", show_name="Test Show"
+        )
+        assert matcher._model_config()["requested_workers"] == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && uv run pytest app/matcher/test_episode_identification.py::TestEpisodeMatcherWorkers -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'requested_workers'`.
+
+- [ ] **Step 3: Implement — add the param and a shared `_model_config()` helper**
+
+In `EpisodeMatcher.__init__` (820-832), add the parameter after `model_name="small",`:
+
+```python
+        model_name="small",
+        requested_workers=1,
+        expected_tmdb_id=None,
+    ):
+```
+
+and store it alongside `self.model_name = model_name` (line 841):
+
+```python
+        self.requested_workers = max(1, int(requested_workers or 1))
+```
+
+Add this method to `EpisodeMatcher` (place it just above `transcribe_full`, near line 1127):
+
+```python
+    def _model_config(self) -> dict:
+        """Single source for the ASR model_config dict (keeps both call sites DRY)."""
+        return {
+            "type": "whisper",
+            "name": self.model_name,
+            "device": self.device,
+            "requested_workers": self.requested_workers,
+        }
+```
+
+Replace the inline dict in `transcribe_full` (line 1143):
+
+```python
+        model_config = {"type": "whisper", "name": self.model_name, "device": self.device}
+```
+
+with:
+
+```python
+        model_config = self._model_config()
+```
+
+Replace the inline dict in `identify_episode` (lines 1361-1365):
+
+```python
+            model_config = {
+                "type": "whisper",
+                "name": self.model_name,
+                "device": self.device,
+            }
+```
+
+with:
+
+```python
+            model_config = self._model_config()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && uv run pytest app/matcher/test_episode_identification.py::TestEpisodeMatcherWorkers -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing matcher config tests (no regressions)**
+
+Run: `cd backend && uv run pytest app/matcher/test_episode_identification.py -v`
+Expected: PASS (existing `TestEpisodeMatcherConfiguration` still green).
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/matcher/episode_identification.py app/matcher/test_episode_identification.py
+git add backend/app/matcher/episode_identification.py backend/app/matcher/test_episode_identification.py
+git commit -m "feat(asr): thread requested_workers through EpisodeMatcher model_config"
+```
+
+---
+
+## Task 4: Curator passes `config.max_concurrent_matches` into the matcher
+
+**Files:**
+- Modify: `backend/app/core/curator.py` — `_ensure_initialized` `EpisodeMatcher(...)` construction (102-107)
+- Test: `backend/tests/unit/test_curator_workers.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_curator_workers.py`:
+
+```python
+"""The curator forwards config.max_concurrent_matches as the matcher's requested_workers."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_ensure_initialized_passes_concurrency_as_workers():
+    from app.core.curator import EpisodeCurator
+
+    fake_config = MagicMock()
+    fake_config.subtitles_cache_path = None
+    fake_config.max_concurrent_matches = 7
+
+    with patch("app.matcher.episode_identification.EpisodeMatcher") as MockMatcher, patch(
+        "app.services.config_service.get_config_sync", return_value=fake_config
+    ), patch("app.matcher.tmdb_client.fetch_show_id", return_value=None), patch(
+        "app.matcher.tmdb_client.fetch_show_details", return_value=None
+    ):
+        curator = EpisodeCurator()
+        curator._ensure_initialized("Test Show")
+
+    assert MockMatcher.call_args.kwargs["requested_workers"] == 7
+```
+
+> Note: `EpisodeCurator` is defined at `backend/app/core/curator.py:30` (module singleton `curator` at line 737). Instantiating a fresh `EpisodeCurator()` in the test is fine.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_curator_workers.py -v`
+Expected: FAIL — `KeyError: 'requested_workers'` (not passed yet).
+
+- [ ] **Step 3: Implement**
+
+In `_ensure_initialized`, update the `EpisodeMatcher(...)` construction (lines 102-107) to pass the requested workers (the `config` local is already populated at line 93):
+
+```python
+            self._matcher = EpisodeMatcher(
+                cache_dir=self._cache_dir,
+                show_name=canonical_name,
+                min_confidence=self.LOW_CONFIDENCE_THRESHOLD,
+                requested_workers=(config.max_concurrent_matches if config else 1),
+                expected_tmdb_id=tmdb_id,
+            )
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_curator_workers.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/curator.py tests/unit/test_curator_workers.py
+git add backend/app/core/curator.py tests/unit/test_curator_workers.py
+git commit -m "feat(asr): forward max_concurrent_matches as matcher requested_workers"
+```
+
+---
+
+## Task 5: Size the match semaphore from real worker capacity
+
+**Files:**
+- Modify: `backend/app/services/job_manager.py` — `start()` semaphore init (174-181) and the startup log line (207)
+- Test: `backend/tests/unit/test_semaphore_sizing.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_semaphore_sizing.py`:
+
+```python
+"""The match semaphore is sized to resolved ASR workers, not the raw config value."""
+
+from unittest.mock import patch
+
+from app.matcher.asr_models import resolve_asr_runtime
+from app.services.matching_coordinator import MatchingCoordinator
+
+
+def test_semaphore_value_equals_resolved_workers_cpu():
+    # 16 cores, requested 4 -> 4 workers -> 4 admission slots.
+    with patch("app.matcher.asr_models.psutil.cpu_count", return_value=16):
+        runtime = resolve_asr_runtime("cpu", requested_workers=4)
+    coord = MatchingCoordinator.__new__(MatchingCoordinator)  # no full __init__ needed
+    coord._match_semaphore = None
+    coord.init_semaphore(runtime.workers)
+    assert coord._match_semaphore._value == 4
+
+
+def test_semaphore_clamped_when_request_exceeds_cores():
+    with patch("app.matcher.asr_models.psutil.cpu_count", return_value=8):
+        runtime = resolve_asr_runtime("cpu", requested_workers=32)
+    coord = MatchingCoordinator.__new__(MatchingCoordinator)
+    coord._match_semaphore = None
+    coord.init_semaphore(runtime.workers)
+    assert coord._match_semaphore._value == 8  # clamped to cores
+```
+
+- [ ] **Step 2: Run the test to verify it fails or passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_semaphore_sizing.py -v`
+Expected: PASS for both (this asserts the helper→semaphore contract; `init_semaphore` already exists). If `MatchingCoordinator.__new__` cannot set `_match_semaphore`, the test will error — in that case construct it normally and call `init_semaphore`. This test locks the contract Step 3 wires into `JobManager`.
+
+- [ ] **Step 3: Implement the JobManager wiring**
+
+In `backend/app/services/job_manager.py` `start()`, replace lines 174-181:
+
+```python
+        # Initialize matching concurrency limiter
+        concurrency = max(1, config.max_concurrent_matches)
+        if concurrency != config.max_concurrent_matches:
+            logger.warning(
+                f"Invalid max_concurrent_matches={config.max_concurrent_matches} "
+                f"in config, using {concurrency}"
+            )
+        self._matching.init_semaphore(concurrency)
+```
+
+with:
+
+```python
+        # Initialize matching concurrency limiter from REAL ASR capacity, so the
+        # dashboard's MATCHING count can't exceed what can actually be transcribing.
+        from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
+
+        _asr_runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+        self._matching.init_semaphore(_asr_runtime.workers)
+```
+
+Replace the startup log line (207):
+
+```python
+        logger.info(f"Job manager started (max_concurrent_matches={concurrency})")
+```
+
+with:
+
+```python
+        logger.info(
+            f"Job manager started (asr_device={_asr_runtime.device}, "
+            f"asr_workers={_asr_runtime.workers}, cpu_threads={_asr_runtime.cpu_threads}, "
+            f"requested={config.max_concurrent_matches})"
+        )
+```
+
+- [ ] **Step 4: Run the test + existing job_manager unit tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_semaphore_sizing.py tests/unit/test_job_manager.py tests/unit/test_stuck_job_recovery.py -v`
+Expected: PASS (the existing stuck-job/semaphore tests call `init_semaphore` directly and are unaffected).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/services/job_manager.py tests/unit/test_semaphore_sizing.py
+git add backend/app/services/job_manager.py tests/unit/test_semaphore_sizing.py
+git commit -m "feat(matching): size match semaphore from real ASR worker capacity"
+```
+
+---
+
+## Task 6: `GET /api/asr-status` endpoint
+
+**Files:**
+- Modify: `backend/app/api/routes.py` — add a new route (place it near the other read-only status routes; the file uses `router = APIRouter(prefix="/api")` at line 40)
+- Test: `backend/tests/unit/test_api_routes.py` (add a test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_api_routes.py` (this file already constructs an `AsyncClient` against the app — mirror its existing client fixture/usage):
+
+```python
+class TestAsrStatusEndpoint:
+    async def test_asr_status_reports_cpu_runtime(self, client):
+        from unittest.mock import patch
+
+        with patch("app.matcher.asr_models.detect_asr_device", return_value="cpu"), patch(
+            "app.matcher.asr_models.psutil.cpu_count", return_value=8
+        ):
+            resp = await client.get("/api/asr-status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["device"] == "cpu"
+        assert body["compute_type"] == "int8"
+        assert body["workers"] >= 1
+        assert "max_concurrent_matches" in body
+        assert "model" in body
+```
+
+> Note: use whatever `client` fixture `test_api_routes.py` already defines (the file at lines 34/212 sets up config and an async client). If the module isn't `asyncio`-marked globally, add `@pytest.mark.asyncio` to the test.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_api_routes.py::TestAsrStatusEndpoint -v`
+Expected: FAIL — 404 (route not defined).
+
+- [ ] **Step 3: Implement the endpoint**
+
+Add to `backend/app/api/routes.py` (anywhere among the route handlers; keep it self-contained). Alias the config getter to avoid colliding with the `get_config` route handler defined at line 1100:
+
+```python
+@router.get("/asr-status")
+async def get_asr_status():
+    """Resolved ASR backend for the dashboard badge (read-only, no secrets)."""
+    from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
+    from app.services.config_service import get_config as _get_app_config
+
+    config = await _get_app_config()
+    runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+    return {
+        "device": runtime.device,
+        "compute_type": runtime.compute_type,
+        "model": "small",  # current hardcoded matcher default (EpisodeMatcher.model_name)
+        "workers": runtime.workers,
+        "cpu_threads": runtime.cpu_threads,
+        "max_concurrent_matches": config.max_concurrent_matches,
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_api_routes.py::TestAsrStatusEndpoint -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/api/routes.py tests/unit/test_api_routes.py
+git add backend/app/api/routes.py tests/unit/test_api_routes.py
+git commit -m "feat(api): add GET /api/asr-status for the dashboard ASR badge"
+```
+
+---
+
+## Task 7: Frontend ASR mode badge
+
+**Files:**
+- Create: `frontend/src/app/components/AsrStatusBadge.tsx`
+- Modify: `frontend/src/app/App.tsx` — mount the badge in the filter/view strip (just after `<SvTopBar ... />`, around line 199)
+
+- [ ] **Step 1: Create the badge component**
+
+Create `frontend/src/app/components/AsrStatusBadge.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+
+type AsrStatus = {
+  device: string;
+  compute_type: string;
+  model: string;
+  workers: number;
+  cpu_threads: number | null;
+  max_concurrent_matches: number;
+};
+
+/** Read-only chip showing the resolved ASR backend (device · compute · N workers). */
+export function AsrStatusBadge() {
+  const [status, setStatus] = useState<AsrStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/asr-status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setStatus(data);
+      })
+      .catch(() => {
+        /* badge is best-effort; stay hidden on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!status) return null;
+
+  const accent = status.device === "cuda" ? "#22d3ee" : "#8893a8";
+  const label = `ASR: ${status.device.toUpperCase()} · ${status.compute_type} · ${status.workers}w`;
+
+  return (
+    <span
+      title={`Whisper "${status.model}" · requested ${status.max_concurrent_matches}${
+        status.cpu_threads != null ? ` · ${status.cpu_threads} threads/worker` : ""
+      } · restart to change`}
+      style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 11,
+        letterSpacing: "0.08em",
+        color: accent,
+        border: `1px solid ${accent}44`,
+        background: `${accent}0a`,
+        padding: "2px 8px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Mount the badge in App.tsx**
+
+In `frontend/src/app/App.tsx`, add the import near the other component imports (top of file):
+
+```tsx
+import { AsrStatusBadge } from "./components/AsrStatusBadge";
+```
+
+Then render it inside the filter/view-mode strip. The strip begins around line 200 with `<div style={{ padding: "10px 28px", ... display: "flex", alignItems: "center", ... }}>`. Add the badge as the last child of that flex row, pushed to the right:
+
+```tsx
+        <div style={{ marginLeft: "auto" }}>
+          <AsrStatusBadge />
+        </div>
+```
+
+> If the strip already has a right-aligned cluster (e.g. the grid/list view toggle), place `<AsrStatusBadge />` immediately before that cluster instead of adding a second `marginLeft: auto`.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `cd frontend && npm run build`
+Expected: TypeScript check + Vite build succeed (no type errors). If `node_modules` is missing in this worktree, run `npm install` first, then `git checkout package-lock.json` before committing (the committed lockfile is stale and `install` rewrites it).
+
+- [ ] **Step 4: Manual visual check (optional but recommended)**
+
+With a backend running (`DEBUG=true`) and `npm run dev`, confirm the chip reads e.g. `ASR: CUDA · float16 · 4w` (your GPU-from-source setup) or `ASR: CPU · int8 · Nw`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/components/AsrStatusBadge.tsx frontend/src/app/App.tsx
+git commit -m "feat(ui): show resolved ASR backend as a dashboard badge"
+```
+
+---
+
+## Task 8: ConfigWizard — honest hint + input bound
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx` — the Max Concurrent Matches field (1239-1251)
+
+- [ ] **Step 1: Update the hint text and input bounds**
+
+Replace the input + hint block (lines 1240-1250) with:
+
+```tsx
+                            <input
+                                id="maxConcurrentMatches"
+                                type="number"
+                                min={1}
+                                max={8}
+                                value={config.maxConcurrentMatches}
+                                onChange={(e) => handleInputChange('maxConcurrentMatches', Math.max(1, Math.min(8, parseInt(e.target.value) || 1)))}
+                            />
+                            <span className="form-hint">
+                                Requested number of episodes transcribed in parallel. Automatically
+                                clamped to your hardware (CPU cores, or a GPU limit). Takes effect
+                                after a backend restart.
+                            </span>
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd frontend && npm run build`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ConfigWizard.tsx
+git commit -m "fix(ui): clarify Max Concurrent Matches semantics + restart note"
+```
+
+---
+
+## Task 9: Full backend regression + final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full backend test suite**
+
+Run: `cd backend && uv run pytest tests/unit/ app/matcher/test_episode_identification.py -v`
+Expected: PASS. Investigate any failure before proceeding (the known pre-existing `test_movie_ambiguous_rip_first_workflow` flake is unrelated to this change).
+
+- [ ] **Step 2: Lint the whole touched surface**
+
+Run: `cd backend && uv run ruff check app/ tests/`
+Expected: no errors.
+
+- [ ] **Step 3: Manual end-to-end sanity (optional)**
+
+Start one backend (`DEBUG=true`), set `max_concurrent_matches` high, and confirm via logs (`Job manager started (asr_device=..., asr_workers=...)`) and `GET /api/asr-status` that the resolved worker count matches expectation, and that on a multi-track disc exactly `workers` tracks show `MATCHING` while the rest show `QUEUED`.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 sizing → Task 1; §2 model wiring + cache keys → Tasks 2-4; §3 semaphore honesty → Task 5; §5 visibility (`/api/asr-status` + badge) → Tasks 6-7; config hint/restart → Task 8. GPU bundling, model-size UI, VRAM auto-sizing, live-apply remain out of scope (spec non-goals).
+- **Type consistency:** `AsrRuntime(device, compute_type, workers, cpu_threads)` and `resolve_asr_runtime(device, requested_workers)` / `detect_asr_device()` are used with identical signatures across Tasks 1, 2, 5, 6. The `model_config` key is `requested_workers` everywhere (Tasks 2, 3). The endpoint is `/api/asr-status` in both Task 6 and Task 7.
+- **Restart semantics:** `num_workers` is fixed at model load; the plan does not attempt live re-init (a spec non-goal) and the ConfigWizard hint states this.
+```

--- a/docs/superpowers/specs/2026-06-04-parallel-asr-matching-visibility.md
+++ b/docs/superpowers/specs/2026-06-04-parallel-asr-matching-visibility.md
@@ -1,0 +1,99 @@
+# Parallel ASR Matching + Honest Dashboard (Piece A)
+
+**Date:** 2026-06-04
+**Status:** Approved design, pending implementation plan
+**Scope:** Backend ASR concurrency + minimal dashboard visibility. GPU release bundling is a separate effort (Piece B) and is explicitly out of scope here.
+
+## Problem
+
+On the dashboard, multiple tracks display as `MATCHING` simultaneously but only one makes real progress (e.g. one track at 58%, four frozen at 5%), even with `max_concurrent_matches` set to 8. The machine shows low CPU activity throughout.
+
+Root cause (verified):
+
+1. **The shared Whisper model is single-worker.** `FasterWhisperModel.load()` constructs `WhisperModel(...)` with no `num_workers`, so it defaults to `num_workers=1` ([asr_models.py:172](../../../backend/app/matcher/asr_models.py)). All concurrent matches funnel through one shared, cached model instance (`get_cached_model` → module-level `_model_cache`, [asr_models.py:399](../../../backend/app/matcher/asr_models.py)). With one worker, ctranslate2 serializes concurrent `transcribe()` calls behind an internal queue — the active title transcribes while the others **block** (consuming ~0 CPU). That is why the CPU looks idle: it is not saturated, it is waiting on a single worker.
+
+2. **The admission semaphore is decoupled from real capacity.** `max_concurrent_matches` sizes an `asyncio.Semaphore` that admits N titles into the `MATCHING` state ([job_manager.py:175](../../../backend/app/services/job_manager.py), [matching_coordinator.py:719](../../../backend/app/services/matching_coordinator.py)) — but the model only services one at a time. So the dashboard's `MATCHING` count overstates real progress: there is a hidden second queue (waiting-for-ASR-worker) the UI never shows. Tracks waiting for a *semaphore* slot correctly show `QUEUED`; tracks waiting for the *model worker* misleadingly show `MATCHING`.
+
+3. **Config changes apply only on restart, silently.** The semaphore is initialized once in `job_manager.start()`; nothing re-initializes it when the config changes. The UI gives no hint that a restart is required.
+
+The fix for the performance symptom and the fix for the visibility symptom are the same change: give the shared model real parallelism, and tie the admission count to that real capacity so the dashboard cannot overstate progress.
+
+## Goals
+
+- Parallelize ASR so multiple titles transcribe at once, on both CPU and GPU, using faster-whisper's supported `num_workers` (shared weights — no per-worker weight-memory multiplication).
+- Make the dashboard honest: exactly the number of tracks that can really be transcribing show `MATCHING`; the rest show `QUEUED`.
+- Surface which ASR backend is active (CPU/GPU, compute type, worker count) and make the "restart to apply" behavior explicit.
+
+## Non-Goals (deferred)
+
+- GPU libraries in the shipped release binary (Piece B).
+- Model-size / device selection in the UI (e.g. `large-v3` on GPU).
+- VRAM-based automatic worker sizing (a fixed conservative GPU cap is used instead).
+- Live apply-without-restart (would require draining in-flight matches).
+- Splitting the fast chromaprint path into its own non-ASR concurrency lane.
+
+## Design
+
+### 1. Single source of truth for ASR runtime sizing
+
+Add one pure helper in the ASR/model layer:
+
+```
+resolve_asr_runtime(device: str, requested_workers: int) -> AsrRuntime
+    # AsrRuntime: workers: int, cpu_threads: int | None
+```
+
+- **CPU:** `workers = clamp(requested_workers, 1, physical_cores)`;
+  `cpu_threads = max(1, physical_cores // workers)` so `workers * cpu_threads ≈ physical_cores` (no thread oversubscription — the trap that makes naive parallelism *slower*). `physical_cores = psutil.cpu_count(logical=False)` (psutil is already a dependency).
+- **GPU (`cuda`):** `workers = clamp(requested_workers, 1, GPU_WORKER_CAP)` with `GPU_WORKER_CAP = 4` (conservative default; float16 inference streams are cheap but not free). `cpu_threads = None` (not applicable).
+
+`requested_workers` is `config.max_concurrent_matches`. The helper is the single place the worker math lives, consumed by the model loader, the semaphore, and the status endpoint, so all three always agree.
+
+### 2. Wire workers/threads into the shared model
+
+- `model_config` (built in `identify_episode` / `transcribe_full`, [episode_identification.py:1361](../../../backend/app/matcher/episode_identification.py)) carries `requested_workers` down to the model layer.
+- `FasterWhisperModel.__init__`/`load()` calls `resolve_asr_runtime(self.device, requested_workers)` and passes `num_workers=workers` and (CPU only) `cpu_threads=cpu_threads` to `WhisperModel(...)`.
+- **Cache-key fix:** both cache keys that index `_model_cache` (the one in `load()`, [asr_models.py:154](../../../backend/app/matcher/asr_models.py), and the one in `get_cached_model`, [asr_models.py:409](../../../backend/app/matcher/asr_models.py)) must include the resolved `workers`/`cpu_threads`, so a config change can never hand back a stale single-worker instance.
+- `requested_workers` flows from config → curator (`_ensure_initialized`) → `EpisodeIdentifier` → `model_config`. The curator learns the requested value from config (resolved once; exact threading is an implementation detail for the plan).
+
+### 3. Couple the semaphore to real capacity (the honesty fix)
+
+`job_manager.start()` computes `runtime = resolve_asr_runtime(detected_device, config.max_concurrent_matches)` and calls `init_semaphore(runtime.workers)` instead of using the raw config value ([job_manager.py:175](../../../backend/app/services/job_manager.py)). Now a title cannot enter `MATCHING` without a real worker behind it — exactly `runtime.workers` tracks show `MATCHING`, the rest show `QUEUED`.
+
+**Accepted tradeoff:** the fast chromaprint prepass also rides this semaphore, so fingerprint-only matches are throttled to `runtime.workers` as well. Acceptable for v1 (the prepass is fast); a dedicated non-ASR fast lane is a possible later refinement, noted as a non-goal.
+
+### 4. Apply-on-restart, stated honestly
+
+`num_workers` is fixed at model-load time, so the setting continues to take effect on backend restart (current behavior). The visibility fix is to stop hiding this: the ConfigWizard field for `max_concurrent_matches` gains a "takes effect after restart" hint. Live rebuild-on-save is deferred (non-goal).
+
+### 5. Visibility surface
+
+- **Honest counts** — fall out of §3 automatically; no extra UI logic. The frontend already distinguishes `QUEUED` (muted chip, 0%) from `MATCHING` ([TrackGrid.tsx:38](../../../frontend/src/app/components/TrackGrid.tsx)).
+- **ASR mode badge** — a small read-only indicator: `ASR: CUDA · float16 · N workers` or `ASR: CPU · int8 · N workers`.
+- **New endpoint** `GET /api/asr-status` returns the resolved runtime: `{ device, compute_type, model, workers, cpu_threads, max_concurrent_matches }`, computed via the same `resolve_asr_runtime` helper + the device/compute-type logic in `FasterWhisperModel`. Rendered in the dashboard (the existing "ACTIVE OPERATION" / "THROUGHPUT" panel area is a natural home). Text only — no live throughput graph in v1.
+
+## Configuration
+
+Reuse the existing `max_concurrent_matches` field — **no schema change** (it already exists across `AppConfig`, `ConfigUpdate`, `ConfigResponse`, and `ConfigWizard`, so the config three-way-sync hazard does not apply). Its semantics change from "admission slots" to "requested parallel ASR workers (hardware-clamped)". Default stays `2`.
+
+## Affected components (orientation for the plan)
+
+- `backend/app/matcher/asr_models.py` — `resolve_asr_runtime` helper; `FasterWhisperModel` passes `num_workers`/`cpu_threads`; cache keys include the resolved values.
+- `backend/app/matcher/episode_identification.py` — `model_config` carries `requested_workers`.
+- `backend/app/core/curator.py` — flow `requested_workers` (from config) into `EpisodeIdentifier`.
+- `backend/app/services/job_manager.py` — size the semaphore from `resolve_asr_runtime(...).workers`.
+- `backend/app/api/routes.py` — `GET /api/asr-status`.
+- `frontend/src/...` — ASR mode badge on the dashboard; "restart to apply" hint in ConfigWizard.
+
+## Testing
+
+- **Unit:** `resolve_asr_runtime` math across core counts and CPU-vs-GPU (pure function); cache key includes worker params; semaphore initialized to the clamped value, not the raw config value.
+- **Integration:** with `workers = N`, exactly N titles reach `MATCHING` and the rest stay `QUEUED` (extends the existing semaphore/QUEUED tests in `tests/unit/test_stuck_job_recovery.py` / `tests/unit/test_job_manager.py`).
+- **API:** `GET /api/asr-status` returns the resolved runtime fields.
+
+## Risks
+
+- **Thread oversubscription on CPU** if `cpu_threads` is not divided down — mitigated by the §1 formula; covered by unit tests.
+- **GPU memory** — bounded by the conservative `GPU_WORKER_CAP`; VRAM auto-sizing is a deferred enhancement, not a v1 risk.
+- **Stale cached model** on config change — mitigated by folding worker params into both cache keys (§2).
+- **faster-whisper concurrency** — `WhisperModel(num_workers=N)` with concurrent `transcribe()` from N threads is the library's supported parallelism path; no change to call sites' threading model (still `asyncio.to_thread` per title).

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -22,6 +22,7 @@ import { buildNavItems } from "./navigation";
 import type { Job } from "../types";
 import { toast } from "sonner";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { AsrStatusBadge } from "./components/AsrStatusBadge";
 import {
   Splash,
   SvAtmosphere,
@@ -241,6 +242,7 @@ function MainDashboard() {
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <AsrStatusBadge />
           {/* View mode toggle */}
           <div style={{ display: "inline-flex", border: `1px solid ${sv.line}` }}>
             <button

--- a/frontend/src/app/components/AsrStatusBadge.tsx
+++ b/frontend/src/app/components/AsrStatusBadge.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+
+type AsrStatus = {
+  device: string;
+  compute_type: string;
+  model: string;
+  workers: number;
+  cpu_threads: number | null;
+  max_concurrent_matches: number;
+};
+
+/** Read-only chip showing the resolved ASR backend (device · compute · N workers). */
+export function AsrStatusBadge() {
+  const [status, setStatus] = useState<AsrStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/asr-status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setStatus(data);
+      })
+      .catch(() => {
+        /* badge is best-effort; stay hidden on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!status) return null;
+
+  const accent = status.device === "cuda" ? "#22d3ee" : "#8893a8";
+  const label = `ASR: ${status.device.toUpperCase()} · ${status.compute_type} · ${status.workers}w`;
+
+  return (
+    <span
+      title={`Whisper "${status.model}" · requested ${status.max_concurrent_matches}${
+        status.cpu_threads != null ? ` · ${status.cpu_threads} threads/worker` : ""
+      } · restart to change`}
+      style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: 11,
+        letterSpacing: "0.08em",
+        color: accent,
+        border: `1px solid ${accent}44`,
+        background: `${accent}0a`,
+        padding: "2px 8px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1241,12 +1241,14 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 id="maxConcurrentMatches"
                                 type="number"
                                 min={1}
-                                max={4}
+                                max={8}
                                 value={config.maxConcurrentMatches}
-                                onChange={(e) => handleInputChange('maxConcurrentMatches', Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+                                onChange={(e) => handleInputChange('maxConcurrentMatches', Math.max(1, Math.min(8, parseInt(e.target.value) || 1)))}
                             />
                             <span className="form-hint">
-                                Number of episodes matched simultaneously (uses GPU for speech recognition). Lower values reduce memory usage.
+                                Requested number of episodes transcribed in parallel. Automatically
+                                clamped to your hardware (CPU cores, or a GPU limit). Takes effect
+                                after a backend restart.
                             </span>
                         </div>
 


### PR DESCRIPTION
## Summary

Fixes the "many tracks show **Matching** but only one actually progresses (and the CPU looks idle)" behavior. This was **not** a UI bug and **not** a stuck semaphore: the shared Whisper model was built with faster-whisper's default `num_workers=1`, so concurrent transcriptions serialized behind a single worker while the admission semaphore — sized from `max_concurrent_matches` — kept admitting many tracks into `MATCHING`. The semaphore (admission) and the model's real concurrency (1) were decoupled, so the count overstated progress.

**Piece A** makes ASR genuinely parallel and the dashboard honest:

- The shared model now runs **N parallel workers** (faster-whisper `num_workers`, sharing one set of weights — no per-worker weight-memory multiplication), sized from `max_concurrent_matches` and **hardware-clamped**: CPU clamps to physical cores with `cpu_threads = cores // workers` (avoids the oversubscription that makes naive parallelism *slower*); GPU clamps to a conservative cap of 4.
- The **match semaphore is tied to that real worker capacity**, so exactly `workers` tracks show `MATCHING` and the rest correctly show `QUEUED` — the count can no longer overstate progress.
- A new **`GET /api/asr-status`** endpoint + a small dashboard **ASR badge** surface the active backend (e.g. `ASR: CUDA · float16 · 4w` / `ASR: CPU · int8 · 8w`).
- The **ConfigWizard hint is now honest** (hardware-clamped, takes effect after a backend restart) and the input bound is consistent.

GPU acceleration in the shipped release binary (bundling the CUDA libraries) is a separate, heavier effort tracked as **Piece B** and is intentionally out of scope here. ASR parallelism benefits the GPU-from-source path today too, since `num_workers=1` previously serialized GPU transcriptions as well.

Single source of truth: `resolve_asr_runtime(device, requested_workers)` in `asr_models.py` is consumed by the model loader, the semaphore, and the status endpoint, so all three always agree.

## Changes

- `asr_models.py` — `AsrRuntime` / `detect_asr_device` / `resolve_asr_runtime`; `FasterWhisperModel` passes `num_workers`/`cpu_threads`; both `_model_cache` keys made worker-aware (no stale single-worker reuse).
- `episode_identification.py` — `EpisodeMatcher` carries `requested_workers` via a DRY `_model_config()` helper.
- `curator.py` — forwards `config.max_concurrent_matches` as the matcher's `requested_workers`.
- `job_manager.py` — sizes the match semaphore from `resolve_asr_runtime(...).workers`.
- `routes.py` — `GET /api/asr-status`.
- Frontend — `AsrStatusBadge.tsx` (mounted in `App.tsx`); ConfigWizard hint/bound.

## Test Plan

- [x] Backend: **1751** unit + matcher tests pass; `ruff check app/ tests/` clean
- [x] Frontend: `npm run build` (tsc + vite) passes
- [x] New unit coverage: runtime sizing math (CPU thread-division, GPU cap, edge cases), model `num_workers`/`cpu_threads` kwargs + worker-aware cache keys (incl. GPU omits `cpu_threads`), semaphore sized to resolved workers, `/api/asr-status` fields
- [ ] Manual (GPU-from-source): on a multi-track disc, confirm exactly *N* tracks show **MATCHING** and the rest **QUEUED**, multiple transcriptions progress concurrently, and the ASR badge reflects the active device/worker count

Spec & plan: `docs/superpowers/specs/2026-06-04-parallel-asr-matching-visibility.md`, `docs/superpowers/plans/2026-06-04-parallel-asr-matching-visibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
