### PR TITLE
fix(updater): change off the install cwd before the Windows restart-to-update swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Restart to update" now actually applies the update on Windows** — the crash-safe swap added in 0.15.3 (copy aside, verify, atomic rename, roll back) was correct, but it never ran to completion: the helper that performs the swap was launched with your install folder as its working directory, and Windows won't rename a folder while it's any program's current directory. So the very first rename failed, the updater rolled back, and you were left on the old version with no visible error — every time. The helper now moves to a neutral working directory before the swap (and is spawned from one), so the rename succeeds and the new build is installed. The `~/.engram/update_helper.log` now also records the helper's working directory and each step's exit code, so any remaining edge case is diagnosable from a single log. (#338)
+
 ## [0.16.0] - 2026-06-05
 
 _Highlights: episode matching now transcribes multiple tracks in parallel — the **Max Concurrent Matches** setting finally drives real concurrency (auto-clamped to your CPU or GPU), with a live ASR backend badge on the dashboard, and the "Matching" count is now honest about which tracks are genuinely transcribing._

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import zipfile
 from enum import StrEnum
 from pathlib import Path
@@ -619,7 +620,11 @@ class UpdateChecker:
         with open(bat_path, "w", newline="\r\n") as f:
             f.write(bat_content)
 
+        # Log where the helper will write its own log, plus the resolved home, so a
+        # support case can reconcile "no update_helper.log" against where it actually
+        # looked (HOME/USERPROFILE drift is a known way the file appears "missing").
         logger.info(f"Launching update helper: {bat_path}")
+        logger.info(f"Update helper log -> {log_path} (home={Path.home()})")
         self._spawn_detached_helper(["cmd", "/c", str(bat_path)])
         os._exit(0)  # Hard exit: avoids asyncio catching SystemExit
 
@@ -668,6 +673,11 @@ class UpdateChecker:
             f'set "LOG={log_path}"',
             f'set "EXE=%INSTALL%\\{exe}"',
             f'echo [engram-update] start (pid {pid}) > "%LOG%"',
+            # Diagnostic context: %CD% here is the cwd we INHERITED from engram. If it
+            # equals %INSTALL%, the `cd /d` below is what saves the swap (see there).
+            'echo [engram-update] cwd=%CD% >> "%LOG%"',
+            "echo [engram-update] INSTALL=%INSTALL% NEWDIR=%NEWDIR% OLDDIR=%OLDDIR%"
+            ' SRC=%SRC% EXE=%EXE% >> "%LOG%"',
             # --- wait for the parent process to exit, then let file handles release ---
             ":wait",
             f'tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL',
@@ -678,11 +688,24 @@ class UpdateChecker:
             'echo [engram-update] process exited; waiting for handles >> "%LOG%"',
             "ping -n 3 127.0.0.1 >nul",
             "ping -n 3 127.0.0.1 >nul",
+            # Move our OWN working directory off the install dir before the swap. A
+            # detached helper inherits the parent engram process's cwd, which for a
+            # double-clicked onedir exe is the install dir. A directory that is any
+            # process's current directory cannot be renamed, so without this the
+            # `move "%INSTALL%"` below fails with "being used by another process" and
+            # every restart silently rolls back (confirmed in an isolated swap harness).
+            # %TEMP% is guaranteed valid — this bat lives there.
+            'cd /d "%TEMP%"',
+            'echo [engram-update] cwd(after cd)=%CD% >> "%LOG%"',
             # --- copy staged build to a sibling of the install (never in place) ---
             'rmdir /S /Q "%NEWDIR%" >nul 2>&1',
             'echo [engram-update] robocopy "%SRC%" to "%NEWDIR%" >> "%LOG%"',
             'robocopy "%SRC%" "%NEWDIR%" /MIR /R:3 /W:2 /NP /NFL /NDL >> "%LOG%" 2>&1',
-            "if %ERRORLEVEL% GEQ 8 goto fail",
+            # Capture robocopy's exit BEFORE any other command (echo resets ERRORLEVEL),
+            # then both log and gate on the captured value. Success is < 8.
+            "set RC=%ERRORLEVEL%",
+            'echo [engram-update] robocopy exit=%RC% >> "%LOG%"',
+            "if %RC% GEQ 8 goto fail",
             # --- verify the copied tree before touching the live install ---
             'if not exist "%NEWDIR%\\engram.exe" goto fail',
             'if not exist "%NEWDIR%\\_internal\\base_library.zip" goto fail',
@@ -696,9 +719,11 @@ class UpdateChecker:
             "if errorlevel 1 goto fail_no_swap",
             'move "%NEWDIR%" "%INSTALL%" >> "%LOG%" 2>&1',
             "if errorlevel 1 goto restore_old",
-            # --- success ---
+            # --- success --- relaunch with cwd pinned to the (new) install dir, exactly
+            # as a double-click would, so nothing depends on the helper's %TEMP% cwd.
             'echo [engram-update] success; relaunching >> "%LOG%"',
