### PR TITLE
docs: add Discord community links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Engram
 
+Have a question or want to talk through an idea before you start? Join us on [Discord](https://discord.gg/G8fjjGswdc) — it's the quickest way to reach the maintainers and other contributors.
+
 ## Local development setup
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://github.com/Jsakkos/engram/releases"><img src="https://img.shields.io/github/v/release/Jsakkos/engram?style=flat-square&color=06b6d4" alt="Release" /></a>
   <a href="https://github.com/Jsakkos/engram/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Jsakkos/engram/ci.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/Jsakkos/engram?style=flat-square&color=ec4899" alt="License" /></a>
+  <a href="https://discord.gg/G8fjjGswdc"><img src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/Jsakkos/engram/releases"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Jsakkos/engram/badges/docs/badges/windows-downloads.json&style=flat-square" alt="Windows Downloads" /></a>
   <a href="https://github.com/Jsakkos/engram/releases"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Jsakkos/engram/badges/docs/badges/linux-downloads.json&style=flat-square" alt="Linux Downloads" /></a>
   <a href="https://github.com/Jsakkos/engram/releases"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Jsakkos/engram/badges/docs/badges/macos-downloads.json&style=flat-square" alt="macOS Downloads" /></a>
@@ -179,6 +180,10 @@ Full documentation is published at **[jsakkos.github.io/engram](https://jsakkos.
 - **API reference** — [REST Endpoints](docs/api/rest.md) · [Data Models](docs/api/models.md)
 - **Development** — [Contributing](CONTRIBUTING.md) · [Testing](docs/development/testing.md) · [Subtitle Cache Build](docs/development/subtitle-cache.md)
 - **[Changelog](CHANGELOG.md)**
+
+## Community
+
+Questions, ideas, or just want to share what you're ripping? Join the Engram community on **[Discord](https://discord.gg/G8fjjGswdc)**. It's the fastest way to get help, follow development, and talk to other users. For bugs and feature requests, [open an issue](https://github.com/Jsakkos/engram/issues).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ and files everything into your media library -- automatically.
 [![Release](https://img.shields.io/github/v/release/Jsakkos/engram?style=flat-square&color=06b6d4)](https://github.com/Jsakkos/engram/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/Jsakkos/engram/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/Jsakkos/engram/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/Jsakkos/engram?style=flat-square&color=ec4899)](https://github.com/Jsakkos/engram/blob/main/LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/G8fjjGswdc)
 
 </div>
 
@@ -95,6 +96,7 @@ Season folders may be written `Season 1` or `Season 01`. When there's no season 
 <div style="text-align: center;" markdown>
 
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
+[Join Discord](https://discord.gg/G8fjjGswdc){ .md-button }
 [API Reference](api/rest.md){ .md-button }
 [Architecture](architecture/overview.md){ .md-button }
 [Brand System](development/brand.md){ .md-button }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Common setup and runtime issues, and how to resolve them. If something here doesn't cover your problem, open an [issue](https://github.com/Jsakkos/engram/issues) — a [diagnostics bundle](#diagnostics-bundle) makes it much easier to help.
+Common setup and runtime issues, and how to resolve them. If something here doesn't cover your problem, ask on [Discord](https://discord.gg/G8fjjGswdc) or open an [issue](https://github.com/Jsakkos/engram/issues) — a [diagnostics bundle](#diagnostics-bundle) makes it much easier to help.
 
 ## FFmpeg not detected (Windows)
 


### PR DESCRIPTION
Adds a reference to the new Engram Discord server (https://discord.gg/G8fjjGswdc) across the user-facing documentation.

## What changed

| File | Where |
|------|-------|
| `README.md` | Discord badge in the badge row + a new **Community** section before License |
| `docs/index.md` | Discord badge in the badge row + a "Join Discord" call-to-action button |
| `docs/troubleshooting.md` | Discord listed as a support channel alongside "open an issue" |
| `CONTRIBUTING.md` | Questions/ideas prompt at the top (transcluded into the docs site via `--8<--`) |

## Notes

- Docs-only change — no code, tests, or build config touched.
- Used a **static** shields.io Discord badge (`badge/Discord-...`) rather than the dynamic `shields.io/discord/{server_id}` member-count badge, since only the invite code is available (the dynamic badge needs the numeric server ID + the server widget enabled).
- Verified with a local `mkdocs build`: no new warnings introduced (the only warnings are the pre-existing `superpowers/specs/*` source-link ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)