### PR TITLE
docs: add Performance & Hardware and Import Watch Folder guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ cd backend
 uv sync --extra gpu
 ```
 
+An NVIDIA GPU is auto-detected and speeds up episode matching considerably. The prebuilt
+standalone and Docker builds are CPU-only — see [Performance & Hardware](docs/guide/performance.md)
+for GPU setup, storage recommendations, and concurrency tuning.
+
 Then start the two dev servers in separate terminals:
 
 ```bash
@@ -167,7 +171,7 @@ See the [configuration guide](docs/getting-started/configuration.md) for the ful
 Full documentation is published at **[jsakkos.github.io/engram](https://jsakkos.github.io/engram/)**.
 
 - **Getting started** — [Installation](docs/getting-started/installation.md) · [Configuration](docs/getting-started/configuration.md) · [Simulation](docs/getting-started/simulation.md) · [Troubleshooting](docs/troubleshooting.md)
-- **User guide** — [Dashboard](docs/guide/dashboard.md) · [Review Queue](docs/guide/review-queue.md) · [Job History](docs/guide/history.md) · [Linux / macOS setup](docs/guide/linux-setup.md)
+- **User guide** — [Dashboard](docs/guide/dashboard.md) · [Import Watch Folder](docs/guide/import-watch-folder.md) · [Performance & Hardware](docs/guide/performance.md) · [Review Queue](docs/guide/review-queue.md) · [Job History](docs/guide/history.md) · [Linux / macOS setup](docs/guide/linux-setup.md)
 - **Architecture** — [Overview](docs/architecture/overview.md) · [State Machine](docs/architecture/state-machine.md) · [WebSocket Protocol](docs/architecture/websocket.md)
 - **API reference** — [REST Endpoints](docs/api/rest.md) · [Data Models](docs/api/models.md)
 - **Development** — [Contributing](CONTRIBUTING.md) · [Testing](docs/development/testing.md) · [Subtitle Cache Build](docs/development/subtitle-cache.md)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -113,14 +113,20 @@ Configuration is resolved in this priority order:
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `max_concurrent_matches` | Parallel episode matching jobs | `3` |
-| `conflict_resolution_default` | File conflict handling | `"skip"` |
+| `max_concurrent_matches` | Parallel episode-matching (ASR) tasks | `2` |
+| `matcher_min_confidence` | Minimum confidence to auto-accept an episode match | `0.6` |
+| `conflict_resolution_default` | File conflict handling | `"ask"` |
 
-The `conflict_resolution_default` field accepts one of three values:
+`max_concurrent_matches` is the main matching-throughput knob. It's clamped to your hardware and
+takes effect on restart — see [Performance & Hardware](../guide/performance.md#concurrency-tuning)
+for how to tune it for CPU vs GPU and bulk imports.
 
+The `conflict_resolution_default` field accepts one of four values:
+
+- `"ask"` -- prompt via the review queue (default)
 - `"skip"` -- skip files that already exist in the library
 - `"overwrite"` -- replace existing files
-- `"ask"` -- prompt via the review queue
+- `"rename"` -- keep both by writing a numbered `(vN)` variant
 
 ### AI-Powered Title Resolution
 
@@ -144,7 +150,30 @@ Controls how bonus content (behind-the-scenes, deleted scenes, etc.) is handled 
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `extras_policy` | How to handle extras | `"skip"` |
+| `extras_policy` | How to handle extras (`"keep"`, `"skip"`, `"ask"`) | `"keep"` |
+
+### Import Watch Folder
+
+Engram can auto-ingest pre-ripped MKV files dropped into a watched folder. See the
+[Import Watch Folder guide](../guide/import-watch-folder.md) for folder layouts and the full
+workflow.
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `import_watch_path` | Folder to watch for incoming MKV files (unset = disabled) | *(none)* |
+| `import_destination_mode` | `"library"` files imports into your Movies/TV libraries; `"in_place"` organizes them inside the watch folder | `"library"` |
+| `staging_watch_enabled` | Also auto-import folders dropped into the staging directory | `false` |
+
+### Staging Cleanup
+
+Controls when the staging directory is reclaimed after a job finishes. Watch-folder imports are
+never deleted regardless of this setting (the source folder is yours). See
+[sizing the staging directory](../guide/performance.md#sizing-the-staging-directory).
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `staging_cleanup_policy` | `"on_success"`, `"on_completion"`, `"manual"`, or `"after_days"` | `"on_success"` |
+| `staging_cleanup_days` | Retention period when policy is `"after_days"` | `7` |
 
 ### Naming Conventions
 

--- a/docs/guide/import-watch-folder.md
+++ b/docs/guide/import-watch-folder.md
@@ -30,23 +30,24 @@ up front (show **and** season), the better and faster the matching.
 
 ```text
 import_watch_path/
-├── The Expanse/              ← 1. Show → Season subfolders  (recommended)
+├── The Expanse/              ← Show → Season subfolders  (recommended)
 │   ├── Season 01/
 │   │   ├── episode.mkv
 │   │   └── episode.mkv
 │   └── Season 02/
 │       └── ...
-├── THE_OFFICE_S1D1/          ← 3. Per-disc / loose subfolder (ARM-style)
+├── THE_OFFICE_S1D1/          ← Per-disc / loose subfolder (ARM-style)
 │   ├── title_t00.mkv
 │   └── title_t01.mkv
-└── loose_episode.mkv         ← 4. Flat: loose files at the root
+└── loose_episode.mkv         ← Flat: loose files at the root
 ```
 
 1. **Show → Season subfolders** — `Show Name/Season 01/*.mkv`. **Recommended.** Both the show and
    the season are read straight from the folder names, which gives the most accurate matching.
 2. **Watch folder is the show** — point `import_watch_path` directly at a single show's folder that
    contains `Season NN` subfolders (`import_watch_path/Season 01/*.mkv`). The show name comes from
-   the watch folder itself, the season from the subfolder.
+   the watch folder itself, the season from the subfolder. *(Not shown in the tree above — this
+   layout points `import_watch_path` at the show root itself rather than at a parent folder.)*
 3. **Per-disc / loose subfolder** — any subfolder of MKVs that isn't a season folder (e.g. an ARM
    per-disc dump like `THE_OFFICE_S1D1/`). With no season hint, Engram identifies the show and
    episodes from the content and matches **across all seasons** — this works but is slower.
@@ -63,9 +64,9 @@ import_watch_path/
 
 Engram doesn't grab files the instant they appear — that would catch them mid-copy. Instead it
 waits for a folder to go **stable**: the MKV count and total size must be unchanged across two
-consecutive polls before an import fires. In practice that's a few seconds after a copy finishes,
-which is what lets you drop in large files (or have ARM write them) without Engram starting too
-early.
+consecutive polls before an import fires. With the poll interval at roughly two seconds, that means
+a folder is picked up about **four or more seconds after the last file finishes copying** — which is
+what lets you drop in large files (or have ARM write them) without Engram starting too early.
 
 Each stable folder becomes one job. A multi-season show in layout 1 produces **one job per season
 folder**.

--- a/docs/guide/import-watch-folder.md
+++ b/docs/guide/import-watch-folder.md
@@ -1,0 +1,123 @@
+# Import Watch Folder
+
+The Import Watch Folder lets Engram ingest **pre-ripped MKV files** without a physical disc. Point
+it at a directory, drop files in (by hand, or automatically from a tool like
+[AutomaticRippingMachine](https://github.com/automatic-ripping-machine/automatic-ripping-machine)),
+and Engram runs them through the same identify → match → organize pipeline it uses for discs.
+
+It's the right tool for:
+
+- Importing an existing library of pre-ripped files.
+- Machines without an optical drive (the primary workflow on macOS).
+- Chaining Engram after an external ripper that writes finished MKVs to a folder.
+
+## Enable it
+
+In **Settings**, set:
+
+| Setting | What it does |
+|---------|--------------|
+| `import_watch_path` | The folder Engram watches for incoming MKVs. |
+| `import_destination_mode` | Where matched files end up. `library` (default) files them into your configured Movies/TV libraries, like a disc rip. `in_place` organizes them into a `Movies/` and `TV/` structure **inside the watch folder itself** — useful when the watch folder *is* your library. |
+
+Saving reloads the watcher immediately (no restart needed). Engram then polls the folder about
+every couple of seconds.
+
+## Folder layouts
+
+What Engram can tell from your folder structure determines how well it matches. The more it knows
+up front (show **and** season), the better and faster the matching.
+
+```text
+import_watch_path/
+├── The Expanse/              ← 1. Show → Season subfolders  (recommended)
+│   ├── Season 01/
+│   │   ├── episode.mkv
+│   │   └── episode.mkv
+│   └── Season 02/
+│       └── ...
+├── THE_OFFICE_S1D1/          ← 3. Per-disc / loose subfolder (ARM-style)
+│   ├── title_t00.mkv
+│   └── title_t01.mkv
+└── loose_episode.mkv         ← 4. Flat: loose files at the root
+```
+
+1. **Show → Season subfolders** — `Show Name/Season 01/*.mkv`. **Recommended.** Both the show and
+   the season are read straight from the folder names, which gives the most accurate matching.
+2. **Watch folder is the show** — point `import_watch_path` directly at a single show's folder that
+   contains `Season NN` subfolders (`import_watch_path/Season 01/*.mkv`). The show name comes from
+   the watch folder itself, the season from the subfolder.
+3. **Per-disc / loose subfolder** — any subfolder of MKVs that isn't a season folder (e.g. an ARM
+   per-disc dump like `THE_OFFICE_S1D1/`). With no season hint, Engram identifies the show and
+   episodes from the content and matches **across all seasons** — this works but is slower.
+4. **Flat** — loose `*.mkv` files directly in the watch root. Same as above: matched across all
+   seasons.
+
+!!! note "Season folder spelling and mixed roots"
+    Season folders may be written `Season 1` or `Season 01` (both parse). If the watch **root**
+    contains *both* loose MKV files and structured subfolders, the subfolders win and the loose
+    top-level files are **left un-imported** — move them into a season (or disc) folder to import
+    them.
+
+## How detection works
+
+Engram doesn't grab files the instant they appear — that would catch them mid-copy. Instead it
+waits for a folder to go **stable**: the MKV count and total size must be unchanged across two
+consecutive polls before an import fires. In practice that's a few seconds after a copy finishes,
+which is what lets you drop in large files (or have ARM write them) without Engram starting too
+early.
+
+Each stable folder becomes one job. A multi-season show in layout 1 produces **one job per season
+folder**.
+
+## The import lifecycle
+
+Because the files already exist, imports **skip the ripping phase** entirely. On the dashboard you'll
+see a job move through:
+
+1. **Identifying** — Engram probes each MKV's duration, then classifies the content (TMDB lookup,
+   using the show/season hints from the folder layout when available) and creates a title per file.
+2. **Matching** *(TV only)* — each title is transcribed and matched to an episode. Titles beyond
+   your `max_concurrent_matches` limit wait in **QUEUED** until a slot frees up (see
+   [Performance & Hardware](performance.md#concurrency-tuning)).
+3. **Organizing** — matched files are moved into your library (or organized in place, per
+   `import_destination_mode`), with subtitles placed alongside. Movies skip matching and go
+   straight here.
+4. **Completed** — the job lands in [history](history.md). Low-confidence matches surface in the
+   [review queue](review-queue.md) for your confirmation rather than being filed automatically.
+
+## Your source files are safe
+
+For watch-folder imports, **Engram never deletes your source folder.** Unlike a disc rip — whose
+staging directory is a throwaway temp folder — an import's source is your own original files. The
+staging-cleanup step explicitly skips import jobs, so even with `staging_cleanup_policy` set to
+delete on success, your watch folder is left intact. Imported files leave the folder only by being
+**moved into the library** on success (in `library` mode); anything Engram didn't import — skipped
+season folders, strays — is never touched.
+
+## Multi-season and bulk imports
+
+Pointing the watch folder at a whole library works well:
+
+- Each season (or disc) folder becomes its own independent job.
+- All of those jobs share the global matching limit, so matching proceeds about
+  `max_concurrent_matches` titles at a time rather than all at once. Raise that setting (within your
+  hardware) before a big import — see [Performance & Hardware](performance.md#bulk-imports-and-large-libraries).
+
+## Import vs physical disc
+
+| Aspect | Physical disc | Import watch folder |
+|--------|---------------|---------------------|
+| Ripping phase | Yes (MakeMKV extracts from the disc) | No — files already exist |
+| Source location | Temporary `job_*` folder under staging | Your watch folder (`import_watch_path`) |
+| Cleanup on success | Temp folder deleted | **Never deleted** — it's your source |
+| Season detection | From the disc volume label | From the folder layout (best) or content |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Nothing imports | Wrong path, files still copying, or an unsupported layout | Confirm `import_watch_path`; wait for the copy to finish (stability gate); check the layouts above |
+| A season folder was skipped | Loose files at the root alongside structured subfolders | Move the loose files into a season/disc folder |
+| Everything goes to review with low confidence | No season hint, or a generic label that didn't resolve a show | Use the **Show → Season subfolders** layout so the show and season are explicit |
+| Matching is slow | Flat / no-season layout searches every season | Organize into season subfolders; see [Performance & Hardware](performance.md) |

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -1,0 +1,165 @@
+# Performance & Hardware
+
+Engram runs comfortably on modest hardware, but a few choices — GPU vs CPU for transcription,
+where you put the staging directory, and how many matches run in parallel — make a large
+difference to how fast a stack of discs gets through the pipeline. This page explains the
+knobs that already exist and how to plan hardware around them.
+
+The expensive stages are **ripping** (disk + optical drive throughput, handled by MakeMKV) and
+**episode matching** (audio transcription via faster-whisper). Everything else — identification,
+organization, the dashboard — is cheap by comparison.
+
+## Hardware at a glance
+
+These are practical recommendations, not enforced minimums. Engram will start and run on less.
+
+| Component | Works on | Recommended | Why it matters |
+|-----------|----------|-------------|----------------|
+| **CPU** | Any modern 64-bit CPU | 4+ **physical** cores | More cores let you raise `max_concurrent_matches` so several titles transcribe at once. |
+| **RAM** | ~4 GB | 8 GB+ | The Whisper model plus ripping buffers; more headroom helps when matching several titles in parallel. |
+| **GPU** | None — CPU is fully supported | NVIDIA GPU with CUDA | Optional. Speeds up **matching only** (not ripping). Auto-detected when present. |
+| **Storage (staging)** | HDD / NAS | **SSD on the same volume as your library** | Transcription re-reads each file, and same-volume organization is an instant rename instead of a full copy. |
+
+## GPU acceleration (faster-whisper ASR)
+
+Episode matching transcribes each ripped title with [faster-whisper](https://github.com/SYSTRAN/faster-whisper).
+Engram **auto-detects** your hardware — there's no device setting to configure:
+
+- If a CUDA-capable NVIDIA GPU is visible, Engram uses it with the `float16` compute type.
+- Otherwise it runs on CPU with the `int8` compute type (quantized for speed).
+- If CUDA libraries are missing or fail to load at runtime, it **silently falls back to CPU** —
+  matching still works, just slower.
+
+GPU transcription is several times faster than CPU for the same model, which is the single
+biggest lever on matching throughput.
+
+### Verify which backend is active
+
+Engram exposes the resolved ASR runtime at **`GET /api/asr-status`** (also shown as the ASR badge
+on the dashboard). It returns no secrets and is the authoritative answer to "is my GPU being used?":
+
+```bash
+curl http://localhost:8000/api/asr-status
+```
+
+```json
+{
+  "device": "cuda",
+  "compute_type": "float16",
+  "model": "small",
+  "workers": 4,
+  "cpu_threads": null,
+  "max_concurrent_matches": 4
+}
+```
+
+`device: "cpu"` means no GPU was detected — check your CUDA install if you expected otherwise.
+
+### Getting a GPU-enabled build
+
+GPU support ships with the CUDA extras when you run **from source**:
+
+```bash
+cd backend
+uv sync --extra gpu
+```
+
+!!! note "Standalone and Docker builds are CPU-only"
+    The prebuilt standalone executables and the Docker image are **CPU-only** today. To use an
+    NVIDIA GPU, run [from source](../getting-started/installation.md) with `uv sync --extra gpu`.
+    See the [Docker guide](../deployment/docker.md) for the container's GPU notes.
+
+### Whisper model
+
+The matcher currently uses the **`small`** model (≈465 MB, English-capable, good accuracy on
+CPU). It is hardcoded — there is no user-facing model selector yet. For reference, faster-whisper
+models trade size for accuracy and speed:
+
+| Model | Disk size | Quality | Speed | GPU |
+|-------|-----------|---------|-------|-----|
+| `tiny` | 75 MB | basic | fastest | not required |
+| `base` | 145 MB | good | fast | not required |
+| **`small`** (default) | 465 MB | better | medium | not required |
+| `medium` | 1.5 GB | best | slow | recommended |
+| `large-v3` | 3 GB | best | slowest | 10 GB+ VRAM |
+
+The model downloads once on first use and is cached locally; larger models also use proportionally
+more memory (VRAM on GPU, RAM on CPU).
+
+## Storage: SSD vs HDD vs NAS
+
+Ripped and imported MKVs land in the **staging directory** (`staging_path`) first, then get moved
+into your library when a job completes.
+
+!!! tip "Keep staging and your library on the same volume"
+    Organization uses an atomic `shutil.move()`. On the **same filesystem** that's an instant
+    rename — no data is copied. Across **different volumes** (e.g. staging on your system SSD,
+    library on a NAS) it becomes a full copy-then-delete of every file, which is slow and uses
+    temporary double space. Put `staging_path`, `library_movies_path`, and `library_tv_path` on
+    the same drive when you can.
+
+Beyond the move, transcription **reads each title's audio repeatedly** while sampling it. That
+makes staging I/O latency matter:
+
+- **SSD** — recommended for staging. Fast random reads keep matching fed.
+- **HDD** — works fine; expect somewhat slower matching and (cross-volume) organization.
+- **NAS / network share** — usable for the **final library**, but avoid it for **staging**:
+  network latency and seek times slow both transcription and the copy fallback. If you must
+  stage on a NAS, expect noticeably longer matching.
+
+### Sizing the staging directory
+
+Staging needs roughly **(number of discs ripping at once) × (disc size)** of free space, plus
+headroom for the copy fallback if your library is on another volume. A dual-layer Blu-ray rip can
+be **30–50 GB**; a DVD is a few GB. Staging is reclaimed automatically per the
+`staging_cleanup_policy` setting (default: delete on success).
+
+## Concurrency tuning
+
+`max_concurrent_matches` (default **2**) controls how many titles transcribe in parallel. It's the
+main throughput knob once ripping is done.
+
+How it works under the hood:
+
+- One shared Whisper model serves all matches (using faster-whisper's `num_workers`), so raising
+  the value adds **CPU/RAM pressure, not duplicated model weights/VRAM**.
+- The value is clamped to your hardware by `resolve_asr_runtime()`: on **CPU** it's capped at your
+  physical core count (and CPU threads are divided across workers to avoid oversubscription); on
+  **GPU** it's capped at 4 parallel streams.
+- It also sizes the matching admission semaphore, so at most that many titles show **MATCHING** at
+  once; the rest wait in **QUEUED**. (You'll see this on the dashboard during a multi-title disc or
+  bulk import.)
+
+Guidance:
+
+- **CPU-only, multi-core:** raising it to ~4–8 (within your core count) speeds up bulk work.
+- **GPU:** keep it modest to avoid VRAM spikes; the GPU cap of 4 already bounds it.
+
+!!! note "Takes effect after a restart"
+    `num_workers` is fixed when the Whisper model loads, so changes to `max_concurrent_matches`
+    apply on the next **backend restart**.
+
+## Bulk imports and large libraries
+
+There's no special batch parallelism for big imports — many files and seasons are naturally
+serialized by the matching semaphore, so steady-state matching throughput is roughly
+`max_concurrent_matches` titles at a time. Practical advice for migrating a large library:
+
+- Raise `max_concurrent_matches` to suit your cores/GPU before starting.
+- Make sure the precomputed subtitle cache is in place (it ships and installs on first run) so
+  matching isn't waiting on subtitle downloads.
+- Kick off large imports when you don't need the machine, and watch the dashboard ASR badge to
+  confirm `workers > 1`.
+
+See the [Import Watch Folder guide](import-watch-folder.md) for how to feed Engram a whole library
+of pre-ripped files.
+
+## Troubleshooting performance
+
+| Symptom | Likely cause | What to check |
+|---------|--------------|---------------|
+| Many titles **MATCHING** but only one progresses; low CPU | Only one ASR worker is active | `GET /api/asr-status` — if `workers` is 1, raise `max_concurrent_matches` and restart |
+| Matching slower than expected on a capable PC | Running on CPU unexpectedly | `device` in `/api/asr-status`; verify your CUDA install / use a `--extra gpu` source build |
+| Organization step is slow / uses lots of temp space | Staging and library are on different volumes | Move them onto the same filesystem so the move is an atomic rename |
+| Identification stalls or is slow | Network latency to TMDB / subtitle / TheDiscDB services | This affects identification only, not ripping; check connectivity |
+| Staging fills up the disk | Concurrent rips × disc size exceeds free space | Free space, or stagger rips; confirm `staging_cleanup_policy` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,8 @@ Import Watch Folder/
 
 Season folders may be written `Season 1` or `Season 01`. When there's no season folder, matching searches every season of the show, which works but is slower.
 
+**→ Full walkthrough: [Import Watch Folder](guide/import-watch-folder.md)** — every layout, the import lifecycle, and why your source files are never deleted.
+
 ---
 
 <div style="text-align: center;" markdown>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,8 @@ nav:
     - Simulation: getting-started/simulation.md
   - User Guide:
     - Dashboard: guide/dashboard.md
+    - Import Watch Folder: guide/import-watch-folder.md
+    - Performance & Hardware: guide/performance.md
     - Linux / macOS Setup: guide/linux-setup.md
     - Review Queue: guide/review-queue.md
     - Job History: guide/history.md


### PR DESCRIPTION
## What & why

A user-perspective review of the docs found that several capabilities **already in the code** were undiscoverable: GPU auto-detection for faster-whisper, the `/api/asr-status` verification endpoint, the `max_concurrent_matches` concurrency knob, same-volume atomic-move organization, and the full import-watch-folder workflow. This PR documents them, plus fixes some stale config defaults found along the way.

Scope is documentation-only (Markdown + `mkdocs.yml`); no code changes.

## New guides (`docs/guide/`)

- **[Performance & Hardware](https://github.com/Jsakkos/engram/blob/claude/serene-lehmann-618952/docs/guide/performance.md)** — hardware-at-a-glance recommendations; GPU auto-detect (CUDA → `float16`, else CPU → `int8`, silent fallback) and how to verify it with `GET /api/asr-status`; SSD vs HDD vs NAS staging (keep staging + library on the same volume so organization is an atomic rename); staging sizing; `max_concurrent_matches` tuning; bulk-import expectations; a perf troubleshooting table.
- **[Import Watch Folder](https://github.com/Jsakkos/engram/blob/claude/serene-lehmann-618952/docs/guide/import-watch-folder.md)** — enable it; the four folder layouts; how stability detection avoids grabbing files mid-copy; the state-by-state import lifecycle (no ripping phase); why import **source folders are never deleted** (the `drive_id == "import"` cleanup guard); multi-season/bulk; a disc-vs-import comparison table; troubleshooting.

## Supporting edits

- `mkdocs.yml` — both pages added to the **User Guide** nav.
- `docs/getting-started/configuration.md` — **fixes three stale defaults** (`max_concurrent_matches` 3→2, `conflict_resolution_default` skip→ask, `extras_policy` skip→keep); adds **Import Watch Folder** and **Staging Cleanup** field groups; cross-links the new guides.
- `README.md` — GPU note now points to the perf guide (flags standalone/Docker builds as CPU-only); both guides added to the Documentation index.
- `docs/index.md` — the import blurb links out to the full walkthrough.

## Notes for reviewers

- Every code-derived claim was verified against current source (e.g. `asr_models.py` auto-detect + `GPU_WORKER_CAP=4`, `app_config.py` defaults, `staging_watcher.py` layout patterns + `STABILITY_THRESHOLD`, `cleanup_service.py` import guard, `organizer.py` `shutil.move`), not from memory.
- Verified with `mkdocs build` — **no warnings on any new or edited page**. (`--strict` aborts only on ~18 **pre-existing** warnings from `docs/superpowers/specs/*` design docs linking to source files; CI deploys without `--strict`.)
- In-page anchor cross-links were hand-checked against headings, since mkdocs `--strict` doesn't validate anchors by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)