### PR TITLE
feat(asr): opt-in GPU acceleration for faster-whisper + honest device badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **GPU acceleration for episode matching (NVIDIA, opt-in)** — Engram can now run Whisper transcription on an NVIDIA GPU instead of the CPU, which is dramatically faster for episode matching. Because the required CUDA libraries (cuDNN + cuBLAS) are ~1.2 GB, they are not bundled into the download; instead a new **GPU Acceleration** control in Settings → Matching detects your GPU and downloads the runtime on demand (one time, into `~/.engram/` so it survives app updates). Supported on Windows and Linux with an NVIDIA GPU; macOS and AMD GPUs continue to run on the CPU (the engine has no GPU path there). Takes effect after a backend restart.
+
+### Fixed
+
+- **The ASR status badge no longer claims "CUDA" when it's actually using the CPU** — on a machine with an NVIDIA GPU, the dashboard badge showed `ASR: CUDA …` based purely on the GPU being *present*, even though the compiled build had no CUDA math libraries and silently fell back to the CPU for every match. The badge now reports the device transcription actually runs on, and when a GPU is available but unused it shows an actionable `CPU · GPU available →` chip that opens the new GPU setting.
+
 ## [0.16.3] - 2026-06-07
 
 _Highlights: a fixes-only release — the Windows "Restart to update" now runs to completion and actually installs the update, and the review panel's AI/LLM episode-matching button works again and clearly reports what it found._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,7 @@ Playwright-based E2E tests (10 spec files) that use simulation endpoints to test
 - **Database migration**: Alembic with async SQLModel metadata. `render_as_batch=True` for SQLite. Existing databases auto-stamped at head on first startup. `app_config` always preserves data via backup/restore (independent of Alembic).
 - **DiscDB mapping persistence**: `discdb_mappings_json` column on `DiscJob` stores serialized `DiscDbTitleMapping` list. Persisted during identification, restored from DB on server startup via `_restore_discdb_mappings()`.
 - **CI caching**: Playwright browsers cached by version, uv packages cached by lockfile hash, apt packages cached via `cache-apt-pkgs-action`.
+- **ASR GPU runtime**: faster-whisper→CTranslate2 supports **NVIDIA CUDA only** (no Metal/ROCm), needing cuDNN 9 + cuBLAS (~1.2 GB). Those libs are NOT bundled — `app/matcher/cuda_runtime.py` downloads them on demand (opt-in) into `~/.engram/cuda/` and registers them (Windows `add_dll_directory`; Linux ordered `ctypes.CDLL` preload) before the first model load. The **effective** device is resolved ONCE at `job_manager.start()` via `set_asr_device()`; every call site reads it through `detect_asr_device()`, so the `/api/asr-status` badge, the match semaphore, and the model loader can't disagree (the badge no longer claims CUDA while silently on CPU). `gpu_detected()` is the raw hardware probe; `cuda_compute_type()` picks float16/int8_float16/float32 per `get_supported_compute_types` so Pascal GPUs don't fail. Endpoints: `POST /api/asr/gpu/enable|disable`. Dev: `uv sync -E gpu` installs the pip `nvidia.*` packages, which `register_cuda_runtime()` falls back to.
 
 ## TMDB Configuration
 
@@ -278,6 +279,7 @@ All WebSocket messages follow the format: `{"type": "...", "data": {...}}`
 | `title_matched` | `{"job_id": int, "title_id": int, ...}` | Successful title match |
 | `title_state_changed` | `{"job_id": int, "title_id": int, "state": str}` | Generic title state change |
 | `title_failed` | `{"job_id": int, "title_id": int, "error": str}` | Title processing failed |
