### PR TITLE
fix(api): correct curator import so the LLM-match button works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "Try LLM match" button in the review Inspector now works** — clicking it on a track in review did nothing useful: the backend failed instantly on a wrong internal import (it looked for an `episode_curator` that doesn't exist), caught the error, and returned a silent success, so the button appeared to do nothing and the failure only showed up in the logs. AI-assisted single-track matching from the review panel now runs the transcription and returns a suggestion as intended. (#347)
+
 ## [0.16.2] - 2026-06-05
 
 _Highlights: a fixes-only release — AI episode matching works again on Google Gemini, multi-season imports now match every episode correctly instead of dropping them into review, and tool detection no longer stalls the Settings screen on a busy optical drive._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3352,7 +3352,7 @@ async def set_show_ordering(
 
 async def _run_llm_match_for_title(*, title: "DiscTitle", job: "DiscJob") -> dict | None:
     """Invoke the LLM episode matcher for a single title. Returns suggestion dict or None."""
-    from app.core.curator import episode_curator
+    from app.core.curator import curator as episode_curator
     from app.matcher.llm_episode_matcher import match_episode_via_llm
     from app.matcher.tmdb_client import fetch_show_id
     from app.services.config_service import get_config

--- a/backend/tests/integration/test_workflow.py
+++ b/backend/tests/integration/test_workflow.py
@@ -952,3 +952,53 @@ class TestLLMMatchEndpoint:
         body = r.json()
         assert body["reason"] == "cached"
         assert body["suggestion"]["episode"] == 9
+
+    @pytest.mark.asyncio
+    async def test_run_llm_match_imports_resolve(self, setup_db, monkeypatch):
+        """Regression: the real helper must import the curator singleton correctly.
+
+        The other tests in this class mock out ``_run_llm_match_for_title`` entirely,
+        so its function-local imports were never executed — which is exactly how a
+        wrong import (``from app.core.curator import episode_curator``; the singleton
+        is named ``curator``) shipped a permanently-broken endpoint that swallowed the
+        ImportError and returned ``reason="internal_error"`` with HTTP 200.
+
+        Here we call the REAL helper. We force an early, graceful ``None`` return by
+        disabling AI matching — but the curator import runs *before* that check, so
+        pre-fix this raises ImportError and post-fix it returns None.
+        """
+        from app.api.routes import _run_llm_match_for_title
+        from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+
+        class _Config:
+            ai_episode_matching_enabled = False
+            ai_api_key = None
+            ai_provider = "gemini"
+            tmdb_api_key = ""
+
+        async def fake_config(*_args, **_kwargs):
+            return _Config()
+
+        # _run_llm_match_for_title imports get_config from this module at call time,
+        # so patching the module attribute before the call takes effect.
+        monkeypatch.setattr("app.services.config_service.get_config", fake_config)
+
+        job = DiscJob(
+            drive_id="TEST:",
+            volume_label="X_S1D1",
+            state=JobState.REVIEW_NEEDED,
+            content_type=ContentType.TV,
+            detected_title="The Expanse",
+            detected_season=1,
+        )
+        title = DiscTitle(
+            job_id=1,
+            title_index=0,
+            state=TitleState.REVIEW,
+            duration_seconds=1200,
+            file_path="/tmp/x.mkv",
+        )
+
+        # Must NOT raise ImportError; returns None because AI matching is disabled.
+        result = await _run_llm_match_for_title(title=title, job=job)
+        assert result is None


### PR DESCRIPTION
## Summary

The review Inspector's **"Try LLM match"** button failed on every click. `_run_llm_match_for_title` did `from app.core.curator import episode_curator`, but that module only exports the singleton `curator` ([curator.py:738](https://github.com/Jsakkos/engram/blob/main/backend/app/core/curator.py#L738)). The neighboring [matching_coordinator.py:17](https://github.com/Jsakkos/engram/blob/main/backend/app/services/matching_coordinator.py#L17) gets it right with `from app.core.curator import curator as episode_curator`.

Because the import is **function-local**, the app booted fine and the failure only surfaced when the button was clicked. The endpoint wraps the call in `try/except Exception` and returns HTTP **200** with `reason: "internal_error"`, so the access log showed success while the feature was silently dead — it had **never worked** since it was added.

Observed in production logs:
```
POST /api/jobs/78/titles/1057/llm-match -> 200   (internally:)
ImportError: cannot import name 'episode_curator' from 'app.core.curator'
  at app/api/routes.py:3355 in _run_llm_match_for_title
```

## Fix

One line — `backend/app/api/routes.py:3355`:
```diff
-    from app.core.curator import episode_curator
+    from app.core.curator import curator as episode_curator
```
The rest of the function already uses the local name `episode_curator`. I traced every other symbol it touches (`_ensure_initialized`, `_matcher.transcribe_full`, `fetch_show_id`, `match_episode_via_llm`) — all resolve correctly, so this fully restores the feature with no hidden second bug.

## Why it slipped through CI

Both existing endpoint tests `monkeypatch.setattr("app.api.routes._run_llm_match_for_title", fake_run)` — they replace the **entire function under test**, so its body (and the broken import) never executed.

## Test

Added `test_run_llm_match_imports_resolve`, which calls the **real** helper (forcing a graceful early return by disabling AI matching, so the curator import on line 3355 still runs first). Confirmed it fails with the exact production `ImportError` against the pre-fix code and passes after the fix.

```
4 passed (tests/integration/test_workflow.py -k llm)
ruff check: All checks passed
```

## Notes

- This needs a release to reach the user's frozen Windows build — the running binary keeps failing until a build with this fix is installed.
- Out of scope (follow-up): the endpoint returns 200 on internal errors, so users get no UI signal of failure. The frontend already carries the `reason` field; surfacing `internal_error` in the Inspector is a separate UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)