### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-11
+
+_Highlights: completed disc cards now summarize their contents at a glance — TV cards show the season and matched episode range, movie cards show the year — instead of repeating the raw volume label; plus a fix for a ripping card that could visibly flicker between "ripping" and "matched" on slow or dirty discs._
+
+### Added
+
+- **Completed disc cards now summarize what's on the disc instead of repeating the raw volume label** — a finished card's subtitle used to show the unprocessed disc label (e.g. `TV • ARRESTED_DEVELOPMENT_S1D1`), which is hard to scan in the Done list. TV cards now show the season and matched episode range (e.g. `TV · S01 E01–E08`), listing each season separately for multi-disc sets that span seasons and appending a count when some episodes are missing from the library; movie cards show `Movie · <year>`. The raw label still appears on its own line for traceability, and active cards (ripping, matching) are unchanged. (#382)
+
 ### Fixed
 
 - **A ripping track no longer flickers between "ripping" and "matched/idle"** — when MakeMKV paused mid-track for a few seconds (common on slow or dirty discs), Engram mistook the brief lull in file growth for the track being finished, handed the still-ripping file to the matcher, and then the progress monitor kept yanking it back to "ripping" as the rip resumed — so the card visibly bounced between the red ripping state and the green matched/idle state for the rest of the rip. A track is now only treated as finished once MakeMKV has provably moved on to the next title (or the rip process exits), so a mid-track write pause can no longer be misread as completion. (#381)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.19.0"
+__version__ = "0.20.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.19.0"
+version = "0.20.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.19.0"
+version = "0.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.19.0",
+    "version": "0.20.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.19.0",
+            "version": "0.20.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.19.0",
+    "version": "0.20.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Cuts the **0.20.0** release. Minor bump because it includes a new feature (#382).

Version bumped in lockstep across all six files: `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and both self-version fields in `frontend/package-lock.json`.

## Release notes (as `extract_changelog.py` will publish them)

### Added
- **Completed disc cards now summarize what's on the disc instead of repeating the raw volume label** — TV cards show the season and matched episode range (e.g. `TV · S01 E01–E08`); movie cards show `Movie · <year>`. The raw label still appears on its own line for traceability. (#382)

### Fixed
- **A ripping track no longer flickers between "ripping" and "matched/idle"** — a mid-track write pause on a slow/dirty disc could be misread as the track finishing, bouncing the card between states for the rest of the rip. (#381)

## Reconciliation notes
- #392 was already documented under the published 0.19.0 release notes (its commit landed just after the v0.19.0 tag), so it is **not** re-listed here — but its fix does ship in this binary.
- Test-only (#395) and Dependabot bumps (react-router-dom, jsdom, docker action) are intentionally omitted per changelog convention.

On squash-merge, `tag-release.yml` will push the `v0.20.0` tag and dispatch the binary + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)