### PR TITLE
fix(detect-tools): don't let MakeMKV's slow drive probe gate /api/detect-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tool detection no longer hangs the Settings/first-run screen on a busy optical drive** — the "Detect tools" check (which runs on the dashboard and in the Config Wizard) read MakeMKV's version by briefly spinning up the drive, and on a slow or busy drive that probe could block the whole check for up to ~20 seconds — so FFmpeg and fpcalc, which were already detected, sat waiting on it before anything showed up. MakeMKV is now reported as found (with its path) without waiting on the slow version read, the version probe is given a short budget and degrades to "version probe timed out" instead of stalling, and a hard per-tool deadline guarantees one slow tool can never gate the others. Server startup and the diagnostics report get the same short budget, so neither stalls on a busy drive either.
+
 ## [0.16.1] - 2026-06-05
 
 _Highlights: a fixes-only release — "Restart to update" on Windows now runs to completion and actually installs the update, and importing a TV-season folder with a generic label (like `Season 3`) now resolves the show and matches its episodes instead of dropping the whole season into Needs Review._

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -152,6 +152,22 @@ def _iter_winget_ffmpeg_paths() -> list[str]:
 _VERSION_NOT_DETECTABLE = "MakeMKV (version not detectable)"
 _VERSION_PROBE_TIMEOUT = "MakeMKV (version probe timed out)"
 
+# The MakeMKV version probe runs `makemkvcon -r info disc:99999`, which enumerates
+# optical drives and can block for many seconds on a slow or busy drive.
+#   * The interactive /validate/makemkv endpoint can afford the full wait.
+#   * detect-tools fires on dashboard/Config-Wizard load, so it uses a short
+#     budget — found+path never depends on the version string, so a stuck drive
+#     shouldn't stall the page. A timed-out probe degrades to _VERSION_PROBE_TIMEOUT.
+_VERSION_PROBE_TIMEOUT_S = 20.0
+_DETECT_VERSION_PROBE_TIMEOUT_S = 3.0
+
+# Hard wall-clock cap on the whole MakeMKV detector inside detect-tools. The short
+# probe budget above handles the common slow-drive case; this is the backstop so
+# anything else hanging in detect_makemkv (e.g. the no-arg validity call) still
+# can't gate the ffmpeg/fpcalc results. Comfortably above the probe budget so a
+# healthy-but-unhurried drive isn't cut off.
+_MAKEMKV_DETECT_DEADLINE_S = 8.0
+
 # Robot mode (-r) prints a startup banner naming the version, e.g.
 #   MSG:1005,0,1,"MakeMKV v1.18.3 win(x64-release) started",...
 # Capture "MakeMKV v1.18.3 win(x64-release)" — product, semantic version, and the
@@ -175,14 +191,16 @@ def _extract_makemkv_version(output: str) -> str:
     return _VERSION_NOT_DETECTABLE
 
 
-def _probe_makemkv_version(path_str: str) -> str:
+def _probe_makemkv_version(path_str: str, *, timeout: float = _VERSION_PROBE_TIMEOUT_S) -> str:
     """Best-effort version read via robot mode.
 
     Running with no arguments only prints usage text (no version), so the version
     comes from the robot-mode (-r) startup banner. Robot mode enumerates optical
     drives, so this is kept separate from the binary validity check and never
     blocks detection on a slow or busy drive. The out-of-range ``disc:99999``
-    index can't open a real disc — it just triggers the banner.
+    index can't open a real disc — it just triggers the banner. ``timeout`` bounds
+    that drive enumeration: callers on a latency-sensitive path (detect-tools)
+    pass a short budget; the interactive validate endpoint takes the default.
     """
     # Refuse to launch anything that isn't a MakeMKV executable, so a
     # user-supplied config path can't coerce this into running an arbitrary
@@ -193,13 +211,13 @@ def _probe_makemkv_version(path_str: str) -> str:
         result = subprocess.run(
             [path_str, "-r", "info", "disc:99999"],
             capture_output=True,
-            timeout=20,
+            timeout=timeout,
             text=True,
         )
     except subprocess.TimeoutExpired:
         # Distinct from "not detectable" so operators can tell a slow/busy drive
         # apart from a binary that simply never emitted a parseable version.
-        logger.warning("MakeMKV version probe timed out (20s)")
+        logger.warning("MakeMKV version probe timed out (%.0fs)", timeout)
         return _VERSION_PROBE_TIMEOUT
     except Exception as e:
         logger.debug(f"MakeMKV version probe failed: {e}")
