### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-05
+
+_Highlights: episode matching now transcribes multiple tracks in parallel — the **Max Concurrent Matches** setting finally drives real concurrency (auto-clamped to your CPU or GPU), with a live ASR backend badge on the dashboard, and the "Matching" count is now honest about which tracks are genuinely transcribing._
+
 ### Added
 
 - **Episode matching now transcribes multiple tracks in parallel** — the dashboard could show several tracks as "Matching" at once while only one actually made progress and the CPU sat mostly idle. The speech-recognition model was running one transcription at a time no matter what, so the **Max Concurrent Matches** setting didn't really do anything. That setting now drives how many episodes are transcribed simultaneously (on CPU or GPU), automatically clamped to your hardware (CPU cores, or a GPU limit) so it can't oversubscribe and slow things down. A small **ASR badge** on the dashboard shows the active backend — e.g. `ASR: CUDA · float16 · 4w` or `ASR: CPU · int8 · 8w`. (#336)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.15.4"
+__version__ = "0.16.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.15.4"
+version = "0.16.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.15.4",
+    "version": "0.16.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.15.4",
+            "version": "0.16.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.15.4",
+    "version": "0.16.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.16.0

Cuts the **0.16.0** release following the merge of #336.

### Version bumps (0.15.4 → 0.16.0)
- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `frontend/package.json` + `frontend/package-lock.json`

A minor bump is used because #336 introduces a new user-facing feature (parallel ASR transcription driven by **Max Concurrent Matches**).

### Changelog
- Moved the `[Unreleased]` entries into a curated `## [0.16.0] - 2026-06-05` section with a leading `_Highlights: …_` summary.
- `backend/scripts/extract_changelog.py --version 0.16.0` verified to extract the section cleanly (CI `changelog-version-check` will pass).

### Release notes preview

_Highlights: episode matching now transcribes multiple tracks in parallel — the **Max Concurrent Matches** setting finally drives real concurrency (auto-clamped to your CPU or GPU), with a live ASR backend badge on the dashboard, and the "Matching" count is now honest about which tracks are genuinely transcribing._

**Added**
- Episode matching now transcribes multiple tracks in parallel — **Max Concurrent Matches** now drives how many episodes transcribe simultaneously (CPU or GPU), auto-clamped to hardware, with an ASR backend badge on the dashboard. (#336)

**Changed**
- The dashboard's "Matching" count is now honest — tracks waiting for a slot show **QUEUED** and flip to **MATCHING** only when a worker actually starts. (#336)

No external contributors in this release (#336 is by the repo owner).

https://claude.ai/code/session_01RA7f6bn49guz4n5TjepMcC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RA7f6bn49guz4n5TjepMcC)_