### PR TITLE
fix: prevent DB connection-pool exhaustion during multi-season imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Processing many jobs at once no longer crashes with a database timeout** — importing several seasons while another disc is ripping could exhaust Engram's database connection pool (`QueuePool limit of size 5 overflow 10 reached, connection timed out`), which stalled episode matching and the dashboard. The connection pool is now sized for that concurrency (and waits politely for SQLite's single-writer lock instead of failing with "database is locked"), and episode matching no longer keeps a database connection open while it looks up episode runtimes over the network. Takes effect after a backend restart.
+
 ## [0.17.0] - 2026-06-08
 
 _Highlights: episode matching can now run on an NVIDIA GPU (opt-in, with the CUDA runtime downloaded on demand) for dramatically faster transcription — and the dashboard's ASR badge now reports the device transcription actually runs on instead of claiming CUDA while silently falling back to the CPU._

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -56,6 +56,22 @@ class Settings(BaseSettings):
     # timeouts; see PR #267). Off by default; set DB_ECHO=true for local SQL tracing.
     db_echo: bool = False
 
+    # Database connection pool sizing. SQLAlchemy's async default (pool_size 5 +
+    # max_overflow 10 = 15 connections) is too small for this app's peak
+    # concurrency: a multi-season import fans out one matching task per title
+    # across every active job (7 seasons × ~22 episodes ≈ 100+ DB-touching
+    # coroutines), plus a concurrent rip's identification and the dashboard. When
+    # simultaneous checkouts exceed the ceiling, the next session waits
+    # db_pool_timeout seconds and raises QueuePool TimeoutError. SQLite in WAL
+    # mode handles many concurrent connections safely — reads are concurrent and
+    # writes serialize at the SQLite level (via busy_timeout, see database.py),
+    # independent of pool size — so a larger pool trades only memory/threads, not
+    # correctness. Overflow connections are created on demand and discarded when
+    # returned, so steady-state cost stays near db_pool_size. Env-overridable.
+    db_pool_size: int = 20
+    db_max_overflow: int = 80
+    db_pool_timeout: int = 30
+
     # Server
     host: str = "127.0.0.1"
     port: int = 8000

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -21,21 +21,42 @@ logger = logging.getLogger(__name__)
 _ALEMBIC_INI = Path(__file__).parent.parent / "alembic.ini"
 
 # Create async engine. echo is gated on the dedicated db_echo setting, NOT
-# debug — see Settings.db_echo for the rationale.
+# debug — see Settings.db_echo for the rationale. Pool sizing is lifted above
+# SQLAlchemy's async default (5 + 10 = 15) because a multi-season import fans out
+# 100+ concurrent DB-touching coroutines; see Settings.db_pool_size for the full
+# rationale on why a larger pool is safe for WAL SQLite.
 engine = create_async_engine(
     settings.database_url,
     echo=settings.db_echo,
     future=True,
     connect_args={"check_same_thread": False},  # Needed for SQLite
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
+    pool_timeout=settings.db_pool_timeout,
 )
 
 