+| `gpu_status` | `{"state": "idle"\|"downloading"\|"installing"\|"error", "downloaded": int, "total": int, "error": str\|null}` | CUDA-runtime download progress for GPU ASR (see `broadcast_gpu_status`) |
 
 ### Client → Server Messages
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ cd backend
 uv sync --extra gpu
 ```
 
-An NVIDIA GPU is auto-detected and speeds up episode matching considerably. The prebuilt
-standalone and Docker builds are CPU-only — see [Performance & Hardware](docs/guide/performance.md)
-for GPU setup, storage recommendations, and concurrency tuning.
+An NVIDIA GPU speeds up episode matching considerably. GPU acceleration is opt-in: enable it in
+**Settings → Matching → GPU Acceleration**, which downloads the CUDA runtime on demand — this works
+in the prebuilt standalone build too (macOS and AMD GPUs run on CPU). The `uv sync --extra gpu` above
+is the from-source shortcut that installs those libraries via pip. See
+[Performance & Hardware](docs/guide/performance.md) for GPU setup, storage recommendations, and
+concurrency tuning.
 
 Then start the two dev servers in separate terminals:
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,6 +2,14 @@
 
 Engram's distributable builds bundle the following third-party binaries.
 
+> **NVIDIA CUDA libraries (cuDNN, cuBLAS)** are *not* bundled. When a user opts in to GPU
+> acceleration, Engram downloads the official NVIDIA pip wheels at runtime (pinned + SHA256
+> verified in `backend/app/matcher/cuda_runtime.py`) into `~/.engram/cuda/`. These libraries
+> are NVIDIA redistributables governed by the
+> [NVIDIA CUDA EULA](https://docs.nvidia.com/cuda/eula/index.html); the user accepts that EULA
+> before the download. The binaries are redistributed unmodified and are not stored in this
+> repository or in Engram's build artifacts.
+
 ## Chromaprint (`fpcalc`)
 
 - **Component:** `fpcalc`, the command-line audio fingerprinter from Chromaprint.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3669,7 +3669,8 @@ def _gpu_state(*, device: str, detected: bool, installed: bool, downloading: dic
     """Collapse the GPU situation into one badge state for the dashboard/settings UI."""
     from app.matcher.cuda_runtime import is_supported_platform
 
-    if downloading.get("state") in ("downloading", "installing"):
+    # In-flight or failed download takes precedence so the field matches gpu_download.state.
+    if downloading.get("state") in ("downloading", "installing", "error"):
         return downloading["state"]
     if device == "cuda":
         return "active"
@@ -3729,7 +3730,12 @@ async def _finish_gpu_enable(success: bool, error: str | None) -> None:
     from app.services.job_manager import event_broadcaster
 
     if success:
-        await update_db_config(enable_gpu_acceleration=True)
+        # Persist the flag, but never let a DB error swallow the completion broadcast —
+        # the UI must still learn the download finished.
+        try:
+            await update_db_config(enable_gpu_acceleration=True)
+        except Exception:
+            logger.error("Failed to persist enable_gpu_acceleration flag", exc_info=True)
     await event_broadcaster.broadcast_gpu_status(get_download_state())
 
 
@@ -3767,8 +3773,16 @@ async def enable_gpu_acceleration():
         return {"status": "ready", "restart_required": True, "gpu_download": get_download_state()}
 
     def _on_done(success: bool, error: str | None) -> None:
-        # Runs on the download thread; hop back to the event loop to touch DB + WS.
-        asyncio.run_coroutine_threadsafe(_finish_gpu_enable(success, error), _loop)
+        # Runs on the download thread; hop back to the event loop to touch DB + WS. Surface any
+        # failure of the coroutine itself (otherwise the discarded Future swallows it silently).
+        fut = asyncio.run_coroutine_threadsafe(_finish_gpu_enable(success, error), _loop)
+        fut.add_done_callback(
+            lambda f: (
+                logger.error("_finish_gpu_enable failed", exc_info=f.exception())
+                if f.exception()
+                else None
+            )
+        )
 
     _loop = asyncio.get_running_loop()
     started = start_background_download(on_done=_on_done)
@@ -3785,8 +3799,11 @@ async def disable_gpu_acceleration():
     """Disable GPU ASR (revert to CPU on the next restart). The cached libraries are kept."""
     from app.matcher.cuda_runtime import get_download_state
     from app.services.config_service import update_config as update_db_config
+    from app.services.job_manager import event_broadcaster
 
     await update_db_config(enable_gpu_acceleration=False)
+    # Broadcast so other connected clients (e.g. a second settings tab) don't show stale state.
+    await event_broadcaster.broadcast_gpu_status(get_download_state())
     return {"status": "disabled", "restart_required": True, "gpu_download": get_download_state()}
 
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -263,6 +263,7 @@ class ConfigResponse(BaseModel):
     library_tv_path: str
     tmdb_api_key: str
     max_concurrent_matches: int
+    enable_gpu_acceleration: bool
     ffmpeg_path: str
     conflict_resolution_default: str
     # Analyst thresholds
@@ -342,6 +343,7 @@ class ConfigUpdate(BaseModel):
     library_tv_path: str | None = None
     tmdb_api_key: str | None = None
     max_concurrent_matches: int | None = None
+    enable_gpu_acceleration: bool | None = None
     ffmpeg_path: str | None = None
     conflict_resolution_default: str | None = None
     # Analyst thresholds
@@ -1115,6 +1117,7 @@ async def get_config() -> ConfigResponse:
         library_tv_path=config.library_tv_path,
         tmdb_api_key="***" if config.tmdb_api_key else "",  # Redacted
         max_concurrent_matches=config.max_concurrent_matches,
+        enable_gpu_acceleration=config.enable_gpu_acceleration,
         ffmpeg_path=config.ffmpeg_path,
         conflict_resolution_default=config.conflict_resolution_default,
         # Analyst thresholds
@@ -3662,22 +3665,129 @@ async def get_update_status():
     return update_checker.get_status()
 
 
+def _gpu_state(*, device: str, detected: bool, installed: bool, downloading: dict) -> str:
+    """Collapse the GPU situation into one badge state for the dashboard/settings UI."""
+    from app.matcher.cuda_runtime import is_supported_platform
+
+    if downloading.get("state") in ("downloading", "installing"):
+        return downloading["state"]
+    if device == "cuda":
+        return "active"
+    if not is_supported_platform():
+        return "unsupported_os"  # macOS / non-NVIDIA arch — CTranslate2 has no GPU path
+    if detected:
+        # NVIDIA GPU present but not running on it: either not enabled or libs not downloaded.
+        return "available_not_installed" if not installed else "available_not_enabled"
+    return "unavailable"  # supported OS but no NVIDIA GPU
+
+
 @router.get("/asr-status")
 async def get_asr_status():
-    """Resolved ASR backend for the dashboard badge (read-only, no secrets)."""
-    from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
+    """Resolved ASR backend for the dashboard badge + GPU-acceleration settings (no secrets).
+
+    ``device`` is the *effective* device (what the model actually loads on), so the badge
+    can't claim CUDA while silently running on CPU. The ``gpu_*`` fields drive the opt-in
+    download toggle in settings.
+    """
+    from app.matcher.asr_models import detect_asr_device, gpu_detected, resolve_asr_runtime
+    from app.matcher.cuda_runtime import (
+        download_size_bytes,
+        get_download_state,
+        is_cuda_runtime_installed,
+    )
     from app.services.config_service import get_config as _get_app_config
 
     config = await _get_app_config()
-    runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+    device = detect_asr_device()
+    runtime = resolve_asr_runtime(device, config.max_concurrent_matches)
+    detected = gpu_detected()
+    installed = is_cuda_runtime_installed()
+    download = get_download_state()
     return {
-        "device": runtime.device,
+        "device": device,
         "compute_type": runtime.compute_type,
         "model": "small",  # current hardcoded matcher default (EpisodeMatcher.model_name)
         "workers": runtime.workers,
         "cpu_threads": runtime.cpu_threads,
         "max_concurrent_matches": config.max_concurrent_matches,
+        # GPU acceleration (opt-in CUDA runtime download)
+        "gpu_detected": detected,
+        "gpu_enabled": config.enable_gpu_acceleration,
+        "gpu_runtime_installed": installed,
+        "gpu_download_size_bytes": download_size_bytes(),
+        "gpu_download": download,
+        "gpu_state": _gpu_state(
+            device=device, detected=detected, installed=installed, downloading=download
+        ),
     }
+
+
+async def _finish_gpu_enable(success: bool, error: str | None) -> None:
+    """Post-download hook: flip the config flag on success, broadcast the final state."""
+    from app.matcher.cuda_runtime import get_download_state
+    from app.services.config_service import update_config as update_db_config
+    from app.services.job_manager import event_broadcaster
+
+    if success:
+        await update_db_config(enable_gpu_acceleration=True)
+    await event_broadcaster.broadcast_gpu_status(get_download_state())
+
+
+@router.post("/asr/gpu/enable")
+async def enable_gpu_acceleration():
+    """Enable GPU ASR: download the CUDA runtime if needed, then arm it for the next restart.
+
+    Rejected when the platform/hardware can't use CUDA. The ~1.2 GB cuDNN/cuBLAS download
+    runs in the background (progress via /api/asr-status + the ``gpu_status`` WS message);
+    activation takes effect on the next backend restart (registration must precede the first
+    model load, especially on Linux).
+    """
+    from app.matcher.asr_models import gpu_detected
+    from app.matcher.cuda_runtime import (
+        get_download_state,
+        is_cuda_runtime_installed,
+        is_supported_platform,
+        start_background_download,
+    )
+    from app.services.config_service import update_config as update_db_config
+    from app.services.job_manager import event_broadcaster
+
+    if not is_supported_platform():
+        raise HTTPException(
+            status_code=400,
+            detail="GPU acceleration requires an NVIDIA GPU on Windows or Linux "
+            "(CTranslate2 has no GPU path on macOS).",
+        )
+    if not gpu_detected():
+        raise HTTPException(status_code=400, detail="No NVIDIA GPU detected on this machine.")
+
+    # Already have the libraries (downloaded earlier, or dev `uv sync -E gpu`): just arm it.
+    if is_cuda_runtime_installed():
+        await update_db_config(enable_gpu_acceleration=True)
+        return {"status": "ready", "restart_required": True, "gpu_download": get_download_state()}
+
+    def _on_done(success: bool, error: str | None) -> None:
+        # Runs on the download thread; hop back to the event loop to touch DB + WS.
+        asyncio.run_coroutine_threadsafe(_finish_gpu_enable(success, error), _loop)
+
+    _loop = asyncio.get_running_loop()
+    started = start_background_download(on_done=_on_done)
+    await event_broadcaster.broadcast_gpu_status(get_download_state())
+    return {
+        "status": "downloading" if started else "already_downloading",
+        "restart_required": True,
+        "gpu_download": get_download_state(),
+    }
+
+
+@router.post("/asr/gpu/disable")
+async def disable_gpu_acceleration():
+    """Disable GPU ASR (revert to CPU on the next restart). The cached libraries are kept."""
+    from app.matcher.cuda_runtime import get_download_state
+    from app.services.config_service import update_config as update_db_config
+
+    await update_db_config(enable_gpu_acceleration=False)
+    return {"status": "disabled", "restart_required": True, "gpu_download": get_download_state()}
 
 
 @router.post("/updates/skip")

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -7,7 +7,6 @@ supporting OpenAI Whisper models via faster-whisper for efficient inference.
 
 import abc
 import hashlib
-import os
 import tempfile
 import threading
 from dataclasses import dataclass
@@ -33,6 +32,48 @@ _model_cache_lock = threading.Lock()
 # Conservative parallel-stream cap on GPU (VRAM auto-sizing is a future enhancement).
 GPU_WORKER_CAP = 4
 
+# Process-wide resolved ASR device, decided ONCE at startup (job_manager.start) after the
+# CUDA runtime is registered. Before this is set, callers fall back to the raw driver probe.
+# Centralizing the decision here is what keeps the semaphore sizing, the /api/asr-status
+# badge, and the model loader from disagreeing — they all read detect_asr_device().
+_asr_device_override: str | None = None
+
+
+def set_asr_device(device: str | None) -> None:
+    """Pin the effective ASR device for the rest of the process (``None`` re-enables probing)."""
+    global _asr_device_override
+    _asr_device_override = device
+
+
+def gpu_detected() -> bool:
+    """True when an NVIDIA CUDA device is visible to the driver — ignores libs and override.
+
+    This is the hardware-capability probe (does a GPU exist?), distinct from
+    ``detect_asr_device()`` which reports the *usable* device. Used to decide whether to even
+    offer the GPU-acceleration toggle.
+    """
+    try:
+        return ctranslate2.get_cuda_device_count() > 0
+    except Exception:  # noqa: BLE001 — any probe failure means no usable GPU
+        return False
+
+
+def cuda_compute_type() -> str:
+    """Pick the best CUDA compute type CTranslate2 reports as supported.
+
+    Hardcoding ``float16`` fails on GPUs without Compute Capability ≥ 7.0 (e.g. Pascal), so
+    fall back to ``int8_float16`` then ``float32``. Degrades to ``float16`` if the probe is
+    unavailable (it always lists float16 on a working CUDA build).
+    """
+    try:
+        supported = set(ctranslate2.get_supported_compute_types("cuda"))
+    except Exception:  # noqa: BLE001 — probe failure (no CUDA): caller only reaches here on cuda
+        return "float16"
+    for candidate in ("float16", "int8_float16", "float32"):
+        if candidate in supported:
+            return candidate
+    return "float16"
+
 
 @dataclass(frozen=True)
 class AsrRuntime:
@@ -50,11 +91,15 @@ class AsrRuntime:
 
 
 def detect_asr_device() -> str:
-    """Return 'cuda' when a CUDA device is visible to ctranslate2, else 'cpu'."""
-    try:
-        return "cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu"
-    except Exception:  # noqa: BLE001 — any probe failure means no usable GPU
-        return "cpu"
+    """Return the effective ASR device ('cuda' only when actually usable, else 'cpu').
+
+    Once ``set_asr_device()`` has run at startup this returns that resolved decision — which
+    accounts for whether the user enabled the GPU *and* the CUDA math libraries are installed,
+    not merely whether a GPU exists. Before startup it falls back to the raw driver probe.
+    """
+    if _asr_device_override is not None:
+        return _asr_device_override
+    return "cuda" if gpu_detected() else "cpu"
 
 
 def resolve_asr_runtime(device: str, requested_workers: int | None) -> AsrRuntime:
@@ -68,7 +113,7 @@ def resolve_asr_runtime(device: str, requested_workers: int | None) -> AsrRuntim
     if device == "cuda":
         return AsrRuntime(
             device="cuda",
-            compute_type="float16",
+            compute_type=cuda_compute_type(),
             workers=min(requested, GPU_WORKER_CAP),
             cpu_threads=None,
         )
@@ -94,10 +139,8 @@ class ASRModel(abc.ABC):
         self._model = None
 
     def _get_default_device(self) -> str:
-        """Get default device for this model type."""
-        if ctranslate2.get_cuda_device_count() > 0:
-            return "cuda"
-        return "cpu"
+        """Get default device for this model type (honors the startup-resolved override)."""
+        return detect_asr_device()
 
     @abc.abstractmethod
     def load(self):
@@ -191,8 +234,10 @@ class FasterWhisperModel(ASRModel):
 
         self.requested_workers = max(1, int(requested_workers or 1))
 
-        # Ensure NVIDIA libraries are in PATH for Windows CUDA support
-        if device == "cuda" or (device is None and ctranslate2.get_cuda_device_count() > 0):
+        # Register the CUDA math libraries (downloaded cache or dev pip packages) so
+        # CTranslate2 can dlopen them. Idempotent — startup already did this; this covers
+        # any model built before/without that path.
+        if device == "cuda" or (device is None and detect_asr_device() == "cuda"):
             _ensure_nvidia_libraries()
 
         super().__init__(model_name, device)
@@ -200,8 +245,9 @@ class FasterWhisperModel(ASRModel):
     def _get_compute_type(self) -> str:
         """Get optimal compute type for the device."""
         if self.device == "cuda":
-            # Use float16 for GPU (faster and lower memory)
-            return "float16"
+            # Best CUDA type the hardware supports (float16, or int8_float16/float32 on
+            # older GPUs) — must match resolve_asr_runtime so the cache key and badge agree.
+            return cuda_compute_type()
         else:
             # Use int8 for CPU (good balance of speed and accuracy)
             return "int8"
@@ -540,35 +586,16 @@ def list_available_models() -> dict:
 
 
 def _ensure_nvidia_libraries():
-    """
-    Ensure NVIDIA CUDA libraries are in the system PATH on Windows.
-    The nvidia-* pip packages do not automatically add their bin directories to PATH.
-    """
-    if os.name != "nt":
-        return
+    """Register the CUDA math libraries (downloaded cache, else dev pip packages).
 
+    Cross-platform: on Windows this adds the DLL directory; on Linux it preloads the .so
+    files into the global symbol namespace. Delegates to ``cuda_runtime.register_cuda_runtime``
+    so the on-demand download cache and the dev ``uv sync -E gpu`` packages are both honored.
+    Safe to call when nothing is installed (no-op).
+    """
     try:
-        import nvidia.cublas
-        import nvidia.cudnn
+        from app.matcher.cuda_runtime import register_cuda_runtime
 
-        nvidia_modules = [nvidia.cublas, nvidia.cudnn]
-
-        for module in nvidia_modules:
-            # Check if the module has a valid __file__ attribute that is not None
-            if hasattr(module, "__file__") and module.__file__:
-                # The DLLs are typically in the 'bin' directory relative to the module file
-                bin_dir = Path(module.__file__).parent / "bin"
-
-                # Ensure existing PATH is not None, though unlikely on Windows
-                existing_path = os.environ.get("PATH", "")
-
-                if bin_dir.exists() and str(bin_dir) not in existing_path:
-                    # Add to the BEGINNING of PATH to ensure these versions are found first
-                    os.environ["PATH"] = str(bin_dir) + os.pathsep + existing_path
-                    logger.debug(f"Added NVIDIA library path to environment: {bin_dir}")
-
-    except ImportError:
-        # Packages might not be installed, which is fine if not using CUDA
-        pass
-    except Exception as e:
-        logger.warning(f"Failed to add NVIDIA library paths: {e}")
+        register_cuda_runtime()
+    except Exception as e:  # noqa: BLE001 — registration is best-effort; load-time fallback covers it
+        logger.warning(f"Failed to register CUDA libraries: {e}")

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -598,4 +598,4 @@ def _ensure_nvidia_libraries():
 
         register_cuda_runtime()
     except Exception as e:  # noqa: BLE001 — registration is best-effort; load-time fallback covers it
-        logger.warning(f"Failed to register CUDA libraries: {e}")
+        logger.warning(f"Failed to register CUDA libraries: {e}", exc_info=True)

--- a/backend/app/matcher/cuda_runtime.py
+++ b/backend/app/matcher/cuda_runtime.py
@@ -332,6 +332,8 @@ def _register_dir(lib_dir: Path) -> bool:
         try:
             os.add_dll_directory(str(lib_dir))
         except (OSError, AttributeError):
+            # Non-fatal: a missing/invalid dir or a Python without add_dll_directory just
+            # means we rely on the PATH prepend below to make the DLLs discoverable.
             pass
         existing = os.environ.get("PATH", "")
         if str(lib_dir) not in existing:
@@ -445,15 +447,19 @@ def start_background_download(on_done=None) -> bool:
         )
 
     def _run():
+        def _progress(done: int, total: int) -> None:
+            # Once all bytes are in, download_cuda_runtime extracts + atomically installs —
+            # report that as the "installing" phase the UI renders separately.
+            phase = "installing" if total and done >= total else "downloading"
+            _set_download_state(phase, done, total)
+
         try:
-            download_cuda_runtime(
-                progress_cb=lambda done, total: _set_download_state("downloading", done, total)
-            )
+            download_cuda_runtime(progress_cb=_progress)
             _set_download_state("idle", 0, 0, None)
             if on_done:
                 on_done(True, None)
-        except BaseException as exc:  # noqa: BLE001 - surface any failure to the UI
-            logger.error(f"CUDA runtime download failed: {exc}")
+        except Exception as exc:  # noqa: BLE001 - surface any failure to the UI
+            logger.error(f"CUDA runtime download failed: {exc}", exc_info=True)
             _set_download_state("error", 0, 0, str(exc))
             if on_done:
                 on_done(False, str(exc))

--- a/backend/app/matcher/cuda_runtime.py
+++ b/backend/app/matcher/cuda_runtime.py
@@ -1,0 +1,463 @@
+"""On-demand NVIDIA CUDA math-library runtime for faster-whisper GPU acceleration.
+
+faster-whisper → CTranslate2 needs **cuDNN 9 + cuBLAS** (CUDA ≥ 12.3) to run ASR on the
+GPU. CTranslate2 ``dlopen``s those libraries lazily by name at runtime, so PyInstaller's
+static analysis never sees them and they aren't in the frozen build. They are also large
+(~1.2 GB), so bundling them into every download would triple the size for the CPU-only
+majority. Instead this module downloads them **on demand, opt-in** into
+``~/.engram/cuda/<version>/`` and makes them loadable before the first ``WhisperModel``
+load. The cache lives outside the install dir, so — like the database and the subtitle
+cache — it survives app updates and needs no updater changes.
+
+The implementation mirrors two patterns already in the repo:
+
+* ``scripts/fetch_fpcalc.py`` — pinned URL + SHA256 + extract the needed members from an
+  archive (the nvidia pip wheels are just zips).
+* the updater's integrity approach — stage into a sibling temp dir, then atomically
+  ``os.replace`` it into place, so a killed/partial download never leaves a half-registered
+  tree (a manifest ``complete`` sentinel is the source of truth).
+
+CTranslate2 only supports NVIDIA CUDA (no Metal/CoreML, and AMD ROCm only via non-PyPI
+wheels), so this is Windows + Linux on x86_64/aarch64 only. macOS and other platforms have
+no asset and report unsupported — they stay on CPU ``int8``.
+
+The pinned versions mirror the ``gpu`` optional-extra in ``pyproject.toml`` so the cuDNN
+major always matches the locked ``ctranslate2``; bump them together.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+# Pinned to match the `gpu` extra (nvidia-cudnn-cu12 9.19.0.56 + its nvidia-cublas-cu12
+# 12.9.1.4) which in turn matches the locked ctranslate2 4.6.x (cuDNN 9 / CUDA 12). The
+# cache dir is versioned by this string so a future ctranslate2 bump that needs a different
+# cuDNN re-fetches into a fresh dir instead of loading stale libs.
+RUNTIME_VERSION = "cudnn9.19.0.56-cublas12.9.1.4"
+
+
+class CudaRuntimeError(RuntimeError):
+    """Raised when the CUDA runtime cannot be downloaded or installed."""
+
+
+@dataclass(frozen=True)
+class _Wheel:
+    """A pinned nvidia wheel (a plain zip) holding the CUDA shared libraries."""
+
+    url: str
+    sha256: str
+    size: int  # bytes, for progress total + UI sizing
+
+
+# Per-platform wheels. cuBLAS is listed first so it is present on disk before cuDNN (cuDNN
+# depends on cuBLAS). URLs + hashes + sizes are copied verbatim from backend/uv.lock — keep
+# them in sync with the `gpu` extra. cuBLAS 12.9.1.4 + cuDNN 9.19.0.56.
+_WHEELS: dict[str, list[_Wheel]] = {
+    "win_amd64": [
+        _Wheel(
+            "https://files.pythonhosted.org/packages/45/a1/a17fade6567c57452cfc8f967a40d1035bb9301db52f27808167fbb2be2f/nvidia_cublas_cu12-12.9.1.4-py3-none-win_amd64.whl",
+            "1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf",
+            553153899,
+        ),
+        _Wheel(
+            "https://files.pythonhosted.org/packages/a7/a5/48f07449fc9c6cc146dcafe6149fa5d69630137d2ec5b7d9e09f255fadd7/nvidia_cudnn_cu12-9.19.0.56-py3-none-win_amd64.whl",
+            "cec70596b9ce878fab83810c3f5a2e606d35f510e5fee579759e4cbc68a23750",
+            644003014,
+        ),
+    ],
+    "linux_x86_64": [
+        _Wheel(
+            "https://files.pythonhosted.org/packages/77/3c/aa88abe01f3be3d1f8f787d1d33dc83e76fec05945f9a28fbb41cfb99cd5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_x86_64.whl",
+            "453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2",
+            581242350,
+        ),
+        _Wheel(
+            "https://files.pythonhosted.org/packages/c5/41/65225d42fba06fb3dd3972485ea258e7dd07a40d6e01c95da6766ad87354/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl",
+            "ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625",
+            657906812,
+        ),
+    ],
+    "linux_aarch64": [
+        _Wheel(
+            "https://files.pythonhosted.org/packages/82/6c/90d3f532f608a03a13c1d6c16c266ffa3828e8011b1549d3b61db2ad59f5/nvidia_cublas_cu12-12.9.1.4-py3-none-manylinux_2_27_aarch64.whl",
+            "7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6",
+            575006342,
+        ),
+        _Wheel(
+            "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl",
+            "08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e",
+            656910700,
+        ),
+    ],
+}
+
+_MANIFEST_NAME = "manifest.json"
+
+# Process-wide download state, readable by GET /api/asr-status and updated during a download
+# so the UI can show progress. Guarded so the worker thread and the event loop don't race.
+_state_lock = threading.Lock()
+_download_state: dict = {"state": "idle", "downloaded": 0, "total": 0, "error": None}
+_download_thread: threading.Thread | None = None
+
+
+# --------------------------------------------------------------------------- platform ----
+
+
+def platform_key() -> str | None:
+    """Return the ``_WHEELS`` key for this OS/arch, or ``None`` if unsupported.
+
+    CTranslate2 ships CUDA support for NVIDIA on Windows + Linux only; macOS (no NVIDIA) and
+    other arches get ``None`` and stay on CPU.
+    """
+    machine = platform.machine().lower()
+    if sys.platform == "win32":
+        return "win_amd64" if machine in ("amd64", "x86_64") else None
+    if sys.platform.startswith("linux"):
+        if machine in ("x86_64", "amd64"):
+            return "linux_x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux_aarch64"
+    return None
+
+
+def is_supported_platform() -> bool:
+    """True if this OS/arch has a pinned CUDA runtime asset (Windows/Linux + NVIDIA-capable)."""
+    return platform_key() is not None
+
+
+def download_size_bytes() -> int:
+    """Total bytes of the CUDA wheels for this platform (0 if unsupported)."""
+    key = platform_key()
+    return sum(w.size for w in _WHEELS[key]) if key else 0
+
+
+# ------------------------------------------------------------------------------ cache ----
+
+
+def engram_home() -> Path:
+    """``~/.engram`` — the per-user state dir (DB, logs, caches) that survives updates."""
+    return Path.home() / ".engram"
+
+
+def cuda_cache_dir() -> Path:
+    """``~/.engram/cuda/<RUNTIME_VERSION>/`` — where the extracted DLLs/.so land."""
+    return engram_home() / "cuda" / RUNTIME_VERSION
+
+
+def is_cuda_runtime_present(cache_dir: Path | None = None) -> bool:
+    """True only when a *complete* downloaded runtime exists in ``cache_dir``.
+
+    The manifest's ``complete`` flag plus an existence check on every listed file is the
+    source of truth, so a partial extraction (killed mid-write) reads as absent and is
+    re-fetched rather than half-loaded.
+    """
+    import json
+
+    cache_dir = cache_dir or cuda_cache_dir()
+    manifest = cache_dir / _MANIFEST_NAME
+    if not manifest.is_file():
+        return False
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not data.get("complete"):
+        return False
+    files = data.get("files", [])
+    return bool(files) and all((cache_dir / name).is_file() for name in files)
+
+
+def _pip_nvidia_available() -> bool:
+    """True when the pip ``nvidia.*`` packages are importable (dev ``uv sync -E gpu``)."""
+    try:
+        return (
+            importlib.util.find_spec("nvidia.cudnn") is not None
+            and importlib.util.find_spec("nvidia.cublas") is not None
+        )
+    except (ImportError, ValueError):
+        return False
+
+
+def is_cuda_runtime_installed() -> bool:
+    """True when CUDA libs are available by *either* path: the download cache or pip (dev)."""
+    return is_cuda_runtime_present() or _pip_nvidia_available()
+
+
+# --------------------------------------------------------------------------- download ----
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _download_verified(wheel: _Wheel, progress_cb=None, base: int = 0, total: int = 0) -> bytes:
+    """Stream a pinned wheel, verifying its SHA256, reporting cumulative bytes via callback."""
+    chunks: list[bytes] = []
+    received = 0
+    try:
+        with urllib.request.urlopen(wheel.url, timeout=120) as resp:  # noqa: S310 - pinned https
+            while True:
+                chunk = resp.read(1024 * 256)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                received += len(chunk)
+                if progress_cb is not None and total:
+                    progress_cb(base + received, total)
+    except urllib.error.HTTPError as exc:
+        raise CudaRuntimeError(f"HTTP {exc.code} fetching {wheel.url}") from exc
+    except urllib.error.URLError as exc:
+        raise CudaRuntimeError(f"network failure fetching {wheel.url}: {exc.reason}") from exc
+
+    data = b"".join(chunks)
+    actual = _sha256(data)
+    if actual != wheel.sha256:
+        raise CudaRuntimeError(
+            f"SHA256 mismatch for {wheel.url}\n  expected {wheel.sha256}\n  got      {actual}"
+        )
+    return data
+
+
+def _is_lib_member(name: str) -> bool:
+    """True for the shared-library members inside an nvidia wheel (skip ``__init__`` etc.).
+
+    Members look like ``nvidia/cublas/bin/cublas64_12.dll`` (Windows) or
+    ``nvidia/cudnn/lib/libcudnn.so.9`` (Linux). We take regular files under a ``bin/`` or
+    ``lib/`` segment whose basename is a DLL or an ``.so``.
+    """
+    parts = name.replace("\\", "/").split("/")
+    if "nvidia" not in parts or not (("bin" in parts) or ("lib" in parts)):
+        return False
+    base = parts[-1]
+    if not base or name.endswith("/"):
+        return False
+    lower = base.lower()
+    return lower.endswith(".dll") or ".so" in lower
+
+
+def _extract_libs(wheel_bytes: bytes, dest: Path) -> list[str]:
+    """Extract the shared libs from a wheel zip into ``dest`` (flat), returning basenames."""
+    extracted: list[str] = []
+    with zipfile.ZipFile(io.BytesIO(wheel_bytes)) as zf:
+        for member in zf.namelist():
+            if not _is_lib_member(member):
+                continue
+            base = Path(member).name
+            with zf.open(member) as src, open(dest / base, "wb") as out:
+                shutil.copyfileobj(src, out)
+            if os.name != "nt":
+                (dest / base).chmod(0o755)
+            extracted.append(base)
+    return extracted
+
+
+def _atomic_install(staging: Path, final: Path) -> None:
+    """Replace ``final`` with ``staging`` atomically (both on the same filesystem)."""
+    if final.exists():
+        shutil.rmtree(final, ignore_errors=True)
+    final.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(staging, final)
+
+
+def download_cuda_runtime(progress_cb=None, *, force: bool = False) -> Path:
+    """Download + verify + install the CUDA runtime for this platform. Returns the cache dir.
+
+    ``progress_cb(downloaded_bytes, total_bytes)`` is called during the network transfer.
+    Idempotent: returns immediately if a complete runtime is already present (unless
+    ``force``). Staging happens in a hidden sibling dir on the same filesystem so a crash
+    never leaves a partially-populated cache dir.
+    """
+    import json
+
+    key = platform_key()
+    if key is None:
+        raise CudaRuntimeError(
+            "GPU acceleration is not available on this platform "
+            "(CTranslate2 supports NVIDIA CUDA on Windows/Linux only)"
+        )
+
+    final = cuda_cache_dir()
+    if is_cuda_runtime_present(final) and not force:
+        return final
+
+    wheels = _WHEELS[key]
+    total = sum(w.size for w in wheels)
+    parent = final.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".staging-{RUNTIME_VERSION}-", dir=parent))
+    try:
+        files: list[str] = []
+        base = 0
+        for wheel in wheels:
+            data = _download_verified(wheel, progress_cb, base=base, total=total)
+            base += wheel.size
+            files.extend(_extract_libs(data, staging))
+        if not files:
+            raise CudaRuntimeError("no CUDA libraries found inside the downloaded wheels")
+        (staging / _MANIFEST_NAME).write_text(
+            json.dumps({"version": RUNTIME_VERSION, "files": sorted(files), "complete": True}),
+            encoding="utf-8",
+        )
+        _atomic_install(staging, final)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    logger.info(f"Installed CUDA runtime ({len(files)} libs) -> {final}")
+    return final
+
+
+# --------------------------------------------------------------------------- register ----
+
+
+def _register_dir(lib_dir: Path) -> bool:
+    """Make every shared lib in ``lib_dir`` loadable by a later CTranslate2 ``dlopen``."""
+    if os.name == "nt":
+        # add_dll_directory is the robust mechanism (Python 3.8+); PATH is belt-and-suspenders
+        # and also helps any child process.
+        try:
+            os.add_dll_directory(str(lib_dir))
+        except (OSError, AttributeError):
+            pass
+        existing = os.environ.get("PATH", "")
+        if str(lib_dir) not in existing:
+            os.environ["PATH"] = str(lib_dir) + os.pathsep + existing
+        logger.debug(f"Registered CUDA DLL directory: {lib_dir}")
+        return True
+    return _preload_linux(lib_dir)
+
+
+def _preload_linux(lib_dir: Path) -> bool:
+    """Preload the .so files with RTLD_GLOBAL so CTranslate2's later dlopen finds them.
+
+    On Linux, ``LD_LIBRARY_PATH`` is read once by the dynamic linker at process start, so
+    setting it now would only help child processes. Instead we ``dlopen`` each library into
+    the global symbol namespace; a subsequent ``dlopen`` of the same soname by CTranslate2
+    returns the already-mapped handle. Inter-library deps (cuDNN→cuBLAS) are resolved by the
+    wheels' ``$ORIGIN`` rpath plus a few retry passes, so explicit ordering isn't required.
+    """
+    import ctypes
+
+    libs = sorted(lib_dir.glob("*.so*"))
+    if not libs:
+        return False
+    remaining = list(libs)
+    for _ in range(4):
+        if not remaining:
+            break
+        still: list[Path] = []
+        for lib in remaining:
+            try:
+                ctypes.CDLL(str(lib), mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                still.append(lib)
+        if len(still) == len(remaining):
+            break  # no progress this pass — give up on the stragglers
+        remaining = still
+    # Belt-and-suspenders for child processes / late soname resolution.
+    os.environ["LD_LIBRARY_PATH"] = (
+        str(lib_dir) + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
+    )
+    loaded = len(libs) - len(remaining)
+    logger.debug(f"Preloaded {loaded}/{len(libs)} CUDA libs from {lib_dir}")
+    return loaded > 0
+
+
+def _register_pip() -> bool:
+    """Dev fallback: register the pip ``nvidia.*`` package lib dirs (``uv sync -E gpu``)."""
+    registered = False
+    for mod_name in ("nvidia.cublas", "nvidia.cudnn"):
+        try:
+            spec = importlib.util.find_spec(mod_name)
+        except (ImportError, ValueError):
+            spec = None
+        if spec is None or not spec.submodule_search_locations:
+            continue
+        pkg_dir = Path(next(iter(spec.submodule_search_locations)))
+        lib_dir = pkg_dir / ("bin" if os.name == "nt" else "lib")
+        if lib_dir.is_dir():
+            registered = _register_dir(lib_dir) or registered
+    return registered
+
+
+def register_cuda_runtime() -> bool:
+    """Make CUDA math libs loadable in this process before the first WhisperModel load.
+
+    Prefers the downloaded cache (``~/.engram/cuda/``); falls back to the pip ``nvidia.*``
+    packages for developers running ``uv sync -E gpu``. Returns True if libs were registered.
+    Safe to call when nothing is installed (returns False).
+    """
+    cache_dir = cuda_cache_dir()
+    if is_cuda_runtime_present(cache_dir):
+        return _register_dir(cache_dir)
+    if _pip_nvidia_available():
+        return _register_pip()
+    return False
+
+
+# ----------------------------------------------------------------------- download task ----
+
+
+def get_download_state() -> dict:
+    """A snapshot of the current download progress for GET /api/asr-status."""
+    with _state_lock:
+        return dict(_download_state)
+
+
+def _set_download_state(state: str, downloaded: int = 0, total: int = 0, error: str | None = None):
+    with _state_lock:
+        _download_state.update(
+            {"state": state, "downloaded": downloaded, "total": total, "error": error}
+        )
+
+
+def is_downloading() -> bool:
+    with _state_lock:
+        return _download_state["state"] in ("downloading", "installing")
+
+
+def start_background_download(on_done=None) -> bool:
+    """Start a background thread that downloads + installs the CUDA runtime.
+
+    ``on_done(success: bool, error: str | None)`` runs after the download finishes (e.g. to
+    flip the config flag + broadcast). Returns False if a download is already running.
+    """
+    global _download_thread
+    with _state_lock:
+        if _download_state["state"] in ("downloading", "installing"):
+            return False
+        _download_state.update(
+            {"state": "downloading", "downloaded": 0, "total": download_size_bytes(), "error": None}
+        )
+
+    def _run():
+        try:
+            download_cuda_runtime(
+                progress_cb=lambda done, total: _set_download_state("downloading", done, total)
+            )
+            _set_download_state("idle", 0, 0, None)
+            if on_done:
+                on_done(True, None)
+        except BaseException as exc:  # noqa: BLE001 - surface any failure to the UI
+            logger.error(f"CUDA runtime download failed: {exc}")
+            _set_download_state("error", 0, 0, str(exc))
+            if on_done:
+                on_done(False, str(exc))
+
+    _download_thread = threading.Thread(target=_run, name="cuda-runtime-download", daemon=True)
+    _download_thread.start()
+    return True

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -52,6 +52,14 @@ class AppConfig(SQLModel, table=True):
     # Matching concurrency (limits parallel Whisper ASR tasks to avoid GPU OOM)
     max_concurrent_matches: int = 2
 
+    # GPU acceleration for ASR (faster-whisper/CTranslate2). Opt-in: when enabled AND an
+    # NVIDIA GPU is present AND the cuDNN/cuBLAS runtime has been downloaded to
+    # ~/.engram/cuda/, matching runs on the GPU. Off by default — the ~1.2 GB CUDA libraries
+    # are fetched on demand, not bundled. macOS/AMD have no CUDA path and stay on CPU.
+    enable_gpu_acceleration: bool = Field(
+        default=False, sa_column_kwargs={"server_default": text("0")}
+    )
+
     # FFmpeg path (empty string = use PATH)
     ffmpeg_path: str = ""
 

--- a/backend/app/services/event_broadcaster.py
+++ b/backend/app/services/event_broadcaster.py
@@ -238,3 +238,12 @@ class EventBroadcaster:
         if last_update_success_version is not None:
             data["last_update_success_version"] = last_update_success_version
         await self._ws.broadcast(data)
+
+    async def broadcast_gpu_status(self, download_state: dict) -> None:
+        """Broadcast CUDA-runtime download progress / GPU-acceleration state to all clients.
+
+        ``download_state`` is the dict from ``cuda_runtime.get_download_state()``:
+        ``{"state": "idle|downloading|installing|error", "downloaded": int, "total": int,
+        "error": str | None}``. The settings UI uses it to drive the download progress bar.
+        """
+        await self._ws.broadcast({"type": "gpu_status", "data": download_state})

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -171,11 +171,32 @@ class JobManager:
         config = await get_config()
         await ensure_paths_exist(config)
 
+        # Resolve the effective ASR device ONCE, here, after (optionally) registering the
+        # CUDA runtime — every other call site reads this decision via detect_asr_device(),
+        # so the badge, the semaphore, and the model loader can't disagree. GPU is used only
+        # when the user enabled it AND an NVIDIA GPU is present AND the cuDNN/cuBLAS libs are
+        # installed and register cleanly; otherwise we stay on CPU.
+        from app.matcher.asr_models import (
+            gpu_detected,
+            resolve_asr_runtime,
+            set_asr_device,
+        )
+        from app.matcher.cuda_runtime import register_cuda_runtime
+
+        asr_device = "cpu"
+        if config.enable_gpu_acceleration and gpu_detected():
+            if register_cuda_runtime():
+                asr_device = "cuda"
+            else:
+                logger.warning(
+                    "GPU acceleration is enabled but the CUDA runtime libraries are not "
+                    "installed; falling back to CPU. Re-enable GPU in Settings to download them."
+                )
+        set_asr_device(asr_device)
+
         # Initialize matching concurrency limiter from REAL ASR capacity, so the
         # dashboard's MATCHING count can't exceed what can actually be transcribing.
-        from app.matcher.asr_models import detect_asr_device, resolve_asr_runtime
-
-        _asr_runtime = resolve_asr_runtime(detect_asr_device(), config.max_concurrent_matches)
+        _asr_runtime = resolve_asr_runtime(asr_device, config.max_concurrent_matches)
         self._matching.init_semaphore(_asr_runtime.workers)
 
         # Start timed staging cleanup if policy is "after_days"

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -87,6 +87,13 @@ if os.path.isdir(static_dir):
 datas += collect_data_files("faster_whisper")
 datas += collect_data_files("ctranslate2")
 
+# NOTE: the NVIDIA CUDA *math* libraries (cuDNN 9 + cuBLAS, ~1.2 GB) are deliberately NOT
+# bundled. CTranslate2's own CUDA-capable extension ships inside the ctranslate2 wheel (so
+# get_cuda_device_count() works in the frozen build), but cuDNN/cuBLAS are huge and CTranslate2
+# dlopen's them lazily by name — invisible to PyInstaller's static analysis. Bundling them would
+# triple every download for the CPU-only majority. Instead they're fetched on demand, opt-in,
+# into ~/.engram/cuda/ at runtime — see app/matcher/cuda_runtime.py.
+
 # TLS CA bundle. httpx/requests load certifi.where() (-> certifi/cacert.pem) for
 # every HTTPS call. Collect it explicitly so the CA bundle can never silently drop
 # out from PyInstaller hook / certifi-version drift — a missing cacert.pem makes

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -3,15 +3,28 @@
 import threading
 from unittest.mock import patch
 
+import pytest
+
 from app.matcher.asr_models import (
     GPU_WORKER_CAP,
     AsrRuntime,
     FasterWhisperModel,
     _model_cache,
+    cuda_compute_type,
     detect_asr_device,
     get_cached_model,
+    gpu_detected,
     resolve_asr_runtime,
+    set_asr_device,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_asr_device_override():
+    """The effective-device override is a module global; reset it around every test."""
+    set_asr_device(None)
+    yield
+    set_asr_device(None)
 
 
 class TestDetectAsrDevice:
@@ -29,6 +42,52 @@ class TestDetectAsrDevice:
             side_effect=RuntimeError("no cuda runtime"),
         ):
             assert detect_asr_device() == "cpu"
+
+
+class TestEffectiveDeviceOverride:
+    """The honesty fix: detect_asr_device reports the *usable* device, not just the hardware."""
+
+    def test_override_wins_over_probe(self):
+        # A GPU is visible, but the startup decision pinned CPU (e.g. user hasn't enabled it
+        # or the CUDA libs aren't installed) — the badge/semaphore must read CPU.
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=1):
+            assert gpu_detected() is True
+            set_asr_device("cpu")
+            assert detect_asr_device() == "cpu"
+
+    def test_override_can_pin_cuda(self):
+        set_asr_device("cuda")
+        assert detect_asr_device() == "cuda"
+
+    def test_gpu_detected_ignores_override(self):
+        set_asr_device("cpu")
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=2):
+            assert gpu_detected() is True
+
+
+class TestCudaComputeType:
+    """Older GPUs (no Compute Capability >= 7.0) can't do float16 — pick a supported type."""
+
+    def test_prefers_float16_when_supported(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"int8", "int8_float16", "float16", "float32"},
+        ):
+            assert cuda_compute_type() == "float16"
+
+    def test_falls_back_to_int8_float16_on_pascal(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"int8", "int8_float16", "float32"},
+        ):
+            assert cuda_compute_type() == "int8_float16"
+
+    def test_falls_back_to_float16_when_probe_unavailable(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            side_effect=RuntimeError("no cuda"),
+        ):
+            assert cuda_compute_type() == "float16"
 
 
 class TestResolveAsrRuntimeCpu:

--- a/backend/tests/unit/test_asr_runtime.py
+++ b/backend/tests/unit/test_asr_runtime.py
@@ -122,6 +122,17 @@ class TestResolveAsrRuntimeCpu:
 
 
 class TestResolveAsrRuntimeGpu:
+    @pytest.fixture(autouse=True)
+    def _stub_supported_compute_types(self):
+        # resolve_asr_runtime("cuda") asks ctranslate2 which compute types the GPU supports.
+        # On a CPU-only runner that probe returns a set without float16 (→ float32), so pin a
+        # float16-capable set to keep these worker-sizing tests hardware-independent.
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"float16", "int8_float16", "float32"},
+        ):
+            yield
+
     def test_caps_workers_at_gpu_cap(self):
         rt = resolve_asr_runtime("cuda", requested_workers=8)
         assert rt == AsrRuntime(

--- a/backend/tests/unit/test_asr_status_state.py
+++ b/backend/tests/unit/test_asr_status_state.py
@@ -26,6 +26,11 @@ def test_downloading_overrides_everything():
     assert _state("cpu", True, True, download={"state": "installing"}) == "installing"
 
 
+def test_failed_download_surfaces_as_error():
+    # gpu_state must agree with gpu_download.state so the field doesn't hide a failed download.
+    assert _state("cpu", True, False, download={"state": "error"}) == "error"
+
+
 def test_gpu_present_but_libs_missing():
     assert _state("cpu", detected=True, installed=False) == "available_not_installed"
 

--- a/backend/tests/unit/test_asr_status_state.py
+++ b/backend/tests/unit/test_asr_status_state.py
@@ -1,0 +1,42 @@
+"""Unit tests for the GPU badge-state derivation (_gpu_state in routes)."""
+
+from unittest.mock import patch
+
+from app.api.routes import _gpu_state
+
+_IDLE = {"state": "idle"}
+
+
+def _state(device, detected, installed, *, supported=True, download=None):
+    with patch("app.matcher.cuda_runtime.is_supported_platform", return_value=supported):
+        return _gpu_state(
+            device=device,
+            detected=detected,
+            installed=installed,
+            downloading=download or _IDLE,
+        )
+
+
+def test_active_when_device_is_cuda():
+    assert _state("cuda", True, True) == "active"
+
+
+def test_downloading_overrides_everything():
+    assert _state("cpu", True, False, download={"state": "downloading"}) == "downloading"
+    assert _state("cpu", True, True, download={"state": "installing"}) == "installing"
+
+
+def test_gpu_present_but_libs_missing():
+    assert _state("cpu", detected=True, installed=False) == "available_not_installed"
+
+
+def test_gpu_present_and_installed_but_disabled():
+    assert _state("cpu", detected=True, installed=True) == "available_not_enabled"
+
+
+def test_unsupported_os_takes_precedence_over_no_gpu():
+    assert _state("cpu", detected=False, installed=False, supported=False) == "unsupported_os"
+
+
+def test_supported_os_without_gpu_is_unavailable():
+    assert _state("cpu", detected=False, installed=False, supported=True) == "unavailable"

--- a/backend/tests/unit/test_config_gpu_field.py
+++ b/backend/tests/unit/test_config_gpu_field.py
@@ -1,0 +1,28 @@
+"""Guard the three-way sync for the GPU-acceleration config field.
+
+A new AppConfig field must also appear in ConfigUpdate (so PUT accepts it), ConfigResponse
+(so GET returns it), and the GET constructor — otherwise Pydantic silently drops it on PUT or
+omits it on GET. This test pins all three at the model level (no DB), so a future refactor
+can't quietly break the toggle.
+"""
+
+from app.api.routes import ConfigResponse, ConfigUpdate
+from app.models.app_config import AppConfig
+
+FIELD = "enable_gpu_acceleration"
+
+
+def test_appconfig_defaults_gpu_off():
+    assert getattr(AppConfig(), FIELD) is False
+
+
+def test_config_update_accepts_and_carries_the_field():
+    update = ConfigUpdate(**{FIELD: True})
+    # Present in the dump (so update_config persists it) and not coerced away.
+    assert update.model_dump()[FIELD] is True
+    # Unset stays None so PUT doesn't clobber it when omitted.
+    assert ConfigUpdate().model_dump()[FIELD] is None
+
+
+def test_config_response_exposes_the_field():
+    assert FIELD in ConfigResponse.model_fields

--- a/backend/tests/unit/test_cuda_runtime.py
+++ b/backend/tests/unit/test_cuda_runtime.py
@@ -1,0 +1,192 @@
+"""Unit tests for the on-demand CUDA runtime downloader/registrar.
+
+These exercise the pure logic — platform selection, wheel-member filtering, SHA256
+verification, manifest-gated presence, and atomic install — without touching the network or
+a real GPU. The download path is driven by monkeypatching the per-wheel fetch to return
+in-memory fake wheel zips.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+
+import pytest
+
+from app.matcher import cuda_runtime as cr
+
+
+def _make_wheel_zip(members: dict[str, bytes]) -> bytes:
+    """Build an in-memory wheel (zip) with the given member paths → contents."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+# ------------------------------------------------------------------ platform selection ----
+
+
+def test_platform_key_maps_known_platforms(monkeypatch):
+    monkeypatch.setattr(cr.sys, "platform", "win32")
+    monkeypatch.setattr(cr.platform, "machine", lambda: "AMD64")
+    assert cr.platform_key() == "win_amd64"
+
+    monkeypatch.setattr(cr.sys, "platform", "linux")
+    monkeypatch.setattr(cr.platform, "machine", lambda: "x86_64")
+    assert cr.platform_key() == "linux_x86_64"
+
+    monkeypatch.setattr(cr.platform, "machine", lambda: "aarch64")
+    assert cr.platform_key() == "linux_aarch64"
+
+
+def test_platform_key_none_on_macos(monkeypatch):
+    monkeypatch.setattr(cr.sys, "platform", "darwin")
+    monkeypatch.setattr(cr.platform, "machine", lambda: "arm64")
+    assert cr.platform_key() is None
+    assert cr.is_supported_platform() is False
+
+
+def test_every_pinned_platform_has_two_wheels():
+    # cuBLAS + cuDNN, cuBLAS first so it's on disk before cuDNN (which depends on it).
+    for key, wheels in cr._WHEELS.items():
+        assert len(wheels) == 2, key
+        assert "cublas" in wheels[0].url
+        assert "cudnn" in wheels[1].url
+
+
+# --------------------------------------------------------------------- member filtering ----
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("nvidia/cublas/bin/cublas64_12.dll", True),
+        ("nvidia/cudnn/bin/cudnn64_9.dll", True),
+        ("nvidia/cudnn/lib/libcudnn.so.9", True),
+        ("nvidia/cublas/lib/libcublasLt.so.12", True),
+        ("nvidia/cudnn/__init__.py", False),
+        ("nvidia_cudnn_cu12-9.19.0.56.dist-info/RECORD", False),
+        ("nvidia/cudnn/include/cudnn.h", False),
+        ("nvidia/cudnn/bin/", False),
+    ],
+)
+def test_is_lib_member(name, expected):
+    assert cr._is_lib_member(name) is expected
+
+
+def test_extract_libs_flattens_and_skips_non_libs(tmp_path):
+    wheel = _make_wheel_zip(
+        {
+            "nvidia/cublas/bin/cublas64_12.dll": b"DLL1",
+            "nvidia/cublas/bin/cublasLt64_12.dll": b"DLL2",
+            "nvidia/cublas/__init__.py": b"# not a lib",
+            "nvidia_cublas_cu12-12.9.1.4.dist-info/RECORD": b"junk",
+        }
+    )
+    extracted = cr._extract_libs(wheel, tmp_path)
+    assert sorted(extracted) == ["cublas64_12.dll", "cublasLt64_12.dll"]
+    assert (tmp_path / "cublas64_12.dll").read_bytes() == b"DLL1"
+    assert not (tmp_path / "__init__.py").exists()
+
+
+# ------------------------------------------------------------------------ verification ----
+
+
+def test_download_verified_rejects_hash_mismatch(monkeypatch):
+    payload = b"some bytes"
+    wheel = cr._Wheel(url="https://example.test/x.whl", sha256="deadbeef", size=len(payload))
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, n):
+            data, self._done = (payload, True) if not getattr(self, "_done", False) else (b"", True)
+            return data
+
+    monkeypatch.setattr(cr.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    with pytest.raises(cr.CudaRuntimeError, match="SHA256 mismatch"):
+        cr._download_verified(wheel)
+
+
+# ----------------------------------------------------------------------- presence gate ----
+
+
+def test_is_cuda_runtime_present_requires_complete_manifest_and_files(tmp_path):
+    d = tmp_path / "cuda"
+    d.mkdir()
+    (d / "libcudnn.so.9").write_bytes(b"x")
+
+    # No manifest yet.
+    assert cr.is_cuda_runtime_present(d) is False
+
+    # Incomplete manifest.
+    (d / cr._MANIFEST_NAME).write_text(json.dumps({"files": ["libcudnn.so.9"], "complete": False}))
+    assert cr.is_cuda_runtime_present(d) is False
+
+    # Complete, but a listed file is missing.
+    (d / cr._MANIFEST_NAME).write_text(
+        json.dumps({"files": ["libcudnn.so.9", "libcublas.so.12"], "complete": True})
+    )
+    assert cr.is_cuda_runtime_present(d) is False
+
+    # Complete and all files present.
+    (d / "libcublas.so.12").write_bytes(b"y")
+    assert cr.is_cuda_runtime_present(d) is True
+
+
+# ----------------------------------------------------------------------- full download ----
+
+
+def test_download_cuda_runtime_installs_and_is_present(tmp_path, monkeypatch):
+    cache = tmp_path / "cuda" / cr.RUNTIME_VERSION
+    monkeypatch.setattr(cr, "cuda_cache_dir", lambda: cache)
+    monkeypatch.setattr(cr, "platform_key", lambda: "linux_x86_64")
+
+    fake_cublas = _make_wheel_zip({"nvidia/cublas/lib/libcublas.so.12": b"B"})
+    fake_cudnn = _make_wheel_zip({"nvidia/cudnn/lib/libcudnn.so.9": b"D"})
+    payloads = iter([fake_cublas, fake_cudnn])
+    monkeypatch.setattr(cr, "_download_verified", lambda wheel, *a, **k: next(payloads))
+
+    result = cr.download_cuda_runtime()
+    assert result == cache
+    assert cr.is_cuda_runtime_present(cache) is True
+    assert (cache / "libcublas.so.12").read_bytes() == b"B"
+    assert (cache / "libcudnn.so.9").read_bytes() == b"D"
+
+    # Idempotent: a second call returns without re-fetching (iterator is exhausted).
+    assert cr.download_cuda_runtime() == cache
+
+
+def test_download_cuda_runtime_unsupported_platform_raises(monkeypatch):
+    monkeypatch.setattr(cr, "platform_key", lambda: None)
+    with pytest.raises(cr.CudaRuntimeError, match="not available on this platform"):
+        cr.download_cuda_runtime()
+
+
+def test_failed_extraction_leaves_no_partial_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "cuda" / cr.RUNTIME_VERSION
+    monkeypatch.setattr(cr, "cuda_cache_dir", lambda: cache)
+    monkeypatch.setattr(cr, "platform_key", lambda: "linux_x86_64")
+
+    def _boom(wheel, *a, **k):
+        raise cr.CudaRuntimeError("network died")
+
+    monkeypatch.setattr(cr, "_download_verified", _boom)
+    with pytest.raises(cr.CudaRuntimeError):
+        cr.download_cuda_runtime()
+    # No cache dir, and no leftover .staging-* siblings.
+    assert not cache.exists()
+    assert list((tmp_path / "cuda").glob(".staging-*")) == []
+
+
+def test_register_cuda_runtime_false_when_nothing_installed(tmp_path, monkeypatch):
+    monkeypatch.setattr(cr, "cuda_cache_dir", lambda: tmp_path / "absent")
+    monkeypatch.setattr(cr, "_pip_nvidia_available", lambda: False)
+    assert cr.register_cuda_runtime() is False

--- a/docs/development/gpu.md
+++ b/docs/development/gpu.md
@@ -1,0 +1,74 @@
+# GPU acceleration (ASR / faster-whisper)
+
+Engram transcribes episode audio with **faster-whisper**, which runs on
+[CTranslate2](https://opennmt.net/CTranslate2/). CTranslate2 supports **NVIDIA CUDA only** —
+there is no Metal/CoreML path (so Apple Silicon stays on CPU) and AMD ROCm is not used. GPU
+ASR is therefore available on **Windows + NVIDIA** and **Linux + NVIDIA**; everything else runs
+on the CPU with `int8`.
+
+## Support matrix
+
+| OS | GPU | Result |
+|----|-----|--------|
+| Windows | NVIDIA (CC ≥ 7.0) | ✅ CUDA `float16` |
+| Windows | NVIDIA (Pascal, CC 6.x) | ✅ CUDA `int8_float16`/`float32` (auto-selected) |
+| Linux | NVIDIA | ✅ CUDA |
+| Windows/Linux | AMD / Intel / none | CPU `int8` |
+| macOS | Apple / AMD | CPU `int8` (no GPU path in the engine) |
+
+## Why the libraries aren't bundled
+
+GPU inference needs **cuDNN 9 + cuBLAS** (CTranslate2 4.6 → CUDA ≥ 12.3 / cuDNN 9). Those
+libraries are ~1.2 GB and CTranslate2 `dlopen`s them lazily by name, so PyInstaller's static
+analysis never bundles them. Shipping them in every build would triple the download for the
+CPU-only majority. Instead they're fetched **on demand, opt-in**.
+
+Note: CTranslate2's own CUDA-capable extension *is* inside the `ctranslate2` wheel, so
+`ctranslate2.get_cuda_device_count()` works in the frozen build — that's why a GPU is
+*detected* even before the math libraries exist.
+
+## Runtime download (end users)
+
+Settings → Matching → **GPU Acceleration**:
+
+1. The panel detects an NVIDIA GPU and offers a one-time **Download & enable** (~1.2 GB after
+   accepting the NVIDIA CUDA EULA).
+2. `POST /api/asr/gpu/enable` starts a background download of the pinned cuDNN/cuBLAS wheels
+   (`backend/app/matcher/cuda_runtime.py`), SHA256-verified, extracted to
+   `~/.engram/cuda/<version>/`. Progress is reported via `GET /api/asr-status` and the
+   `gpu_status` WebSocket message.
+3. The download lives outside the install dir, so it **survives app updates** (like the DB and
+   subtitle cache) and the updater needs no changes.
+4. **Restart the backend** to activate. On restart `job_manager.start()` registers the libs
+   (Windows `os.add_dll_directory`; Linux ordered `ctypes.CDLL` preload) and pins the effective
+   device with `set_asr_device("cuda")`.
+
+`POST /api/asr/gpu/disable` reverts to CPU on the next restart (the cached libraries are kept).
+
+## Developer setup (no download)
+
+```bash
+cd backend
+uv sync -E gpu      # installs nvidia-cudnn-cu12 + nvidia-cublas-cu12
+```
+
+`register_cuda_runtime()` falls back to the pip `nvidia.*` packages when the download cache is
+absent, so `uv sync -E gpu` is all a developer needs. Enable the toggle in Settings (it'll
+report the runtime already installed) and restart.
+
+Verify:
+
+```bash
+curl localhost:8000/api/asr-status      # device:"cuda", gpu_state:"active"
+# run a match; ~/.engram/engram.log should show "Loaded ... on cuda" (no "Falling back to CPU")
+# watch nvidia-smi for the python/uvicorn process during matching
+```
+
+## How the device decision stays honest
+
+Historically four call sites each probed `get_cuda_device_count()`, so the status badge could
+claim CUDA while the model silently fell back to CPU. Now the **effective** device is resolved
+once at startup (after the libs are registered) and pinned via `set_asr_device()`. Everything —
+the `/api/asr-status` badge, the match semaphore, and the model loader — reads it through
+`detect_asr_device()`. `gpu_detected()` remains the raw hardware probe used only to decide
+whether to offer the toggle.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -115,11 +115,16 @@ Configuration is resolved in this priority order:
 |-------|-------------|---------|
 | `max_concurrent_matches` | Parallel episode-matching (ASR) tasks | `2` |
 | `matcher_min_confidence` | Minimum confidence to auto-accept an episode match | `0.6` |
+| `enable_gpu_acceleration` | Run transcription on an NVIDIA GPU (opt-in; downloads the CUDA runtime) | `false` |
 | `conflict_resolution_default` | File conflict handling | `"ask"` |
 
 `max_concurrent_matches` is the main matching-throughput knob. It's clamped to your hardware and
 takes effect on restart — see [Performance & Hardware](../guide/performance.md#concurrency-tuning)
 for how to tune it for CPU vs GPU and bulk imports.
+
+`enable_gpu_acceleration` is best toggled from **Settings → Matching → GPU Acceleration** rather than
+edited directly, since enabling it triggers the one-time CUDA-runtime download. See
+[GPU acceleration](../guide/performance.md#gpu-acceleration-faster-whisper-asr).
 
 The `conflict_resolution_default` field accepts one of four values:
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -22,21 +22,42 @@ These are practical recommendations, not enforced minimums. Engram will start an
 
 ## GPU acceleration (faster-whisper ASR)
 
-Episode matching transcribes each ripped title with [faster-whisper](https://github.com/SYSTRAN/faster-whisper).
-Engram **auto-detects** your hardware — there's no device setting to configure:
+Episode matching transcribes each ripped title with [faster-whisper](https://github.com/SYSTRAN/faster-whisper),
+which runs on NVIDIA CUDA via CTranslate2. GPU transcription is several times faster than CPU for
+the same model — the single biggest lever on matching throughput.
 
-- If a CUDA-capable NVIDIA GPU is visible, Engram uses it with the `float16` compute type.
-- Otherwise it runs on CPU with the `int8` compute type (quantized for speed).
-- If CUDA libraries are missing or fail to load at runtime, it **silently falls back to CPU** —
-  matching still works, just slower.
+GPU acceleration is **opt-in** and available on **Windows and Linux with an NVIDIA GPU**. macOS and
+AMD GPUs have no GPU path in the engine and always run on CPU (`int8`).
 
-GPU transcription is several times faster than CPU for the same model, which is the single
-biggest lever on matching throughput.
+### Enable it
+
+In **Settings → Matching → GPU Acceleration**:
+
+1. When an NVIDIA GPU is detected, Engram offers a one-time **Download & enable** (after you accept
+   the [NVIDIA CUDA EULA](https://docs.nvidia.com/cuda/eula/index.html)). The required cuDNN + cuBLAS
+   libraries (~1.2 GB) are **not** bundled into the build — they're fetched on demand into
+   `~/.engram/cuda/`, where they **persist across app updates** (like your database and subtitle
+   cache).
+2. The download runs in the background; you can keep using Engram while it completes.
+3. **Restart the backend** to activate. Matching then runs on the GPU using the best compute type
+   your card supports — `float16`, or `int8_float16`/`float32` on older GPUs (e.g. Pascal) that
+   can't do `float16`. CPU continues to use `int8`.
+
+This works in the **prebuilt standalone build** — the CUDA libraries are downloaded at runtime, not
+compiled in. (Developers running from source can instead install them via pip with
+`uv sync --extra gpu`; see below.)
+
+!!! note "Docker"
+    In a container, GPU access additionally requires the host NVIDIA driver, the
+    [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit), and running with
+    `--gpus all`. With those in place the same in-app download applies. See the
+    [Docker guide](../deployment/docker.md).
 
 ### Verify which backend is active
 
-Engram exposes the resolved ASR runtime at **`GET /api/asr-status`** (also shown as the ASR badge
-on the dashboard). It returns no secrets and is the authoritative answer to "is my GPU being used?":
+Engram exposes the resolved ASR runtime at **`GET /api/asr-status`** (also shown as the ASR badge on
+the dashboard). The `device` field is the **effective** device — what transcription actually runs on
+— so the badge can't claim CUDA while silently falling back to CPU:
 
 ```bash
 curl http://localhost:8000/api/asr-status
