### PR TITLE
chore: release v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-06-07
+
+_Highlights: a fixes-only release — the Windows "Restart to update" now runs to completion and actually installs the update, and the review panel's AI/LLM episode-matching button works again and clearly reports what it found._
+
 ### Changed
 
 - The review Inspector's "Try LLM match" endpoint now returns a differentiated `reason` (e.g. `ai_disabled`, `not_configured`, `no_season`, `show_not_found`, `transcription_failed`, `no_match`, `llm_error`) and uses HTTP 503 for retryable operational failures (matcher/transcription/LLM-provider errors) and 500 for unexpected errors, instead of reporting every failure as a 200. This lets the UI tell "AI matching is off / couldn't find a match" apart from "the LLM provider failed, retry". (#347 follow-up)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.16.2"
+__version__ = "0.16.3"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.16.2"
+version = "0.16.3"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.16.2"
+version = "0.16.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.16.2",
+    "version": "0.16.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.16.2",
+            "version": "0.16.3",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.16.2",
+    "version": "0.16.3",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Cut **v0.16.3** — a fixes-only release.

On squash-merge, `tag-release.yml` matches the `chore: release v` subject, re-reads the version from `backend/pyproject.toml`, pushes the `v0.16.3` tag, and dispatches `release.yml` (Win/Linux/macOS-arm64 binaries + GitHub release) and `docker.yml` (GHCR image).

## Version bump (6 fields, lockstep)
- `backend/pyproject.toml`
- `backend/app/__init__.py` (`__version__`)
- `backend/uv.lock` (`engram-backend`)
- `frontend/package.json`
- `frontend/package-lock.json` (both root + `packages.""` self-version)
- `CHANGELOG.md` — new `## [0.16.3] - 2026-06-07` section (UTC date), `[Unreleased]` left empty above it

## Release notes (extracted into the GitHub release body)
_Highlights: a fixes-only release — the Windows "Restart to update" now runs to completion and actually installs the update, and the review panel's AI/LLM episode-matching button works again and clearly reports what it found._

### Changed
- llm-match endpoint returns a differentiated `reason` + correct HTTP status (503 retryable / 500 unexpected) instead of always-200 (#347 follow-up)

### Fixed
- Review episode-ordering picker now offers only Aired and DVD (#348)
- "Try LLM match" button in the review Inspector now works (curator import fix) (#347)
- "Try AI match" now reports its outcome + shows a pending state (#349)
- Windows "Restart to update" runs to completion — console-less `tasklist` hang fix + no duplicate tab (#351)

## Verification
- `changelog-version-check` extractor passes: `extract_changelog.py --version 0.16.3 --check` → `ok`
- Diff is exactly the 6 version files (no `npm install` lockfile churn)
- No new external contributors this release, so `CONTRIBUTORS.md` is unchanged

> Do not merge this yourself — merging triggers the publish. Leaving it for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)