@@ -207,8 +225,15 @@ def _probe_makemkv_version(path_str: str) -> str:
     return _extract_makemkv_version(result.stdout + result.stderr)
 
 
-def _validate_makemkv_binary(path_str: str) -> ToolDetectionResult:
-    """Validate a MakeMKV binary and extract version info."""
+def _validate_makemkv_binary(
+    path_str: str, *, version_probe_timeout: float = _VERSION_PROBE_TIMEOUT_S
+) -> ToolDetectionResult:
+    """Validate a MakeMKV binary and extract version info.
+
+    ``version_probe_timeout`` bounds only the drive-enumerating version probe,
+    not the fast no-arg validity check — so found+path is returned regardless of
+    how slow the optical drive is. detect-tools passes a short budget here.
+    """
     # Self-guard the subprocess sink: never execute a path whose basename isn't
     # a known MakeMKV executable, independent of the caller (py/command-line-injection).
     if not executable_basename_allowed(path_str, _MAKEMKV_EXE_NAMES):
@@ -231,7 +256,11 @@ def _validate_makemkv_binary(path_str: str) -> ToolDetectionResult:
 
     # Probe is decoupled from the validity check above: it self-catches all its
     # own errors, so its subprocess lifetime never interacts with this try block.
-    return ToolDetectionResult(found=True, path=path_str, version=_probe_makemkv_version(path_str))
+    return ToolDetectionResult(
+        found=True,
+        path=path_str,
+        version=_probe_makemkv_version(path_str, timeout=version_probe_timeout),
+    )
 
 
 def _validate_ffmpeg_binary(path_str: str) -> ToolDetectionResult:
@@ -364,14 +393,24 @@ def detect_fpcalc() -> ToolDetectionResult:
     )
 
 
-def detect_makemkv() -> ToolDetectionResult:
-    """Auto-detect MakeMKV by searching PATH then common install locations."""
+def detect_makemkv(
+    *, version_probe_timeout: float = _DETECT_VERSION_PROBE_TIMEOUT_S
+) -> ToolDetectionResult:
+    """Auto-detect MakeMKV by searching PATH then common install locations.
+
+    The version probe defaults to the short budget because every caller is
+    latency-sensitive and uses the version only cosmetically: detect-tools (on
+    page load), lifespan startup (blocks the server coming up), and the
+    diagnostics report. found+path is the load-bearing result and never depends
+    on the probe, so a busy drive degrades the version to _VERSION_PROBE_TIMEOUT
+    rather than stalling the caller.
+    """
     # 1. Check system PATH
     for name in ("makemkvcon64", "makemkvcon"):
         found = shutil.which(name)
         if found:
             logger.info(f"Found MakeMKV on PATH: {found}")
-            result = _validate_makemkv_binary(found)
+            result = _validate_makemkv_binary(found, version_probe_timeout=version_probe_timeout)
             if result.found:
                 return result
 
@@ -379,7 +418,7 @@ def detect_makemkv() -> ToolDetectionResult:
     for path_str in _get_makemkv_search_paths():
         if Path(path_str).is_file():
             logger.info(f"Found MakeMKV at: {path_str}")
-            result = _validate_makemkv_binary(path_str)
+            result = _validate_makemkv_binary(path_str, version_probe_timeout=version_probe_timeout)
             if result.found:
                 return result
 
@@ -409,13 +448,51 @@ def detect_ffmpeg() -> ToolDetectionResult:
     return ToolDetectionResult(found=False, error="FFmpeg not found")
 
 
