### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-06-05
+
+_Highlights: a fixes-only release — "Restart to update" on Windows now runs to completion and actually installs the update, and importing a TV-season folder with a generic label (like `Season 3`) now resolves the show and matches its episodes instead of dropping the whole season into Needs Review._
+
 ### Fixed
 
 - **"Restart to update" now actually applies the update on Windows** — the crash-safe swap added in 0.15.3 (copy aside, verify, atomic rename, roll back) was correct, but it never ran to completion: the helper that performs the swap was launched with your install folder as its working directory, and Windows won't rename a folder while it's any program's current directory. So the very first rename failed, the updater rolled back, and you were left on the old version with no visible error — every time. The helper now moves to a neutral working directory before the swap (and is spawned from one), so the rename succeeds and the new build is installed. The `~/.engram/update_helper.log` now also records the helper's working directory and each step's exit code, so any remaining edge case is diagnosable from a single log. (#338)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.16.0"
+__version__ = "0.16.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.16.0"
+version = "0.16.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.15.4"
+version = "0.16.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.16.0",
+            "version": "0.16.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.16.0",
+    "version": "0.16.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## chore: release v0.16.1

Patch release gathering the two bug fixes that landed on `main` since **v0.16.0** (#338, #340). Both are fixes — no new `### Added` entries in `[Unreleased]` — so this is a **patch** bump.

On squash-merge, this PR's `chore: release v0.16.1` title arms `tag-release.yml`, which tags `v0.16.1` from `main`; `release.yml` then builds the binaries and publishes the GitHub release using the extracted `## [0.16.1]` CHANGELOG section as the body.

### Version bump (0.16.0 → 0.16.1)
- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `frontend/package.json`
- `frontend/package-lock.json` — both the top-level `version` and `packages[""].version`
- `backend/uv.lock` — `engram-backend` self-version (was stale at `0.15.4`; now consistent with `pyproject.toml`)

`CONTRIBUTORS.md` was regenerated via `backend/scripts/contributors.py --roster` and is unchanged — both #338 and #340 are owner-authored, so there's no new external contributor.

### Release notes preview
_Exactly what `extract_changelog.py --version 0.16.1` will place in the GitHub release body:_

---

_Highlights: a fixes-only release — "Restart to update" on Windows now runs to completion and actually installs the update, and importing a TV-season folder with a generic label (like `Season 3`) now resolves the show and matches its episodes instead of dropping the whole season into Needs Review._

### Fixed

- **"Restart to update" now actually applies the update on Windows** — the crash-safe swap added in 0.15.3 was correct, but never ran to completion: the swap helper was launched with the install folder as its working directory, and Windows won't rename a folder while it's any program's current directory, so the first rename failed and the updater silently rolled back. The helper now moves to a neutral working directory before the swap, so the rename succeeds and the new build installs; `~/.engram/update_helper.log` also records the working directory and each step's exit code. (#338)
- **Imported TV seasons with generic folder labels now match instead of sending every episode to review** — importing a pre-ripped folder like `…\Seinfeld\Season 3\` gave the job a disc "label" of just `SEASON_3`, so the show was never looked up on TMDB and the job had no TMDB id; with reference subtitles now stored per-TMDB-id, the matcher hunted for references in a folder that didn't exist and dropped every track into Needs Review. Imports (and hand-named discs) now resolve the show's TMDB id from its name *before* matching. Genuinely ambiguous same-name shows (e.g. *Frasier* 1993 vs the 2023 revival) still pause for you to pick. (#340)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
