### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-08
+
+_Highlights: episode matching can now run on an NVIDIA GPU (opt-in, with the CUDA runtime downloaded on demand) for dramatically faster transcription — and the dashboard's ASR badge now reports the device transcription actually runs on instead of claiming CUDA while silently falling back to the CPU._
+
 ### Added
 
 - **GPU acceleration for episode matching (NVIDIA, opt-in)** — Engram can now run Whisper transcription on an NVIDIA GPU instead of the CPU, which is dramatically faster for episode matching. Because the required CUDA libraries (cuDNN + cuBLAS) are ~1.2 GB, they are not bundled into the download; instead a new **GPU Acceleration** control in Settings → Matching detects your GPU and downloads the runtime on demand (one time, into `~/.engram/` so it survives app updates). Supported on Windows and Linux with an NVIDIA GPU; macOS and AMD GPUs continue to run on the CPU (the engine has no GPU path there). Takes effect after a backend restart.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.16.3"
+__version__ = "0.17.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.16.3"
+version = "0.17.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.16.3"
+version = "0.17.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.16.3",
+    "version": "0.17.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.16.3",
+            "version": "0.17.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.16.3",
+    "version": "0.17.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Release **v0.17.0** — first minor release since 0.16.3 (new opt-in GPU feature → minor bump per convention).

## Version bump (6 files in lockstep)
- `backend/pyproject.toml`
- `backend/app/__init__.py` (`__version__`)
- `backend/uv.lock` (engram-backend self-version)
- `frontend/package.json`
- `frontend/package-lock.json` (both self-version fields)
- `CHANGELOG.md` — moved `[Unreleased]` into `## [0.17.0] - 2026-06-08` (dated UTC) with a `_Highlights:_` lead

## Release notes (extracted by `release.yml`)
_Highlights: episode matching can now run on an NVIDIA GPU (opt-in, with the CUDA runtime downloaded on demand) for dramatically faster transcription — and the dashboard's ASR badge now reports the device transcription actually runs on instead of claiming CUDA while silently falling back to the CPU._

### Added
- **GPU acceleration for episode matching (NVIDIA, opt-in)** ([#354](https://github.com/Jsakkos/engram/pull/354))

### Fixed
- **The ASR status badge no longer claims "CUDA" when it's actually using the CPU** ([#354](https://github.com/Jsakkos/engram/pull/354))

## Verification
- `extract_changelog.py --version 0.17.0 --check` → `ok: CHANGELOG has a section for 0.17.0`
- All 6 version fields confirmed at `0.17.0`; `package.json`/`package-lock.json` validated as JSON
- Only PRs since v0.16.3: #354 (logged) and #353 (docs-only, intentionally not in user-facing notes)

On squash-merge, the `chore: release v` title triggers `tag-release.yml` → tags `v0.17.0` → dispatches binary + Docker builds. **Leaving the merge to you.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)