-            'start "" "%EXE%"',
+            'start "" /D "%INSTALL%" "%EXE%"',
+            'echo [engram-update] done (success) >> "%LOG%"',
             'rmdir /S /Q "%OLDDIR%" >nul 2>&1',
             '(goto) 2>nul & del "%~f0"',  # exit batch context, then delete self (idiom)
             # --- rollback paths (bat is NOT deleted — left with the log for diagnosis) ---
@@ -716,7 +741,8 @@ class UpdateChecker:
             "goto relaunch_old",
             ":relaunch_old",
             'echo [engram-update] rolled back to previous install >> "%LOG%"',
-            'start "" "%EXE%"',
+            'start "" /D "%INSTALL%" "%EXE%"',
+            'echo [engram-update] done (rolled back) >> "%LOG%"',
             "endlocal",
         ]
         return "\n".join(lines) + "\n"
@@ -736,11 +762,19 @@ class UpdateChecker:
         new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
         breakaway = getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
         base = detached | new_group
+        # Pin a neutral working directory. Without an explicit cwd the detached helper
+        # inherits engram's cwd — the install dir for a double-clicked onedir exe — and a
+        # process whose cwd is a directory holds an open handle that blocks renaming it,
+        # so the helper's own `move install -> .old` fails and the swap silently rolls
+        # back. The bat also `cd /d "%TEMP%"`s for defense in depth.
+        safe_cwd = tempfile.gettempdir()
         try:
-            subprocess.Popen(args, shell=False, close_fds=True, creationflags=base | breakaway)
+            subprocess.Popen(
+                args, shell=False, close_fds=True, cwd=safe_cwd, creationflags=base | breakaway
+            )
         except OSError as exc:
             logger.warning(f"Update helper breakaway spawn failed ({exc}); retrying detached")
-            subprocess.Popen(args, shell=False, close_fds=True, creationflags=base)
+            subprocess.Popen(args, shell=False, close_fds=True, cwd=safe_cwd, creationflags=base)
 
     async def _broadcast(self) -> None:
         """Push current update state to all WebSocket clients."""

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -676,8 +676,8 @@ class UpdateChecker:
             # Diagnostic context: %CD% here is the cwd we INHERITED from engram. If it
             # equals %INSTALL%, the `cd /d` below is what saves the swap (see there).
             'echo [engram-update] cwd=%CD% >> "%LOG%"',
-            "echo [engram-update] INSTALL=%INSTALL% NEWDIR=%NEWDIR% OLDDIR=%OLDDIR%"
-            ' SRC=%SRC% EXE=%EXE% >> "%LOG%"',
+            'echo [engram-update] INSTALL=%INSTALL% NEWDIR=%NEWDIR% OLDDIR=%OLDDIR% >> "%LOG%"',
+            'echo [engram-update] SRC=%SRC% EXE=%EXE% >> "%LOG%"',
             # --- wait for the parent process to exit, then let file handles release ---
             ":wait",
             f'tasklist /FI "PID eq {pid}" 2>NUL | find /I "{pid}" >NUL',

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -636,6 +636,43 @@ class TestSpawnDetachedHelper:
         assert flags_seen[0] & breakaway  # tried with breakaway
         assert not (flags_seen[1] & breakaway)  # then fell back without
 
+    def test_spawns_with_neutral_cwd(self, monkeypatch):
+        """Helper must be spawned with an explicit cwd OFF the install dir.
+
+        Regression (confirmed in an isolated swap harness): Popen was called with no
+        ``cwd=``, so the detached ``cmd /c bat`` inherited engram's working directory —
+        the install dir for a double-clicked onedir exe. A process whose cwd is a
+        directory holds an open handle on it, so the helper's own ``move install -> .old``
+        failed with "being used by another process" and every restart silently rolled
+        back. The spawn must pin a neutral, existing cwd.
+        """
+        seen = []
+        monkeypatch.setattr(
+            subprocess, "Popen", lambda *a, **kw: seen.append(kw.get("cwd")) or MagicMock()
+        )
+        UpdateChecker._spawn_detached_helper(["cmd", "/c", "x.bat"])
+
+        assert seen, "Popen was never called"
+        assert seen[0] is not None, "helper spawned with no cwd — inherits the install dir"
+        assert Path(seen[0]).is_dir()
+
+    def test_fallback_spawn_also_gets_neutral_cwd(self, monkeypatch):
+        """The plain-detached fallback path must also pin the neutral cwd."""
+        breakaway = self._breakaway_flag()
+        seen = []
+
+        def fake_popen(*a, **kw):
+            seen.append(kw.get("cwd"))
+            if kw.get("creationflags", 0) & breakaway:
+                raise OSError("Access is denied")
+            return MagicMock()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        UpdateChecker._spawn_detached_helper(["cmd", "/c", "x.bat"])
+
+        assert len(seen) == 2
+        assert all(c is not None and Path(c).is_dir() for c in seen)
+
 
 # Representative real-world paths: the user runs out of a parens'd Downloads folder
 # and staging lives under ~/.engram on a (possibly) different volume.
@@ -695,7 +732,9 @@ class TestRenderUpdateBat:
 
     def test_checks_exit_codes(self):
         bat = self._bat()
