### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-10
+
+_Highlights: a damaged track can now be recovered without re-ripping the whole disc — clean the disc, reinsert it, and Engram re-rips just that title — and box-set discs that don't reveal their season now prompt you to pick one up front instead of dead-ending every episode in Needs Review._
+
 ### Added
 
 - Recover a single damaged track without re-ripping the whole disc. When a title fails at the rip level (a scratch/bad-sector truncation or a ripping stall), Engram now holds it in review with a "clean the disc and reinsert to re-rip this title" prompt. Reinserting the **same** disc (verified by its content fingerprint) automatically re-rips just that track, re-matches it, and finishes the job — with a manual "Re-rip this title" button and a bounded automatic-retry cap as fallbacks. (#371)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.17.0"
+version = "0.18.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.17.0"
+version = "0.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.17.0",
+    "version": "0.18.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.17.0",
+            "version": "0.18.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.17.0",
+    "version": "0.18.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Cuts the **v0.18.0** release. Squash-merging this PR (keeping the `chore: release v` title) triggers `tag-release.yml`, which tags `v0.18.0` from main and dispatches the binary + Docker builds.

## What's in this PR

Version bumped to `0.18.0` in all six lockstep locations (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and both self-version fields in `frontend/package-lock.json`), and the accumulated `[Unreleased]` changelog entries promoted into a dated `## [0.18.0] - 2026-06-10` section (dated to the UTC publish day).

This is a **minor** bump because the release adds a new feature (single-track re-rip).

## Release highlights

_A damaged track can now be recovered without re-ripping the whole disc — clean the disc, reinsert it, and Engram re-rips just that title — and box-set discs that don't reveal their season now prompt you to pick one up front instead of dead-ending every episode in Needs Review._

### Added
- Single-track re-rip after clean & reinsert (#371)

### Changed
- A disc with an unrecoverable track waits in review instead of silently auto-completing (#371)

### Fixed
- Season prompt for discs that reveal no season; review-screen season picker; subtitle-download/cache fixes (#370)
- Hide dead-end review button for unconfirmed discs + show year/TMDB id in re-identify modal (#358)
- Release year in History detail panel (#365)
- DB connection-pool exhaustion during multi-season imports (async + sync engines) (#356, #360)
- Organizing state during library moves (#359)
- Bad-sector / truncated rip no longer wedges the job for hours (#366)
- Run-together volume labels filed under the correct TMDB name + posters by tmdb_id (#368)
- Same-label season discs told apart by content hash (#369)

## Reconciliation

All 13 commits since `v0.17.0` are accounted for: every user-facing PR maps to a changelog entry; the two Dependabot bumps (#362, #363) and the docs-only Discord-links PR (#367) are intentionally omitted from user-facing notes. CONTRIBUTORS.md regenerated — no change (no new external contributors). `extract_changelog.py --version 0.18.0 --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)