### PR TITLE
fix(re-identify): offload blocking TMDB lookup off the event loop

### DIFF
--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1086,7 +1086,9 @@ class IdentificationCoordinator:
 
                     config = await get_config()
                     if config.tmdb_api_key:
-                        _signal = classify_from_tmdb(title, config.tmdb_api_key)
+                        _signal = await asyncio.to_thread(
+                            classify_from_tmdb, title, config.tmdb_api_key
+                        )
                         # The key was tried and accepted (no TmdbAuthError) — any
                         # stale "rejected" marker from identify time is now wrong
                         # regardless of whether results were found (#243).


### PR DESCRIPTION
## What

`IdentificationCoordinator.re_identify` called `classify_from_tmdb(title, config.tmdb_api_key)` synchronously inside an `async def`. `classify_from_tmdb` makes blocking `requests.get` network calls, so this stalled the asyncio event loop for the full duration of the TMDB re-lookup — blocking WebSocket broadcasts, other jobs' progress updates, and every other coroutine until the HTTP request returned.

This wraps the call in `asyncio.to_thread`, matching the established convention already used by the sibling `_resolve_missing_tmdb_id` and the adjacent `_resolve_show_year` call on the very next line.

```python
config = await get_config()
if config.tmdb_api_key:
    _signal = await asyncio.to_thread(
        classify_from_tmdb, title, config.tmdb_api_key
    )
```

## Why it's safe

`asyncio.to_thread` re-raises any exception thrown inside the worker thread at the `await` site, so the surrounding `try` / `except Exception:` handler still catches a `TmdbAuthError` (or any other error) raised from inside `classify_from_tmdb`. The error-handling contract is unchanged — only *which thread blocks* changes.

This is a concurrency fix, not a logic change: the re-identification outcome (resolved `tmdb_id`, derived year, state transitions) is identical, which is why the existing tests stay green.

## Context

Flagged in the [#376](https://github.com/Jsakkos/engram/pull/376) review as a pre-existing event-loop-blocking issue, deferred as out of scope for that PR.

## Verification

- `cd backend && uv run pytest tests/integration/test_re_identify.py -q` → **9 passed**
- `uv run ruff check app/services/identification_coordinator.py` → **All checks passed!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
