### PR TITLE
fix(dashboard): hide dead-end review button for unconfirmed discs + show year/TMDB id in re-identify modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **Processing many jobs at once no longer crashes with a database timeout** — importing several seasons while another disc is ripping could exhaust Engram's database connection pool (`QueuePool limit of size 5 overflow 10 reached, connection timed out`), which stalled episode matching and the dashboard. The connection pool is now sized for that concurrency (and waits politely for SQLite's single-writer lock instead of failing with "database is locked"), and episode matching no longer keeps a database connection open while it looks up episode runtimes over the network. Takes effect after a backend restart.
+- **Discs awaiting a "Wrong title?" correction no longer show a dead-end "Review needed" button** — when a disc matched multiple same-name shows on TMDB (e.g. "The Office"), the card showed a yellow "Review needed" action button next to an identical "REVIEW NEEDED" status badge, but that button only opened an empty episode-review queue because the show identity wasn't settled yet. The episode-review button is now hidden while a disc's identity is unconfirmed, leaving the corrective "Wrong title?" action (and an explanatory banner) as the clear next step. (An earlier attempt only covered discs with no enumerated titles, which never happens for this case since titles are listed at scan time.)
+- **The Re-Identify ("Wrong title?") modal now shows the release year and TMDB id** — after you pick a show from the search results (or the "Did you mean?" quick-pick), the modal confirms the exact match as `Name (year) · TMDB #id` so you can tell same-name shows apart, and it now also shows what the disc is *currently* identified as for comparison.
 
 ## [0.17.0] - 2026-06-08
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -131,6 +131,13 @@ class JobResponse(BaseModel):
     # Transient auto-resolution note set during conflict / review escalation
     # (e.g. "Resolving episode conflicts — pass 2 of 3"). Cleared on resolution.
     conflict_status: str | None = None
+    # Resolved TMDB identity. tmdb_id is null while identity is unconfirmed (e.g. a
+    # same-name collision the analyst withholds an id for) — the dashboard reads that
+    # to suppress the dead-end episode-review button, and the re-identify modal shows
+    # tmdb_name/tmdb_year/tmdb_id so the user can confirm which show is selected.
+    tmdb_id: int | None = None
+    tmdb_name: str | None = None
+    tmdb_year: int | None = None
     destination_mode: str = "library"
     created_at: datetime | str | None = None
 

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -151,6 +151,25 @@ class TestJobEndpoints:
         assert detail.status_code == 200
         assert detail.json()["candidates_json"] == payload
 