-        assert "if %ERRORLEVEL% GEQ 8 goto fail" in bat  # robocopy: success is < 8
+        # robocopy's exit is captured first (echo resets ERRORLEVEL) then gated; success
+        # is < 8. The gate may read the captured var rather than %ERRORLEVEL% directly.
+        assert "GEQ 8 goto fail" in bat
         assert bat.count("if errorlevel 1") >= 2  # one per move
 
     def test_rollback_restores_previous_install(self):
@@ -728,6 +767,34 @@ class TestRenderUpdateBat:
     def test_preserves_parens_in_paths(self):
         bat = self._bat()
         assert r'set "INSTALL=C:\Users\jonat\Downloads\engram-windows-x64(8)\engram"' in bat
+
+    def test_changes_cwd_off_install_before_swap(self):
+        """The helper must cd off the install dir before the swap renames.
+
+        Regression (reproduced in an isolated swap harness): the detached helper
+        inherited engram's cwd (the install dir). A directory that is any process's
+        current directory can't be renamed, so ``move install -> .old`` failed and the
+        update silently rolled back on every attempt. Changing the helper's own cwd to a
+        neutral dir releases that handle. Must occur before the first ``move``.
+        """
+        bat = self._bat()
+        assert 'cd /d "%TEMP%"' in bat
+        assert bat.index('cd /d "%TEMP%"') < bat.index('move "%INSTALL%" "%OLDDIR%"')
+
+    def test_logs_diagnostic_context_before_swap(self):
+        """The helper echoes its cwd + key paths so a field failure is diagnosable
+        from update_helper.log alone (the capability that was missing every prior time)."""
+        bat = self._bat()
+        assert "%CD%" in bat  # the resolved working directory
+        assert "%INSTALL%" in bat
+        # robocopy's real exit code is recorded before the GEQ-8 gate
+        assert "%ERRORLEVEL%" in bat
+
+    def test_emits_done_marker_on_terminal_paths(self):
+        """Every terminal branch writes a final marker, so a log that stops mid-step is
+        distinguishable from a clean (if failed) finish."""
+        bat = self._bat()
+        assert "[engram-update] done" in bat
 
 
 class TestRestartWindowsWiring:


### PR DESCRIPTION
## Summary

Restart-to-update has failed on Windows across many attempts. Systematic debugging (root cause confirmed empirically, not guessed) found that **download/unpack was never the problem** — the failure was entirely in the self-overwrite swap, and the crash-safe robocopy swap added in #322 **never actually completed once**.

**Root cause:** `_spawn_detached_helper` launched the detached `cmd /c engram_update.bat` with **no `cwd=`**, so it inherited engram's working directory — the install dir for a double-clicked onedir exe. On Windows a directory that is any process's current directory cannot be renamed, so the helper's own first swap step `move "%INSTALL%" "%OLDDIR%"` failed with *"being used by another process"* → `:fail_no_swap` → rollback → **update silently never applied, no UI error, on every attempt.** (The absence of `~/.engram/update_helper.log` despite 6 logged helper launches was because those ran the even-older xcopy-in-place bat, which wrote no log.)

## Evidence

Reproduced and then verified in an isolated swap harness that runs the **real** `_render_update_bat` against throwaway copies, A/B-testing the helper's cwd (never touches the real install):

| Run | helper cwd | `move install -> .old` | Before fix | After fix |
|-----|-----------|------------------------|-----------|-----------|
| A | == install dir (production) | `0 dir(s) moved` / *used by another process* | rolled back | **success** |
| B | neutral dir | `1 dir(s) moved` | success | success |

robocopy succeeds in both; the only variable is cwd.

## Fix

`backend/app/core/updater.py`:
- `_spawn_detached_helper` passes `cwd=tempfile.gettempdir()` to both Popen calls.
- `_render_update_bat` does `cd /d "%TEMP%"` before the swap (defense in depth).
- Relaunch via `start "" /D "%INSTALL%"` so the new app keeps the install dir as cwd (matches a normal double-click; frozen DB is absolute `~/.engram/engram.db` regardless).
- Captures robocopy's exit into `%RC%` **before** logging it (a stray `echo` resets `%ERRORLEVEL%`, which would have made every copy look successful).
- Logs the inherited `%CD%`, all resolved paths, the robocopy exit, and a `done` marker on every terminal branch — so a single `update_helper.log` self-diagnoses any future edge case.

## Tests

- `tests/unit/test_updater.py`: added failing-first tests for the neutral spawn cwd (both spawn paths), the bat `cd` off the install dir before the swap, the diagnostic context, and the `done` markers. 40 unit + 6 integration update tests pass; ruff clean.

## ⚠️ Chicken-and-egg (important)

The swap is performed by the **currently-running** binary, so this fix only takes effect once a user is running a build that *contains* it. A user on 0.15.4 updating to the next release still runs 0.15.4's buggy helper, so that jump still rolls back — existing installs need **one more manual download** to a fixed build, after which restart-to-update works for good. This is the standing argument for the deferred side-by-side-launcher re-architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)