+async def _detect_within_deadline(
+    detector,
+    *,
+    deadline: float,
+    on_timeout: ToolDetectionResult,
+    label: str,
+) -> ToolDetectionResult:
+    """Run a blocking detector off the event loop under a wall-clock deadline.
+
+    Bounds a single detector so a slow tool can't gate /detect-tools. A blocking
+    subprocess can't be interrupted, so ``asyncio.wait`` is used to *return at*
+    the deadline without cancelling — the over-deadline worker thread is left to
+    finish and its result discarded, and ``on_timeout`` is returned in its place.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(detector))
+    done, _pending = await asyncio.wait({task}, timeout=deadline)
+    if task in done:
+        return task.result()
+    logger.warning(
+        "%s detection exceeded its %.1fs deadline; returning degraded result", label, deadline
+    )
+    # Retrieve the eventual result/exception when the orphaned probe finishes so a
+    # late failure isn't logged as "exception never retrieved"; the value is dropped.
+    task.add_done_callback(lambda t: t.cancelled() or t.exception())
+    return on_timeout
+
+
 @router.get("/detect-tools", response_model=DetectToolsResponse)
 async def detect_tools() -> DetectToolsResponse:
-    """Auto-detect MakeMKV, FFmpeg, and fpcalc installations."""
-    # Detection shells out to the tools (blocking, multi-second on slow/busy
-    # drives), so run it off the event loop to avoid stalling other requests.
+    """Auto-detect MakeMKV, FFmpeg, and fpcalc installations.
+
+    Detection shells out to the tools (blocking), so each detector runs off the
+    event loop. MakeMKV is additionally bounded by a deadline: its version probe
+    enumerates optical drives and can block for seconds on a busy drive, so it
+    must never gate the quick ffmpeg/fpcalc ``-version`` results.
+    """
     makemkv, ffmpeg, fpcalc = await asyncio.gather(
-        asyncio.to_thread(detect_makemkv),
+        _detect_within_deadline(
+            detect_makemkv,
+            deadline=_MAKEMKV_DETECT_DEADLINE_S,
+            on_timeout=ToolDetectionResult(
+                found=False, error="MakeMKV detection timed out (drive busy?)"
+            ),
+            label="MakeMKV",
+        ),
         asyncio.to_thread(detect_ffmpeg),
         asyncio.to_thread(detect_fpcalc),
     )

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -462,7 +462,7 @@ async def _detect_within_deadline(
     the deadline without cancelling — the over-deadline worker thread is left to
     finish and its result discarded, and ``on_timeout`` is returned in its place.
     """
-    task = asyncio.ensure_future(asyncio.to_thread(detector))
+    task = asyncio.create_task(asyncio.to_thread(detector))
     done, _pending = await asyncio.wait({task}, timeout=deadline)
     if task in done:
         return task.result()

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -469,9 +469,16 @@ async def _detect_within_deadline(
     logger.warning(
         "%s detection exceeded its %.1fs deadline; returning degraded result", label, deadline
     )
-    # Retrieve the eventual result/exception when the orphaned probe finishes so a
-    # late failure isn't logged as "exception never retrieved"; the value is dropped.
-    task.add_done_callback(lambda t: t.cancelled() or t.exception())
+
+    # When the orphaned probe eventually finishes, retrieve its result/exception so a
+    # late failure isn't logged as "exception never retrieved". The result is dropped
+    # (the response already moved on), but an unexpected exception — detectors are
+    # meant to catch their own errors — is traced at debug rather than vanishing.
+    def _discard_orphan(t):
+        if not t.cancelled() and (exc := t.exception()):
+            logger.debug("%s orphaned detector finished with error: %s", label, exc)
+
+    task.add_done_callback(_discard_orphan)
     return on_timeout
 
 

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -1131,6 +1131,53 @@ class TestDetectToolsDeadline:
         # The response landed near the 0.2s deadline, nowhere near the 10s block.
         assert elapsed < 2.0
 
+    def test_orphaned_makemkv_exception_is_traced_not_swallowed(self, caplog):
+        """If the over-deadline detector later raises, the error is logged at debug
+        rather than vanishing — detectors normally catch their own errors, so this
+        backstop path shouldn't be silent."""
+        import asyncio
+        import logging
+        import threading
+
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult, detect_tools
+
+        release = threading.Event()
+
+        def stuck_then_raise() -> ToolDetectionResult:
+            release.wait(timeout=10)
+            raise RuntimeError("drive exploded")
+
+        def fast_ffmpeg() -> ToolDetectionResult:
+            return ToolDetectionResult(found=True, path="f", version="ffmpeg 6.0")
+
+        def fast_fpcalc() -> ToolDetectionResult:
+            return ToolDetectionResult(found=True, path="fp", version="fpcalc 1.5.1")
+
+        async def drive():
+            result = await detect_tools()
+            release.set()  # let the orphaned detector finish (and raise)
+            await asyncio.sleep(0.3)  # let its done-callback run before teardown
+            return result
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="app.api.validation"),
+            patch.object(validation, "_MAKEMKV_DETECT_DEADLINE_S", 0.2),
+            patch.object(validation, "detect_makemkv", stuck_then_raise),
+            patch.object(validation, "detect_ffmpeg", fast_ffmpeg),
+            patch.object(validation, "detect_fpcalc", fast_fpcalc),
+        ):
+            result = asyncio.run(drive())
+
+        # The endpoint still returned the degraded result for the timed-out detector...
+        assert result.makemkv.found is False
+        assert "timed out" in (result.makemkv.error or "").lower()
+        # ...and the orphan's late exception was traced, not silently discarded.
+        assert any(
+            "orphaned detector finished with error" in m and "drive exploded" in m
+            for m in caplog.messages
+        )
+
 
 class TestTmdbValidationRemainingBranches:
     """The status/timeout/generic-exception branches not covered elsewhere."""

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -1015,6 +1015,123 @@ class TestValidateFfmpegEndpoint:
         assert result.error == "FFmpeg command timeout (10s)"
 
 