-@sqlalchemy.event.listens_for(engine.sync_engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
+    """Apply per-connection SQLite pragmas (registered as the engine 'connect' hook).
+
+    WAL + synchronous=NORMAL is the standard high-concurrency SQLite setup. The
+    busy_timeout is essential now that the pool allows many concurrent
+    connections: SQLite still permits only ONE writer at a time, so concurrent
+    committers (e.g. 7 seasons matching at once, plus a rip) contend for the
+    single write lock. With the default busy_timeout of 0, a writer that can't
+    immediately acquire the lock fails fast with "database is locked"; 30s makes
+    it WAIT and retry instead, turning the larger pool's write contention into
+    polite queueing rather than errors. Module-level (not a decorator closure) so
+    it can be unit-tested against a throwaway connection.
+    """
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA journal_mode=WAL")
     cursor.execute("PRAGMA synchronous=NORMAL")
+    cursor.execute("PRAGMA busy_timeout=30000")
     cursor.close()
+
+
+sqlalchemy.event.listens_for(engine.sync_engine, "connect")(set_sqlite_pragma)
 
 
 # Async session factory

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -50,10 +50,14 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
     it can be unit-tested against a throwaway connection.
     """
     cursor = dbapi_connection.cursor()
-    cursor.execute("PRAGMA journal_mode=WAL")
-    cursor.execute("PRAGMA synchronous=NORMAL")
-    cursor.execute("PRAGMA busy_timeout=30000")
-    cursor.close()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+    finally:
+        # Close even if a PRAGMA raises (e.g. journal_mode=WAL on a read-only
+        # path) so the cursor never leaks.
+        cursor.close()
 
 
 sqlalchemy.event.listens_for(engine.sync_engine, "connect")(set_sqlite_pragma)

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import time
+from collections import defaultdict
 from datetime import UTC
 from pathlib import Path
 
@@ -150,6 +151,13 @@ class MatchingCoordinator:
         # Shared state (moved from JobManager)
         self._discdb_mappings: dict[int, list] = {}
         self._episode_runtimes: dict[int, list[int]] = {}
+        # Per-job lock guarding the runtimes cache population. Collapses the
+        # cold-window stampede where many titles of one job fetch runtimes at
+        # once (see _episode_runtimes_for_job). defaultdict creates each lock
+        # synchronously on first access, so there is no create-time race on the
+        # single event loop. asyncio.Lock() binds to the loop lazily (py3.11),
+        # so constructing it here (no running loop) is safe.
+        self._episode_runtimes_locks: defaultdict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._subtitle_ready: dict[int, asyncio.Event] = {}
         self._subtitle_tasks: dict[int, asyncio.Task] = {}
         self._match_semaphore: asyncio.Semaphore | None = None
@@ -174,6 +182,7 @@ class MatchingCoordinator:
         ``on_terminal_state`` callback signature.
         """
         self._episode_runtimes.pop(job_id, None)
+        self._episode_runtimes_locks.pop(job_id, None)
         self._discdb_mappings.pop(job_id, None)
         self._subtitle_ready.pop(job_id, None)
         task = self._subtitle_tasks.pop(job_id, None)
@@ -682,38 +691,61 @@ class MatchingCoordinator:
                 await self._check_job_completion(session, job_id)
             return
 
-        # 4. Duration pre-filter
-        async with async_session() as session:
-            job = await session.get(DiscJob, job_id)
-            title = await session.get(DiscTitle, title_id)
-            if job and title and job.detected_season:
-                try:
-                    runtimes = await self._episode_runtimes_for_job(job)
-                    if runtimes and title.duration_seconds:
-                        title_minutes = title.duration_seconds / 60
-                        if not _duration_matches_episode_runtime(title_minutes, runtimes):
-                            handled = await self._handle_extras(
-                                job_id,
-                                title_id,
-                                title,
-                                job,
-                                file_path,
-                                title_minutes,
-                                runtimes,
-                                session,
-                            )
-                            if handled:
-                                return
-                except Exception as e:
-                    # Surface the full traceback: a silently-failing TMDB runtime
-                    # fetch here disables automatic extras detection (the pre-filter
-                    # is the only thing that flags non-episode bonus tracks before
-                    # the matcher tries to force them onto an episode).
-                    logger.warning(
-                        f"[MATCH] Title {title_id} (Job {job_id}): duration pre-filter failed: {e}. "
-                        f"Proceeding with matching normally.",
-                        exc_info=True,
-                    )
+        # 4. Duration pre-filter. Fetch episode runtimes WITHOUT a DB connection
+        # held: the lookup can hit TMDB over the network, and holding a pooled
+        # connection across that round-trip — across every title of every active
+        # job — is what exhausted the connection pool. Mirror the rip path: read
+        # the scalars under a brief session, release it, do the network work,
+        # then reopen only to act on the result.
+        try:
+            job_tmdb_id: int | None = None
+            job_detected_title: str | None = None
+            job_detected_season: int | None = None
+            title_duration: float | None = None
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                title = await session.get(DiscTitle, title_id)
+                if job and title and job.detected_season:
+                    job_tmdb_id = job.tmdb_id
+                    job_detected_title = job.detected_title
+                    job_detected_season = job.detected_season
+                    title_duration = title.duration_seconds
+
+            if job_detected_season:
+                # No connection held across this (possibly networked) lookup.
+                runtimes = await self._episode_runtimes_for_job(
+                    job_id, job_tmdb_id, job_detected_title, job_detected_season
+                )
+                if runtimes and title_duration:
+                    title_minutes = title_duration / 60
+                    if not _duration_matches_episode_runtime(title_minutes, runtimes):
+                        # Re-fetch under a fresh session: _handle_extras writes.
+                        async with async_session() as session:
+                            job = await session.get(DiscJob, job_id)
+                            title = await session.get(DiscTitle, title_id)
+                            if job and title:
+                                handled = await self._handle_extras(
+                                    job_id,
+                                    title_id,
+                                    title,
+                                    job,
+                                    file_path,
+                                    title_minutes,
+                                    runtimes,
+                                    session,
+                                )
+                                if handled:
+                                    return
+        except Exception as e:
+            # Surface the full traceback: a silently-failing TMDB runtime
+            # fetch here disables automatic extras detection (the pre-filter
+            # is the only thing that flags non-episode bonus tracks before
+            # the matcher tries to force them onto an episode).
+            logger.warning(
+                f"[MATCH] Title {title_id} (Job {job_id}): duration pre-filter failed: {e}. "
+                f"Proceeding with matching normally.",
+                exc_info=True,
+            )
 
         # 5. Acquire semaphore to limit concurrent matching
         if self._match_semaphore is not None:
@@ -755,39 +787,60 @@ class MatchingCoordinator:
                 self._match_semaphore.release()
                 logger.info(f"[MATCH] Title {title_id} (Job {job_id}): released match semaphore")
 
-    async def _episode_runtimes_for_job(self, job: DiscJob) -> list[int]:
+    async def _episode_runtimes_for_job(
+        self,
+        job_id: int,
+        tmdb_id: int | None,
+        detected_title: str | None,
+        detected_season: int | None,
+    ) -> list[int]:
         """Episode runtimes (minutes) for the job's season, cached per job.
 
-        Backs the duration pre-filter that flags non-episode bonus tracks as
-        extras before the matcher tries to force them onto an episode.
+        Takes scalars rather than a ``DiscJob`` so the caller can release its DB
+        session before this (network) TMDB lookup: holding a pooled connection
+        across the round-trip, across every title of every active job, is what
+        exhausted the connection pool. Backs the duration pre-filter that flags
+        non-episode bonus tracks as extras before the matcher forces them onto an
+        episode.
         """
-        if job.id in self._episode_runtimes:
-            return self._episode_runtimes[job.id]
+        if job_id in self._episode_runtimes:
+            return self._episode_runtimes[job_id]
 
-        from app.matcher.tmdb_client import (
-            fetch_season_episode_runtimes,
-            fetch_show_id,
-        )
+        # Collapse the cold-window stampede: in a multi-season import, every
+        # title of a job hits this at once. The lock makes only the first caller
+        # perform the (network) TMDB fetch; the rest await it and read the
+        # populated cache via the double-check below. Because the caller already
+        # released its DB session, a title waiting on this lock holds no pooled
+        # connection — without that ordering the lock would merely convert a
+        # connection-per-fetch storm into a connection-per-waiter storm.
+        async with self._episode_runtimes_locks[job_id]:
+            if job_id in self._episode_runtimes:
+                return self._episode_runtimes[job_id]
 
-        # Prefer the job's authoritative tmdb_id (e.g. set when the user
-        # re-identified a same-name collision in review). Re-resolving by name
-        # here would return the dominant same-name twin (Frasier 1993 #3452,
-        # 24×23min) instead of the re-identified revival (#195241, 10 eps),
-        # whose real episodes would then fail the duration filter and be
-        # misclassified as extras. Sibling to PR #282's curator/chromaprint/LLM
-        # threading.
-        if job.tmdb_id:
-            show_id = str(job.tmdb_id)
-        else:
-            show_id = await asyncio.to_thread(fetch_show_id, job.detected_title)
-        if show_id:
-            runtimes = await asyncio.to_thread(
-                fetch_season_episode_runtimes, show_id, job.detected_season
+            from app.matcher.tmdb_client import (
+                fetch_season_episode_runtimes,
+                fetch_show_id,
             )
-        else:
-            runtimes = []
-        self._episode_runtimes[job.id] = runtimes
-        return runtimes
+
+            # Prefer the job's authoritative tmdb_id (e.g. set when the user
+            # re-identified a same-name collision in review). Re-resolving by name
+            # here would return the dominant same-name twin (Frasier 1993 #3452,
+            # 24×23min) instead of the re-identified revival (#195241, 10 eps),
+            # whose real episodes would then fail the duration filter and be
+            # misclassified as extras. Sibling to PR #282's curator/chromaprint/LLM
+            # threading.
+            if tmdb_id:
+                show_id = str(tmdb_id)
+            else:
+                show_id = await asyncio.to_thread(fetch_show_id, detected_title)
+            if show_id:
+                runtimes = await asyncio.to_thread(
+                    fetch_season_episode_runtimes, show_id, detected_season
+                )
+            else:
+                runtimes = []
+            self._episode_runtimes[job_id] = runtimes
+            return runtimes
 
     async def _converge_job_to_matching(self, session, job_id: int) -> None:
         """Ensure the parent job reflects MATCHING the moment a title starts matching.

--- a/backend/tests/unit/test_db_pool_config.py
+++ b/backend/tests/unit/test_db_pool_config.py
@@ -1,0 +1,48 @@
+"""Regression guard for the database connection-pool configuration.
+
+These tests pin the fix for the QueuePool exhaustion that struck multi-season
+imports (7 Seinfeld seasons matching concurrently + a rip): SQLAlchemy's async
+default pool of 5 + 10 = 15 connections was too small for the app's fan-out, and
+the absence of a SQLite busy_timeout meant concurrent writers failed fast with
+"database is locked" instead of queueing. See app/config.py:db_pool_size and
+app/database.py:set_sqlite_pragma.
+"""
+
+import sqlite3
+
+from app.config import settings
+from app.database import engine, set_sqlite_pragma
+
+
+def test_engine_pool_sized_above_async_default():
+    """The pool must be sized from settings, comfortably above the 5+10 default."""
+    pool = engine.sync_engine.pool
+    assert pool.size() == settings.db_pool_size
+    assert pool._max_overflow == settings.db_max_overflow
+
+    # The whole point of the fix: the ceiling must exceed the old default of 15
+    # so a multi-season import's concurrent checkouts don't time out.
+    assert settings.db_pool_size + settings.db_max_overflow > 15
+
+
+def test_busy_timeout_pragma_applied():
+    """set_sqlite_pragma must set a non-zero busy_timeout so writers wait, not error."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        set_sqlite_pragma(conn, None)
+        busy_timeout = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert busy_timeout == 30000
+    finally:
+        conn.close()
+
+
+def test_pragma_sets_synchronous_normal():
+    """Co-pinned: WAL's companion synchronous=NORMAL stays applied."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        set_sqlite_pragma(conn, None)
+        # synchronous: 0=OFF, 1=NORMAL, 2=FULL
+        synchronous = conn.execute("PRAGMA synchronous").fetchone()[0]
+        assert synchronous == 1
+    finally:
+        conn.close()

--- a/backend/tests/unit/test_db_pool_config.py
+++ b/backend/tests/unit/test_db_pool_config.py
@@ -18,6 +18,9 @@ def test_engine_pool_sized_above_async_default():
     """The pool must be sized from settings, comfortably above the 5+10 default."""
     pool = engine.sync_engine.pool
     assert pool.size() == settings.db_pool_size
+    # _max_overflow is a private SQLAlchemy attr (no public accessor for the
+    # overflow ceiling exists); if a future upgrade renames it this assertion
+    # turns into an AttributeError — verify on SQLAlchemy bumps.
     assert pool._max_overflow == settings.db_max_overflow
 
     # The whole point of the fix: the ceiling must exceed the old default of 15

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -8,6 +8,7 @@ stubbed.
 
 import asyncio
 import json
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -625,7 +626,9 @@ class TestEpisodeRuntimesShowIdentity:
             await session.commit()
             await session.refresh(job)
 
-            runtimes = await coord._episode_runtimes_for_job(job)
+            runtimes = await coord._episode_runtimes_for_job(
+                job.id, job.tmdb_id, job.detected_title, job.detected_season
+            )
 
         assert runtimes == [22, 22, 22]
         # The known id flowed straight through — NOT the name-resolved twin (3452).
@@ -656,11 +659,58 @@ class TestEpisodeRuntimesShowIdentity:
             await session.commit()
             await session.refresh(job)
 
-            runtimes = await coord._episode_runtimes_for_job(job)
+            runtimes = await coord._episode_runtimes_for_job(
+                job.id, job.tmdb_id, job.detected_title, job.detected_season
+            )
 
         assert runtimes == [23, 23]
         fake_fetch_id.assert_called_once_with("Frasier")
         assert captured["show_id"] == "3452"
+
+
+@pytest.mark.unit
+class TestEpisodeRuntimesCacheConcurrency:
+    """When many titles of the same job hit the duration pre-filter at once (the
+    cold window of a multi-season import), the episode-runtimes lookup must
+    collapse to a SINGLE TMDB fetch. A stampede here means one in-flight TMDB
+    round-trip per title — and, in the caller, one held DB connection per title
+    across that round-trip — which is the connection-pool exhaustion aggravator
+    this fix targets.
+    """
+
+    async def test_concurrent_calls_for_same_job_fetch_once(self, monkeypatch):
+        coord = _make_coord()
+        calls: list[tuple] = []
+
+        def slow_runtimes(show_id, season):
+            # Append (GIL-atomic) BEFORE sleeping so a stampede records every
+            # entrant; the sleep keeps the first fetch in-flight long enough for
+            # all concurrent callers to race past the cache check.
+            calls.append((show_id, season))
+            time.sleep(0.05)
+            return [22, 22, 22]
+
+        monkeypatch.setattr("app.matcher.tmdb_client.fetch_season_episode_runtimes", slow_runtimes)
+        monkeypatch.setattr("app.matcher.tmdb_client.fetch_show_id", MagicMock(return_value="999"))
+
+        async with _unit_session_factory() as session:
+            job, _title = await _seed(session)
+            job.tmdb_id = 195241
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+
+            results = await asyncio.gather(
+                *[
+                    coord._episode_runtimes_for_job(
+                        job.id, job.tmdb_id, job.detected_title, job.detected_season
+                    )
+                    for _ in range(8)
+                ]
+            )
+
+        assert all(r == [22, 22, 22] for r in results)
+        assert len(calls) == 1, f"expected one fetch, got {len(calls)} (stampede)"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
@
## Problem

Processing several seasons concurrently while ripping another disc crashed with:

```
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

**Root cause.** `database.py` created the async engine with SQLAlchemys *default* pool (`pool_size=5` + `max_overflow=10` = 15 connections). A multi-season import fans out one match task **per title** — 7 seasons × ~22 episodes ≈ 100+ concurrent DB-touching coroutines — plus a concurrent rips identification and the dashboard. When simultaneous checkouts exceed 15, the next `async with async_session()` waits 30s and raises.

It was *not* a session leak (every session uses `async with`), and *not* the rip path (already hardened to capture scalars + `expunge()` + release before the long rip).

## Changes

**1. Size the connection pool to the workload (`fbab100`)**
- New env-overridable settings `db_pool_size=20` / `db_max_overflow=80` / `db_pool_timeout=30` (`config.py`), wired into `create_async_engine`. Ceiling 15 → 100.
- Added `PRAGMA busy_timeout=30000` to the SQLite connect hook so concurrent writers **wait** for SQLites single write lock instead of failing fast with "database is locked" (essential once the pool allows many connections). WAL keeps reads concurrent, so a larger pool is safe — overflow connections are created on demand and discarded on return, so steady-state stays near `pool_size`.

**2. Stop holding a DB connection across the TMDB lookup (`5783c83`)**
- The duration pre-filter held a pooled connection across `_episode_runtimes_for_job`s TMDB **network** call, for every title of every active job — the unbounded, pre-semaphore aggravator. Restructured to mirror the rip path: capture scalars under a brief session → release → fetch runtimes with no connection held → reopen only to write extras.
- `_episode_runtimes_for_job` now takes scalars (not a `DiscJob`) and a per-job `asyncio.Lock` collapses the cold-window stampede to a single TMDB fetch. (Safe **only** because the caller releases its session first — otherwise the lock would convert a connection-per-fetch storm into a connection-per-waiter storm.)

## Why the ASR-held session was left alone (deliberate)

`_match_single_file_inner` also holds a session across the Whisper run, but its bounded by the match semaphore (≤ `GPU_WORKER_CAP=4` on GPU / ~2 on CPU) → ≤4 of 100 connections = negligible. Restructuring that ~400-line race-guarded function for ~zero pool benefit is high-risk, and the unit suite doesnt exercise the matcher pipeline (not TDD-verifiable). Recorded as a known follow-up, along with a lower-risk twin: `config_service`s **sync** engine still uses the default 15-pool.

## Testing

- New `tests/unit/test_db_pool_config.py` (pool sizing + `busy_timeout` pragma) and `TestEpisodeRuntimesCacheConcurrency` (TDD: watched it fail at 8 fetches/stampede, pass at 1 after the lock).
- **1821 unit tests pass**; matching-coordinator suite (33) + pipeline & matching-integration (114, run twice, stable); ruff lint + format clean.
- Verified against the v0.17.0 GPU rebase: `resolve_asr_runtime`/`GPU_WORKER_CAP=4` does not invalidate the fix, and async `get_config()` shares the enlarged pool.

## Reviewer notes

- **Takes effect after a backend restart** (the engine is built at import); frozen builds need a new build.
- Pool size is env-tunable via `DB_POOL_SIZE` / `DB_MAX_OVERFLOW` / `DB_POOL_TIMEOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@