### PR TITLE
fix(ordering): narrow episode-ordering selector to aired + DVD only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Engram will be documented in this file.
 
 ### Fixed
 
+- **The review panel's episode-ordering picker now offers only Aired and DVD order** — the per-show ordering selector in the review queue could show extra buttons (digital, story-arc, production, TV) whenever a show happened to have those alternative orderings on TMDB, even though the global Episode Ordering setting only ever offered Aired and DVD. The two surfaces now agree: both offer just Aired and DVD. The other orderings are still recognized internally but no longer selectable, and matching, history, and the fingerprint network remain on canonical aired numbering as before. (#348)
 - **The "Try LLM match" button in the review Inspector now works** — clicking it on a track in review did nothing useful: the backend failed instantly on a wrong internal import (it looked for an `episode_curator` that doesn't exist), caught the error, and returned a silent success, so the button appeared to do nothing and the failure only showed up in the logs. AI-assisted single-track matching from the review panel now runs the transcription and returns a suggestion as intended. (#347)
 
 ## [0.16.2] - 2026-06-05

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -615,7 +615,7 @@ class RosterEpisode(BaseModel):
 class OrderingOption(BaseModel):
     """One selectable output ordering for a show (#200)."""
 
-    ordering: str  # "aired" | "dvd" | "digital" | ...
+    ordering: str  # "aired" | "dvd" (v1 scope)
     label: str  # human label (TMDB group name, e.g. "DVD Order")
     tmdb_type: int  # TMDB episode-group type enum
     diverges: bool  # does this ordering renumber any matched episode on the disc

--- a/backend/app/core/episode_ordering.py
+++ b/backend/app/core/episode_ordering.py
@@ -48,17 +48,19 @@ _TMDB_TYPE_TO_ORDERING = {
 }
 _ORDERING_TO_TMDB_TYPE = {v: k for k, v in _TMDB_TYPE_TO_ORDERING.items()}
 
-# Orderings selectable in v1. Aired is the canonical default (identity, never
-# fetches a group). Absolute (type 2) is DEFERRED: it dissolves season
-# boundaries and anime corpora are frequently mislabeled — a separate follow-up.
+# Orderings selectable in v1: aired + DVD only. Aired is the canonical default
+# (identity, never fetches a group); DVD is the one alternative users actually
+# ask for (Firefly et al.) and the only one the Config UI exposes. The remaining
+# TMDB group types are recognized (see the type map above) but DEFERRED so the
+# review-queue selector never offers more than these two — keeping the per-show
+# selector in lock-step with the global Config dropdown:
+#   - absolute (type 2): dissolves season boundaries; anime corpora mislabeled
+#   - digital (4) / story_arc (5) / production (6) / tv (7): no demonstrated need
+# Re-enable one by adding its constant back to this frozenset (and the Config UI).
 ALLOWED_ORDERINGS = frozenset(
     {
         ORDERING_AIRED,
         ORDERING_DVD,
-        ORDERING_DIGITAL,
-        ORDERING_STORY_ARC,
-        ORDERING_PRODUCTION,
-        ORDERING_TV,
     }
 )
 

--- a/backend/app/models/show_ordering.py
+++ b/backend/app/models/show_ordering.py
@@ -25,7 +25,7 @@ class ShowOrderingPreference(SQLModel, table=True):
 
     # tmdb_id is the natural key — one preference per show.
     tmdb_id: int = Field(primary_key=True)
-    # One of episode_ordering.ALLOWED_ORDERINGS ("aired", "dvd", "digital", ...).
+    # One of episode_ordering.ALLOWED_ORDERINGS ("aired" or "dvd" in v1).
     ordering: str = Field(default="aired")
     # The resolved TMDB episode-group id for this ordering, cached so the
     # projection can skip re-resolving the group on every organize. NULL until

--- a/backend/tests/unit/test_episode_ordering.py
+++ b/backend/tests/unit/test_episode_ordering.py
@@ -69,7 +69,8 @@ class TestProjectEpisode:
         assert episode_ordering.project_episode(FIREFLY, "dvd", 9, 99, "k") == (9, 99)
 
     def test_ordering_with_no_group_falls_back(self, firefly_tmdb):
-        # Firefly has no "digital" (type 4) group -> identity.
+        # "digital" is deferred (not in ALLOWED_ORDERINGS), so get_projection_map
+        # short-circuits to identity before any group lookup.
         assert episode_ordering.project_episode(FIREFLY, "digital", 1, 1, "k") == (1, 1)
 
     def test_missing_key_falls_back_without_fetching(self, firefly_tmdb):

--- a/backend/tests/unit/test_episode_ordering.py
+++ b/backend/tests/unit/test_episode_ordering.py
@@ -170,6 +170,44 @@ class TestBuildOrderingOptions:
         assert opts["diverges"] is False
         assert [o["ordering"] for o in opts["options"]] == ["aired"]
 
+    def test_only_aired_and_dvd_surfaced_even_when_other_groups_exist(self):
+        # v1 scope is narrowed to aired + DVD: a show carrying digital/story-arc/
+        # production/tv groups that diverge must still surface ONLY aired + DVD,
+        # so the review-queue selector never shows more than two buttons.
+        groups = [
+            {"id": "g_dvd", "type": 3, "name": "DVD Order", "episode_count": 14, "group_count": 1},
+            {"id": "g_dig", "type": 4, "name": "Digital", "episode_count": 14, "group_count": 1},
+            {"id": "g_sto", "type": 5, "name": "Story Arc", "episode_count": 14, "group_count": 1},
+            {"id": "g_pro", "type": 6, "name": "Production", "episode_count": 14, "group_count": 1},
+            {"id": "g_tv", "type": 7, "name": "TV", "episode_count": 14, "group_count": 1},
+        ]
+        remap = {(1, 1): (1, 2), (1, 2): (1, 1)}  # every non-aired ordering diverges
+        with (
+            patch(
+                "app.core.episode_ordering.tmdb_client.fetch_episode_groups", return_value=groups
+            ),
+            patch("app.core.episode_ordering.get_projection_map", return_value=remap),
+        ):
+            opts = episode_ordering.build_ordering_options(
+                "999", 1, roster_pairs=[(1, 1), (1, 2)], matched_pairs=[(1, 1)], api_key="k"
+            )
+        orderings = [o["ordering"] for o in opts["options"]]
+        assert orderings == ["aired", "dvd"]
+        for deferred in ("digital", "story_arc", "production", "tv"):
+            assert deferred not in orderings
+
+
+@pytest.mark.unit
+class TestAllowedOrderingsScope:
+    """v1 selectable scope is narrowed to aired + DVD; everything else deferred."""
+
+    def test_allowed_orderings_are_exactly_aired_and_dvd(self):
+        assert episode_ordering.ALLOWED_ORDERINGS == frozenset({"aired", "dvd"})
+
+    @pytest.mark.parametrize("deferred", ["digital", "story_arc", "production", "tv", "absolute"])
+    def test_deferred_orderings_excluded(self, deferred):
+        assert deferred not in episode_ordering.ALLOWED_ORDERINGS
+
 
 @pytest.mark.unit
 class TestComputeDivergence:

--- a/backend/tests/unit/test_episode_ordering_api.py
+++ b/backend/tests/unit/test_episode_ordering_api.py
@@ -39,6 +39,12 @@ class TestConfigOrderingPreference:
         resp = await client.put("/api/config", json={"episode_ordering_preference": "absolute"})
         assert resp.status_code == 422
 
+    @pytest.mark.parametrize("deferred", ["digital", "story_arc", "production", "tv"])
+    async def test_put_config_rejects_deferred_orderings(self, client, deferred):
+        # v1 scope is aired + DVD only; the other TMDB group types are deferred.
+        resp = await client.put("/api/config", json={"episode_ordering_preference": deferred})
+        assert resp.status_code == 422
+
     async def test_put_config_rejects_unknown(self, client):
         resp = await client.put("/api/config", json={"episode_ordering_preference": "bogus"})
         assert resp.status_code == 422

--- a/frontend/src/components/ReviewQueue/types.ts
+++ b/frontend/src/components/ReviewQueue/types.ts
@@ -45,7 +45,7 @@ export interface RosterEpisode {
 
 /** One selectable output ordering for a show (#200). */
 export interface OrderingOption {
-    ordering: string; // "aired" | "dvd" | "digital" | ...
+    ordering: string; // "aired" | "dvd" (v1 scope)
     label: string; // human label (e.g. "DVD Order")
     tmdb_type: number;
     /** Whether this ordering renumbers any episode matched on this disc. */


### PR DESCRIPTION
## What

The review-queue per-show **episode-ordering selector** could show more than two buttons — one per TMDB episode-group type a show happens to have (digital, story-arc, production, TV) — even though the global **Episode Ordering** setting in the Config wizard only ever offered **Aired** and **DVD**. The two surfaces disagreed; a show with several diverging groups showed up to 6 options in review.

This narrows the selectable set so both surfaces agree: **Aired + DVD only.**

## Why

`ALLOWED_ORDERINGS` in `backend/app/core/episode_ordering.py` is the single gate consumed by:
- `build_ordering_options()` — the review-panel selector (frontend just renders what the backend sends)
- config + per-show API validation (`PUT /api/config`, `PUT /api/shows/{id}/ordering`)
- the per-show ordering resolver

It contained six orderings while the Config UI was deliberately limited to `aired`/`dvd` (#259). Narrowing the frozenset to `{aired, dvd}` brings every surface into lock-step in one change.

The deferred group-type constants and the TMDB `type`→ordering map are **kept** (recognized-but-deferred, mirroring how `absolute` was already handled), so re-enabling any later is a one-token change (add the constant back to the frozenset + the Config UI).

## Reviewer notes

- **Reverses a previously-deliberate decision.** PR #259 intentionally kept the per-show selector wide while the global dropdown stayed narrow. The maintainer confirmed they want both surfaces at aired+DVD, so this reverses that.
- **Invariant untouched:** canonical TMDB **aired** numbering remains the sole identity for matching, job history, and the fingerprint network. This only affects which output orderings a user can *select*.
- Config/per-show API now returns **422** for `digital`/`story_arc`/`production`/`tv` (same as `absolute` already did).

## Tests

- New `TestAllowedOrderingsScope` (allow-list is exactly `{aired, dvd}`; deferred types excluded).
- New `test_only_aired_and_dvd_surfaced_even_when_other_groups_exist` — a show with diverging digital/story-arc/production/tv groups still surfaces only Aired + DVD.
- Extended config API rejection coverage to the deferred orderings.
- Followed TDD (watched all 10 new assertions fail first). Full ordering suite: **58 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)