+    async def test_tmdb_identity_fields_exposed_in_job_response(self, client):
+        """The dashboard reads tmdb_id to suppress the dead-end episode-review
+        button, and the re-identify modal shows tmdb_name/tmdb_year. These must
+        survive the JobResponse serializer in both list and by-id endpoints —
+        present (even as null) for an unconfirmed disc, populated for a known one."""
+        confirmed = await _seed_job(tmdb_id=18409, tmdb_name="The Office", tmdb_year=2005)
+        unconfirmed = await _seed_job(volume_label="AMBIGUOUS", tmdb_id=None)
+
+        by_id = (await client.get(f"/api/jobs/{confirmed.id}")).json()
+        assert by_id["tmdb_id"] == 18409
+        assert by_id["tmdb_name"] == "The Office"
+        assert by_id["tmdb_year"] == 2005
+
+        listed = {j["id"]: j for j in (await client.get("/api/jobs")).json()}
+        # Null identity is present-as-null (not omitted), so `tmdb_id == null`
+        # is a reliable client-side discriminator.
+        assert listed[unconfirmed.id]["tmdb_id"] is None
+        assert listed[confirmed.id]["tmdb_id"] == 18409
+
     async def test_get_job_titles(self, client):
         job = await _seed_job()
         await _seed_titles(job.id, count=3)

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -601,7 +601,7 @@ function MainDashboard() {
                   disc={disc}
                   onCancel={disc.state !== 'completed' && disc.state !== 'error' ? () => cancelJob(disc.id) : undefined}
                   onAdvance={disc.state !== 'completed' && disc.state !== 'error' ? () => advanceJob(disc.id) : undefined}
-                  onReview={disc.needsReview && (disc.tracks?.length ?? 0) > 0 ? () => navigate(reviewPath(disc.id)) : undefined}
+                  onReview={disc.needsReview && !disc.identityReview && (disc.tracks?.length ?? 0) > 0 ? () => navigate(reviewPath(disc.id)) : undefined}
                   onReIdentify={disc.needsReview && disc.title ? () => {
                     const job = jobs.find(j => String(j.id) === disc.id);
                     if (job) setReIdentifyTarget(job);
@@ -931,7 +931,7 @@ function CompactList({
               </span>
               {/* Actions */}
               <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                {disc.needsReview && (disc.tracks?.length ?? 0) > 0 && (
+                {disc.needsReview && !disc.identityReview && (disc.tracks?.length ?? 0) > 0 && (
                   <CompactRowButton color={sv.yellow} onClick={() => onReview(disc.id)}>
                     Review
                   </CompactRowButton>

--- a/frontend/src/app/components/DiscCard.test.tsx
+++ b/frontend/src/app/components/DiscCard.test.tsx
@@ -32,15 +32,16 @@ afterEach(() => {
 });
 
 describe('DiscCard — review affordances', () => {
-  it('pre-rip review (no tracks): hides the review-queue button, keeps "Wrong title?", and shows the reason banner', () => {
+  it('identity review (no tracks): hides the review-queue button, keeps "Wrong title?", and shows the reason banner', () => {
     render(
       <DiscCard
         disc={makeDisc({
+          identityReview: true,
           tracks: [],
           reviewReason:
             '"Frasier" has multiple same-name shows on TMDB and the disc label has no year to tell them apart.',
         })}
-        // App passes onReview=undefined when there are no tracks to review yet.
+        // App passes onReview=undefined for an identity review.
         onReview={undefined}
         onReIdentify={vi.fn()}
       />,
@@ -60,14 +61,42 @@ describe('DiscCard — review affordances', () => {
     // ...and the card explains the ambiguity, pointing the user at "Wrong title?".
     expect(screen.getByText(/multiple same-name shows on TMDB/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/use "wrong title\?" to pick the correct one/i),
+      screen.getByText(/use "wrong title\?" to pick the correct show/i),
     ).toBeInTheDocument();
   });
 
-  it('post-rip review (has tracks): shows the review-queue button and no banner', () => {
+  it('identity review WITH enumerated (pending) tracks: still hides the button + shows the banner', () => {
+    // The real ambiguous-disc case (e.g. The Office): titles are enumerated at
+    // scan time, so the disc has tracks even before ripping. The old tracks===0
+    // gate never fired here; identityReview must drive the declutter regardless.
     render(
       <DiscCard
         disc={makeDisc({
+          identityReview: true,
+          tracks: [
+            { id: 't1', title: 'Title 0', duration: '22:14', state: 'pending', progress: 0 },
+            { id: 't2', title: 'Title 1', duration: '21:58', state: 'pending', progress: 0 },
+          ],
+          reviewReason: '"The Office" has multiple same-name shows on TMDB. Pick the correct one.',
+        })}
+        onReview={undefined}
+        onReIdentify={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /review needed — open review queue/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/use "wrong title\?" to pick the correct show/i),
+    ).toBeInTheDocument();
+  });
+
+  it('episode review (identity confirmed, has review tracks): shows the review-queue button and no banner', () => {
+    render(
+      <DiscCard
+        disc={makeDisc({
+          identityReview: false,
           reviewReason: undefined,
           tracks: [
             { id: 't1', title: 'Title 0', duration: '22:14', state: 'review', progress: 0 },
@@ -82,17 +111,18 @@ describe('DiscCard — review affordances', () => {
       screen.getByRole('button', { name: /review needed — open review queue/i }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/use "wrong title\?" to pick the correct one/i),
+      screen.queryByText(/use "wrong title\?" to pick the correct show/i),
     ).not.toBeInTheDocument();
   });
 
-  it('titles not loaded yet: does not flash the pre-rip banner (title-load race)', () => {
-    // A post-rip review_needed job whose titles haven't been fetched yet looks
-    // identical to a pre-rip disc (tracks=[]). tracksLoaded=false must suppress
-    // the banner so it doesn't flash on page load / WebSocket reconnect.
+  it('titles not loaded yet: does not flash the identity-review banner (title-load race)', () => {
+    // A post-rip review_needed job whose titles haven't been fetched yet can have
+    // identityReview=true transiently (the adapter sees titles=[]). tracksLoaded=false
+    // must suppress the banner so it doesn't flash on page load / WebSocket reconnect.
     render(
       <DiscCard
         disc={makeDisc({
+          identityReview: true,
           tracks: [],
           tracksLoaded: false,
           reviewReason: 'some pending reason',
@@ -103,7 +133,7 @@ describe('DiscCard — review affordances', () => {
     );
 
     expect(
-      screen.queryByText(/use "wrong title\?" to pick the correct one/i),
+      screen.queryByText(/use "wrong title\?" to pick the correct show/i),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/some pending reason/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -76,8 +76,18 @@ export interface DiscData {
   startedAt?: string;
   needsReview?: boolean;
   reviewReason?: string;
+  /** Review is about confirming the disc's IDENTITY (an ambiguous/unconfirmed
+   *  show), not assigning episodes. Derived in the adapter from a null tmdb_id
+   *  (or a same-name collision with no ripped titles). Drives the on-card hint
+   *  banner + "Wrong title?" emphasis and suppresses the dead-end review-queue
+   *  button. See transformJobToDiscData. */
+  identityReview?: boolean;
+  /** Resolved TMDB identity (null/absent until confirmed). */
+  tmdbId?: number | null;
+  tmdbName?: string | null;
+  tmdbYear?: number | null;
   /** Whether this disc's titles have been fetched yet (vs. genuinely empty).
-   *  Guards the pre-rip banner against the title-load race — see reviewPreRip. */
+   *  Guards the identity-review banner against the title-load race. */
   tracksLoaded?: boolean;
   conflictStatus?: string;
 }
@@ -196,13 +206,16 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
       disc.tracks?.filter(t => ["matched", "completed"].includes(t.state)).length ?? 0;
     const failedTrackCount = disc.tracks?.filter(t => t.state === "failed").length ?? 0;
 
-    // A disc that needs review but hasn't ripped yet (no tracks) has nothing to
-    // review in the queue — the only useful action is "Wrong title?" (re-identify).
-    // Drives both the on-card hint banner and the emphasis on the re-identify button.
-    // `tracksLoaded` gates out the title-load race: titles resolve after the job
-    // list, so a post-rip review_needed job momentarily has tracks=[] on first
-    // render — without this guard the banner/emphasis would flash then vanish.
-    const reviewPreRip = !!disc.needsReview && totalTrackCount === 0 && !!disc.tracksLoaded;
+    // A disc in review to confirm its IDENTITY (ambiguous/unconfirmed show) has
+    // nothing to do in the episode review queue — the only useful action is
+    // "Wrong title?" (re-identify). `identityReview` is derived in the adapter
+    // (null tmdb_id, or a same-name collision with no ripped titles) so it fires
+    // even though such discs DO have titles enumerated at scan time — the reason
+    // the old tracks-count check never triggered. Drives the on-card hint banner
+    // and the emphasis on the re-identify button. `tracksLoaded` gates out the
+    // title-load race: titles resolve after the job list, so without this guard
+    // the banner/emphasis could flash then vanish on first render / reconnect.
+    const identityReview = !!disc.identityReview && !!disc.tracksLoaded;
 
     return (
       <motion.div
@@ -389,15 +402,16 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                     onReIdentify={onReIdentify}
                     onAdvance={onAdvance}
                     onReportBug={onReportBug}
-                    emphasizeReIdentify={reviewPreRip}
+                    emphasizeReIdentify={identityReview}
                   />
                 </div>
               </div>
 
-              {/* Ambiguous / unconfirmed identity, pre-rip — the review queue is
-                  empty until ripping, so point the user at "Wrong title?" instead
-                  and explain why (reuses the backend's review_reason sentence). */}
-              {reviewPreRip && (
+              {/* Ambiguous / unconfirmed identity — the episode review queue can't
+                  help until the show is confirmed, so point the user at "Wrong
+                  title?" instead and explain why (reuses the backend's
+                  review_reason sentence). */}
+              {identityReview && (
                 <div
                   role="alert"
                   style={{
@@ -419,8 +433,8 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   <span aria-hidden style={{ flexShrink: 0 }}>⚠</span>
                   <span>
                     {disc.reviewReason ||
-                      "This disc's identity needs confirming before ripping."}{" "}
-                    Use "Wrong title?" to pick the correct one.
+                      "This disc's identity isn't confirmed yet."}{" "}
+                    Use "Wrong title?" to pick the correct show.
                   </span>
                 </div>
               )}

--- a/frontend/src/components/ReIdentifyModal.test.tsx
+++ b/frontend/src/components/ReIdentifyModal.test.tsx
@@ -40,8 +40,9 @@ describe('ReIdentifyModal quick-pick candidates', () => {
             />,
         );
 
-        expect(screen.getByRole('button', { name: /frasier \(1993\)/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /frasier \(2023\)/i })).toBeInTheDocument();
+        // Labels carry the disambiguating year AND the tmdb id.
+        expect(screen.getByRole('button', { name: /frasier \(1993\).*#3452/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /frasier \(2023\).*#195241/i })).toBeInTheDocument();
     });
 
     it('submits the chosen candidate tmdb_id with content_type tv and the detected season', async () => {
@@ -115,5 +116,76 @@ describe('ReIdentifyModal quick-pick candidates', () => {
         expect(screen.queryByText(/did you mean/i)).not.toBeInTheDocument();
         // The free-text search fallback is still available.
         expect(screen.getByPlaceholderText(/search for correct title/i)).toBeInTheDocument();
+    });
+});
+
+describe('ReIdentifyModal selection + current identity', () => {
+    it('shows the selected result year + tmdb id after picking a search hit, and clears it on manual edit', async () => {
+        const user = userEvent.setup();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    results: [
+                        {
+                            tmdb_id: 195241,
+                            name: 'Frasier',
+                            type: 'tv',
+                            year: '2023',
+                            poster_path: null,
+                            popularity: 5.7,
+                        },
+                    ],
+                }),
+            }),
+        );
+        try {
+            render(<ReIdentifyModal job={makeJob()} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+            await user.type(
+                screen.getByPlaceholderText(/search for correct title/i),
+                'frasier',
+            );
+            // The search is debounced 500ms; findBy polls until the result renders.
+            const resultBtn = await screen.findByRole(
+                'button',
+                { name: /frasier.*tv.*2023/i },
+                { timeout: 2000 },
+            );
+            await user.click(resultBtn);
+
+            expect(screen.getByText(/TMDB #195241/i)).toBeInTheDocument();
+            expect(screen.getByText(/\(2023\)/)).toBeInTheDocument();
+
+            // Editing the title manually drops the confirmed-match line.
+            await user.clear(screen.getByDisplayValue('Frasier'));
+            expect(screen.queryByText(/TMDB #195241/i)).not.toBeInTheDocument();
+        } finally {
+            vi.unstubAllGlobals();
+        }
+    });
+
+    it('shows the current identification when the job has a committed tmdb_id', () => {
+        render(
+            <ReIdentifyModal
+                job={makeJob({ tmdb_id: 18409, tmdb_name: 'The Office', tmdb_year: 2005 })}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+        expect(screen.getByText(/currently: the office \(2005\)/i)).toBeInTheDocument();
+        expect(screen.getByText(/tmdb #18409/i)).toBeInTheDocument();
+    });
+
+    it('omits the current identification when tmdb_id is null (ambiguous disc)', () => {
+        render(
+            <ReIdentifyModal
+                job={makeJob({ tmdb_id: null })}
+                onSubmit={vi.fn()}
+                onCancel={vi.fn()}
+            />,
+        );
+        expect(screen.queryByText(/currently:/i)).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/components/ReIdentifyModal.tsx
+++ b/frontend/src/components/ReIdentifyModal.tsx
@@ -34,6 +34,10 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
     );
     const [season, setSeason] = useState<string>(String(job.detected_season || 1));
     const [tmdbId, setTmdbId] = useState<number | undefined>();
+    // First-air year of the selected TMDB result, retained alongside tmdbId so the
+    // confirmation line can show "Name (year) · TMDB #id". Cleared when the user
+    // types a manual title (no confirmed match anymore).
+    const [selectedYear, setSelectedYear] = useState<string | undefined>();
     const [searchQuery, setSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState<TmdbResult[]>([]);
     const [isSearching, setIsSearching] = useState(false);
@@ -77,6 +81,7 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
         setTitle(result.name);
         setContentType(result.type);
         setTmdbId(result.tmdb_id);
+        setSelectedYear(result.year || undefined);
         setSearchResults([]);
         setSearchQuery('');
     };
@@ -98,7 +103,8 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
         }
     }, [job.candidates_json]);
 
-    const candidateLabel = (c: Candidate) => (c.year ? `${c.name} (${c.year})` : c.name);
+    const candidateLabel = (c: Candidate) =>
+        `${c.name}${c.year ? ` (${c.year})` : ''} · #${c.tmdb_id}`;
 
     const selectCandidate = (c: Candidate) => {
         // Reuse the disc's detected content type (collisions are TV today, but
@@ -260,6 +266,23 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
                                         }}
                                     >
                                         {job.review_reason}
+                                    </p>
+                                )}
+                                {/* What the disc is identified as right now — only when
+                                    a TMDB id is committed (an ambiguous disc has none)
+                                    and the user hasn't yet picked a replacement, so they
+                                    can compare wrong-vs-right before re-identifying. */}
+                                {job.tmdb_id != null && tmdbId == null && (
+                                    <p
+                                        style={{
+                                            fontFamily: sv.mono,
+                                            fontSize: 11,
+                                            color: `${sv.yellow}99`,
+                                            margin: 0,
+                                        }}
+                                    >
+                                        Currently: {job.tmdb_name || job.detected_title}
+                                        {job.tmdb_year ? ` (${job.tmdb_year})` : ''} · TMDB #{job.tmdb_id}
                                     </p>
                                 )}
                             </div>
@@ -486,6 +509,7 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
                                 onChange={(e) => {
                                     setTitle(e.target.value);
                                     setTmdbId(undefined);
+                                    setSelectedYear(undefined);
                                 }}
                                 placeholder="e.g. Thunderbirds"
                                 style={inputStyle(!!title)}
@@ -494,6 +518,21 @@ export default function ReIdentifyModal({ job, onSubmit, onCancel }: ReIdentifyM
                                     (e.currentTarget.style.borderColor = title ? sv.lineHi : sv.lineMid)
                                 }
                             />
+                            {/* Confirms which TMDB show is selected (year + id) so the
+                                user isn't picking a same-name show blind. Only shown
+                                once a search result / candidate set the tmdbId. */}
+                            {tmdbId != null && (
+                                <span
+                                    style={{
+                                        fontFamily: sv.mono,
+                                        fontSize: 11,
+                                        color: sv.cyan,
+                                    }}
+                                >
+                                    Selected → {title}
+                                    {selectedYear ? ` (${selectedYear})` : ''} · TMDB #{tmdbId}
+                                </span>
+                            )}
                         </div>
 
                         {/* Media Type Toggle */}

--- a/frontend/src/types/adapters.test.ts
+++ b/frontend/src/types/adapters.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { transformJobToDiscData } from './adapters';
+import type { DiscTitle, Job, TitleState } from './index';
+
+/** Minimal valid Job; override only the fields a test cares about. */
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 1,
+    drive_id: 'E:',
+    volume_label: 'THE_OFFICE_S2D1',
+    content_type: 'tv',
+    state: 'review_needed',
+    current_speed: '',
+    eta_seconds: 0,
+    progress_percent: 0,
+    current_title: 0,
+    total_titles: 0,
+    error_message: null,
+    detected_title: 'The Office',
+    detected_season: 2,
+    ...overrides,
+  };
+}
+
+/** Minimal valid DiscTitle in a given state. */
+function makeTitle(state: TitleState, id = 1): DiscTitle {
+  return {
+    id,
+    job_id: 1,
+    title_index: id,
+    duration_seconds: 1320,
+    file_size_bytes: 0,
+    chapter_count: 6,
+    is_selected: true,
+    output_filename: null,
+    matched_episode: null,
+    match_confidence: 0,
+    state,
+  };
+}
+
+const TWO_CANDIDATES = JSON.stringify([
+  { tmdb_id: 18409, name: 'The Office', year: '2005', popularity: 250 },
+  { tmdb_id: 17730, name: 'The Office', year: '2001', popularity: 84 },
+]);
+
+describe('transformJobToDiscData — identityReview derivation', () => {
+  it('is true when tmdb_id is null (analyst withheld the id) even with enumerated pending tracks', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ tmdb_id: null, candidates_json: TWO_CANDIDATES }),
+      [makeTitle('pending', 1), makeTitle('pending', 2)],
+    );
+    expect(disc.identityReview).toBe(true);
+  });
+
+  it('is false when identity is confirmed (tmdb_id set) and titles are in review', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ tmdb_id: 18409, tmdb_name: 'The Office', tmdb_year: 2005 }),
+      [makeTitle('review', 1)],
+    );
+    expect(disc.identityReview).toBe(false);
+  });
+
+  it('is true for a same-name collision with a best-guess id but no ripped titles (no-year twin)', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ tmdb_id: 18409, candidates_json: TWO_CANDIDATES }),
+      [makeTitle('pending', 1), makeTitle('queued', 2)],
+    );
+    expect(disc.identityReview).toBe(true);
+  });
+
+  it('is false for a same-name collision once a title has been matched (post-rip wrong-show keeps its button)', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ tmdb_id: 18409, candidates_json: TWO_CANDIDATES }),
+      [makeTitle('matched', 1)],
+    );
+    expect(disc.identityReview).toBe(false);
+  });
+
+  it('is false when the job is not in review_needed', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ state: 'matching', tmdb_id: null }),
+      [makeTitle('matching', 1)],
+    );
+    expect(disc.identityReview).toBe(false);
+  });
+
+  it('passes tmdb identity fields through to DiscData', () => {
+    const disc = transformJobToDiscData(
+      makeJob({ tmdb_id: 18409, tmdb_name: 'The Office', tmdb_year: 2005 }),
+      [],
+    );
+    expect(disc.tmdbId).toBe(18409);
+    expect(disc.tmdbName).toBe('The Office');
+    expect(disc.tmdbYear).toBe(2005);
+  });
+});

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -38,6 +38,17 @@ export function mapTitleStateToTrackState(
   return stateMap[titleState] || 'pending';
 }
 
+/** Count of same-name TMDB twins recorded on the job (0 when absent/malformed). */
+function countCandidates(candidatesJson?: string | null): number {
+  if (!candidatesJson) return 0;
+  try {
+    const parsed = JSON.parse(candidatesJson);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData {
   // Determine media type - handle case-insensitively
   const contentTypeLower = job.content_type?.toLowerCase();
@@ -50,6 +61,20 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
   }
 
   const displayType = mediaType === 'movie' ? 'MOVIE' : mediaType === 'tv' ? 'TV' : 'DETECTING';
+
+  // "Identity review" = the disc is in review to confirm WHICH show it is, not to
+  // assign episodes. The episode review queue is a dead end here. Primary signal:
+  // a null tmdb_id (the analyst withholds the id for an ambiguous/unconfirmed
+  // disc). Fallback: a same-name collision (>=2 twins) the analyst kept a
+  // best-guess id for (the no-year-twin case) — but only while nothing has been
+  // ripped/matched yet, so a genuine post-rip wrong-show disc keeps its button.
+  const hasProcessedTitles = titles.some(
+    t => t.state === 'matched' || t.state === 'review' || t.state === 'completed',
+  );
+  const identityReview =
+    job.state === 'review_needed' &&
+    (job.tmdb_id == null ||
+      (countCandidates(job.candidates_json) >= 2 && !hasProcessedTitles));
 
   return {
     id: job.id.toString(),
@@ -69,6 +94,10 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     subtitleError: job.subtitle_error_message || undefined,
     conflictStatus: job.conflict_status || undefined,
     reviewReason: job.review_reason || undefined,
+    identityReview,
+    tmdbId: job.tmdb_id ?? null,
+    tmdbName: job.tmdb_name ?? null,
+    tmdbYear: job.tmdb_year ?? null,
     startedAt: job.created_at
       ? (job.created_at.endsWith('Z') || job.created_at.includes('+') ? job.created_at : job.created_at + 'Z')
       : undefined,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,15 @@ export interface Job {
     destination_mode?: string;
     created_at?: string;
     /**
+     * Resolved TMDB identity. `tmdb_id` is null while identity is unconfirmed
+     * (e.g. a same-name collision the analyst withheld an id for). The dashboard
+     * uses it to suppress the dead-end episode-review button, and the re-identify
+     * modal shows name/year/id so the user can confirm which show is selected.
+     */
+    tmdb_id?: number | null;
+    tmdb_name?: string | null;
+    tmdb_year?: number | null;
+    /**
      * Raw JSON string (from the API) of same-name TMDB candidates recorded at
      * identify time when >=2 shows share a name, e.g. Frasier 1993 + 2023 revival.
      * Each entry: `{ tmdb_id, name, year, popularity }`. Drives the quick-pick in


### PR DESCRIPTION
## What & why

Two fixes to how the dashboard handles **ambiguous / unconfirmed-title discs** (e.g. "The Office", which maps to several same-name TMDB shows).

### 1. Hide the dead-end "Review needed" button while identity is unconfirmed
Such a disc showed three header controls — a "REVIEW NEEDED" **state badge**, a "WRONG TITLE?" button, and a yellow "REVIEW NEEDED" **action button** that only opened an *empty* episode-review queue (the show identity isn't settled yet, so there's nothing to assign).

PR #308 already tried to declutter this, but it gated on `totalTrackCount === 0` — and `DiscTitle` rows are created at **scan/identify time**, before ripping, so an ambiguous disc *always* has tracks and the gate never fired. The declutter has effectively been dead code for the real case.

This replaces the broken track-count gate with a semantic signal, **`identityReview`**, derived once in the adapter:

```
identityReview = review_needed && (
  tmdb_id == null ||                                  // analyst withholds the id for an ambiguous/unconfirmed disc
  (>=2 same-name candidates && no ripped titles)      // no-year-twin: best-guess id kept, but nothing matched yet
)
```

When true, the episode-review button is hidden (expanded **and** compact views) and the explanatory banner + emphasized "Wrong title?" now actually appear. A genuine episode review (identity confirmed, titles in `review`) keeps its button.

### 2. Show release year + TMDB id in the Re-Identify modal
The modal discarded the selected result's `year` and surfaced neither year nor id. It now:
- confirms the picked show as `Selected → Name (year) · TMDB #id` (cleared if you hand-edit the title),
- shows `Currently: …` for the disc's existing identification, so you can compare wrong-vs-right,
- adds the TMDB id to the "Did you mean?" candidate labels.

### Shared plumbing
`tmdb_id` / `tmdb_name` / `tmdb_year` are now exposed on `JobResponse` → frontend `Job` type → `DiscData`. No WebSocket change was needed — no `broadcast_job_update` call passes `tmdb_id`, and the frontend merge (`{...job, ...message}`) can't clobber the REST-fetched value.

## Testing
- **Backend:** `uv run pytest tests/unit/` → **1818 passed** (incl. new `test_tmdb_identity_fields_exposed_in_job_response`).
- **Frontend:** `npm run test:unit` → **149 passed** — rewritten `DiscCard` tests (incl. the real "enumerated pending tracks" regression that #308 missed), new `adapters.test.ts` derivation matrix, new `ReIdentifyModal` selection/current-identity tests.
- `npm run build` (tsc + vite), `npm run lint`, `ruff check` — all clean.

## Reviewer notes
- The discriminator deliberately lives in the adapter (`transformJobToDiscData`) — the one layer that sees both the `Job` and its loaded `titles`. The `hasProcessedTitles` guard keeps the no-year-twin fallback from misfiring on a genuine post-rip wrong-show disc.
- Added an `[Unreleased]` CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