+class TestDetectToolsVersionProbeBudget:
+    """detect-tools probes MakeMKV's version on a short budget; the interactive
+    validate path keeps the full budget.
+
+    The version probe runs ``makemkvcon -r info disc:99999``, which enumerates
+    optical drives and can block for many seconds on a slow/busy drive. The
+    found+path answer never depends on it, so detect-tools must not pay the full
+    20s for a cosmetic version string.
+    """
+
+    @staticmethod
+    def _capture_probe_timeout():
+        """Stub subprocess.run, recording the timeout handed to the -r probe."""
+        seen: dict[str, float | None] = {}
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 1
+            m.stderr = ""
+            if "-r" in cmd:  # the drive-enumerating version probe
+                seen["probe_timeout"] = kwargs.get("timeout")
+                m.stdout = (
+                    'MSG:1005,0,1,"MakeMKV v1.18.3 win(x64-release) started",'
+                    '"%1 started","MakeMKV v1.18.3 win(x64-release)"'
+                )
+            else:  # the fast no-arg validity check
+                m.stdout = "Use: makemkvcon [switches] Command [Parameters]"
+            return m
+
+        return seen, fake_run
+
+    def test_detect_makemkv_uses_short_probe_timeout(self):
+        """The auto-detect path (only caller is detect-tools) probes on the short budget."""
+        from app.api import validation
+        from app.api.validation import detect_makemkv
+
+        seen, fake_run = self._capture_probe_timeout()
+        with (
+            patch.object(validation.shutil, "which", return_value="/usr/bin/makemkvcon64"),
+            patch("app.api.validation.subprocess.run", side_effect=fake_run),
+        ):
+            result = detect_makemkv()
+
+        # Found + path + version still resolve when the drive responds quickly...
+        assert result.found is True
+        assert result.path == "/usr/bin/makemkvcon64"
+        assert result.version == "MakeMKV v1.18.3 win(x64-release)"
+        # ...but the drive-enumerating probe got the short detect-tools budget, not 20s.
+        assert seen["probe_timeout"] == validation._DETECT_VERSION_PROBE_TIMEOUT_S
+        assert seen["probe_timeout"] < validation._VERSION_PROBE_TIMEOUT_S
+
+    def test_validate_binary_default_keeps_full_probe_timeout(self):
+        """The interactive /validate/makemkv path keeps the full version-probe budget."""
+        from app.api import validation
+        from app.api.validation import _validate_makemkv_binary
+
+        seen, fake_run = self._capture_probe_timeout()
+        with patch("app.api.validation.subprocess.run", side_effect=fake_run):
+            result = _validate_makemkv_binary("C:/MakeMKV/makemkvcon64.exe")
+
+        assert result.found is True
+        assert seen["probe_timeout"] == validation._VERSION_PROBE_TIMEOUT_S
+
+
+class TestDetectToolsDeadline:
+    """A slow MakeMKV detector (busy optical drive) must not gate the response."""
+
+    def test_slow_makemkv_does_not_delay_ffmpeg_and_fpcalc(self):
+        """detect-tools caps MakeMKV with a per-detector deadline, so its
+        drive-enumerating probe can't stall the ffmpeg/fpcalc results."""
+        import asyncio
+        import threading
+        import time
+
+        from app.api import validation
+        from app.api.validation import ToolDetectionResult, detect_tools
+
+        release = threading.Event()
+
+        def stuck_makemkv() -> ToolDetectionResult:
+            # Simulate a busy optical drive: blocks well past the deadline.
+            release.wait(timeout=10)
+            return ToolDetectionResult(found=True, path="m", version="MakeMKV v1.18.3")
+
+        def fast_ffmpeg() -> ToolDetectionResult:
+            return ToolDetectionResult(found=True, path="f", version="ffmpeg 6.0")
+
+        def fast_fpcalc() -> ToolDetectionResult:
+            return ToolDetectionResult(found=True, path="fp", version="fpcalc 1.5.1")
+
+        async def drive():
+            start = time.monotonic()
+            result = await detect_tools()
+            elapsed = time.monotonic() - start
+            release.set()  # unblock the orphaned probe thread so teardown is prompt
+            return result, elapsed
+
+        with (
+            patch.object(validation, "_MAKEMKV_DETECT_DEADLINE_S", 0.2),
+            patch.object(validation, "detect_makemkv", stuck_makemkv),
+            patch.object(validation, "detect_ffmpeg", fast_ffmpeg),
+            patch.object(validation, "detect_fpcalc", fast_fpcalc),
+        ):
+            result, elapsed = asyncio.run(drive())
+
+        # ffmpeg + fpcalc came back intact; the stuck MakeMKV probe never gated them.
+        assert result.ffmpeg.found is True
+        assert result.ffmpeg.version == "ffmpeg 6.0"
+        assert result.fpcalc.found is True
+        assert result.fpcalc.version == "fpcalc 1.5.1"
+        # MakeMKV hit its deadline -> degraded result, not a multi-second hang.
+        assert result.makemkv.found is False
+        assert "timed out" in (result.makemkv.error or "").lower()
+        # The response landed near the 0.2s deadline, nowhere near the 10s block.
+        assert elapsed < 2.0
+
+
 class TestTmdbValidationRemainingBranches:
     """The status/timeout/generic-exception branches not covered elsewhere."""
 