@@ -49,25 +70,35 @@ curl http://localhost:8000/api/asr-status
   "model": "small",
   "workers": 4,
   "cpu_threads": null,
-  "max_concurrent_matches": 4
+  "max_concurrent_matches": 4,
+  "gpu_detected": true,
+  "gpu_enabled": true,
+  "gpu_runtime_installed": true,
+  "gpu_state": "active"
 }
 ```
 
-`device: "cpu"` means no GPU was detected — check your CUDA install if you expected otherwise.
+`gpu_state` tells you exactly where you stand:
 
-### Getting a GPU-enabled build
+- `active` — running on the GPU.
+- `available_not_enabled` / `available_not_installed` — an NVIDIA GPU is present but acceleration is
+  off, or the runtime hasn't been downloaded yet. The dashboard badge shows **CPU · GPU available →**;
+  click it to open Settings.
+- `downloading` / `installing` — the CUDA runtime download is in progress.
+- `unsupported_os` — macOS or another platform with no NVIDIA path.
+- `unavailable` — a supported OS with no NVIDIA GPU.
 
-GPU support ships with the CUDA extras when you run **from source**:
+### Running from source (developers)
+
+When running from source you can install the CUDA libraries via pip instead of the in-app download:
 
 ```bash
 cd backend
 uv sync --extra gpu
 ```
 
-!!! note "Standalone and Docker builds are CPU-only"
-    The prebuilt standalone executables and the Docker image are **CPU-only** today. To use an
-    NVIDIA GPU, run [from source](../getting-started/installation.md) with `uv sync --extra gpu`.
-    See the [Docker guide](../deployment/docker.md) for the container's GPU notes.
+Engram falls back to these pip-installed libraries automatically, so the GPU Acceleration setting
+reports the runtime already installed — just enable it and restart.
 
 ### Whisper model
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -230,7 +230,7 @@ function MainDashboard() {
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <AsrStatusBadge />
+          <AsrStatusBadge onOpenSettings={() => setShowSettings(true)} />
           {/* View mode toggle */}
           <div style={{ display: "inline-flex", border: `1px solid ${sv.line}` }}>
             <button

--- a/frontend/src/app/components/AsrStatusBadge.tsx
+++ b/frontend/src/app/components/AsrStatusBadge.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
 
+type GpuDownload = {
+  state: "idle" | "downloading" | "installing" | "error";
+  downloaded: number;
+  total: number;
+  error: string | null;
+};
+
 type AsrStatus = {
   device: string;
   compute_type: string;
@@ -7,48 +14,122 @@ type AsrStatus = {
   workers: number;
   cpu_threads: number | null;
   max_concurrent_matches: number;
+  gpu_detected?: boolean;
+  gpu_enabled?: boolean;
+  gpu_runtime_installed?: boolean;
+  gpu_state?:
+    | "active"
+    | "available_not_enabled"
+    | "available_not_installed"
+    | "downloading"
+    | "installing"
+    | "unsupported_os"
+    | "unavailable";
+  gpu_download?: GpuDownload;
 };
 
-/** Read-only chip showing the resolved ASR backend (device · compute · N workers). */
-export function AsrStatusBadge() {
+const CYAN = "#22d3ee";
+const AMBER = "#f5a623";
+const GRAY = "#8893a8";
+
+/**
+ * Read-only chip showing the *effective* ASR backend. Crucially it reports the device the
+ * model actually loads on — so when an NVIDIA GPU is present but unused (libs not downloaded
+ * or acceleration off), it shows an actionable "GPU available →" chip that opens Settings,
+ * rather than falsely claiming CUDA.
+ */
+export function AsrStatusBadge({ onOpenSettings }: { onOpenSettings?: () => void }) {
   const [status, setStatus] = useState<AsrStatus | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/asr-status")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!cancelled) setStatus(data);
-      })
-      .catch(() => {
-        /* badge is best-effort; stay hidden on failure */
-      });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = () => {
+      fetch("/api/asr-status")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: AsrStatus | null) => {
+          if (cancelled || !data) return;
+          setStatus(data);
+          // While a download is in flight, keep polling so the chip animates to completion.
+          if (data.gpu_state === "downloading" || data.gpu_state === "installing") {
+            timer = setTimeout(poll, 1500);
+          }
+        })
+        .catch(() => {
+          /* badge is best-effort; stay hidden on failure */
+        });
+    };
+    poll();
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, []);
 
   if (!status) return null;
 
-  const accent = status.device === "cuda" ? "#22d3ee" : "#8893a8";
-  const label = `ASR: ${status.device.toUpperCase()} · ${status.compute_type} · ${status.workers}w`;
+  const gpuState = status.gpu_state;
+  const dl = status.gpu_download;
+  const pct = dl && dl.total > 0 ? Math.floor((dl.downloaded / dl.total) * 100) : 0;
+
+  let accent = GRAY;
+  let label: string;
+  let clickable = false;
+  let title = `Whisper "${status.model}" · requested ${status.max_concurrent_matches}${
+    status.cpu_threads != null ? ` · ${status.cpu_threads} threads/worker` : ""
+  } · restart to change`;
+
+  if (status.device === "cuda") {
+    accent = CYAN;
+    label = `ASR: CUDA · ${status.compute_type} · ${status.workers}w`;
+  } else if (gpuState === "downloading") {
+    accent = CYAN;
+    label = `ASR: GPU libraries ⬇ ${pct}%`;
+    title = "Downloading the NVIDIA CUDA runtime (~1.2 GB). Restart to activate when done.";
+  } else if (gpuState === "installing") {
+    accent = CYAN;
+    label = "ASR: GPU installing…";
+  } else if (gpuState === "available_not_enabled" || gpuState === "available_not_installed") {
+    accent = AMBER;
+    label = "ASR: CPU · GPU available →";
+    clickable = true;
+    title =
+      gpuState === "available_not_installed"
+        ? "An NVIDIA GPU is available. Click to enable GPU acceleration in Settings (one-time ~1.2 GB download)."
+        : "An NVIDIA GPU is available but acceleration is off. Click to enable it in Settings.";
+  } else {
+    // cpu / unavailable / unsupported_os
+    label = `ASR: CPU · ${status.compute_type} · ${status.workers}w`;
+  }
+
+  const baseStyle: React.CSSProperties = {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 11,
+    letterSpacing: "0.08em",
+    color: accent,
+    border: `1px solid ${accent}44`,
+    background: `${accent}0a`,
+    padding: "2px 8px",
+    whiteSpace: "nowrap",
+  };
+
+  if (clickable && onOpenSettings) {
+    return (
+      <button
+        type="button"
+        title={title}
+        onClick={onOpenSettings}
+        data-testid="asr-status-badge"
+        style={{ ...baseStyle, cursor: "pointer" }}
+      >
+        {label}
+      </button>
+    );
+  }
 
   return (
-    <span
-      title={`Whisper "${status.model}" · requested ${status.max_concurrent_matches}${
-        status.cpu_threads != null ? ` · ${status.cpu_threads} threads/worker` : ""
-      } · restart to change`}
-      style={{
-        fontFamily: "'JetBrains Mono', monospace",
-        fontSize: 11,
-        letterSpacing: "0.08em",
-        color: accent,
-        border: `1px solid ${accent}44`,
-        background: `${accent}0a`,
-        padding: "2px 8px",
-        whiteSpace: "nowrap",
-      }}
-    >
+    <span title={title} data-testid="asr-status-badge" style={baseStyle}>
       {label}
     </span>
   );

--- a/frontend/src/app/components/AsrStatusBadge.tsx
+++ b/frontend/src/app/components/AsrStatusBadge.tsx
@@ -1,36 +1,5 @@
 import { useEffect, useState } from "react";
-
-type GpuDownload = {
-  state: "idle" | "downloading" | "installing" | "error";
-  downloaded: number;
-  total: number;
-  error: string | null;
-};
-
-type AsrStatus = {
-  device: string;
-  compute_type: string;
-  model: string;
-  workers: number;
-  cpu_threads: number | null;
-  max_concurrent_matches: number;
-  gpu_detected?: boolean;
-  gpu_enabled?: boolean;
-  gpu_runtime_installed?: boolean;
-  gpu_state?:
-    | "active"
-    | "available_not_enabled"
-    | "available_not_installed"
-    | "downloading"
-    | "installing"
-    | "unsupported_os"
-    | "unavailable";
-  gpu_download?: GpuDownload;
-};
-
-const CYAN = "#22d3ee";
-const AMBER = "#f5a623";
-const GRAY = "#8893a8";
+import { ASR_AMBER as AMBER, ASR_CYAN as CYAN, ASR_GRAY as GRAY, type AsrStatus } from "./asrStatus";
 
 /**
  * Read-only chip showing the *effective* ASR backend. Crucially it reports the device the
@@ -90,14 +59,20 @@ export function AsrStatusBadge({ onOpenSettings }: { onOpenSettings?: () => void
   } else if (gpuState === "installing") {
     accent = CYAN;
     label = "ASR: GPU installing…";
-  } else if (gpuState === "available_not_enabled" || gpuState === "available_not_installed") {
+  } else if (
+    gpuState === "available_not_enabled" ||
+    gpuState === "available_not_installed" ||
+    gpuState === "error"
+  ) {
     accent = AMBER;
     label = "ASR: CPU · GPU available →";
     clickable = true;
     title =
-      gpuState === "available_not_installed"
-        ? "An NVIDIA GPU is available. Click to enable GPU acceleration in Settings (one-time ~1.2 GB download)."
-        : "An NVIDIA GPU is available but acceleration is off. Click to enable it in Settings.";
+      gpuState === "error"
+        ? "The GPU runtime download failed. Click to retry in Settings."
+        : gpuState === "available_not_installed"
+          ? "An NVIDIA GPU is available. Click to enable GPU acceleration in Settings (one-time ~1.2 GB download)."
+          : "An NVIDIA GPU is available but acceleration is off. Click to enable it in Settings.";
   } else {
     // cpu / unavailable / unsupported_os
     label = `ASR: CPU · ${status.compute_type} · ${status.workers}w`;

--- a/frontend/src/app/components/asrStatus.ts
+++ b/frontend/src/app/components/asrStatus.ts
@@ -1,0 +1,42 @@
+// Shared shape + colors for the ASR / GPU-acceleration status, served by GET /api/asr-status.
+// Single source of truth so the dashboard badge and the settings panel can't drift.
+
+export const ASR_CYAN = "#22d3ee";
+export const ASR_AMBER = "#f5a623";
+export const ASR_GRAY = "#8893a8";
+
+export type GpuDownload = {
+  state: "idle" | "downloading" | "installing" | "error";
+  downloaded: number;
+  total: number;
+  error: string | null;
+};
+
+export type GpuState =
+  | "active"
+  | "available_not_enabled"
+  | "available_not_installed"
+  | "downloading"
+  | "installing"
+  | "error"
+  | "unsupported_os"
+  | "unavailable";
+
+export type AsrStatus = {
+  device: string;
+  compute_type: string;
+  model: string;
+  workers: number;
+  cpu_threads: number | null;
+  max_concurrent_matches: number;
+  gpu_detected: boolean;
+  gpu_enabled: boolean;
+  gpu_runtime_installed: boolean;
+  gpu_download_size_bytes: number;
+  gpu_download: GpuDownload;
+  gpu_state: GpuState;
+};
+
+export function gpuDownloadGb(bytes: number): string {
+  return `${(bytes / 1e9).toFixed(1)} GB`;
+}

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -5,6 +5,7 @@ import { FEATURES } from '../config/constants';
 import { EngramSelect } from './ui/EngramSelect';
 import { SvActionButton } from '../app/components/synapse/SvActionButton';
 import { BootstrapLibraryFlow } from './BootstrapLibraryFlow';
+import GpuAccelerationSetting from './GpuAccelerationSetting';
 import './ConfigWizard.css';
 
 interface ConfigWizardProps {
@@ -1251,6 +1252,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true }: ConfigWizard
                                 after a backend restart.
                             </span>
                         </div>
+
+                        <GpuAccelerationSetting />
 
                         <div className="form-group">
                             <label htmlFor="conflictResolution">Default Conflict Resolution</label>

--- a/frontend/src/components/GpuAccelerationSetting.tsx
+++ b/frontend/src/components/GpuAccelerationSetting.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ASR_CYAN as CYAN, type AsrStatus, gpuDownloadGb as gb } from "../app/components/asrStatus";
 
 /**
  * Self-contained GPU-acceleration control for the settings wizard.
@@ -9,37 +10,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * config save can never accidentally kick off the download). Activation takes effect after a
  * backend restart. Only NVIDIA on Windows/Linux is supported; macOS/AMD stay on CPU.
  */
-
-type GpuDownload = {
-    state: "idle" | "downloading" | "installing" | "error";
-    downloaded: number;
-    total: number;
-    error: string | null;
-};
-
-type AsrStatus = {
-    device: string;
-    compute_type: string;
-    gpu_detected: boolean;
-    gpu_enabled: boolean;
-    gpu_runtime_installed: boolean;
-    gpu_download_size_bytes: number;
-    gpu_download: GpuDownload;
-    gpu_state:
-        | "active"
-        | "available_not_enabled"
-        | "available_not_installed"
-        | "downloading"
-        | "installing"
-        | "unsupported_os"
-        | "unavailable";
-};
-
-const CYAN = "#22d3ee";
-
-function gb(bytes: number): string {
-    return `${(bytes / 1e9).toFixed(1)} GB`;
-}
 
 export default function GpuAccelerationSetting() {
     const [status, setStatus] = useState<AsrStatus | null>(null);
@@ -183,7 +153,7 @@ export default function GpuAccelerationSetting() {
                 </>
             )}
 
-            {s === "available_not_installed" && (
+            {(s === "available_not_installed" || s === "error") && (
                 <>
                     <span className="form-hint">
                         An NVIDIA GPU is available. Enabling downloads the cuDNN + cuBLAS runtime

--- a/frontend/src/components/GpuAccelerationSetting.tsx
+++ b/frontend/src/components/GpuAccelerationSetting.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Self-contained GPU-acceleration control for the settings wizard.
+ *
+ * GPU ASR (faster-whisper/CTranslate2) needs the NVIDIA cuDNN + cuBLAS runtime (~1.2 GB),
+ * which is downloaded on demand into ~/.engram/cuda/ rather than bundled. This panel owns its
+ * own /api/asr-status fetch and drives the dedicated enable/disable endpoints (so the generic
+ * config save can never accidentally kick off the download). Activation takes effect after a
+ * backend restart. Only NVIDIA on Windows/Linux is supported; macOS/AMD stay on CPU.
+ */
+
+type GpuDownload = {
+    state: "idle" | "downloading" | "installing" | "error";
+    downloaded: number;
+    total: number;
+    error: string | null;
+};
+
+type AsrStatus = {
+    device: string;
+    compute_type: string;
+    gpu_detected: boolean;
+    gpu_enabled: boolean;
+    gpu_runtime_installed: boolean;
+    gpu_download_size_bytes: number;
+    gpu_download: GpuDownload;
+    gpu_state:
+        | "active"
+        | "available_not_enabled"
+        | "available_not_installed"
+        | "downloading"
+        | "installing"
+        | "unsupported_os"
+        | "unavailable";
+};
+
+const CYAN = "#22d3ee";
+
+function gb(bytes: number): string {
+    return `${(bytes / 1e9).toFixed(1)} GB`;
+}
+
+export default function GpuAccelerationSetting() {
+    const [status, setStatus] = useState<AsrStatus | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [eulaAccepted, setEulaAccepted] = useState(false);
+    const [actionError, setActionError] = useState<string | null>(null);
+    const pollRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    const fetchStatus = useCallback(async () => {
+        try {
+            const r = await fetch("/api/asr-status");
+            if (!r.ok) return;
+            const data: AsrStatus = await r.json();
+            setStatus(data);
+            if (data.gpu_state === "downloading" || data.gpu_state === "installing") {
+                pollRef.current = setTimeout(fetchStatus, 1500);
+            }
+        } catch {
+            /* best-effort */
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchStatus();
+        return () => {
+            if (pollRef.current) clearTimeout(pollRef.current);
+        };
+    }, [fetchStatus]);
+
+    const enable = async () => {
+        setBusy(true);
+        setActionError(null);
+        try {
+            const r = await fetch("/api/asr/gpu/enable", { method: "POST" });
+            if (!r.ok) {
+                const body = await r.json().catch(() => ({}));
+                throw new Error(body.detail || `Request failed (${r.status})`);
+            }
+            await fetchStatus();
+        } catch (e) {
+            setActionError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const disable = async () => {
+        setBusy(true);
+        setActionError(null);
+        try {
+            await fetch("/api/asr/gpu/disable", { method: "POST" });
+            await fetchStatus();
+        } catch (e) {
+            setActionError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (!status) return null;
+
+    const s = status.gpu_state;
+
+    // Platforms with no CUDA path: don't show a useless toggle, just explain.
+    if (s === "unsupported_os") {
+        return (
+            <div className="form-group">
+                <label>GPU Acceleration</label>
+                <span className="form-hint">
+                    Not available on this platform. GPU transcription requires an NVIDIA GPU on
+                    Windows or Linux — macOS and AMD GPUs run on CPU.
+                </span>
+            </div>
+        );
+    }
+    if (s === "unavailable") {
+        return (
+            <div className="form-group">
+                <label>GPU Acceleration</label>
+                <span className="form-hint">
+                    No NVIDIA GPU detected. Episode transcription runs on the CPU.
+                </span>
+            </div>
+        );
+    }
+
+    const dl = status.gpu_download;
+    const pct = dl.total > 0 ? Math.floor((dl.downloaded / dl.total) * 100) : 0;
+
+    return (
+        <div className="form-group">
+            <label>GPU Acceleration</label>
+
+            {s === "active" && (
+                <>
+                    <span className="form-hint" style={{ color: CYAN }}>
+                        ✓ Active — transcription runs on the GPU (CUDA · {status.compute_type}).
+                    </span>
+                    <button
+                        type="button"
+                        className="btn-secondary"
+                        disabled={busy}
+                        onClick={disable}
+                        style={{ marginTop: 8, alignSelf: "flex-start" }}
+                    >
+                        Disable GPU acceleration
+                    </button>
+                </>
+            )}
+
+            {(s === "downloading" || s === "installing") && (
+                <>
+                    <span className="form-hint">
+                        {s === "installing"
+                            ? "Installing CUDA runtime…"
+                            : `Downloading NVIDIA CUDA runtime… ${pct}% (${gb(dl.downloaded)} / ${gb(
+                                  dl.total,
+                              )})`}
+                    </span>
+                    <div
+                        style={{
+                            marginTop: 6,
+                            height: 6,
+                            background: "rgba(136,147,168,0.2)",
+                            overflow: "hidden",
+                        }}
+                    >
+                        <div
+                            style={{
+                                width: `${pct}%`,
+                                height: "100%",
+                                background: CYAN,
+                                transition: "width 0.4s",
+                            }}
+                        />
+                    </div>
+                    <span className="form-hint" style={{ marginTop: 6 }}>
+                        You can keep using Engram. Restart the backend once the download finishes to
+                        activate the GPU.
+                    </span>
+                </>
+            )}
+
+            {s === "available_not_installed" && (
+                <>
+                    <span className="form-hint">
+                        An NVIDIA GPU is available. Enabling downloads the cuDNN + cuBLAS runtime
+                        (~{gb(status.gpu_download_size_bytes)}, one time) into{" "}
+                        <code>~/.engram/cuda/</code>. It persists across app updates. Activation
+                        takes effect after a backend restart.
+                    </span>
+                    <label
+                        style={{
+                            display: "flex",
+                            alignItems: "flex-start",
+                            gap: 8,
+                            marginTop: 8,
+                            fontSize: 13,
+                            fontWeight: 400,
+                        }}
+                    >
+                        <input
+                            type="checkbox"
+                            checked={eulaAccepted}
+                            onChange={(e) => setEulaAccepted(e.target.checked)}
+                            style={{ marginTop: 3 }}
+                        />
+                        <span>
+                            I accept the{" "}
+                            <a
+                                href="https://docs.nvidia.com/cuda/eula/index.html"
+                                target="_blank"
+                                rel="noreferrer"
+                                style={{ color: CYAN }}
+                            >
+                                NVIDIA CUDA EULA
+                            </a>{" "}
+                            for the cuDNN and cuBLAS libraries.
+                        </span>
+                    </label>
+                    <button
+                        type="button"
+                        className="btn-primary"
+                        disabled={busy || !eulaAccepted}
+                        onClick={enable}
+                        style={{ marginTop: 8, alignSelf: "flex-start" }}
+                    >
+                        {busy ? "Starting…" : `Download & enable (~${gb(status.gpu_download_size_bytes)})`}
+                    </button>
+                </>
+            )}
+
+            {s === "available_not_enabled" && (
+                <>
+                    <span className="form-hint">
+                        An NVIDIA GPU is available and the CUDA runtime is installed. Enable GPU
+                        acceleration to transcribe on the GPU (takes effect after a backend restart).
+                    </span>
+                    <button
+                        type="button"
+                        className="btn-primary"
+                        disabled={busy}
+                        onClick={enable}
+                        style={{ marginTop: 8, alignSelf: "flex-start" }}
+                    >
+                        {busy ? "Enabling…" : "Enable GPU acceleration"}
+                    </button>
+                </>
+            )}
+
+            {(actionError || (dl.state === "error" && dl.error)) && (
+                <span className="form-hint" style={{ color: "#f87171", marginTop: 6 }}>
+                    {actionError || `Download failed: ${dl.error}`}
+                </span>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## What & why

On a machine with an NVIDIA GPU, the dashboard badge read `ASR: CUDA …` but the compiled build never actually used the GPU — it silently transcribed on CPU. Two stacked bugs:

1. **The badge was dishonest.** `detect_asr_device()` returned `"cuda"` whenever `ctranslate2.get_cuda_device_count() > 0` — a probe that only needs the NVIDIA **driver**, not the math libraries. `/api/asr-status` recomputed that and never loaded a model, so it claimed CUDA even when CUDA inference was impossible.
2. **The frozen build had no CUDA math libraries.** faster-whisper → CTranslate2 needs **cuDNN 9 + cuBLAS** (~1.2 GB). They were declared only in the `gpu` optional-extra (never `uv sync`'d in CI) and not bundled — and CTranslate2 `dlopen`s them lazily by name, so PyInstaller's static analysis can't see them anyway. At first transcription the `device="cuda"` load failed and the code silently fell back to CPU/`int8`.

## What this PR does

Two independent improvements:

**1. Honest device reporting.** The *effective* ASR device is resolved **once** at `job_manager.start()` (after the libs are registered) and pinned via `set_asr_device()`. Every call site — the `/api/asr-status` badge, the match semaphore, the model loader — now reads it through `detect_asr_device()`, so they can't disagree. When a GPU is present but unused, the badge shows an actionable `CPU · GPU available →` chip that opens Settings.

**2. On-demand, opt-in CUDA runtime** — new `backend/app/matcher/cuda_runtime.py`:
- Downloads the pinned cuDNN/cuBLAS PyPI wheels (SHA256-verified, atomic stage-then-replace) into `~/.engram/cuda/`. It lives **outside the install dir**, so — like the DB and subtitle cache — it survives app updates and the updater needs **zero** changes.
- Registers them before the first model load: Windows `os.add_dll_directory`; Linux ordered `ctypes.CDLL(RTLD_GLOBAL)` preload (since `LD_LIBRARY_PATH` is read once at process start and can't be injected at runtime).
- Falls back to the pip `nvidia.*` packages for developers running `uv sync --extra gpu`.
- A **GPU Acceleration** panel in Settings → Matching (shown only when an NVIDIA GPU is detected) handles the EULA acknowledgement, download progress, and the "restart to activate" flow. New endpoints `POST /api/asr/gpu/enable|disable`; `/api/asr-status` gains `gpu_detected/gpu_enabled/gpu_runtime_installed/gpu_state/gpu_download`; new `gpu_status` WS message.

Two correctness guards: `cuda_compute_type()` picks `float16`/`int8_float16`/`float32` per `get_supported_compute_types()` so older (Pascal) GPUs don't choke on `float16`, and the new `enable_gpu_acceleration` config field has the full three-way sync.

## Scope

NVIDIA on **Windows + Linux** only — CTranslate2 has no Metal/CoreML path, so macOS (and AMD) stay on CPU `int8`. A Metal/MLX backend would be a separate engine and is an explicit non-goal here.

## Docs

Updates the **GPU acceleration** section of the Performance & Hardware guide added in #353 (it described the pre-change behavior — "auto-detect", "silent CPU fallback", "standalone builds are CPU-only"), plus the README GPU note and the config reference. Adds a developer guide at `docs/development/gpu.md`. CHANGELOG `[Unreleased]` + a `THIRD_PARTY_LICENSES.md` note for the runtime-downloaded NVIDIA redistributables.

## Verification

- ✅ 47 new backend unit tests (download/verify/extract/atomic-install, effective-device honesty, compute-type selection, badge-state derivation, config three-way sync) + the full backend unit suite (1807) pass.
- ✅ Frontend `tsc` + `vite build` and ESLint clean; `mkdocs build` clean on the edited pages (only the pre-existing `superpowers/specs/*` source-link warnings remain).
- ⚠️ **Not live-verified end-to-end** (download → restart → real GPU transcription). Verifying it here would require starting a second backend, whose unconditional drive sentinel risks a `makemkvcon`/port conflict with the running release. Maintainer can verify per `docs/development/gpu.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