### PR DESCRIPTION
## Problem

`GET /api/detect-tools` (called on the dashboard and in the Config Wizard) ran the three tool detectors concurrently via `asyncio.gather` and waited for **all** of them. `detect_makemkv` → `_validate_makemkv_binary` → `_probe_makemkv_version` runs `makemkvcon -r info disc:99999`, which enumerates optical drives with a **20s** subprocess timeout. On a slow or busy optical drive that cosmetic version read gated the whole response — FFmpeg and fpcalc finished in milliseconds but the endpoint still hung up to ~20s before returning anything.

Noticed while fixing the v0.16.1 release smoke-test timeout (#342), but it's a separate product/UX concern.

## Fix

The version probe is purely informational — the Config Wizard only consumes `found` + `path` (to auto-fill the path field); `version` is a cosmetic label. Two complementary layers:

- **(a) Short version-probe budget — primary fix.** `detect_makemkv` now probes the version with a **3s** budget (`_DETECT_VERSION_PROBE_TIMEOUT_S`) instead of 20s. On a busy drive MakeMKV still resolves found+path quickly and the version degrades to `"MakeMKV (version probe timed out)"`. The interactive `/validate/makemkv` endpoint goes through `_validate_makemkv_binary` directly and keeps the full 20s budget (`_VERSION_PROBE_TIMEOUT_S`).
- **(b) Per-detector deadline — backstop.** `_detect_within_deadline` caps the whole MakeMKV detector at **8s** (`_MAKEMKV_DETECT_DEADLINE_S`) inside `detect_tools`. A blocking subprocess can't be interrupted, so it uses `asyncio.wait({task}, timeout=…)` to *return at* the deadline without cancelling — the orphaned worker thread finishes and its result is discarded. This structurally guarantees no slow tool can gate the others, even if something other than the probe hangs (e.g. the no-arg validity call). FFmpeg/fpcalc stay as plain `to_thread`.

`detect_makemkv` is also called by lifespan startup (`main.py`) and the diagnostics report (`_collect_environment`); both inherit the short budget, so neither stalls on a busy drive either — and both only use the version cosmetically/in a log line.

## Reviewer notes

- **Security guards unchanged.** `executable_basename_allowed` still self-guards both subprocess sinks (`_validate_makemkv_binary` and `_probe_makemkv_version`).
- **Frontend contract unchanged.** `DetectToolsResponse` shape is identical; `version` may be `null`/degraded, but the UI keys off `found`/`path`. No frontend changes needed.
- **Not implemented: option (c)** (a per-tool query param). (a)+(b) fully meet the goal without adding API surface.

## Tests (TDD — written first, watched fail, then implemented)

- `TestDetectToolsVersionProbeBudget` — the auto-detect path probes on the short budget and still returns found+path+version; the interactive path keeps the full budget.
- `TestDetectToolsDeadline::test_slow_makemkv_does_not_delay_ffmpeg_and_fpcalc` — a genuinely blocking MakeMKV detector returns degraded at the deadline while FFmpeg/fpcalc come back intact, asserting wall-clock `< 2.0s` (the slow probe never gated them).

## Verification

- `74/74` in `test_validation.py`, **1746/1746** unit tests, and the live-endpoint chromaprint integration tests all pass.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
