### PR TITLE
feat(matcher): persistent ASR transcript cache + background pre-transcription (walk-away Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
-## [0.20.0] - 2026-06-11
-
-_Highlights: completed disc cards now summarize their contents at a glance — TV cards show the season and matched episode range, movie cards show the year — instead of repeating the raw volume label; plus a fix for a ripping card that could visibly flicker between "ripping" and "matched" on slow or dirty discs._
-
-### Added
-
-- **Completed disc cards now summarize what's on the disc instead of repeating the raw volume label** — a finished card's subtitle used to show the unprocessed disc label (e.g. `TV • ARRESTED_DEVELOPMENT_S1D1`), which is hard to scan in the Done list. TV cards now show the season and matched episode range (e.g. `TV · S01 E01–E08`), listing each season separately for multi-disc sets that span seasons and appending a count when some episodes are missing from the library; movie cards show `Movie · <year>`. The raw label still appears on its own line for traceability, and active cards (ripping, matching) are unchanged. (#382)
 ### Added
 
 - **Episode re-matching no longer re-runs speech recognition** — Whisper transcripts are now kept in a persistent on-disk cache keyed by the exact file, audio offset, and speech-recognition model, so re-matching a track — after a review decision, a "Wrong title?" re-identification, a "Re-match", or even a full app restart — reuses the transcription work it already did instead of grinding through it again. Re-matches that used to take minutes now take seconds. The cache prunes itself, and a re-ripped file simply gets fresh entries, so stale transcripts are never served.
@@ -23,6 +16,17 @@ _Highlights: completed disc cards now summarize their contents at a glance — T
 ### Fixed
 
 - **Disabling GPU acceleration now fully applies to episode matching** — the matcher could still select CUDA for its transcription model after GPU ASR was turned off (or when the CUDA libraries weren't usable), because it probed the GPU hardware directly instead of honoring the device resolved at startup. It now follows the same startup-pinned device as the rest of the app — including the cached-transcript identity — so "GPU off" means matching genuinely runs on the CPU.
+
+## [0.20.0] - 2026-06-11
+
+_Highlights: completed disc cards now summarize their contents at a glance — TV cards show the season and matched episode range, movie cards show the year — instead of repeating the raw volume label; plus a fix for a ripping card that could visibly flicker between "ripping" and "matched" on slow or dirty discs._
+
+### Added
+
+- **Completed disc cards now summarize what's on the disc instead of repeating the raw volume label** — a finished card's subtitle used to show the unprocessed disc label (e.g. `TV • ARRESTED_DEVELOPMENT_S1D1`), which is hard to scan in the Done list. TV cards now show the season and matched episode range (e.g. `TV · S01 E01–E08`), listing each season separately for multi-disc sets that span seasons and appending a count when some episodes are missing from the library; movie cards show `Movie · <year>`. The raw label still appears on its own line for traceability, and active cards (ripping, matching) are unchanged. (#382)
+
+### Fixed
+
 - **A ripping track no longer flickers between "ripping" and "matched/idle"** — when MakeMKV paused mid-track for a few seconds (common on slow or dirty discs), Engram mistook the brief lull in file growth for the track being finished, handed the still-ripping file to the matcher, and then the progress monitor kept yanking it back to "ripping" as the rip resumed — so the card visibly bounced between the red ripping state and the green matched/idle state for the rest of the rip. A track is now only treated as finished once MakeMKV has provably moved on to the next title (or the rip process exits), so a mid-track write pause can no longer be misread as completion. (#381)
 
 ## [0.19.0] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,18 @@ _Highlights: completed disc cards now summarize their contents at a glance — T
 ### Added
 
 - **Completed disc cards now summarize what's on the disc instead of repeating the raw volume label** — a finished card's subtitle used to show the unprocessed disc label (e.g. `TV • ARRESTED_DEVELOPMENT_S1D1`), which is hard to scan in the Done list. TV cards now show the season and matched episode range (e.g. `TV · S01 E01–E08`), listing each season separately for multi-disc sets that span seasons and appending a count when some episodes are missing from the library; movie cards show `Movie · <year>`. The raw label still appears on its own line for traceability, and active cards (ripping, matching) are unchanged. (#382)
+### Added
+
+- **Episode re-matching no longer re-runs speech recognition** — Whisper transcripts are now kept in a persistent on-disk cache keyed by the exact file, audio offset, and speech-recognition model, so re-matching a track — after a review decision, a "Wrong title?" re-identification, a "Re-match", or even a full app restart — reuses the transcription work it already did instead of grinding through it again. Re-matches that used to take minutes now take seconds. The cache prunes itself, and a re-ripped file simply gets fresh entries, so stale transcripts are never served.
+- **Background pre-transcription while a disc waits in review** — while a job sits in Needs Review, Engram now quietly transcribes its unresolved tracks in the background (politely yielding to any live matching, and stopping the moment you act on the job), so by the time you pick an episode or fix the show identity the re-match is near-instant. On by default with a **Background Pre-Transcription** toggle in Settings → Preferences, plus an optional **Pre-Transcribe Entire Files** mode for setups that often hit the expensive full-file fallback.
+
+### Changed
+
+- **Deep re-match passes now build on each other instead of starting over** — the escalating "deep re-match" scan depths are aligned to a nested grid of audio offsets, so a deeper pass re-visits exactly the chunks a shallower pass already transcribed plus new ones in between; combined with the persistent transcript cache, each escalation only pays for the new offsets. A requested scan depth now equals the realized depth, and the final escalation tier no longer runs a redundant deeper pass on typical-length episodes.
 
 ### Fixed
 
+- **Disabling GPU acceleration now fully applies to episode matching** — the matcher could still select CUDA for its transcription model after GPU ASR was turned off (or when the CUDA libraries weren't usable), because it probed the GPU hardware directly instead of honoring the device resolved at startup. It now follows the same startup-pinned device as the rest of the app — including the cached-transcript identity — so "GPU off" means matching genuinely runs on the CPU.
 - **A ripping track no longer flickers between "ripping" and "matched/idle"** — when MakeMKV paused mid-track for a few seconds (common on slow or dirty discs), Engram mistook the brief lull in file growth for the track being finished, handed the still-ripping file to the matcher, and then the progress monitor kept yanking it back to "ripping" as the rip resumed — so the card visibly bounced between the red ripping state and the green matched/idle state for the rest of the rip. A track is now only treated as finished once MakeMKV has provably moved on to the next title (or the rip process exits), so a mid-track write pause can no longer be misread as completion. (#381)
 
 ## [0.19.0] - 2026-06-11

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -283,6 +283,9 @@ class ConfigResponse(BaseModel):
     tmdb_configured: bool
     max_concurrent_matches: int
     enable_gpu_acceleration: bool
+    # Background pre-transcription (transcript cache prewarmer)
+    enable_background_pretranscription: bool
+    pretranscribe_full_file: bool
     ffmpeg_path: str
     conflict_resolution_default: str
     # Analyst thresholds
@@ -363,6 +366,9 @@ class ConfigUpdate(BaseModel):
     tmdb_api_key: str | None = None
     max_concurrent_matches: int | None = None
     enable_gpu_acceleration: bool | None = None
+    # Background pre-transcription (transcript cache prewarmer)
+    enable_background_pretranscription: bool | None = None
+    pretranscribe_full_file: bool | None = None
     ffmpeg_path: str | None = None
     conflict_resolution_default: str | None = None
     # Analyst thresholds
@@ -1222,6 +1228,9 @@ async def get_config() -> ConfigResponse:
         tmdb_configured=bool(config.tmdb_api_key),
         max_concurrent_matches=config.max_concurrent_matches,
         enable_gpu_acceleration=config.enable_gpu_acceleration,
+        # Background pre-transcription (transcript cache prewarmer)
+        enable_background_pretranscription=config.enable_background_pretranscription,
+        pretranscribe_full_file=config.pretranscribe_full_file,
         ffmpeg_path=config.ffmpeg_path,
         conflict_resolution_default=config.conflict_resolution_default,
         # Analyst thresholds

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -478,6 +478,59 @@ class FasterWhisperModel(ASRModel):
                     logger.debug(f"Failed to clean up preprocessed audio: {e}")
 
 
+def model_output_key(model_config: dict) -> str:
+    """Return a stable string identifying the *output-affecting* ASR model configuration.
+
+    This key is designed for use as the ``model_key`` component of a persistent
+    transcript-cache lookup (file_key, start_s, duration_s, model_key), ensuring that
+    cached transcripts are only reused when the model would produce identical output.
+
+    **Included fields** (all change Whisper's output text):
+    - ``type`` — model family/architecture (e.g. "whisper", "faster-whisper")
+    - ``name`` — model size/checkpoint (e.g. "small", "large-v3"); different sizes have
+      different vocabularies, encoder capacities, and word-error rates.
+    - ``device`` — resolved effective device ("cpu" or "cuda"). Transcripts produced on
+      CUDA with float16 differ from CPU int8 transcripts due to floating-point rounding.
+      An unresolved value ("auto", None, or missing) is resolved via ``detect_asr_device()``
+      so the key reflects the actual runtime, not the config placeholder.
+    - ``compute_type`` — quantization scheme (e.g. "int8", "float16", "int8_float16").
+      Quantization changes numeric precision throughout the encoder, directly affecting
+      transcription output.  Derived from ``device`` via ``cuda_compute_type()`` /
+      the fixed CPU value "int8".
+
+    **Excluded fields** (affect only speed/parallelism, not transcript content):
+    - ``requested_workers`` / ``num_workers`` — controls how many parallel transcription
+      streams the WhisperModel object runs; does not change what any individual stream
+      produces.
+    - ``cpu_threads`` — thread-pool size for BLAS ops inside CTranslate2; same model
+      weights, same output.
+
+    Returns:
+        ``"{type}_{name}_{device}_{compute_type}"`` — underscore-joined, deterministic
+        across process restarts for the same effective configuration.
+    """
+    model_type = model_config.get("type", "")
+    model_name = model_config.get("name", "")
+
+    # Resolve the effective device: honor explicit "cpu"/"cuda", fall back to the
+    # startup-pinned value for "auto", None, or missing so that a config placeholder
+    # never produces a key that disagrees with the actual runtime.
+    raw_device = model_config.get("device")
+    if raw_device in ("cpu", "cuda"):
+        device = raw_device
+    else:
+        device = detect_asr_device()
+
+    # Derive compute_type from the resolved device, matching the logic in
+    # FasterWhisperModel._get_compute_type() and resolve_asr_runtime().
+    if device == "cuda":
+        compute_type = cuda_compute_type()
+    else:
+        compute_type = "int8"
+
+    return f"{model_type}_{model_name}_{device}_{compute_type}"
+
+
 def create_asr_model(model_config: dict) -> ASRModel:
     """
     Factory function to create ASR models from configuration.

--- a/backend/app/matcher/asr_models.py
+++ b/backend/app/matcher/asr_models.py
@@ -482,8 +482,16 @@ def model_output_key(model_config: dict) -> str:
     """Return a stable string identifying the *output-affecting* ASR model configuration.
 
     This key is designed for use as the ``model_key`` component of a persistent
-    transcript-cache lookup (file_key, start_s, duration_s, model_key), ensuring that
-    cached transcripts are only reused when the model would produce identical output.
+    transcript-cache lookup (file_key, start_s, duration_s, model_key).
+
+    **Assumption — caller owns device honesty.** The key is only as accurate as the
+    config it receives.  An explicit ``device="cuda"`` is taken at face value; if the
+    model actually loads on CPU (e.g. the CUDA→CPU fallback in
+    ``FasterWhisperModel.__init__`` when cuDNN libraries are missing), the key will be
+    stale.  Callers that build a config from a raw GPU probe must resolve the *effective*
+    device (via ``set_asr_device`` / ``detect_asr_device()``) before calling this
+    function.  "auto" / None / missing are safe — they are resolved here via
+    ``detect_asr_device()``.
 
     **Included fields** (all change Whisper's output text):
     - ``type`` — model family/architecture (e.g. "whisper", "faster-whisper")

--- a/backend/app/matcher/chromaprint_matcher.py
+++ b/backend/app/matcher/chromaprint_matcher.py
@@ -181,7 +181,13 @@ class ChromaprintMatcher:
 def _scan_points(
     video_duration: float, num_points: int, skip_initial: float, chunk_duration: int
 ) -> list[float]:
-    """Evenly-spaced start times across the body of the file (mirrors identify_episode)."""
+    """Evenly-spaced start times across the body of the file.
+
+    Intentionally does NOT share the ASR integer lattice from
+    ``canonical_scan_points``: the chromaprint path has no persistent
+    per-offset transcript cache, so float spacing is fine and there is no
+    cache-reuse requirement that mandates the nested lattice structure.
+    """
     usable_start = min(skip_initial, max(0.0, video_duration - chunk_duration))
     usable_end = max(usable_start, video_duration - chunk_duration)
     if num_points <= 1 or usable_end <= usable_start:

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -30,6 +30,37 @@ console = Console()
 _SCAN_LATTICE_LEVELS = (10, 19, 37, 73, 145)
 
 
+def snap_to_lattice_level(num_points) -> int:
+    """Smallest lattice level >= ``num_points``, capped at the deepest (145).
+
+    The single source of truth for how a requested scan depth realizes on the
+    lattice: ``canonical_scan_points`` snaps through here, and depth constants
+    elsewhere (deep re-match, conflict-escalation ladder) are validated against
+    it so requested and realized depths can't drift. ``None`` or < 2 means the
+    default shallow scan (10).
+    """
+    if not num_points or num_points < 2:
+        num_points = 10
+    return next(
+        (lvl for lvl in _SCAN_LATTICE_LEVELS if lvl >= num_points), _SCAN_LATTICE_LEVELS[-1]
+    )
+
+
+def floor_to_lattice_level(num_points) -> int:
+    """Largest lattice level <= ``num_points``, never below the base level (10).
+
+    The cost-ceiling counterpart of :func:`snap_to_lattice_level`: use it when a
+    depth budget (e.g. "enough points for ~full coverage") must not be overshot —
+    snapping UP past the budget would transcribe overlapping audio for no new
+    evidence. Below the base level the matcher can't scan any shallower, so 10 is
+    returned (``canonical_scan_points`` dedups colliding points on short files).
+    """
+    for lvl in reversed(_SCAN_LATTICE_LEVELS):
+        if lvl <= num_points:
+            return lvl
+    return _SCAN_LATTICE_LEVELS[0]
+
+
 def canonical_scan_points(
     video_duration,
     *,
@@ -55,9 +86,7 @@ def canonical_scan_points(
     are never negative, and adjacent lattice points that collide after floor
     division on short files are deduplicated.
     """
-    if not num_points or num_points < 2:
-        num_points = 10
-    n = next((lvl for lvl in _SCAN_LATTICE_LEVELS if lvl >= num_points), _SCAN_LATTICE_LEVELS[-1])
+    n = snap_to_lattice_level(num_points)
 
     skip_initial = max(int(skip_initial), 0)
     available = int(video_duration) - skip_initial - int(skip_final)

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -1478,6 +1478,8 @@ class EpisodeMatcher:
                 try:
                     Path(p).unlink(missing_ok=True)
                 except OSError:
+                    # Best-effort temp cleanup — a locked wav (e.g. Windows AV
+                    # scan) is reaped on a later run; missing_ok covers ENOENT.
                     pass
             # Drop the audio-chunk memo for the wav we just deleted so a future
             # compute path re-extracts instead of returning a dangling path

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -1448,6 +1448,10 @@ class EpisodeMatcher:
             )
             return None
 
+        # The full-file wav (tens of MB) is tracked here and removed in the
+        # finally below — mirroring identify_episode's temp_files_to_remove.
+        # On an L1/L2 hit no wav is extracted, so the list stays empty.
+        temp_files: list[str] = []
         try:
             # Memoized by (source, 0, duration): the full-file fallback fires once per
             # candidate season when no chunk votes, so without this the season-unknown
@@ -1460,13 +1464,26 @@ class EpisodeMatcher:
             full = self.transcriptions.get(full_key)
             if full is None:
                 model = get_cached_model(self._model_config())
-                full = self.transcribe_chunk_cached(video_file, 0, duration, model)
+                full = self.transcribe_chunk_cached(
+                    video_file, 0, duration, model, temp_files=temp_files
+                )
         except Exception as e:
             logger.warning(
                 f"transcribe_full: transcription failed for {video_file}: {e}",
                 exc_info=True,
             )
             return None
+        finally:
+            for p in temp_files:
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except OSError:
+                    pass
+            # Drop the audio-chunk memo for the wav we just deleted so a future
+            # compute path re-extracts instead of returning a dangling path
+            # (same hygiene as TranscriptionPrewarmer._transcribe_span).
+            if temp_files:
+                self.audio_chunks.pop((self._resolve_source(video_file), 0, duration), None)
 
         if len(full) < 50:
             logger.info(f"transcribe_full: too little text ({len(full)} chars) for {video_file}")
@@ -1510,10 +1527,14 @@ class EpisodeMatcher:
             self._tfidf_cache[signature] = tm
             return tm
 
-    def _match_full_file(self, video_file, model_config, reference_files, duration, tfidf_matcher):
+    def _match_full_file(self, video_file, reference_files, tfidf_matcher):
         """
         Fallback: matching by transcribing the ENTIRE file.
         This is resource intensive but necessary if chunk matching fails.
+
+        Model interaction (loading, duration lookup, the layered transcript
+        cache) lives entirely in ``transcribe_full``; this method only matches
+        the resulting text against the references.
 
         ``tfidf_matcher`` is the per-call matcher already prepared for this season
         (passed in, not read from shared state, so a concurrent season can't swap
@@ -2000,9 +2021,7 @@ class EpisodeMatcher:
                 f"or calibrated confidence ≥ {self.confidence_accept_floor}, with enough votes). "
                 f"Attempting FULL FILE fallback..."
             )
-            match = self._match_full_file(
-                video_file, model_config, reference_files, video_duration, tfidf_matcher
-            )
+            match = self._match_full_file(video_file, reference_files, tfidf_matcher)
 
             if match:
                 # Intentional exception to calibration: the full-file fallback

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -25,6 +25,55 @@ from app.matcher.vectorizer_config import apply_tfidf
 
 console = Console()
 
+# Nested scan-point lattice levels: n_k = 9 * 2**k + 1. Level k+1 inserts the
+# midpoint of every level-k gap, so each level is a strict subset of all deeper ones.
+_SCAN_LATTICE_LEVELS = (10, 19, 37, 73, 145)
+
+
+def canonical_scan_points(
+    video_duration,
+    *,
+    skip_initial,
+    skip_final=120,
+    chunk_len=30,
+    num_points=10,
+) -> list[int]:
+    """Evenly-spaced scan offsets on a nested lattice, stable across scan depths.
+
+    Levels follow ``n_k = 9 * 2**k + 1`` (10, 19, 37, 73, 145); a shallow scan's
+    offsets are a strict subset of every deeper scan's, so a transcript cache
+    keyed by (file, offset, duration) gets full reuse when a deep re-match
+    revisits a file. ``num_points`` snaps UP to the smallest level that covers
+    it (capped at 145); ``None`` or < 2 means the default 10.
+
+    Integer arithmetic (multiply before floor-divide) is mandatory for subset
+    exactness: level-k point i equals level-(k+1) point 2i because
+    ``n_{k+1} - 1 == 2 * (n_k - 1)``; per-level float intervals can differ in
+    the last ulp and break the equality after truncation.
+
+    Returns ``[]`` when no usable window remains (duration <= skips); offsets
+    are never negative, and adjacent lattice points that collide after floor
+    division on short files are deduplicated.
+    """
+    if not num_points or num_points < 2:
+        num_points = 10
+    n = next((lvl for lvl in _SCAN_LATTICE_LEVELS if lvl >= num_points), _SCAN_LATTICE_LEVELS[-1])
+
+    skip_initial = max(int(skip_initial), 0)
+    available = int(video_duration) - skip_initial - int(skip_final)
+    if available <= 0:
+        return []
+
+    points: list[int] = []
+    for i in range(n):
+        point = skip_initial + (i * available) // (n - 1)
+        if point >= video_duration - chunk_len:
+            continue
+        if points and points[-1] == point:
+            continue
+        points.append(point)
+    return points
+
 
 def load_precomputed_manifest(cache_dir) -> dict | None:
     """Load and validate the precomputed-cache manifest. Returns the dict or None.
@@ -1525,30 +1574,23 @@ class EpisodeMatcher:
                     ep_name = Path(rf).stem
                     coverages[str(rf)] = MatchCoverage(ep_name, ref_dur, video_duration)
 
-            # 5. Scan Chunks - Evenly Spaced Strategy
-            # Distribute scan points evenly across the episode (after skipping intro)
-            # Scales automatically based on media length
+            # 5. Scan Chunks - Canonical Nested Lattice
+            # Offsets come from canonical_scan_points so a shallow scan is a strict
+            # subset of any deeper re-match (transcript-cache reuse across depths).
 
             chunk_len = 30
-            skip_initial = self.skip_initial_duration  # 300s - skip opening credits
-            skip_final = 120  # Skip closing credits/black frames
-
-            available_duration = video_duration - skip_initial - skip_final
+            skip_initial = self.skip_initial_duration  # 90s - skip opening title cards
 
             # TF-IDF matching is fast (~1ms/query) and accurate. More sample
             # points reduce false positives from commentary/alternate audio tracks.
-            # Caller may request a denser scan (deep re-match) for disambiguation.
-            num_points = num_points if num_points and num_points > 1 else 10
-
-            # Calculate actual interval to evenly distribute points across available duration
-            interval = available_duration / (num_points - 1)
-
-            # Generate evenly-spaced scan points
-            scan_points = []
-            for i in range(num_points):
-                point = int(skip_initial + i * interval)
-                if point < video_duration - chunk_len:
-                    scan_points.append(point)
+            # Caller may request a denser scan (deep re-match) for disambiguation;
+            # canonical_scan_points handles None/<2 (default 10) and level snapping.
+            scan_points = canonical_scan_points(
+                video_duration,
+                skip_initial=skip_initial,
+                chunk_len=chunk_len,
+                num_points=num_points,
+            )
 
             model_config = self._model_config()
             model = get_cached_model(model_config)
@@ -1577,9 +1619,10 @@ class EpisodeMatcher:
                 reference_files=reference_files,
             )
 
+            span = f"{scan_points[0]}s-{scan_points[-1]}s" if scan_points else "empty"
             logger.info(
-                f"Scanning {len(scan_points)} chunks using {model_config['name']} + TF-IDF matching "
-                f"(~{interval:.0f}s intervals from {skip_initial}s to {video_duration - skip_final}s)"
+                f"Scanning {len(scan_points)} chunks using {model_config['name']} + TF-IDF "
+                f"matching (canonical lattice, span {span})"
             )
             logger.debug(
                 f"Scan points: {scan_points[:5]}... {scan_points[-3:]} (showing first 5 and last 3)"

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -1465,9 +1465,12 @@ class EpisodeMatcher:
         """
         Identify episode using ranked voting with weighted confidence scoring.
 
-        ``num_points`` overrides the number of evenly-spaced audio scan points
-        (default 10); a denser scan yields more robust votes and a clearer
-        score gap — used by the "deep re-match" path to disambiguate conflicts.
+        ``num_points`` overrides the number of audio scan points (default 10);
+        the requested count is snapped up to the nearest lattice level
+        (10/19/37/73/145) — see ``canonical_scan_points`` — so the transcript
+        cache can be fully reused between shallow and deep scans. A denser scan
+        yields more robust votes and a clearer score gap — used by the "deep
+        re-match" path to disambiguate conflicts.
         ``min_vote_count`` overrides the minimum matched-chunk count required to
         accept a match (default ``self.min_vote_count``).
 

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -9,7 +9,6 @@ from functools import lru_cache
 from pathlib import Path
 
 import chardet
-import ctranslate2
 import numpy as np
 from loguru import logger
 from rich.console import Console
@@ -18,7 +17,8 @@ from scipy.sparse import vstack as scipy_vstack
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity as sklearn_cosine_similarity
 
-from app.matcher.asr_models import get_cached_model
+from app.matcher import transcript_store
+from app.matcher.asr_models import detect_asr_device, get_cached_model, model_output_key
 from app.matcher.subtitle_utils import corpus_dir_name, sanitize_filename
 from app.matcher.utils import extract_season_episode
 from app.matcher.vectorizer_config import apply_tfidf
@@ -958,7 +958,12 @@ class EpisodeMatcher:
         )
         self.model_name = model_name
         self.requested_workers = max(1, int(requested_workers or 1))
-        self.device = device or ("cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu")
+        # Effective startup-pinned device (set_asr_device), NOT the raw GPU probe:
+        # probing ctranslate2 directly here claimed "cuda" even when the user had
+        # disabled GPU ASR, which would poison _model_config() — and through it the
+        # persistent transcript-cache model_key (claiming cuda/float16 for output
+        # actually produced on cpu/int8).
+        self.device = device or detect_asr_device()
         self.temp_dir = Path(tempfile.gettempdir()) / "whisper_chunks"
         self.temp_dir.mkdir(exist_ok=True)
         # Initialize subtitle cache
@@ -1039,6 +1044,77 @@ class EpisodeMatcher:
         if len(self.transcriptions) >= self._max_transcription_cache:
             self.transcriptions.clear()
         self.transcriptions[key] = text
+
+    def _model_key_for(self, model) -> str:
+        """L2 transcript-cache model identity, preferring the LOADED model's device.
+
+        ``FasterWhisperModel.load()`` can silently fall back CUDA→CPU when the math
+        libraries are missing; deriving the key from the loaded object's post-load
+        ``device`` means a persisted key can't claim cuda/float16 for output that
+        was actually produced on cpu/int8. Model objects that don't expose a
+        resolved device (e.g. test fakes) fall back to ``_model_config()``, whose
+        device is the startup-pinned effective value (see __init__).
+        """
+        config = self._model_config()
+        loaded_device = getattr(model, "device", None)
+        if loaded_device in ("cpu", "cuda"):
+            config["device"] = loaded_device
+        return model_output_key(config)
+
+    def transcribe_chunk_cached(
+        self,
+        video_file,
+        start_time,
+        chunk_len,
+        model,
+        *,
+        file_key=None,
+        model_key=None,
+        temp_files=None,
+    ) -> str:
+        """Transcribe one chunk through the layered cache: L1 dict → L2 SQLite → Whisper.
+
+        On an L1/L2 hit no wav is extracted, so nothing is appended to
+        ``temp_files`` (same as the historical L1-hit path); on compute the
+        extracted wav IS appended (before transcription, so cleanup happens even
+        if Whisper raises) and the text is written through to BOTH layers so it
+        survives process restarts and re-matches.
+
+        ``file_key``/``model_key`` may be precomputed by the caller (one stat +
+        one key derivation per identify_episode call, reused across offsets);
+        when absent they are derived here so direct callers stay correct.
+        ``transcript_store`` is fail-safe — a broken cache degrades to "just
+        transcribe again", never into a matching error.
+        """
+        chunk_key = self._transcription_key(video_file, start_time, chunk_len)
+        # L1: in-memory memo (persists across identify_episode calls).
+        text = self.transcriptions.get(chunk_key)
+        if text is not None:
+            return text
+
+        if file_key is None:
+            file_key = transcript_store.file_key_for(video_file)
+        if model_key is None:
+            model_key = self._model_key_for(model)
+
+        # L2: persistent store. "" is a valid cached transcript (silent audio);
+        # only None is a miss. On a hit, also populate L1 for this process.
+        text = transcript_store.get(file_key, start_time, chunk_len, model_key)
+        if text is not None:
+            self._remember_transcription(chunk_key, text)
+            return text
+
+        audio_path = self.extract_audio_chunk(video_file, start_time, duration=chunk_len)
+        if temp_files is not None:
+            temp_files.append(audio_path)  # Track for caller's cleanup
+        # `or ""` guards a wrapper returning {"text": None}: caching None would
+        # make this offset a perpetual miss (the `is None` guards above would
+        # re-transcribe it every season). The caller's `len(text) < 10` check
+        # still skips genuinely empty audio.
+        text = (model.transcribe(audio_path).get("text") or "").strip()
+        self._remember_transcription(chunk_key, text)
+        transcript_store.put(file_key, start_time, chunk_len, model_key, text)
+        return text
 
     def extract_audio_chunk(self, mkv_file, start_time, duration=None):
         """Extract a chunk of audio from MKV file with caching."""
@@ -1339,18 +1415,19 @@ class EpisodeMatcher:
             )
             return None
 
-        model_config = self._model_config()
         try:
             # Memoized by (source, 0, duration): the full-file fallback fires once per
             # candidate season when no chunk votes, so without this the season-unknown
             # path re-transcribes the ENTIRE file per season — the single biggest cost.
+            # transcribe_chunk_cached layers the persistent L2 store underneath, so a
+            # full-file transcript is also persisted when produced (free at that point)
+            # and survives restarts; nothing prewarms full files. The L1 check stays
+            # first so an in-memory hit doesn't even touch the model loader.
             full_key = self._transcription_key(video_file, 0, duration)
             full = self.transcriptions.get(full_key)
             if full is None:
-                model = get_cached_model(model_config)
-                audio_path = self.extract_audio_chunk(video_file, start_time=0, duration=duration)
-                full = (model.transcribe(audio_path).get("text") or "").strip()
-                self._remember_transcription(full_key, full)
+                model = get_cached_model(self._model_config())
+                full = self.transcribe_chunk_cached(video_file, 0, duration, model)
         except Exception as e:
             logger.warning(
                 f"transcribe_full: transcription failed for {video_file}: {e}",
@@ -1597,6 +1674,10 @@ class EpisodeMatcher:
 
             model_config = self._model_config()
             model = get_cached_model(model_config)
+            # L2 transcript-cache identity, computed ONCE per call (one stat, one
+            # key derivation) and passed into every chunk lookup below.
+            l2_file_key = transcript_store.file_key_for(video_file)
+            l2_model_key = self._model_key_for(model)
 
             # Resolve the TF-IDF matcher for THIS season's reference set as a
             # per-call local — never a shared instance slot. The matcher singleton
@@ -1639,24 +1720,21 @@ class EpisodeMatcher:
                 scan_percent = 10.0 + (i / len(scan_points)) * 80.0
 
                 try:
-                    # Transcribe, memoized by (source, offset, duration). On a hit
-                    # (e.g. a later candidate season re-scanning the same file) we
-                    # skip both ffmpeg extraction and Whisper — only the ~1ms TF-IDF
-                    # match below re-runs.
-                    chunk_key = self._transcription_key(video_file, start_time, chunk_len)
-                    text = self.transcriptions.get(chunk_key)
-                    if text is None:
-                        audio_path = self.extract_audio_chunk(
-                            video_file, start_time, duration=chunk_len
-                        )
-                        temp_files_to_remove.append(audio_path)  # Track for cleanup
-                        # `or ""` guards a wrapper returning {"text": None}: caching
-                        # None would make this offset a perpetual miss (the `is None`
-                        # guard above would re-transcribe it every season). Matches
-                        # transcribe_full; the `len(text) < 10` check below still skips
-                        # genuinely empty audio.
-                        text = (model.transcribe(audio_path).get("text") or "").strip()
-                        self._remember_transcription(chunk_key, text)
+                    # Transcribe through the layered cache (L1 dict → L2 SQLite →
+                    # Whisper). On a hit (a later candidate season re-scanning the
+                    # same file, or a re-match after a restart) we skip both ffmpeg
+                    # extraction and Whisper — only the ~1ms TF-IDF match below
+                    # re-runs. The wav is appended to temp_files_to_remove only
+                    # when actually extracted (compute path).
+                    text = self.transcribe_chunk_cached(
+                        video_file,
+                        start_time,
+                        chunk_len,
+                        model,
+                        file_key=l2_file_key,
+                        model_key=l2_model_key,
+                        temp_files=temp_files_to_remove,
+                    )
 
                     if len(text) < 10:
                         logger.debug(

--- a/backend/app/matcher/episode_identification.py
+++ b/backend/app/matcher/episode_identification.py
@@ -54,6 +54,10 @@ def floor_to_lattice_level(num_points) -> int:
     snapping UP past the budget would transcribe overlapping audio for no new
     evidence. Below the base level the matcher can't scan any shallower, so 10 is
     returned (``canonical_scan_points`` dedups colliding points on short files).
+
+    Unlike :func:`snap_to_lattice_level`, ``num_points`` must be an ``int``; passing
+    ``None`` raises ``TypeError``.  The sole caller feeds ``_full_coverage_points``,
+    which always returns an int, so this is never an issue in practice.
     """
     for lvl in reversed(_SCAN_LATTICE_LEVELS):
         if lvl <= num_points:

--- a/backend/app/matcher/transcript_store.py
+++ b/backend/app/matcher/transcript_store.py
@@ -1,0 +1,326 @@
+"""Disk-backed ASR transcript cache (L2 store).
+
+Whisper transcription of a 30 s audio chunk is expensive (~30-60 s on CPU).
+The transcript text depends ONLY on (audio file, offset, duration, ASR model
+identity) — it is completely independent of which show/season we later match
+against.  Today ``EpisodeMatcher.transcriptions`` memoises results only in an
+in-memory dict that is discarded on restart.  This module adds a SQLite layer
+underneath that in-memory cache.
+
+The cache lives at ``~/.engram/cache/transcripts.sqlite`` — a separate file
+from ``tmdb_cache.sqlite`` so the two caches have independent lifecycle and
+pruning strategies.  Like its sibling it is a regen-able artifact that does
+NOT need Alembic migrations.
+
+Cache key design
+----------------
+*file_key* = ``sha1("{resolved_path}|{st_size}|{st_mtime_ns}").hexdigest()``
+
+Encoding size *and* mtime means that a re-rip of the same title produces a new
+key, so stale transcripts simply never hit again — they age out via LRU prune.
+``file_key_for(path)`` computes this once and the caller passes it to
+``get()`` / ``put()`` so stat() is paid only once per chunk even when multiple
+offsets are looked up for the same file.
+
+LRU pruning
+-----------
+To cap unbounded growth (large-library users) the table is pruned to at most
+``_MAX_ROWS`` rows ordered by ``last_used_at`` (oldest first).  The check runs
+every ``_PUT_PRUNE_INTERVAL`` puts, not on every call.  A module-level counter
+tracks puts; the check is fast (one SELECT COUNT(*) before the DELETE).
+
+Fail-safe contract
+------------------
+Every public function catches all ``sqlite3.Error`` and ``OSError`` exceptions,
+logs at WARNING level, and returns ``None`` (or no-ops for ``put``).  A broken
+or corrupted cache degrades to "just transcribe again" — it must NEVER break
+the calling matcher.
+
+Corrupt-DB recovery
+-------------------
+If ``sqlite3.connect()`` / ``PRAGMA journal_mode`` / ``CREATE TABLE`` raises
+``sqlite3.DatabaseError`` on the *first* connection in a process, the module
+deletes the file and retries once.  This mirrors the pattern used in the
+companion ``tmdb_persistent_cache`` module.
+
+Thread safety
+-------------
+Same strategy as ``tmdb_persistent_cache``: each thread gets its own
+``sqlite3.Connection`` via ``threading.local()``.  WAL mode allows concurrent
+readers/writers on the same file.  Schema creation is protected by
+``_init_lock`` so threads don't race to ``CREATE TABLE``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+from loguru import logger
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+CACHE_DB_PATH = Path("~/.engram/cache/transcripts.sqlite").expanduser()
+
+# LRU pruning constants
+_MAX_ROWS: int = 100_000
+_PUT_PRUNE_INTERVAL: int = 200  # check row-count every N puts
+
+# ---------------------------------------------------------------------------
+# Internal state
+# ---------------------------------------------------------------------------
+
+_local = threading.local()
+_init_lock = threading.Lock()
+_put_counter_lock = threading.Lock()
+_put_counter: int = 0
+
+
+class _SchemaState:
+    """One-shot schema-init flag (same pattern as tmdb_persistent_cache).
+
+    Wrapped in an object rather than a bare module global to avoid CodeQL's
+    ``unused global variable`` false positive on ``global _initialized``
+    read-then-write-across-calls.
+    """
+
+    initialized: bool = False
+
+
+_schema = _SchemaState()
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS transcripts (
+  file_key     TEXT    NOT NULL,
+  start_s      INTEGER NOT NULL,
+  duration_s   INTEGER NOT NULL,
+  model_key    TEXT    NOT NULL,
+  text         TEXT    NOT NULL,
+  created_at   INTEGER NOT NULL,
+  last_used_at INTEGER NOT NULL,
+  PRIMARY KEY (file_key, start_s, duration_s, model_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_transcripts_lru ON transcripts(last_used_at);
+"""
+
+# ---------------------------------------------------------------------------
+# Connection management
+# ---------------------------------------------------------------------------
+
+
+def _get_conn() -> sqlite3.Connection:
+    """Return a thread-local connection to the transcript cache DB.
+
+    On first use per-process, creates the DB file (and parent directories) and
+    applies the schema under ``_init_lock`` so concurrent threads don't race.
+    Each subsequent call in the same thread reuses the open connection.
+
+    If the DB file is corrupt (``sqlite3.DatabaseError`` during bootstrap),
+    the file is deleted and recreated once.
+    """
+    conn = getattr(_local, "conn", None)
+    if conn is not None:
+        return conn
+
+    if not _schema.initialized:
+        with _init_lock:
+            if not _schema.initialized:
+                _bootstrap_db()
+                _schema.initialized = True
+
+    conn = sqlite3.connect(CACHE_DB_PATH, timeout=30)
+    conn.execute("PRAGMA journal_mode=WAL")
+    _local.conn = conn
+    return conn
+
+
+def _bootstrap_db() -> None:
+    """Create the DB file + schema.  Called once per process under _init_lock."""
+    try:
+        CACHE_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # Parent path is blocked (e.g. a file sits where a directory is needed).
+        # Raise so _get_conn() propagates a sqlite3-compatible error that get/put
+        # will catch and convert to None / no-op.
+        raise sqlite3.OperationalError(
+            f"transcript_store: cannot create cache directory: {exc}"
+        ) from exc
+    try:
+        _create_schema()
+    except sqlite3.DatabaseError:
+        # Corrupt file — delete and retry once.
+        logger.warning(f"transcript_store: corrupt DB at {CACHE_DB_PATH}; deleting and recreating")
+        try:
+            CACHE_DB_PATH.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(f"transcript_store: could not delete corrupt DB: {exc}")
+        _create_schema()
+
+
+def _create_schema() -> None:
+    """Open a bootstrap connection, apply WAL + schema, close immediately."""
+    bootstrap = sqlite3.connect(CACHE_DB_PATH, timeout=30)
+    try:
+        bootstrap.execute("PRAGMA journal_mode=WAL")
+        bootstrap.executescript(_SCHEMA)
+        bootstrap.commit()
+    finally:
+        bootstrap.close()
+
+
+def close() -> None:
+    """Close the calling thread's connection and reset the schema-init flag.
+
+    Test fixtures call this when redirecting ``CACHE_DB_PATH`` to a tmp_path
+    SQLite file between tests, exactly as ``tmdb_persistent_cache.close()``
+    is used in the global ``_isolate_tmdb_persistent_cache`` conftest fixture.
+
+    Connections held by OTHER threads are left open — they drain when their
+    owning thread exits.
+    """
+    conn = getattr(_local, "conn", None)
+    if conn is not None:
+        conn.close()
+        _local.conn = None
+    _schema.initialized = False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def file_key_for(path: str | Path) -> str | None:
+    """Compute a stable cache key for *path*.
+
+    Resolves the path, stats it, and returns
+    ``sha1("{resolved}|{st_size}|{st_mtime_ns}").hexdigest()``.
+
+    Returns ``None`` (never raises) if the file is missing or unstatable.
+    Re-rips of the same title produce a new ``mtime_ns`` → new key, so stale
+    entries simply age out via LRU rather than being served.
+    """
+    try:
+        p = Path(path).resolve()
+        st = p.stat()
+        raw = f"{p}|{st.st_size}|{st.st_mtime_ns}"
+        return hashlib.sha1(raw.encode()).hexdigest()
+    except OSError as exc:
+        logger.debug(f"transcript_store.file_key_for({path!r}): {exc}")
+        return None
+
+
+def get(file_key: str, start_s: int, duration_s: int, model_key: str) -> str | None:
+    """Return the cached transcript text, or ``None`` on a miss.
+
+    *Distinguishes* a cached empty string (``""`` — silent audio) from a cache
+    miss (``None``).  On a hit, bumps ``last_used_at`` so active entries survive
+    LRU pruning longer.
+    """
+    try:
+        conn = _get_conn()
+        row = conn.execute(
+            "SELECT text FROM transcripts "
+            "WHERE file_key=? AND start_s=? AND duration_s=? AND model_key=?",
+            (file_key, start_s, duration_s, model_key),
+        ).fetchone()
+        if row is None:
+            return None
+        # Bump LRU timestamp on every hit.
+        now = int(time.time())
+        conn.execute(
+            "UPDATE transcripts SET last_used_at=? "
+            "WHERE file_key=? AND start_s=? AND duration_s=? AND model_key=?",
+            (now, file_key, start_s, duration_s, model_key),
+        )
+        conn.commit()
+        return row[0]
+    except sqlite3.Error as exc:
+        logger.warning(f"transcript_store.get: sqlite error: {exc}")
+        return None
+
+
+def put(file_key: str, start_s: int, duration_s: int, model_key: str, text: str) -> None:
+    """Insert or replace a transcript entry.
+
+    Also increments the put counter and triggers an LRU prune every
+    ``_PUT_PRUNE_INTERVAL`` puts so the table doesn't grow without bound.
+    """
+    global _put_counter
+    try:
+        conn = _get_conn()
+        now = int(time.time())
+        conn.execute(
+            "INSERT OR REPLACE INTO transcripts "
+            "(file_key, start_s, duration_s, model_key, text, created_at, last_used_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (file_key, start_s, duration_s, model_key, text, now, now),
+        )
+        conn.commit()
+    except sqlite3.Error as exc:
+        logger.warning(f"transcript_store.put: sqlite error: {exc}")
+        return
+
+    # Increment counter outside the try so a DB error above still doesn't
+    # corrupt the counter; prune is best-effort anyway.
+    with _put_counter_lock:
+        _put_counter += 1
+        should_prune = (_put_counter % _PUT_PRUNE_INTERVAL) == 0
+
+    if should_prune:
+        _prune()
+
+
+def _prune() -> None:
+    """Delete the oldest rows (by last_used_at) until at most _MAX_ROWS remain."""
+    try:
+        conn = _get_conn()
+        (count,) = conn.execute("SELECT COUNT(*) FROM transcripts").fetchone()
+        excess = count - _MAX_ROWS
+        if excess <= 0:
+            return
+        conn.execute(
+            "DELETE FROM transcripts WHERE rowid IN ("
+            "  SELECT rowid FROM transcripts ORDER BY last_used_at ASC LIMIT ?"
+            ")",
+            (excess,),
+        )
+        conn.commit()
+        logger.debug(f"transcript_store: pruned {excess} rows (was {count}, cap {_MAX_ROWS})")
+    except sqlite3.Error as exc:
+        logger.warning(f"transcript_store._prune: sqlite error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def reset_for_tests(db_path: Path) -> None:
+    """Redirect the cache to *db_path* and reset all state.
+
+    Intended for use in test fixtures — mirrors the conftest pattern used by
+    ``tmdb_persistent_cache`` (close + monkeypatch ``CACHE_DB_PATH``).  Tests
+    should call ``close()`` at teardown to release the connection.
+
+    Example (pytest)::
+
+        @pytest.fixture(autouse=True)
+        def _isolate_transcript_store(tmp_path, monkeypatch):
+            import app.matcher.transcript_store as ts
+            ts.close()
+            monkeypatch.setattr(ts, "CACHE_DB_PATH", tmp_path / "transcripts.sqlite")
+            yield
+            ts.close()
+    """
+    global _put_counter
+    close()
+    # Caller must monkeypatch CACHE_DB_PATH; this just resets the counter.
+    with _put_counter_lock:
+        _put_counter = 0

--- a/backend/app/matcher/transcript_store.py
+++ b/backend/app/matcher/transcript_store.py
@@ -83,11 +83,23 @@ _init_lock = threading.Lock()
 _put_counter_lock = threading.Lock()
 _put_counter: int = 0
 
-# Log-spam latch: after the first bootstrap failure we drop subsequent
-# failures to DEBUG so we don't flood the log with thousands of identical
-# warnings across 37-145 chunks × threads in degraded mode.
-_bootstrap_warned: bool = False
 _bootstrap_warned_lock = threading.Lock()
+
+
+class _BootstrapState:
+    """Log-spam latch: after the first bootstrap failure we drop subsequent
+    failures to DEBUG so we don't flood the log with thousands of identical
+    warnings across 37-145 chunks × threads in degraded mode.
+
+    Wrapped in an object rather than a bare module global (same rationale as
+    ``_SchemaState`` — avoids CodeQL's ``unused global variable`` false
+    positive on the ``global`` read-then-write-across-calls pattern).
+    """
+
+    warned: bool = False
+
+
+_bootstrap = _BootstrapState()
 
 
 class _SchemaState:
@@ -191,10 +203,9 @@ def _log_bootstrap_failure(exc: Exception) -> None:
     The latch is reset in ``close()`` / ``reset_module_state_for_tests()`` so
     recovery is possible once the environment is fixed.
     """
-    global _bootstrap_warned
     with _bootstrap_warned_lock:
-        first_time = not _bootstrap_warned
-        _bootstrap_warned = True
+        first_time = not _bootstrap.warned
+        _bootstrap.warned = True
 
     if first_time:
         logger.warning(
@@ -216,14 +227,13 @@ def close() -> None:
     Connections held by OTHER threads are left open — they drain when their
     owning thread exits.
     """
-    global _bootstrap_warned
     conn = getattr(_local, "conn", None)
     if conn is not None:
         conn.close()
         _local.conn = None
     _schema.initialized = False
     with _bootstrap_warned_lock:
-        _bootstrap_warned = False
+        _bootstrap.warned = False
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +405,6 @@ def reset_module_state_for_tests() -> None:
             ts.reset_module_state_for_tests()
     """
     global _put_counter
-    close()  # also resets _bootstrap_warned
+    close()  # also resets the bootstrap-warning latch (_bootstrap.warned)
     with _put_counter_lock:
         _put_counter = 0

--- a/backend/app/matcher/transcript_store.py
+++ b/backend/app/matcher/transcript_store.py
@@ -31,10 +31,12 @@ tracks puts; the check is fast (one SELECT COUNT(*) before the DELETE).
 
 Fail-safe contract
 ------------------
-Every public function catches all ``sqlite3.Error`` and ``OSError`` exceptions,
-logs at WARNING level, and returns ``None`` (or no-ops for ``put``).  A broken
-or corrupted cache degrades to "just transcribe again" — it must NEVER break
-the calling matcher.
+Every public function catches ``sqlite3.Error`` exceptions and returns ``None``
+(or no-ops for ``put``).  ``OSError`` from the filesystem is converted to a
+``sqlite3.OperationalError`` in ``_bootstrap_db`` before reaching get/put.
+``file_key_for`` catches ``OSError`` and logs at DEBUG level (missing files are
+expected, not warnings).  A broken or corrupted cache degrades to "just
+transcribe again" — it must NEVER break the calling matcher.
 
 Corrupt-DB recovery
 -------------------
@@ -80,6 +82,12 @@ _local = threading.local()
 _init_lock = threading.Lock()
 _put_counter_lock = threading.Lock()
 _put_counter: int = 0
+
+# Log-spam latch: after the first bootstrap failure we drop subsequent
+# failures to DEBUG so we don't flood the log with thousands of identical
+# warnings across 37-145 chunks × threads in degraded mode.
+_bootstrap_warned: bool = False
+_bootstrap_warned_lock = threading.Lock()
 
 
 class _SchemaState:
@@ -175,6 +183,29 @@ def _create_schema() -> None:
         bootstrap.close()
 
 
+def _log_bootstrap_failure(exc: Exception) -> None:
+    """Log a bootstrap failure at WARNING on first occurrence, DEBUG thereafter.
+
+    This prevents thousands of identical WARNING lines per job when the cache
+    directory is permanently unwritable (disk full, permissions error, etc.).
+    The latch is reset in ``close()`` / ``reset_module_state_for_tests()`` so
+    recovery is possible once the environment is fixed.
+    """
+    global _bootstrap_warned
+    with _bootstrap_warned_lock:
+        first_time = not _bootstrap_warned
+        _bootstrap_warned = True
+
+    if first_time:
+        logger.warning(
+            f"transcript_store: cache unavailable, running without transcript cache: {exc}"
+        )
+    else:
+        logger.debug(
+            f"transcript_store: cache still unavailable (suppressing repeat warnings): {exc}"
+        )
+
+
 def close() -> None:
     """Close the calling thread's connection and reset the schema-init flag.
 
@@ -185,11 +216,14 @@ def close() -> None:
     Connections held by OTHER threads are left open — they drain when their
     owning thread exits.
     """
+    global _bootstrap_warned
     conn = getattr(_local, "conn", None)
     if conn is not None:
         conn.close()
         _local.conn = None
     _schema.initialized = False
+    with _bootstrap_warned_lock:
+        _bootstrap_warned = False
 
 
 # ---------------------------------------------------------------------------
@@ -217,13 +251,29 @@ def file_key_for(path: str | Path) -> str | None:
         return None
 
 
-def get(file_key: str, start_s: int, duration_s: int, model_key: str) -> str | None:
+def get(
+    file_key: str | None,
+    start_s: int | float,
+    duration_s: int | float,
+    model_key: str,
+) -> str | None:
     """Return the cached transcript text, or ``None`` on a miss.
 
     *Distinguishes* a cached empty string (``""`` — silent audio) from a cache
     miss (``None``).  On a hit, bumps ``last_used_at`` so active entries survive
     LRU pruning longer.
+
+    *file_key* may be ``None`` (e.g. when ``file_key_for`` could not stat the
+    file); in that case ``None`` is returned immediately without touching the DB.
+
+    *start_s* and *duration_s* are normalised to integers via ``round()`` so
+    float values from ``get_video_duration()`` hit the same DB rows as integer
+    call sites.
     """
+    if file_key is None:
+        return None
+    start_s = int(round(start_s))
+    duration_s = int(round(duration_s))
     try:
         conn = _get_conn()
         row = conn.execute(
@@ -243,17 +293,36 @@ def get(file_key: str, start_s: int, duration_s: int, model_key: str) -> str | N
         conn.commit()
         return row[0]
     except sqlite3.Error as exc:
-        logger.warning(f"transcript_store.get: sqlite error: {exc}")
+        _log_bootstrap_failure(exc)
         return None
 
 
-def put(file_key: str, start_s: int, duration_s: int, model_key: str, text: str) -> None:
+def put(
+    file_key: str | None,
+    start_s: int | float,
+    duration_s: int | float,
+    model_key: str,
+    text: str,
+) -> None:
     """Insert or replace a transcript entry.
 
     Also increments the put counter and triggers an LRU prune every
     ``_PUT_PRUNE_INTERVAL`` puts so the table doesn't grow without bound.
+
+    *file_key* may be ``None`` (e.g. when ``file_key_for`` could not stat the
+    file); in that case the call is silently ignored (no DB write, no counter
+    increment).
+
+    *start_s* and *duration_s* are normalised to integers via ``round()`` so
+    float values from ``get_video_duration()`` hit the same DB rows as integer
+    call sites.
     """
+    if file_key is None:
+        logger.debug("transcript_store.put: file_key is None, skipping")
+        return
     global _put_counter
+    start_s = int(round(start_s))
+    duration_s = int(round(duration_s))
     try:
         conn = _get_conn()
         now = int(time.time())
@@ -265,7 +334,7 @@ def put(file_key: str, start_s: int, duration_s: int, model_key: str, text: str)
         )
         conn.commit()
     except sqlite3.Error as exc:
-        logger.warning(f"transcript_store.put: sqlite error: {exc}")
+        _log_bootstrap_failure(exc)
         return
 
     # Increment counter outside the try so a DB error above still doesn't
@@ -311,17 +380,21 @@ def reset_module_state_for_tests() -> None:
     the redirect takes effect on the next ``get()``/``put()`` that opens a
     new connection.
 
+    This also resets the bootstrap-warning latch so that tests that exercise
+    degraded-mode behaviour see the WARNING on the first failure (not silently
+    suppressed by a previous test).
+
     Example (pytest)::
 
         @pytest.fixture(autouse=True)
         def _isolate_transcript_store(tmp_path, monkeypatch):
             import app.matcher.transcript_store as ts
-            ts.close()
             monkeypatch.setattr(ts, "CACHE_DB_PATH", tmp_path / "transcripts.sqlite")
+            ts.reset_module_state_for_tests()
             yield
-            ts.close()
+            ts.reset_module_state_for_tests()
     """
     global _put_counter
-    close()
+    close()  # also resets _bootstrap_warned
     with _put_counter_lock:
         _put_counter = 0

--- a/backend/app/matcher/transcript_store.py
+++ b/backend/app/matcher/transcript_store.py
@@ -40,8 +40,9 @@ Corrupt-DB recovery
 -------------------
 If ``sqlite3.connect()`` / ``PRAGMA journal_mode`` / ``CREATE TABLE`` raises
 ``sqlite3.DatabaseError`` on the *first* connection in a process, the module
-deletes the file and retries once.  This mirrors the pattern used in the
-companion ``tmdb_persistent_cache`` module.
+deletes the file and retries once.  This is this module's own recovery policy;
+the companion ``tmdb_persistent_cache`` module does not implement the same
+pattern.
 
 Thread safety
 -------------
@@ -211,7 +212,7 @@ def file_key_for(path: str | Path) -> str | None:
         st = p.stat()
         raw = f"{p}|{st.st_size}|{st.st_mtime_ns}"
         return hashlib.sha1(raw.encode()).hexdigest()
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
         logger.debug(f"transcript_store.file_key_for({path!r}): {exc}")
         return None
 
@@ -302,12 +303,13 @@ def _prune() -> None:
 # ---------------------------------------------------------------------------
 
 
-def reset_for_tests(db_path: Path) -> None:
-    """Redirect the cache to *db_path* and reset all state.
+def reset_module_state_for_tests() -> None:
+    """Close the current connection and reset all in-process mutable state.
 
-    Intended for use in test fixtures — mirrors the conftest pattern used by
-    ``tmdb_persistent_cache`` (close + monkeypatch ``CACHE_DB_PATH``).  Tests
-    should call ``close()`` at teardown to release the connection.
+    Intended for use in test fixtures.  Callers are expected to redirect
+    ``CACHE_DB_PATH`` via ``monkeypatch.setattr`` *before or after* this call;
+    the redirect takes effect on the next ``get()``/``put()`` that opens a
+    new connection.
 
     Example (pytest)::
 
@@ -321,6 +323,5 @@ def reset_for_tests(db_path: Path) -> None:
     """
     global _put_counter
     close()
-    # Caller must monkeypatch CACHE_DB_PATH; this just resets the counter.
     with _put_counter_lock:
         _put_counter = 0

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -60,6 +60,20 @@ class AppConfig(SQLModel, table=True):
         default=False, sa_column_kwargs={"server_default": text("0")}
     )
 
+    # Background pre-transcription (persistent ASR transcript cache). When a job
+    # parks in review, a prewarmer background-transcribes the canonical scan-grid
+    # chunks for its unresolved tracks so a later re-match is near-instant.
+    # server_default="1" so the column arrives enabled for pre-existing databases.
+    enable_background_pretranscription: bool = Field(
+        default=True, sa_column_kwargs={"server_default": text("1")}
+    )
+    # Also pre-transcribe the ENTIRE file (the full-file fallback input). Expensive
+    # (~5-10 min GPU per file) — for users with idle GPUs who hit the full-file
+    # fallback often. Off by default.
+    pretranscribe_full_file: bool = Field(
+        default=False, sa_column_kwargs={"server_default": text("0")}
+    )
+
     # FFmpeg path (empty string = use PATH)
     ffmpeg_path: str = ""
 

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -130,8 +130,10 @@ def _library_path_for_job(job, content_type: str) -> "Path | None":
 _CHUNK_DURATION_S = 30  # mirrors EpisodeMatcher.chunk_duration
 _MAX_SCAN_POINTS = 200  # bound the RAW count even for very long tracks (realized depth <= 145)
 # First two tiers; the final tier is full coverage floored to the lattice. Tiers
-# must be lattice levels (see canonical_scan_points) so escalation passes share
-# cached transcripts with shallower scans instead of re-transcribing.
+# must be lattice levels (see canonical_scan_points): canonical_scan_points snaps
+# ANY requested depth to a lattice level, so a non-lattice constant would silently
+# realize onto a different grid — requested != realized — causing ladder dedup and
+# exhaustion bookkeeping to operate on the wrong depth and pass counters to lie.
 _CONFLICT_FIXED_DEPTHS = (37, 73)
 _EP_CODE_RE = re.compile(r"[Ss](\d+)[Ee](\d+)")
 
@@ -478,6 +480,8 @@ class FinalizationCoordinator:
             # sampling, which is exactly the false positive we must avoid.
             # Full coverage is a FLOOR here (the pass must see ~everything), unlike the
             # ladder's cost ceiling — so snap UP to the lattice, never floor down.
+            # Lazy — keep heavy matcher deps (sklearn/scipy) out of service import;
+            # see _conflict_scan_ladder for the same pattern.
             from app.matcher.episode_identification import snap_to_lattice_level
 
             full = snap_to_lattice_level(_full_coverage_points(review_titles))

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -128,8 +128,11 @@ def _library_path_for_job(job, content_type: str) -> "Path | None":
 # but keep the matcher's default vote gate so a genuinely-correct match on a
 # hard episode isn't demoted straight to review.
 _CHUNK_DURATION_S = 30  # mirrors EpisodeMatcher.chunk_duration
-_MAX_SCAN_POINTS = 200  # bound runtime even for very long tracks
-_CONFLICT_FIXED_DEPTHS = (25, 50)  # first two tiers; final tier is full coverage
+_MAX_SCAN_POINTS = 200  # bound the RAW count even for very long tracks (realized depth <= 145)
+# First two tiers; the final tier is full coverage floored to the lattice. Tiers
+# must be lattice levels (see canonical_scan_points) so escalation passes share
+# cached transcripts with shallower scans instead of re-transcribing.
+_CONFLICT_FIXED_DEPTHS = (37, 73)
 _EP_CODE_RE = re.compile(r"[Ss](\d+)[Ee](\d+)")
 
 
@@ -210,18 +213,26 @@ def _full_coverage_points(titles) -> int:
 
 
 def _conflict_scan_ladder(titles) -> list[int]:
-    """Strictly-increasing escalation ladder, capped at full coverage.
+    """Strictly-increasing escalation ladder of lattice scan depths.
 
-    For short episodes the fixed tiers already exceed full coverage, so the
-    ladder collapses (e.g. ``[25, 45]``); for long tracks it grows
-    (``[25, 50, 180]``). The last entry is always full coverage — there is no
-    "deeper" to go, which is the natural termination point.
+    Every tier is a canonical lattice level (see ``canonical_scan_points``), so
+    each pass realizes exactly at the requested depth and reuses the cached
+    transcripts of every shallower pass. The final tier is full coverage FLOORED
+    to the lattice — full coverage is a cost ceiling ("scan everything once");
+    snapping UP past it would transcribe overlapping audio for no new evidence.
+    Tiers at or above that ceiling are dropped (capping them would duplicate the
+    final tier's grid), so for short episodes the ladder collapses (e.g. ``[19]``)
+    while long tracks get the full ``[37, 73, 145]``. There is no "deeper" than
+    the last tier, which is the natural termination point.
     """
-    full = _full_coverage_points(titles)
+    # Lazy: keep heavy matcher deps (sklearn/scipy) out of service import.
+    from app.matcher.episode_identification import floor_to_lattice_level
+
+    full_level = floor_to_lattice_level(_full_coverage_points(titles))
     ladder: list[int] = []
-    for depth in (*_CONFLICT_FIXED_DEPTHS, full):
-        depth = min(depth, full)
-        if depth > 1 and (not ladder or depth > ladder[-1]):
+    for depth in (*_CONFLICT_FIXED_DEPTHS, full_level):
+        depth = min(depth, full_level)
+        if not ladder or depth > ladder[-1]:
             ladder.append(depth)
     return ladder
 
@@ -437,7 +448,7 @@ class FinalizationCoordinator:
         ``wrong_show_suspected`` collapses the ladder to a SINGLE full-coverage
         confirming pass (see below) — the caller passes the pre-escalation
         :func:`_detect_wrong_show` verdict so a probable wrong-show disc doesn't
-        burn the whole 25→50→full ladder against the wrong reference corpus.
+        burn the whole 37→73→full ladder against the wrong reference corpus.
 
         Returns ``True`` if a re-match was dispatched (job held in MATCHING; the
         caller should return and let completion re-entry pick it back up).
@@ -456,7 +467,7 @@ class FinalizationCoordinator:
         if wrong_show_suspected:
             # Suspected same-name wrong-show pick: every episode candidate matched
             # nothing AND a same-name twin is persisted. Don't climb the gradual
-            # 25→50→full ladder against a corpus that's probably the wrong show —
+            # 37→73→full ladder against a corpus that's probably the wrong show —
             # that's up to 3 wasted ASR passes. Do ONE full-coverage confirming
             # pass instead: it's the strongest possible evidence, so a still-empty
             # result lets the wrong-show branch fire with confidence, while a
@@ -465,8 +476,12 @@ class FinalizationCoordinator:
             # pass MUST be full coverage — a sparse tier matching nothing cannot
             # distinguish a wrong corpus from a disc that just needed denser
             # sampling, which is exactly the false positive we must avoid.
-            full = _full_coverage_points(review_titles)
-            ladder = [full] if full > 1 else []
+            # Full coverage is a FLOOR here (the pass must see ~everything), unlike the
+            # ladder's cost ceiling — so snap UP to the lattice, never floor down.
+            from app.matcher.episode_identification import snap_to_lattice_level
+
+            full = snap_to_lattice_level(_full_coverage_points(review_titles))
+            ladder = [full]
         else:
             ladder = _conflict_scan_ladder(review_titles)
         last_depth = self._review_passes.get(job_id, 0)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -823,7 +823,8 @@ class JobManager:
     ) -> None:
         """Set a user-provided name for an unlabeled disc and resume ripping."""
         # The real pipeline owns the ASR from here; it reuses whatever the
-        # prewarmer already cached.
+        # prewarmer already cached. cancel_for_job prevents future chunks;
+        # the in-flight thread still finishes its current chunk (~60 s).
         self._prewarmer.cancel_for_job(job_id)
         await self._identification.set_name_and_resume(job_id, name, content_type_str, season)
 
@@ -841,6 +842,8 @@ class JobManager:
     ) -> None:
         """Re-identify a job with user-corrected metadata."""
         # A real match (or re-rip) starts now — stop background prewarming.
+        # cancel_for_job prevents future chunks; the in-flight thread still
+        # finishes its current chunk (~60 s).
         self._prewarmer.cancel_for_job(job_id)
         result = await self._identification.re_identify(
             job_id, title, content_type_str, season, tmdb_id
@@ -859,6 +862,8 @@ class JobManager:
     async def _rerun_matching(self, job_id: int, source_preference: str | None = None) -> None:
         """Re-run episode matching for already-ripped titles."""
         # The real match owns the GPU now; it reuses what the prewarmer cached.
+        # cancel_for_job prevents future chunks; the in-flight thread still
+        # finishes its current chunk (~60 s).
         self._prewarmer.cancel_for_job(job_id)
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
@@ -1330,10 +1335,18 @@ class JobManager:
         edition: str | None = None,
     ) -> None:
         """Apply a user's review decision for a title."""
+        # Organization (shutil.move) starts now — stop background prewarming so
+        # ffmpeg/ffprobe don't hold the file open when the rename runs. The
+        # in-flight thread finishes its current chunk (~60s) before yielding.
+        self._prewarmer.cancel_for_job(job_id)
         await self._finalization.apply_review(job_id, title_id, episode_code, edition)
 
     async def apply_review_batch(self, job_id: int, decisions: list[dict]) -> None:
         """Apply several review decisions for a job in one atomic pass."""
+        # Organization (shutil.move) starts now — stop background prewarming so
+        # ffmpeg/ffprobe don't hold the file open when the rename runs. The
+        # in-flight thread finishes its current chunk (~60s) before yielding.
+        self._prewarmer.cancel_for_job(job_id)
         await self._finalization.apply_review_batch(job_id, decisions)
 
     async def reassign_episode(
@@ -1457,6 +1470,8 @@ class JobManager:
         conflict callers invoke the coordinator method directly (advisory False).
         """
         # A real (user-initiated) match starts now — stop background prewarming.
+        # cancel_for_job prevents future chunks; the in-flight thread still
+        # finishes its current chunk (~60 s).
         self._prewarmer.cancel_for_job(job_id)
         await self._matching.rematch_single_title(
             job_id,

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -49,6 +49,7 @@ from app.services.ripping_helpers import (
     resolve_title_from_filename,
 )
 from app.services.simulation_service import SimulationService
+from app.services.transcription_prewarm import TranscriptionPrewarmer
 
 # Per-disc ContentHash is computable the instant a disc mounts (validated on
 # real hardware: +0.00s after mount, 4/4 inserts). The retry exists only for a
@@ -140,6 +141,13 @@ class JobManager:
             self._analyst, self._extractor, event_broadcaster, state_machine
         )
         self._simulation = SimulationService(event_broadcaster, state_machine)
+        # Transcript prewarmer: fills the persistent ASR cache while a job sits
+        # in review, so the user's eventual re-match is near-instant. It draws
+        # chunks through the SAME match semaphore as live matching (acquired
+        # per chunk), so real matches always preempt it between chunks.
+        self._prewarmer = TranscriptionPrewarmer(
+            semaphore_provider=lambda: self._matching._match_semaphore
+        )
 
         # Wire cross-coordinator callbacks
         self._matching.set_callbacks(
@@ -179,9 +187,17 @@ class JobManager:
         state_machine.on_terminal_state(self._cleanup.on_job_terminal)
         state_machine.on_terminal_state(self._matching.clear_job_caches)
         state_machine.on_terminal_state(self._finalization.on_terminal_clear_conflicts)
+        state_machine.on_terminal_state(self._prewarmer.on_job_terminal)
 
         # Reset the watchdog activity clock whenever a job changes phase.
         state_machine.on_transition(self._note_activity_on_transition)
+        # Prewarm transcripts whenever a job parks in review. Registering on the
+        # state machine is the single chokepoint every review-parking path flows
+        # through (finalization's check_job_completion, the ambiguous-movie
+        # post-rip review, FILE_EXISTS conflicts, ...) and fires only AFTER the
+        # REVIEW_NEEDED transition committed. Pre-rip reviews (e.g. name prompt)
+        # also land here, but with no files on disk the task no-ops cheaply.
+        state_machine.on_transition(self._start_prewarm_on_review)
 
     async def start(self) -> None:
         """Start the job manager and begin monitoring drives."""
@@ -397,6 +413,9 @@ class JobManager:
             logger.info(f"Cancelled job {job_id}")
 
         self._active_jobs.clear()
+
+        # Stop any background transcript prewarming.
+        self._prewarmer.cancel_all()
 
         # Drain any MakeMKV subprocesses so none survive shutdown as orphans.
         await self._extractor.shutdown()
@@ -803,6 +822,9 @@ class JobManager:
         season: int | None = None,
     ) -> None:
         """Set a user-provided name for an unlabeled disc and resume ripping."""
+        # The real pipeline owns the ASR from here; it reuses whatever the
+        # prewarmer already cached.
+        self._prewarmer.cancel_for_job(job_id)
         await self._identification.set_name_and_resume(job_id, name, content_type_str, season)
 
         task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
@@ -818,6 +840,8 @@ class JobManager:
         tmdb_id: int | None = None,
     ) -> None:
         """Re-identify a job with user-corrected metadata."""
+        # A real match (or re-rip) starts now — stop background prewarming.
+        self._prewarmer.cancel_for_job(job_id)
         result = await self._identification.re_identify(
             job_id, title, content_type_str, season, tmdb_id
         )
@@ -834,6 +858,8 @@ class JobManager:
 
     async def _rerun_matching(self, job_id: int, source_preference: str | None = None) -> None:
         """Re-run episode matching for already-ripped titles."""
+        # The real match owns the GPU now; it reuses what the prewarmer cached.
+        self._prewarmer.cancel_for_job(job_id)
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
             if not job or not job.staging_path:
@@ -941,6 +967,11 @@ class JobManager:
             self._last_activity.pop(job_id, None)
         else:
             self._last_activity[job_id] = time.monotonic()
+
+    def _start_prewarm_on_review(self, job_id: int, state: JobState) -> None:
+        """on_transition observer: prewarm transcripts when a job parks in review."""
+        if state == JobState.REVIEW_NEEDED:
+            self._prewarmer.kickoff(job_id)
 
     @staticmethod
     def _has_complete_output(output_dir: Path, title_index: int) -> bool:
@@ -1425,6 +1456,8 @@ class JobManager:
         in review for confirmation and never auto-organized. Pipeline/escalation/
         conflict callers invoke the coordinator method directly (advisory False).
         """
+        # A real (user-initiated) match starts now — stop background prewarming.
+        self._prewarmer.cancel_for_job(job_id)
         await self._matching.rematch_single_title(
             job_id,
             title_id,

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -31,8 +31,10 @@ logger = logging.getLogger(__name__)
 # Stricter matcher parameters for the "deep re-match" conflict path: sample more
 # audio chunks (vs the default 10) for more robust votes + a clearer score gap,
 # and require more matched chunks before accepting (vs the default 2).
-# Deep re-match depths must be lattice levels (see canonical_scan_points) so they
-# share cached transcripts with the 10-point standard scan.
+# Deep re-match depths must be lattice levels (see canonical_scan_points):
+# canonical_scan_points snaps ANY requested depth to a lattice level, so a
+# non-lattice constant silently realizes onto a different grid — requested !=
+# realized — causing ladder dedup/exhaustion bookkeeping and pass counters to lie.
 STRICT_SCAN_POINTS = 37
 STRICT_MIN_VOTES = 4
 

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -31,7 +31,9 @@ logger = logging.getLogger(__name__)
 # Stricter matcher parameters for the "deep re-match" conflict path: sample more
 # audio chunks (vs the default 10) for more robust votes + a clearer score gap,
 # and require more matched chunks before accepting (vs the default 2).
-STRICT_SCAN_POINTS = 25
+# Deep re-match depths must be lattice levels (see canonical_scan_points) so they
+# share cached transcripts with the 10-point standard scan.
+STRICT_SCAN_POINTS = 37
 STRICT_MIN_VOTES = 4
 
 # Duration pre-filter tolerances (minutes). DVD/Blu-ray episode tracks run LONGER

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -1,0 +1,385 @@
+"""Background transcript prewarmer for review-parked jobs.
+
+When a job parks in REVIEW_NEEDED its unresolved tracks are very likely to be
+re-matched soon (the user reassigns an episode, re-identifies the show, or hits
+"Re-match all"). Re-matching re-transcribes the same canonical scan-grid chunks
+Whisper already saw — unless they are sitting in the persistent transcript
+store (``app/matcher/transcript_store.py``, the L2 cache under
+``transcribe_chunk_cached``). This service fills that store in the background
+while the job idles in review, so the eventual re-match is near-instant.
+
+Design notes
+------------
+* **One dedicated EpisodeMatcher**, built lazily in a thread on first use.
+  It is constructed with the SAME model-affecting args production matching
+  uses (see ``EpisodeCurator._ensure_initialized``): default model name,
+  startup-pinned device, ``requested_workers`` from config — so its
+  ``model_key`` (and even its ``get_cached_model`` cache slot) match what live
+  matching produces and looks up. ``show_name`` does not affect transcription;
+  a sentinel is used.
+* **Coverage check without a model load**: the model-free
+  ``model_output_key(matcher._model_config())`` plus ``transcript_store.get``
+  per offset decide whether anything is missing. A fully-cached file never
+  touches the Whisper loader.
+* **Honest-key recheck**: after the model loads, ``_model_key_for(model)``
+  may differ from the config-derived key (CUDA→CPU fallback). When it does,
+  coverage is re-checked under the honest key before transcribing.
+* **Semaphore per chunk**: each chunk acquires the matching semaphore and
+  releases it before the next one, so a live match preempts the prewarmer
+  between chunks instead of queueing behind a whole file.
+* **Fail-soft everywhere**: a chunk or file failure logs and continues; the
+  background task can never propagate into job state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+from sqlmodel import select
+
+from app.core.log_context import with_job_log_context
+from app.database import async_session
+from app.models import DiscJob
+from app.models.disc_job import DiscTitle, TitleState
+
+logger = logging.getLogger(__name__)
+
+# The default (shallowest) scan-lattice depth — the offsets every normal match
+# visits first. Deeper re-scans are strict supersets (nested lattice), so
+# warming level 0 always pays off regardless of later scan depth.
+DEFAULT_SCAN_POINTS = 10
+
+# Title states whose files can never benefit from prewarming: COMPLETED is
+# already organized (the file has moved out of staging), FAILED is discarded,
+# RIPPING is still being written. Everything else with a real file on disk
+# (PENDING/QUEUED/MATCHING/MATCHED/REVIEW) is a re-match candidate.
+_SKIP_STATES = {TitleState.COMPLETED, TitleState.FAILED, TitleState.RIPPING}
+
+# A span is (start_s, duration_s) — the transcript-store key minus file/model.
+_Span = tuple[int, int]
+
+
+class TranscriptionPrewarmer:
+    """Pre-fills the persistent ASR transcript cache for review-parked jobs."""
+
+    def __init__(
+        self,
+        semaphore_provider: Callable[[], asyncio.Semaphore | None] | None = None,
+    ) -> None:
+        """``semaphore_provider`` returns the live match semaphore (or None).
+
+        A callable rather than the semaphore itself because the semaphore is
+        created at ``job_manager.start()`` (after ASR capacity is resolved),
+        long after this service is constructed.
+        """
+        self._semaphore_provider = semaphore_provider
+        self._tasks: dict[int, asyncio.Task] = {}
+        # Strong refs to the short-lived kickoff tasks (asyncio keeps only weak
+        # refs to tasks; an unreferenced task can be garbage-collected mid-run).
+        self._kickoffs: set[asyncio.Task] = set()
+        self._matcher = None
+        # asyncio.Lock binds to the loop lazily (py3.11), so constructing it
+        # here (no running loop) is safe — same pattern as matching_coordinator.
+        self._matcher_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def kickoff(self, job_id: int) -> None:
+        """Fire-and-forget ``start_for_job`` — sync seam for state-machine callbacks."""
+        task = asyncio.create_task(self.start_for_job(job_id))
+        self._kickoffs.add(task)
+        task.add_done_callback(self._kickoffs.discard)
+
+    async def start_for_job(self, job_id: int) -> None:
+        """Start a background prewarm task for ``job_id`` (idempotent, fail-soft)."""
+        try:
+            existing = self._tasks.get(job_id)
+            if existing is not None and not existing.done():
+                return
+
+            from app.services.config_service import get_config
+
+            config = await get_config()
+            if not config.enable_background_pretranscription:
+                logger.debug(f"Job {job_id}: background pre-transcription disabled; skipping")
+                return
+            full_file = bool(config.pretranscribe_full_file)
+
+            # Re-check after the await: a concurrent start could have spawned.
+            existing = self._tasks.get(job_id)
+            if existing is not None and not existing.done():
+                return
+
+            task = asyncio.create_task(
+                with_job_log_context(job_id, self._prewarm_job(job_id, full_file=full_file))
+            )
+            self._tasks[job_id] = task
+            task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
+            logger.info(f"Job {job_id}: transcript prewarm task started (full_file={full_file})")
+        except Exception as e:  # never let prewarm startup ripple into the caller
+            logger.warning(f"Job {job_id}: failed to start transcript prewarm: {e}", exc_info=True)
+
+    def cancel_for_job(self, job_id: int) -> None:
+        """Cancel and forget the prewarm task for ``job_id``. Safe when absent."""
+        task = self._tasks.pop(job_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+            logger.info(f"Job {job_id}: transcript prewarm cancelled")
+
+    async def on_job_terminal(self, job_id: int, _state) -> None:
+        """JobStateMachine ``on_terminal_state`` hook: stop warming a finished job."""
+        self.cancel_for_job(job_id)
+
+    def cancel_all(self) -> None:
+        """Cancel every prewarm task (shutdown seam)."""
+        for task in self._kickoffs:
+            task.cancel()
+        self._kickoffs.clear()
+        for job_id in list(self._tasks):
+            self.cancel_for_job(job_id)
+
+    # ------------------------------------------------------------------
+    # Per-job task
+    # ------------------------------------------------------------------
+
+    def _on_task_done(self, task: asyncio.Task, job_id: int) -> None:
+        if self._tasks.get(job_id) is task:
+            del self._tasks[job_id]
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(f"Job {job_id}: transcript prewarm task died: {exc}")
+
+    async def _prewarm_job(self, job_id: int, *, full_file: bool) -> None:
+        """Warm the transcript store for every candidate file of one job."""
+        try:
+            files = await self._load_candidate_files(job_id)
+            if not files:
+                logger.debug(f"Job {job_id}: no prewarm candidates (no files on disk)")
+                return
+
+            matcher = await self._get_matcher()
+            if matcher is None:
+                return
+
+            for file_path in files:
+                try:
+                    await self._prewarm_file(matcher, file_path, full_file=full_file)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(
+                        f"Job {job_id}: prewarm failed for {file_path}: {e}", exc_info=True
+                    )
+            logger.info(f"Job {job_id}: transcript prewarm finished ({len(files)} file(s))")
+        except asyncio.CancelledError:
+            logger.debug(f"Job {job_id}: transcript prewarm cancelled mid-run")
+            raise
+        except Exception as e:
+            logger.warning(f"Job {job_id}: transcript prewarm aborted: {e}", exc_info=True)
+
+    async def _load_candidate_files(self, job_id: int) -> list[Path]:
+        """Files worth warming: a real ``output_filename`` on disk, not yet organized.
+
+        Mirrors the file resolution in ``JobManager._rerun_matching`` (absolute
+        path first, then basename under the job's staging dir).
+        """
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if job is None:
+                return []
+            staging = Path(job.staging_path) if job.staging_path else None
+            result = await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id))
+            titles = result.scalars().all()
+
+        files: list[Path] = []
+        seen: set[str] = set()
+        for title in titles:
+            if not title.output_filename or title.state in _SKIP_STATES:
+                continue
+            path = Path(title.output_filename)
+            if not path.exists() and staging is not None:
+                path = staging / path.name
+            if not path.exists():
+                continue
+            key = str(path)
+            if key not in seen:
+                seen.add(key)
+                files.append(path)
+        return files
+
+    async def _prewarm_file(self, matcher, file_path: Path, *, full_file: bool) -> None:
+        """Warm all missing scan-grid spans (and optionally the full file) for one file."""
+        from app.matcher import transcript_store
+        from app.matcher.asr_models import get_cached_model, model_output_key
+        from app.matcher.episode_identification import (
+            canonical_scan_points,
+            get_video_duration,
+        )
+
+        duration = await asyncio.to_thread(get_video_duration, str(file_path))
+        chunk_len = matcher.chunk_duration
+        offsets = canonical_scan_points(
+            duration,
+            skip_initial=matcher.skip_initial_duration,
+            chunk_len=chunk_len,
+            num_points=DEFAULT_SCAN_POINTS,
+        )
+
+        file_key = transcript_store.file_key_for(file_path)
+        if file_key is None:
+            logger.debug(f"Prewarm: cannot derive file_key for {file_path}; skipping")
+            return
+
+        # Grid first, then the full-file span — same order they are warmed in,
+        # so the cheap chunks land before the expensive full transcription.
+        # (start=0, duration) is exactly how transcribe_full keys its L2 entry.
+        wanted: list[_Span] = [(int(off), int(chunk_len)) for off in offsets]
+        if full_file:
+            wanted.append((0, int(duration)))
+
+        # Coverage check WITHOUT loading the model: the config-derived key.
+        config_key = model_output_key(matcher._model_config())
+        missing = await asyncio.to_thread(self._missing_spans, file_key, wanted, config_key)
+        if not missing:
+            logger.debug(f"Prewarm: {file_path.name} fully cached ({len(wanted)} spans); skipping")
+            return
+
+        # Something is missing — now load the model (thread; shares the live
+        # matcher's cache slot) and re-derive the honest post-load key.
+        model = await asyncio.to_thread(get_cached_model, matcher._model_config())
+        model_key = matcher._model_key_for(model)
+        if model_key != config_key:
+            # Post-load device differs from the config-derived assumption
+            # (e.g. CUDA→CPU fallback). Re-check before transcribing anything.
+            missing = await asyncio.to_thread(self._missing_spans, file_key, wanted, model_key)
+            if not missing:
+                logger.debug(f"Prewarm: {file_path.name} cached under honest key; skipping")
+                return
+
+        logger.info(
+            f"Prewarm: transcribing {len(missing)}/{len(wanted)} span(s) for {file_path.name}"
+        )
+        for start, length in missing:
+            semaphore = self._semaphore_provider() if self._semaphore_provider else None
+            try:
+                if semaphore is not None:
+                    # Acquire/release PER CHUNK so live matches preempt between chunks.
+                    async with semaphore:
+                        await asyncio.to_thread(
+                            self._transcribe_span,
+                            matcher,
+                            file_path,
+                            start,
+                            length,
+                            model,
+                            file_key,
+                            model_key,
+                        )
+                else:
+                    await asyncio.to_thread(
+                        self._transcribe_span,
+                        matcher,
+                        file_path,
+                        start,
+                        length,
+                        model,
+                        file_key,
+                        model_key,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(f"Prewarm: chunk {start}s of {file_path.name} failed: {e}")
+
+    # ------------------------------------------------------------------
+    # Sync helpers (run inside asyncio.to_thread)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _missing_spans(file_key: str, spans: list[_Span], model_key: str) -> list[_Span]:
+        """Spans with no transcript-store entry. ``""`` is a hit; only None misses."""
+        from app.matcher import transcript_store
+
+        return [
+            (start, length)
+            for start, length in spans
+            if transcript_store.get(file_key, start, length, model_key) is None
+        ]
+
+    @staticmethod
+    def _transcribe_span(matcher, file_path, start, length, model, file_key, model_key) -> None:
+        """Transcribe one span through the matcher's write-through cache, then clean up.
+
+        ``transcribe_chunk_cached`` appends the extracted wav to ``temp_files``
+        before transcribing, so cleanup happens even if Whisper raises. The
+        matcher's per-file audio-chunk memo is also dropped — the prewarmer has
+        no later use for the wav path it caches.
+        """
+        temp_files: list = []
+        try:
+            matcher.transcribe_chunk_cached(
+                file_path,
+                start,
+                length,
+                model,
+                file_key=file_key,
+                model_key=model_key,
+                temp_files=temp_files,
+            )
+        finally:
+            for p in temp_files:
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except OSError:
+                    pass
+            matcher.audio_chunks.pop((matcher._resolve_source(file_path), start, length), None)
+
+    # ------------------------------------------------------------------
+    # Lazy matcher construction
+    # ------------------------------------------------------------------
+
+    async def _get_matcher(self):
+        """Return the dedicated EpisodeMatcher, building it once in a thread."""
+        if self._matcher is not None:
+            return self._matcher
+        async with self._matcher_lock:
+            if self._matcher is None:
+                try:
+                    self._matcher = await asyncio.to_thread(self._build_matcher)
+                except Exception as e:
+                    logger.warning(f"Prewarm: matcher unavailable: {e}", exc_info=True)
+                    return None
+        return self._matcher
+
+    @staticmethod
+    def _build_matcher():
+        """Construct the prewarmer's EpisodeMatcher (heavy import — thread only).
+
+        Model-affecting args mirror ``EpisodeCurator._ensure_initialized``:
+        default ``model_name`` ("small"), default device (the startup-pinned
+        ``detect_asr_device()``), and ``requested_workers`` from config — so
+        ``_model_config()`` / ``_model_key_for`` agree with live matching and
+        ``get_cached_model`` resolves to the same shared WhisperModel.
+        ``show_name`` is irrelevant to transcription; a sentinel is passed.
+        """
+        from app.matcher.episode_identification import EpisodeMatcher
+        from app.services.config_service import get_config_sync
+
+        config = get_config_sync()
+        if config and config.subtitles_cache_path:
+            cache_dir = Path(config.subtitles_cache_path).expanduser()
+        else:
+            cache_dir = Path.home() / ".engram" / "cache"
+
+        return EpisodeMatcher(
+            cache_dir=cache_dir,
+            show_name="__prewarm__",
+            requested_workers=(config.max_concurrent_matches if config else 1),
+        )

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -347,6 +347,8 @@ class TranscriptionPrewarmer:
                 try:
                     Path(p).unlink(missing_ok=True)
                 except OSError:
+                    # Best-effort temp cleanup — a locked wav (e.g. Windows AV
+                    # scan) is reaped on a later run; missing_ok covers ENOENT.
                     pass
             matcher.audio_chunks.pop((matcher._resolve_source(file_path), start, length), None)
 

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -229,7 +229,9 @@ class TranscriptionPrewarmer:
         from app.matcher.asr_models import get_cached_model, model_output_key
         from app.matcher.episode_identification import (
             canonical_scan_points,
-            get_video_duration,
+            get_video_duration,  # int (np.ceil) — same helper transcribe_full keys its
+            # L2 row with. Do NOT swap in srt_utils.get_video_duration (returns float):
+            # a fractional duration would fork the (0, duration) full-file cache key.
         )
 
         duration = await asyncio.to_thread(get_video_duration, str(file_path))

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -34,6 +34,7 @@ Design notes
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -125,11 +126,19 @@ class TranscriptionPrewarmer:
             logger.warning(f"Job {job_id}: failed to start transcript prewarm: {e}", exc_info=True)
 
     def cancel_for_job(self, job_id: int) -> None:
-        """Cancel and forget the prewarm task for ``job_id``. Safe when absent."""
+        """Cancel and forget the prewarm task for ``job_id``. Safe when absent.
+
+        Cancellation prevents *future* chunks from being dispatched.  The
+        in-flight thread (if any) finishes its current chunk — up to ~60 s —
+        before the asyncio.CancelledError propagates; callers must not assume
+        the GPU or the file handle is freed instantly.
+        """
         task = self._tasks.pop(job_id, None)
         if task is not None and not task.done():
             task.cancel()
-            logger.info(f"Job {job_id}: transcript prewarm cancelled")
+            logger.info(
+                f"Job {job_id}: transcript prewarm cancelled (in-flight thread finishes current chunk)"
+            )
 
     async def on_job_terminal(self, job_id: int, _state) -> None:
         """JobStateMachine ``on_terminal_state`` hook: stop warming a finished job."""
@@ -154,7 +163,7 @@ class TranscriptionPrewarmer:
             return
         exc = task.exception()
         if exc is not None:
-            logger.warning(f"Job {job_id}: transcript prewarm task died: {exc}")
+            logger.warning(f"Job {job_id}: transcript prewarm task died: {exc}", exc_info=exc)
 
     async def _prewarm_job(self, job_id: int, *, full_file: bool) -> None:
         """Warm the transcript store for every candidate file of one job."""
@@ -267,22 +276,20 @@ class TranscriptionPrewarmer:
             f"Prewarm: transcribing {len(missing)}/{len(wanted)} span(s) for {file_path.name}"
         )
         for start, length in missing:
+            # Guard: the file may have been organized (moved) between the
+            # coverage check above and this chunk — break cleanly rather than
+            # emitting a cascade of WARNINGs and ERRORs from ffprobe.
+            if not file_path.exists():
+                logger.info(f"Prewarm: {file_path.name} no longer on disk; stopping")
+                break
             semaphore = self._semaphore_provider() if self._semaphore_provider else None
+            # Acquire/release PER CHUNK so live matches preempt between chunks.
+            # nullcontext() is a no-op async CM on py3.11 when no semaphore is set.
+            ctx: contextlib.AbstractAsyncContextManager = (
+                semaphore if semaphore is not None else contextlib.nullcontext()
+            )
             try:
-                if semaphore is not None:
-                    # Acquire/release PER CHUNK so live matches preempt between chunks.
-                    async with semaphore:
-                        await asyncio.to_thread(
-                            self._transcribe_span,
-                            matcher,
-                            file_path,
-                            start,
-                            length,
-                            model,
-                            file_key,
-                            model_key,
-                        )
-                else:
+                async with ctx:
                     await asyncio.to_thread(
                         self._transcribe_span,
                         matcher,
@@ -368,7 +375,14 @@ class TranscriptionPrewarmer:
         ``_model_config()`` / ``_model_key_for`` agree with live matching and
         ``get_cached_model`` resolves to the same shared WhisperModel.
         ``show_name`` is irrelevant to transcription; a sentinel is passed.
+
+        The matcher's ``temp_dir`` is redirected to a prewarm-only subdirectory
+        so that cancelled tasks can't leave half-written wavs in the shared
+        ``whisper_chunks/`` namespace that live matchers read via the bare
+        ``exists()`` check in ``extract_audio_chunk``.
         """
+        import tempfile
+
         from app.matcher.episode_identification import EpisodeMatcher
         from app.services.config_service import get_config_sync
 
@@ -378,8 +392,14 @@ class TranscriptionPrewarmer:
         else:
             cache_dir = Path.home() / ".engram" / "cache"
 
-        return EpisodeMatcher(
+        matcher = EpisodeMatcher(
             cache_dir=cache_dir,
             show_name="__prewarm__",
             requested_workers=(config.max_concurrent_matches if config else 1),
         )
+        # Override the default whisper_chunks/ namespace so a cancelled prewarm
+        # thread can't poison the shared chunk cache with a half-written wav.
+        # Mirror EpisodeMatcher.__init__: assign then mkdir.
+        matcher.temp_dir = Path(tempfile.gettempdir()) / "whisper_chunks_prewarm"
+        matcher.temp_dir.mkdir(exist_ok=True)
+        return matcher

--- a/backend/migrations/versions/37a6eb38baeb_add_pretranscription_flags.py
+++ b/backend/migrations/versions/37a6eb38baeb_add_pretranscription_flags.py
@@ -1,4 +1,12 @@
-"""add_pretranscription_flags
+"""Add app_config pre-transcription flags
+
+Adds two boolean columns to app_config: enable_background_pretranscription
+(master switch, default ON — transcribe unresolved tracks while a job waits in
+review so re-matching is near-instant) and pretranscribe_full_file (default OFF —
+also transcribe each track end-to-end, not just short scan-point samples; useful
+when full-file fallbacks are common but expensive). Frozen builds skip Alembic
+entirely and converge via database.py::_add_missing_columns(), which honours the
+same server defaults — the two paths must stay in agreement.
 
 Revision ID: 37a6eb38baeb
 Revises: e7a2b9c4d1f8

--- a/backend/migrations/versions/37a6eb38baeb_add_pretranscription_flags.py
+++ b/backend/migrations/versions/37a6eb38baeb_add_pretranscription_flags.py
@@ -1,0 +1,44 @@
+"""add_pretranscription_flags
+
+Revision ID: 37a6eb38baeb
+Revises: e7a2b9c4d1f8
+Create Date: 2026-06-11 14:22:44.061656
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "37a6eb38baeb"
+down_revision: str | Sequence[str] | None = "e7a2b9c4d1f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "enable_background_pretranscription",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "pretranscribe_full_file",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("0"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("pretranscribe_full_file")
+        batch_op.drop_column("enable_background_pretranscription")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,6 +24,25 @@ def _isolate_tmdb_persistent_cache(tmp_path, monkeypatch):
     tmdb_persistent_cache.close()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_transcript_store(tmp_path, monkeypatch):
+    """Redirect the on-disk ASR transcript cache to a tmp_path-scoped SQLite file.
+
+    Without this, every test inherits the developer's real
+    ``~/.engram/cache/transcripts.sqlite`` — a populated row for a previously
+    matched file could silently satisfy ``transcribe_chunk_cached`` lookups in
+    unrelated matcher tests (zero ``model.transcribe`` calls where the test
+    expects N), and tests would write their fake transcripts into the real
+    cache.
+    """
+    from app.matcher import transcript_store
+
+    transcript_store.reset_module_state_for_tests()
+    monkeypatch.setattr(transcript_store, "CACHE_DB_PATH", tmp_path / "transcripts.sqlite")
+    yield
+    transcript_store.reset_module_state_for_tests()
+
+
 @pytest.fixture
 def temp_cache_dir(tmp_path):
     """Isolated cache directory for each test."""

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -131,6 +131,10 @@ async def isolate_database(monkeypatch):
     _cleanup_mod = importlib.import_module("app.services.cleanup_service")
     _final_mod = importlib.import_module("app.services.finalization_coordinator")
     _match_mod = importlib.import_module("app.services.matching_coordinator")
+    # transcription_prewarm spawns background tasks off REVIEW_NEEDED transitions
+    # (via job_manager's module-level state machine) — patch it too so a prewarm
+    # task kicked off by an unrelated unit test never touches engram.db.
+    _prewarm_mod = importlib.import_module("app.services.transcription_prewarm")
 
     monkeypatch.setattr(_db_mod, "async_session", _unit_session_factory)
     monkeypatch.setattr(_config_mod, "async_session", _unit_session_factory)
@@ -138,6 +142,7 @@ async def isolate_database(monkeypatch):
     monkeypatch.setattr(_cleanup_mod, "async_session", _unit_session_factory)
     monkeypatch.setattr(_final_mod, "async_session", _unit_session_factory)
     monkeypatch.setattr(_match_mod, "async_session", _unit_session_factory)
+    monkeypatch.setattr(_prewarm_mod, "async_session", _unit_session_factory)
 
     # Redirect the cached sync engine in config_service so get_config_sync()
     # uses the in-memory test database instead of connecting to engram.db.

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -157,6 +157,24 @@ async def isolate_database(monkeypatch):
     _reg_mod = importlib.import_module("app.core.makemkv_registration")
     monkeypatch.setattr(_reg_mod, "write_makemkv_settings", lambda *a, **k: False)
 
+    # Stub the production prewarmer's kickoff so that unit tests which
+    # transition jobs into REVIEW_NEEDED (via the real module-level
+    # JobStateMachine) never spawn real background tasks.  Real tasks build an
+    # EpisodeMatcher in a thread, call ffprobe on fake files, and hold DB
+    # sessions on the StaticPool — when the autouse isolate_database fixture
+    # later calls drop_all the task is still alive → OperationalError: database
+    # table is locked.  Tests that want to assert on kickoff calls replace
+    # _prewarmer entirely with their own MagicMock (via monkeypatch.setattr on
+    # jm.job_manager._prewarmer), which takes precedence over this stub; see
+    # TestJobManagerWiring.
+    _jm_inst = _jm_mod.job_manager
+    prewarm_kickoff_calls: list[int] = []
+
+    def _stub_kickoff(job_id: int) -> None:
+        prewarm_kickoff_calls.append(job_id)
+
+    monkeypatch.setattr(_jm_inst._prewarmer, "kickoff", _stub_kickoff)
+
     yield
 
     async with _unit_engine.begin() as conn:

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -168,12 +168,7 @@ async def isolate_database(monkeypatch):
     # jm.job_manager._prewarmer), which takes precedence over this stub; see
     # TestJobManagerWiring.
     _jm_inst = _jm_mod.job_manager
-    prewarm_kickoff_calls: list[int] = []
-
-    def _stub_kickoff(job_id: int) -> None:
-        prewarm_kickoff_calls.append(job_id)
-
-    monkeypatch.setattr(_jm_inst._prewarmer, "kickoff", _stub_kickoff)
+    monkeypatch.setattr(_jm_inst._prewarmer, "kickoff", lambda job_id: None)  # no-op stub
 
     yield
 

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -298,6 +298,51 @@ class TestConfigEndpoints:
         config = (await client.get("/api/config")).json()
         assert config["ai_episode_matching_enabled"] is True
 
+    async def test_pretranscription_flags_default_on_and_off(self, client):
+        """GET must expose both prewarmer flags with their defaults.
+
+        The master switch ships enabled; the expensive full-file option ships
+        disabled. If either is missing from ConfigResponse the prewarmer
+        becomes uncontrollable from the UI (the PR #283 bug class).
+        """
+        await _seed_config()
+        config = (await client.get("/api/config")).json()
+        assert config["enable_background_pretranscription"] is True
+        assert config["pretranscribe_full_file"] is False
+
+    async def test_pretranscription_flags_roundtrip(self, client):
+        """PUT must persist each prewarmer flag and read it back."""
+        await _seed_config()
+        r = await client.put(
+            "/api/config",
+            json={
+                "enable_background_pretranscription": False,
+                "pretranscribe_full_file": True,
+            },
+        )
+        assert r.status_code == 200
+        config = (await client.get("/api/config")).json()
+        assert config["enable_background_pretranscription"] is False
+        assert config["pretranscribe_full_file"] is True
+
+    async def test_pretranscription_flags_unrelated_put_leaves_unchanged(self, client):
+        """A PUT that omits both flags must not reset them to defaults."""
+        await _seed_config()
+        r = await client.put(
+            "/api/config",
+            json={
+                "enable_background_pretranscription": False,
+                "pretranscribe_full_file": True,
+            },
+        )
+        assert r.status_code == 200
+        # Unrelated update — neither flag in the payload.
+        r = await client.put("/api/config", json={"staging_path": "/some/where"})
+        assert r.status_code == 200
+        config = (await client.get("/api/config")).json()
+        assert config["enable_background_pretranscription"] is False
+        assert config["pretranscribe_full_file"] is True
+
 
 # ---------------------------------------------------------------------------
 # Network info

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -14,9 +14,11 @@ import pytest
 from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
+from app.matcher.episode_identification import snap_to_lattice_level
 from app.models import DiscJob, DiscTitle
 from app.models.disc_job import ContentType, JobState, TitleState
 from app.services.finalization_coordinator import (
+    _CONFLICT_FIXED_DEPTHS,
     FinalizationCoordinator,
     _conflict_scan_ladder,
     _detect_conflicts,
@@ -98,12 +100,58 @@ class TestConflictHelpers:
         assert _full_coverage_points([_matched("S01E03", duration=0)]) == 200
 
     def test_ladder_collapses_for_short_episodes(self):
-        # 23-min episode: full coverage (47) < the 50 tier, so the ladder is
-        # capped and de-duplicated to two strictly-increasing tiers.
-        assert _conflict_scan_ladder([_matched("S01E03", duration=1380)]) == [25, 47]
+        # 23-min episode: full coverage (47) floors to lattice level 37, which
+        # swallows both fixed tiers → single-pass ladder.
+        assert _conflict_scan_ladder([_matched("S01E03", duration=1380)]) == [37]
 
-    def test_ladder_is_three_tier_for_long_episodes(self):
-        assert _conflict_scan_ladder([_matched("S01E03", duration=3000)]) == [25, 50, 101]
+    def test_ladder_is_two_tier_for_typical_long_episodes(self):
+        # 50-min track: full coverage (101) floors to 73 — the second fixed
+        # tier IS the cost ceiling, so there is no third pass.
+        assert _conflict_scan_ladder([_matched("S01E03", duration=3000)]) == [37, 73]
+
+    def test_ladder_is_three_tier_for_very_long_tracks(self):
+        # full coverage (201) caps at _MAX_SCAN_POINTS (200), floors to 145.
+        assert _conflict_scan_ladder([_matched("S01E03", duration=6000)]) == [37, 73, 145]
+
+
+@pytest.mark.unit
+class TestLadderLatticeAlignment:
+    """The realized ladder — what ``canonical_scan_points`` actually scans for
+    each requested depth — must equal the requested ladder: every tier a lattice
+    level (a fixed point of the snap), strictly increasing with no duplicate
+    effective depths, and the final tier never above the full-coverage point
+    count (cost ceiling). Pre-lattice depths like 25/50 silently snapped UP,
+    collapsing adjacent tiers onto one grid and overshooting full coverage."""
+
+    @pytest.mark.parametrize(
+        "duration",
+        [870, 2520, 7200, 0],
+        ids=["short-full~30", "typical-42min", "long-full>200", "unknown-duration"],
+    )
+    def test_realized_ladder_is_lattice_true(self, duration):
+        titles = [_matched("S01E03", duration=duration)]
+        ladder = _conflict_scan_ladder(titles)
+        assert ladder
+        # Lattice-true: each tier is a fixed point of the snap, so the realized
+        # ladder is identical and no two tiers can collapse onto one grid.
+        assert [snap_to_lattice_level(d) for d in ladder] == ladder
+        # Strictly increasing — no duplicate or decreasing effective depths.
+        assert all(a < b for a, b in zip(ladder, ladder[1:], strict=False))
+        # Cost ceiling: the final tier never overshoots full coverage.
+        assert ladder[-1] <= _full_coverage_points(titles)
+
+    def test_short_episode_ladder_shape(self):
+        # full = ceil(870/30) + 1 = 30 → floor 19; both fixed tiers exceed the
+        # ceiling and drop out.
+        assert _conflict_scan_ladder([_matched("S01E03", duration=870)]) == [19]
+
+    def test_depth_constants_are_lattice_levels(self):
+        """One source of truth: deep-rematch and ladder depth constants must be
+        fixed points of the lattice snap, or requested != realized depth."""
+        from app.services.matching_coordinator import STRICT_SCAN_POINTS
+
+        for depth in (*_CONFLICT_FIXED_DEPTHS, STRICT_SCAN_POINTS):
+            assert snap_to_lattice_level(depth) == depth
 
 
 @pytest.fixture(autouse=True)
@@ -176,14 +224,15 @@ class TestEscalation:
         result, status = await _escalate(coord, job_id)
 
         assert result is True
-        assert coord._conflict_passes[job_id] == 25
-        assert calls and all(np == 25 for np, _mv in calls)
+        assert coord._conflict_passes[job_id] == 37
+        assert calls and all(np == 37 for np, _mv in calls)
         # Depth-only: the vote gate is never raised on the auto path.
         assert all(mv is None for _np, mv in calls)
-        assert status and "pass 1 of 3" in status
+        assert status and "pass 1 of 2" in status
 
-    async def test_escalates_25_50_full_then_exhausts(self):
-        job_id = await _seed_conflict(duration=3000)  # full coverage = 101
+    async def test_escalates_37_73_145_then_exhausts(self):
+        # full coverage = 201, capped at 200, floored to lattice level 145.
+        job_id = await _seed_conflict(duration=6000)
         depths: list[int] = []
 
         async def fake(jid, ep, num_points=None, min_vote_count=None):
@@ -192,7 +241,7 @@ class TestEscalation:
 
         coord = _coord_with(fake)
 
-        for expected in (25, 50, 101):
+        for expected in (37, 73, 145):
             result, _status = await _escalate(coord, job_id)
             assert result is True
             assert coord._conflict_passes[job_id] == expected
@@ -202,15 +251,15 @@ class TestEscalation:
         assert result is False
         # Counter stays at last_depth so a recheck (e.g. unrelated title
         # finishing) sees "exhausted" again and doesn't re-fire pass 1.
-        assert coord._conflict_passes[job_id] == 101
+        assert coord._conflict_passes[job_id] == 145
         assert status is None
-        assert {25, 50, 101}.issubset(set(depths))
+        assert {37, 73, 145}.issubset(set(depths))
 
     async def test_exhausted_does_not_re_dispatch_on_recheck(self):
         """After exhaustion, a re-entry from check_job_completion must NOT
         re-fire pass 1 — that loops forever on conflicts that depth alone
         can't break."""
-        job_id = await _seed_conflict(duration=3000)
+        job_id = await _seed_conflict(duration=6000)  # ladder = [37, 73, 145]
         depths: list[int] = []
 
         async def fake(jid, ep, num_points=None, min_vote_count=None):
@@ -399,7 +448,7 @@ class TestEscalation:
             await session.commit()
 
         coord = _coord_with(None)
-        coord._conflict_passes[job_id] = 25
+        coord._conflict_passes[job_id] = 37
 
         await coord.on_terminal_clear_conflicts(job_id, JobState.FAILED)
 
@@ -441,6 +490,6 @@ class TestEscalation:
 
     async def test_reset_conflict_passes(self):
         coord = _coord_with(None)
-        coord._conflict_passes[42] = 50
+        coord._conflict_passes[42] = 73
         coord.reset_conflict_passes(42)
         assert 42 not in coord._conflict_passes

--- a/backend/tests/unit/test_auto_conflict_escalation.py
+++ b/backend/tests/unit/test_auto_conflict_escalation.py
@@ -138,7 +138,25 @@ class TestLadderLatticeAlignment:
         # Strictly increasing — no duplicate or decreasing effective depths.
         assert all(a < b for a, b in zip(ladder, ladder[1:], strict=False))
         # Cost ceiling: the final tier never overshoots full coverage.
+        # Exception: sub-5-min tracks whose full-coverage point (< 10) falls
+        # below the base lattice level — floor_to_lattice_level clamps to 10,
+        # so ladder[-1] can be 10 while _full_coverage_points returns 9.
+        # That edge case is covered separately by test_tiny_duration_ladder_base_clamp.
         assert ladder[-1] <= _full_coverage_points(titles)
+
+    def test_tiny_duration_ladder_base_clamp(self):
+        """A sub-5-min track (duration=240 s) has full_coverage_points = 9, which
+        is below the base lattice level (10).  floor_to_lattice_level clamps to 10,
+        so the ladder is [10] even though 10 > full_coverage_points (9).  This is
+        the documented exception to the cost-ceiling property: the matcher can't
+        scan shallower than the base level, and canonical_scan_points deduplicates
+        the colliding chunk positions on such a short file anyway."""
+        titles = [_matched("S01E03", duration=240)]
+        assert _full_coverage_points(titles) == 9
+        ladder = _conflict_scan_ladder(titles)
+        assert ladder == [10]
+        # Ladder is still lattice-true and strictly non-empty.
+        assert [snap_to_lattice_level(d) for d in ladder] == ladder
 
     def test_short_episode_ladder_shape(self):
         # full = ceil(870/30) + 1 = 30 → floor 19; both fixed tiers exceed the

--- a/backend/tests/unit/test_auto_review_escalation.py
+++ b/backend/tests/unit/test_auto_review_escalation.py
@@ -98,15 +98,16 @@ class TestReviewEscalation:
         result, status = await _escalate(coord, job_id)
 
         assert result is True
-        assert coord._review_passes[job_id] == 25
-        assert calls and all(np == 25 for _src, np, _mv in calls)
+        assert coord._review_passes[job_id] == 37
+        assert calls and all(np == 37 for _src, np, _mv in calls)
         # Depth-only: vote gate stays default; engram source forced.
         assert all(mv is None for _src, _np, mv in calls)
         assert all(src == "engram" for src, _np, _mv in calls)
-        assert status and "pass 1 of 3" in status
+        assert status and "pass 1 of 2" in status
 
     async def test_escalates_then_exhausts(self):
-        job_id = await _seed_review(duration=3000)  # full coverage = 101
+        # full coverage = 201, capped at 200, floored to lattice level 145.
+        job_id = await _seed_review(duration=6000)
         depths: list[int] = []
 
         async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
@@ -114,7 +115,7 @@ class TestReviewEscalation:
 
         coord = _coord_with(fake)
 
-        for expected in (25, 50, 101):
+        for expected in (37, 73, 145):
             result, _status = await _escalate(coord, job_id)
             assert result is True
             assert coord._review_passes[job_id] == expected
@@ -123,9 +124,9 @@ class TestReviewEscalation:
         assert result is False
         # Counter must NOT be popped on exhaustion — see
         # test_exhausted_does_not_re_dispatch_on_recheck for why.
-        assert coord._review_passes[job_id] == 101
+        assert coord._review_passes[job_id] == 145
         assert status is None
-        assert {25, 50, 101}.issubset(set(depths))
+        assert {37, 73, 145}.issubset(set(depths))
 
     async def test_exhausted_does_not_re_dispatch_on_recheck(self):
         """After the ladder exhausts on titles still in REVIEW, a subsequent
@@ -134,7 +135,7 @@ class TestReviewEscalation:
         are missing match nothing on every pass; if exhaustion pops the
         counter, the next recheck reads last_depth=0 and starts pass 1 again.
         """
-        job_id = await _seed_review(duration=3000)  # ladder = [25, 50, 101]
+        job_id = await _seed_review(duration=6000)  # ladder = [37, 73, 145]
         depths: list[int] = []
 
         async def fake(jid, tid, source_preference=None, num_points=None, min_vote_count=None):
@@ -259,9 +260,9 @@ class TestReviewEscalation:
     async def test_review_pass_advances_across_no_conflict_reentry(self):
         """A check_job_completion re-entry where conflict-escalate finds nothing
         must NOT wipe review-escalation's pass counter. Otherwise review-escalate
-        always re-dispatches at depth 25 and never advances to 50 / full coverage
+        always re-dispatches at depth 37 and never advances to 73 / full coverage
         — visible as 'one track keeps re-matching forever.'"""
-        job_id = await _seed_review(duration=3000)  # full coverage = 101
+        job_id = await _seed_review(duration=3000)  # ladder = [37, 73]
 
         depths: list[int] = []
 
@@ -276,7 +277,7 @@ class TestReviewEscalation:
         coord = _coord_with(fake_rematch)
         coord._rematch_conflict = fake_conflict
 
-        # First review-escalation pass dispatches at depth 25.
+        # First review-escalation pass dispatches at depth 37.
         async with _unit_session_factory() as session:
             job = await session.get(DiscJob, job_id)
             titles = (
@@ -285,7 +286,7 @@ class TestReviewEscalation:
                 .all()
             )
             assert await coord._maybe_escalate_reviews(session, job, titles) is True
-            assert coord._review_passes[job_id] == 25
+            assert coord._review_passes[job_id] == 37
 
         # Now simulate the next check_job_completion re-entry: conflict-escalate runs
         # first, finds no conflicts (titles are REVIEW, not MATCHED), and bails. That
@@ -299,9 +300,9 @@ class TestReviewEscalation:
             )
             await coord._maybe_escalate_conflicts(session, job, titles)
             # Review pass counter must survive.
-            assert coord._review_passes[job_id] == 25
+            assert coord._review_passes[job_id] == 37
 
-        # Review-escalate fires again — must now escalate to depth 50, not 25.
+        # Review-escalate fires again — must now escalate to depth 73, not 37.
         async with _unit_session_factory() as session:
             job = await session.get(DiscJob, job_id)
             titles = (
@@ -310,9 +311,9 @@ class TestReviewEscalation:
                 .all()
             )
             assert await coord._maybe_escalate_reviews(session, job, titles) is True
-            assert coord._review_passes[job_id] == 50
+            assert coord._review_passes[job_id] == 73
 
-        assert depths == [25, 50]
+        assert depths == [37, 73]
 
     async def test_movie_job_never_escalates(self):
         job_id = await _seed_review(content_type=ContentType.MOVIE)

--- a/backend/tests/unit/test_canonical_scan_points.py
+++ b/backend/tests/unit/test_canonical_scan_points.py
@@ -7,7 +7,11 @@ gets full reuse between a 10-point scan and a deeper re-match.
 
 import pytest
 
-from app.matcher.episode_identification import canonical_scan_points
+from app.matcher.episode_identification import (
+    canonical_scan_points,
+    floor_to_lattice_level,
+    snap_to_lattice_level,
+)
 
 SKIP_INITIAL = 90
 LEVELS = (10, 19, 37, 73, 145)
@@ -40,6 +44,30 @@ class TestSubsetProperty:
         deep = canonical_scan_points(2643.7, skip_initial=SKIP_INITIAL, num_points=145)
         assert shallow  # sanity: not vacuous
         assert set(shallow) <= set(deep)
+
+
+class TestLatticeLevelHelpers:
+    """snap_to_lattice_level / floor_to_lattice_level — the single source of
+    truth for how requested depths map onto the lattice."""
+
+    @pytest.mark.parametrize(
+        ("requested", "expected"),
+        [(None, 10), (0, 10), (1, 10), (2, 10), (10, 10), (11, 19), (25, 37), (146, 145)],
+    )
+    def test_snap_up(self, requested, expected):
+        assert snap_to_lattice_level(requested) == expected
+
+    @pytest.mark.parametrize(
+        ("requested", "expected"),
+        [(5, 10), (10, 10), (18, 10), (19, 19), (30, 19), (47, 37), (101, 73), (200, 145)],
+    )
+    def test_floor_down(self, requested, expected):
+        assert floor_to_lattice_level(requested) == expected
+
+    @pytest.mark.parametrize("level", LEVELS)
+    def test_levels_are_fixed_points_of_both(self, level):
+        assert snap_to_lattice_level(level) == level
+        assert floor_to_lattice_level(level) == level
 
 
 class TestSnapping:

--- a/backend/tests/unit/test_canonical_scan_points.py
+++ b/backend/tests/unit/test_canonical_scan_points.py
@@ -1,0 +1,136 @@
+"""Tests for ``canonical_scan_points`` — the nested scan-point lattice.
+
+The critical invariant: every shallower lattice level is a strict subset of
+every deeper one, so a transcript cache keyed by (file, offset, duration)
+gets full reuse between a 10-point scan and a deeper re-match.
+"""
+
+import pytest
+
+from app.matcher.episode_identification import canonical_scan_points
+
+SKIP_INITIAL = 90
+LEVELS = (10, 19, 37, 73, 145)
+# Mix of round and awkward durations (2643 is prime).
+DURATIONS = (1200, 2700, 5000, 7200, 2643)
+
+
+class TestSubsetProperty:
+    """Level k must be a subset of level k+1 — the cache-reuse guarantee."""
+
+    @pytest.mark.parametrize("duration", DURATIONS)
+    @pytest.mark.parametrize("k", range(len(LEVELS) - 1))
+    def test_consecutive_levels_nest(self, duration, k):
+        shallow = canonical_scan_points(duration, skip_initial=SKIP_INITIAL, num_points=LEVELS[k])
+        deep = canonical_scan_points(duration, skip_initial=SKIP_INITIAL, num_points=LEVELS[k + 1])
+        assert set(shallow) <= set(deep), (
+            f"level {LEVELS[k]} not nested in level {LEVELS[k + 1]} for duration {duration}: "
+            f"missing {set(shallow) - set(deep)}"
+        )
+
+    @pytest.mark.parametrize("duration", DURATIONS)
+    @pytest.mark.parametrize("deep_level", (37, 145))
+    def test_level_10_nests_in_non_adjacent_levels(self, duration, deep_level):
+        base = canonical_scan_points(duration, skip_initial=SKIP_INITIAL, num_points=10)
+        deep = canonical_scan_points(duration, skip_initial=SKIP_INITIAL, num_points=deep_level)
+        assert set(base) <= set(deep)
+
+    def test_float_duration_still_nests(self):
+        shallow = canonical_scan_points(2643.7, skip_initial=SKIP_INITIAL, num_points=10)
+        deep = canonical_scan_points(2643.7, skip_initial=SKIP_INITIAL, num_points=145)
+        assert shallow  # sanity: not vacuous
+        assert set(shallow) <= set(deep)
+
+
+class TestSnapping:
+    """num_points snaps UP to the smallest lattice level >= the request."""
+
+    @pytest.mark.parametrize(
+        ("requested", "expected_level"),
+        [
+            (10, 10),
+            (11, 19),
+            (19, 19),
+            (25, 37),
+            (37, 37),
+            (50, 73),
+            (100, 145),
+            (145, 145),
+            (146, 145),
+            (500, 145),
+            (None, 10),
+            (1, 10),
+            (0, 10),
+            (2, 10),
+        ],
+    )
+    def test_snaps_to_lattice_level(self, requested, expected_level):
+        # 7200s leaves plenty of room: no tail-filter drops, no dedupe collisions,
+        # so the returned count equals the snapped lattice level exactly.
+        points = canonical_scan_points(7200, skip_initial=SKIP_INITIAL, num_points=requested)
+        assert len(points) == expected_level
+
+
+class TestDefaultBehavior:
+    def test_typical_episode_default_count(self):
+        # A ~40-minute episode at the default depth yields exactly 10 points,
+        # all inside the usable window.
+        duration = 2400
+        points = canonical_scan_points(duration, skip_initial=SKIP_INITIAL)
+        assert len(points) == 10
+        assert all(SKIP_INITIAL <= p < duration - 30 for p in points)
+        assert points == sorted(points)
+
+    def test_even_coverage(self):
+        # Floor-division jitter: consecutive gaps differ by at most 1 second.
+        points = canonical_scan_points(2643, skip_initial=SKIP_INITIAL, num_points=10)
+        gaps = [b - a for a, b in zip(points, points[1:], strict=False)]
+        assert max(gaps) - min(gaps) <= 1
+
+
+class TestEdgeCases:
+    @pytest.mark.parametrize("duration", (30, 200, 209, 210))
+    def test_no_usable_window_returns_empty(self, duration):
+        # skip_initial(90) + skip_final(120) = 210 >= duration -> nothing usable.
+        assert canonical_scan_points(duration, skip_initial=SKIP_INITIAL) == []
+
+    def test_short_positive_window(self):
+        # duration 250 -> available = 40s: valid but cramped.
+        duration = 250
+        points = canonical_scan_points(duration, skip_initial=SKIP_INITIAL)
+        assert points
+        assert all(p >= 0 for p in points)
+        assert len(points) == len(set(points))
+        assert all(p < duration - 30 for p in points)
+        assert points == sorted(points)
+
+    def test_very_short_window_dedupes_collisions(self):
+        # available = 5s: floor division collapses adjacent lattice points.
+        duration = 215
+        points = canonical_scan_points(duration, skip_initial=SKIP_INITIAL)
+        assert points
+        assert len(points) == len(set(points))
+        assert points == sorted(points)
+        assert all(SKIP_INITIAL <= p < duration - 30 for p in points)
+
+    def test_float_duration_truncates_like_int(self):
+        float_points = canonical_scan_points(2643.7, skip_initial=SKIP_INITIAL, num_points=10)
+        int_points = canonical_scan_points(2643, skip_initial=SKIP_INITIAL, num_points=10)
+        assert float_points == int_points
+        assert all(isinstance(p, int) for p in float_points)
+
+    def test_no_negative_offsets_anywhere(self):
+        for duration in (*DURATIONS, 215, 250, 300):
+            for level in LEVELS:
+                points = canonical_scan_points(
+                    duration, skip_initial=SKIP_INITIAL, num_points=level
+                )
+                assert all(p >= 0 for p in points)
+
+    def test_tail_filter_respected_at_every_level(self):
+        for duration in DURATIONS:
+            for level in LEVELS:
+                points = canonical_scan_points(
+                    duration, skip_initial=SKIP_INITIAL, num_points=level
+                )
+                assert all(p < duration - 30 for p in points)

--- a/backend/tests/unit/test_canonical_scan_points.py
+++ b/backend/tests/unit/test_canonical_scan_points.py
@@ -119,7 +119,9 @@ class TestEdgeCases:
         assert float_points == int_points
         assert all(isinstance(p, int) for p in float_points)
 
-    def test_no_negative_offsets_anywhere(self):
+    def test_no_negative_offsets_invariant(self):
+        """Default skip_initial=90 > 0 so the clamp never fires; this is a
+        smoke test for the normal path, not an exercise of the clamp guard."""
         for duration in (*DURATIONS, 215, 250, 300):
             for level in LEVELS:
                 points = canonical_scan_points(
@@ -127,10 +129,47 @@ class TestEdgeCases:
                 )
                 assert all(p >= 0 for p in points)
 
-    def test_tail_filter_respected_at_every_level(self):
+    def test_negative_skip_initial_clamps_to_zero(self):
+        """Negative skip_initial exercises the clamp guard — usable_start must
+        not go below 0."""
+        duration = 2700
+        points = canonical_scan_points(duration, skip_initial=-50, num_points=10)
+        assert points, "should return points for a long video"
+        assert all(p >= 0 for p in points), "clamp must prevent negative offsets"
+        assert points[0] == 0, "first point should start at 0, not a negative value"
+
+    def test_tail_filter_respected_invariant(self):
+        """Default skip_final=120 > chunk_len=30 so the tail filter never drops
+        a point when skip_initial=90; this is a smoke test for the normal path."""
         for duration in DURATIONS:
             for level in LEVELS:
                 points = canonical_scan_points(
                     duration, skip_initial=SKIP_INITIAL, num_points=level
                 )
                 assert all(p < duration - 30 for p in points)
+
+    def test_tail_filter_drops_points_when_skip_final_is_zero(self):
+        """skip_final=0 means the guard triggers only because chunk_len=30
+        enforces p < duration - chunk_len; use a tiny skip_final (1) so the
+        unfiltered lattice would include points inside the last chunk."""
+        duration = 2700
+        chunk_len = 30
+        # With skip_final=0 the effective tail boundary is duration - chunk_len.
+        # Use many points so the densest level places points near the end.
+        points = canonical_scan_points(
+            duration, skip_initial=0, skip_final=0, chunk_len=chunk_len, num_points=145
+        )
+        assert points, "should return points"
+        # Every returned point must be strictly before the tail boundary.
+        assert all(p < duration - chunk_len for p in points), (
+            "tail filter must drop points >= duration - chunk_len"
+        )
+        # The unfiltered lattice level 145 would place the last raw point at
+        # skip_initial + ((n-1) * available) // (n-1) == 0 + available == duration,
+        # which is >= duration - chunk_len, so the filter is non-trivial.
+        n = 145
+        available = duration - 0 - 0  # skip_initial=0, skip_final=0
+        raw_last = 0 + ((n - 1) * available) // (n - 1)  # == duration
+        assert raw_last >= duration - chunk_len, (
+            "raw lattice endpoint should violate the tail boundary so the filter is non-trivial"
+        )

--- a/backend/tests/unit/test_config_pretranscription_fields.py
+++ b/backend/tests/unit/test_config_pretranscription_fields.py
@@ -1,0 +1,36 @@
+"""Guard the three-way sync for the background pre-transcription config fields.
+
+A new AppConfig field must also appear in ConfigUpdate (so PUT accepts it), ConfigResponse
+(so GET returns it), and the GET constructor — otherwise Pydantic silently drops it on PUT or
+omits it on GET. This test pins all three at the model level (no DB), so a future refactor
+can't quietly break the toggles.
+"""
+
+import pytest
+
+from app.api.routes import ConfigResponse, ConfigUpdate
+from app.models.app_config import AppConfig
+
+FIELDS_AND_DEFAULTS = [
+    ("enable_background_pretranscription", True),
+    ("pretranscribe_full_file", False),
+]
+
+
+@pytest.mark.parametrize(("field", "default"), FIELDS_AND_DEFAULTS)
+def test_appconfig_defaults(field, default):
+    assert getattr(AppConfig(), field) is default
+
+
+@pytest.mark.parametrize(("field", "default"), FIELDS_AND_DEFAULTS)
+def test_config_update_accepts_and_carries_the_field(field, default):
+    update = ConfigUpdate(**{field: not default})
+    # Present in the dump (so update_config persists it) and not coerced away.
+    assert update.model_dump()[field] is (not default)
+    # Unset stays None so PUT doesn't clobber it when omitted.
+    assert ConfigUpdate().model_dump()[field] is None
+
+
+@pytest.mark.parametrize(("field", "_default"), FIELDS_AND_DEFAULTS)
+def test_config_response_exposes_the_field(field, _default):
+    assert field in ConfigResponse.model_fields

--- a/backend/tests/unit/test_episode_identification.py
+++ b/backend/tests/unit/test_episode_identification.py
@@ -694,9 +694,7 @@ class TestMatchFullFileSurfacesTranscript:
         with patch.object(matcher, "transcribe_full", return_value="long fake transcript " * 50):
             result = matcher._match_full_file(
                 video_file=tmp_path / "x.mkv",
-                model_config={"type": "whisper", "name": "small", "device": "cpu"},
                 reference_files=[tmp_path / "S01E03.srt"],
-                duration=1320,
                 tfidf_matcher=tfidf_mock,
             )
 

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -13,6 +13,7 @@ import pytest
 from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
+from app.matcher.episode_identification import snap_to_lattice_level
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.finalization_coordinator import (
@@ -557,7 +558,7 @@ class TestCheckJobCompletion:
 
         # Escalation dispatched a re-match, so finalization is deferred.
         coord.finalize_disc_job.assert_not_called()
-        assert coord._conflict_passes.get(job_id) == 25
+        assert coord._conflict_passes.get(job_id) == 37
 
 
 @pytest.mark.unit
@@ -720,7 +721,7 @@ class TestWrongShowRoutingInCompletion:
     async def test_true_wrong_show_does_single_full_pass_not_three(self, tmp_path):
         # A genuine same-name wrong-show disc: every selected episode candidate
         # matched NOTHING (wrong reference corpus) and a same-name twin is
-        # persisted. The old flow burned the whole 25→50→full review-escalation
+        # persisted. The old flow burned the whole 37→73→full review-escalation
         # ladder against that wrong corpus before the wrong-show branch fired —
         # up to 3 wasted ASR passes. The new flow does ONE decisive full-coverage
         # confirming pass; if it STILL matches nothing, wrong-show fires.
@@ -732,10 +733,11 @@ class TestWrongShowRoutingInCompletion:
             staging=str(tmp_path),
             tmdb_id=3452,
             candidates_json=FRASIER_CANDS,
-            duration=3000,  # full coverage = 101 scan points, distinct from 25/50
+            duration=3000,  # raw full = 101; snapped UP to lattice = 145, distinct from 37/73
         )
         _, seeded = await _load(job_id)
-        full = _full_coverage_points(list(seeded.values()))
+        # snap UP (coverage floor — pass must see ~everything).
+        full = snap_to_lattice_level(_full_coverage_points(list(seeded.values())))
 
         depths: list[int] = []
 
@@ -751,7 +753,7 @@ class TestWrongShowRoutingInCompletion:
         coord._rematch_title = fake_rematch
 
         # Pass 1: a single full-coverage confirming dispatch, NOT the shallow
-        # 25/50 tiers the old ladder would have wasted first.
+        # 37/73 tiers the ladder would have wasted first.
         async with _unit_session_factory() as session:
             await coord.check_job_completion(session, job_id)
         job, _ = await _load(job_id)
@@ -767,7 +769,7 @@ class TestWrongShowRoutingInCompletion:
         assert "re-identify" in job.review_reason.lower()
         # No further escalation, and never the wasteful shallow tiers.
         assert depths == [full, full]
-        assert 25 not in depths and 50 not in depths
+        assert 37 not in depths and 73 not in depths
         coord.finalize_disc_job.assert_not_called()
 
     async def test_legit_hard_twin_disc_resolves_on_confirming_pass(self, tmp_path):
@@ -788,7 +790,8 @@ class TestWrongShowRoutingInCompletion:
             duration=3000,
         )
         _, seeded = await _load(job_id)
-        full = _full_coverage_points(list(seeded.values()))
+        # snap UP (coverage floor — pass must see ~everything).
+        full = snap_to_lattice_level(_full_coverage_points(list(seeded.values())))
 
         depths: list[int] = []
 
@@ -830,7 +833,7 @@ class TestWrongShowRoutingInCompletion:
         # It got exactly its one deep pass — never re-escalated, never the
         # shallow tiers.
         assert depths == [full, full]
-        assert 25 not in depths and 50 not in depths
+        assert 37 not in depths and 73 not in depths
         assert all(t.state == TitleState.MATCHED for t in titles.values())
 
 

--- a/backend/tests/unit/test_model_output_key.py
+++ b/backend/tests/unit/test_model_output_key.py
@@ -115,13 +115,11 @@ class TestModelOutputKeyOutputAffectingFields:
         )
         assert key1 == key2
 
-    def test_cpu_threads_does_not_change_key(self):
-        """cpu_threads is a speed knob, not present in model_config but tested for completeness."""
-        # cpu_threads is resolved inside resolve_asr_runtime, not part of model_config at all.
-        # Both configs below omit it → same key.
-        key1 = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
-        key2 = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
-        assert key1 == key2
+    def test_extraneous_keys_are_ignored(self):
+        """Unknown/future config keys must not perturb the cache key (forward-compatible)."""
+        base = {"type": "whisper", "name": "small", "device": "cpu"}
+        key_with_extras = model_output_key({**base, "cpu_threads": 16, "some_future_knob": "x"})
+        assert key_with_extras == model_output_key(base)
 
     def test_compute_type_is_included_in_key(self):
         """Float16 vs int8 changes quantization → output text may differ."""

--- a/backend/tests/unit/test_model_output_key.py
+++ b/backend/tests/unit/test_model_output_key.py
@@ -1,0 +1,152 @@
+"""Unit tests for model_output_key() — transcript cache identity helper."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.matcher.asr_models import model_output_key, set_asr_device
+
+
+@pytest.fixture(autouse=True)
+def _reset_asr_device_override():
+    """Reset the process-wide ASR device override around every test."""
+    set_asr_device(None)
+    yield
+    set_asr_device(None)
+
+
+class TestModelOutputKeyFormat:
+    """Key must be underscore-joined, stable, and unambiguous."""
+
+    def test_cpu_config_returns_expected_format(self):
+        config = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 1}
+        key = model_output_key(config)
+        assert key == "whisper_small_cpu_int8"
+
+    def test_cuda_config_returns_expected_format(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"float16", "int8_float16", "float32"},
+        ):
+            config = {
+                "type": "whisper",
+                "name": "large-v3",
+                "device": "cuda",
+                "requested_workers": 2,
+            }
+            key = model_output_key(config)
+        assert key == "whisper_large-v3_cuda_float16"
+
+    def test_key_has_exactly_four_underscore_separated_parts(self):
+        config = {"type": "whisper", "name": "base", "device": "cpu", "requested_workers": 1}
+        parts = model_output_key(config).split("_")
+        # "base" has no internal underscores, so expect exactly 4 parts
+        assert len(parts) == 4
+
+    def test_key_is_a_non_empty_string(self):
+        config = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 1}
+        assert isinstance(model_output_key(config), str)
+        assert model_output_key(config) != ""
+
+
+class TestModelOutputKeyDeviceResolution:
+    """Device 'auto' / None must be resolved to the effective runtime device."""
+
+    def test_auto_device_resolves_to_pinned_cpu(self):
+        set_asr_device("cpu")
+        config = {"type": "whisper", "name": "small", "device": "auto", "requested_workers": 1}
+        key = model_output_key(config)
+        assert "_cpu_" in key
+        assert "_cuda_" not in key
+
+    def test_auto_device_resolves_to_pinned_cuda(self):
+        set_asr_device("cuda")
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"float16", "int8_float16", "float32"},
+        ):
+            config = {"type": "whisper", "name": "small", "device": "auto", "requested_workers": 1}
+            key = model_output_key(config)
+        assert "_cuda_" in key
+        assert "_cpu_" not in key
+
+    def test_none_device_resolves_via_detect_asr_device(self):
+        set_asr_device("cpu")
+        config = {"type": "whisper", "name": "small", "device": None, "requested_workers": 1}
+        key = model_output_key(config)
+        assert "_cpu_" in key
+
+    def test_missing_device_field_resolves_via_detect_asr_device(self):
+        set_asr_device("cpu")
+        config = {"type": "whisper", "name": "small", "requested_workers": 1}
+        key = model_output_key(config)
+        assert "_cpu_" in key
+
+    def test_cpu_and_cuda_produce_different_keys(self):
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"float16", "int8_float16", "float32"},
+        ):
+            cpu_key = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+            cuda_key = model_output_key({"type": "whisper", "name": "small", "device": "cuda"})
+        assert cpu_key != cuda_key
+
+
+class TestModelOutputKeyOutputAffectingFields:
+    """Output-affecting fields must change the key; concurrency knobs must NOT."""
+
+    def test_different_model_names_produce_different_keys(self):
+        small = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+        large = model_output_key({"type": "whisper", "name": "large-v3", "device": "cpu"})
+        assert small != large
+
+    def test_different_model_types_produce_different_keys(self):
+        whisper = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+        fw = model_output_key({"type": "faster-whisper", "name": "small", "device": "cpu"})
+        assert whisper != fw
+
+    def test_requested_workers_does_not_change_key(self):
+        """Workers only affect parallelism, not transcript content."""
+        key1 = model_output_key(
+            {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 1}
+        )
+        key2 = model_output_key(
+            {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 8}
+        )
+        assert key1 == key2
+
+    def test_cpu_threads_does_not_change_key(self):
+        """cpu_threads is a speed knob, not present in model_config but tested for completeness."""
+        # cpu_threads is resolved inside resolve_asr_runtime, not part of model_config at all.
+        # Both configs below omit it → same key.
+        key1 = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+        key2 = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+        assert key1 == key2
+
+    def test_compute_type_is_included_in_key(self):
+        """Float16 vs int8 changes quantization → output text may differ."""
+        # CPU always → int8
+        cpu_key = model_output_key({"type": "whisper", "name": "small", "device": "cpu"})
+        assert cpu_key.endswith("int8")
+
+    def test_cuda_compute_type_int8_float16_included_when_float16_unsupported(self):
+        """Pascal-class GPUs fall back to int8_float16 — that must appear in the key."""
+        with patch(
+            "app.matcher.asr_models.ctranslate2.get_supported_compute_types",
+            return_value={"int8_float16", "float32"},
+        ):
+            key = model_output_key({"type": "whisper", "name": "small", "device": "cuda"})
+        assert key.endswith("int8_float16")
+
+
+class TestModelOutputKeyDeterminism:
+    """Key must be stable across repeated calls with the same config."""
+
+    def test_same_config_returns_same_key(self):
+        config = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 2}
+        assert model_output_key(config) == model_output_key(config)
+
+    def test_dict_ordering_does_not_matter(self):
+        config_a = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 1}
+        config_b = {"device": "cpu", "name": "small", "requested_workers": 1, "type": "whisper"}
+        assert model_output_key(config_a) == model_output_key(config_b)

--- a/backend/tests/unit/test_transcript_cache_wiring.py
+++ b/backend/tests/unit/test_transcript_cache_wiring.py
@@ -1,0 +1,300 @@
+"""Wiring tests for the persistent L2 transcript cache in EpisodeMatcher.
+
+Covers the layered lookup (L1 dict → L2 SQLite → Whisper) added in
+``EpisodeMatcher.transcribe_chunk_cached`` / ``transcribe_full``, the
+effective-device fix in ``EpisodeMatcher.__init__``, and the golden scan-point
+offsets that the persisted cache keys depend on.
+
+The fake ASR model here is a *call-counting stand-in for Whisper only* — the
+matcher methods, ``transcript_store`` and the key derivation all run for real
+(against the tmp_path-scoped store from the conftest
+``_isolate_transcript_store`` fixture).
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.matcher import transcript_store
+from app.matcher.asr_models import set_asr_device
+from app.matcher.episode_identification import EpisodeMatcher, canonical_scan_points
+
+OFFSETS = [90, 366, 643, 920]
+CHUNK_LEN = 30
+
+
+@pytest.fixture(autouse=True)
+def _reset_asr_device_override():
+    """Reset the process-wide ASR device override around every test."""
+    set_asr_device(None)
+    yield
+    set_asr_device(None)
+
+
+class FakeModel:
+    """Counts transcribe() calls; output is deterministic per audio path.
+
+    Exposes ``device`` like a loaded FasterWhisperModel so ``_model_key_for``
+    exercises its loaded-model derivation path.
+    """
+
+    device = "cpu"
+
+    def __init__(self, text_template="spoken words from {stem} again and again and again"):
+        self.calls = 0
+        self.text_template = text_template
+
+    def transcribe(self, audio_path):
+        self.calls += 1
+        return {"text": " " + self.text_template.format(stem=Path(audio_path).stem) + " "}
+
+
+def _matcher(tmp_path):
+    # Explicit device="cpu" keeps the derived model_key deterministic on
+    # GPU-equipped dev machines.
+    return EpisodeMatcher(
+        cache_dir=tmp_path, show_name="Test Show", model_name="tiny", device="cpu"
+    )
+
+
+def _video(tmp_path, name="episode.mkv"):
+    video = tmp_path / name
+    video.write_bytes(b"\x00" * 4096)
+    return video
+
+
+def _fake_extract(tmp_path):
+    """extract_audio_chunk stand-in: a distinct wav path per offset (never touches ffmpeg)."""
+    return lambda mkv_file, start_time, duration=None: str(tmp_path / f"chunk_{start_time}.wav")
+
+
+class TestRestartSurvival:
+    """The headline guarantee: ASR output survives a process restart."""
+
+    def test_fresh_matcher_instance_reuses_persisted_transcripts(self, tmp_path):
+        video = _video(tmp_path)
+
+        # Instance #1 (cold caches): every offset is computed once.
+        m1 = _matcher(tmp_path)
+        model1 = FakeModel()
+        with patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            texts1 = [m1.transcribe_chunk_cached(video, off, CHUNK_LEN, model1) for off in OFFSETS]
+        assert model1.calls == len(OFFSETS)
+        assert len(set(texts1)) == len(OFFSETS)  # sanity: per-offset transcripts are distinct
+
+        # Instance #2 = simulated process restart: L1 empty, same L2 store.
+        # Zero transcribe calls AND zero wav extractions — everything from L2.
+        m2 = _matcher(tmp_path)
+        model2 = FakeModel()
+        no_extract = Mock(side_effect=AssertionError("L2 hit must not extract a wav"))
+        with patch.object(m2, "extract_audio_chunk", no_extract):
+            texts2 = [m2.transcribe_chunk_cached(video, off, CHUNK_LEN, model2) for off in OFFSETS]
+
+        assert model2.calls == 0
+        assert texts2 == texts1
+
+    def test_transcribe_full_round_trips_across_instances(self, tmp_path):
+        video = _video(tmp_path)
+
+        m1 = _matcher(tmp_path)
+        model1 = FakeModel()
+        with (
+            patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=model1),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=1320),
+        ):
+            first = m1.transcribe_full(video)
+        assert first is not None
+        assert model1.calls == 1
+
+        m2 = _matcher(tmp_path)
+        model2 = FakeModel()
+        no_extract = Mock(side_effect=AssertionError("L2 hit must not extract a wav"))
+        with (
+            patch.object(m2, "extract_audio_chunk", no_extract),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=model2),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=1320),
+        ):
+            second = m2.transcribe_full(video)
+
+        assert model2.calls == 0
+        assert second == first
+
+
+class TestLayering:
+    """L1 → L2 → compute ordering and write-through behaviour."""
+
+    def test_compute_writes_through_to_l2(self, tmp_path):
+        video = _video(tmp_path)
+        m = _matcher(tmp_path)
+        model = FakeModel()
+        with patch.object(m, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            text = m.transcribe_chunk_cached(video, 90, CHUNK_LEN, model)
+
+        file_key = transcript_store.file_key_for(video)
+        model_key = m._model_key_for(model)
+        assert transcript_store.get(file_key, 90, CHUNK_LEN, model_key) == text
+        # The write landed in the tmp_path store the conftest fixture redirected
+        # to — NOT the developer's real ~/.engram cache.
+        assert (tmp_path / "transcripts.sqlite").exists()
+
+    def test_l2_hit_populates_l1_so_store_is_read_once(self, tmp_path, monkeypatch):
+        video = _video(tmp_path)
+
+        m1 = _matcher(tmp_path)
+        model1 = FakeModel()
+        with patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            m1.transcribe_chunk_cached(video, 90, CHUNK_LEN, model1)
+
+        # Fresh instance: first call is an L2 hit (one store.get), second call
+        # must be served from the L1 entry that hit populated (no more gets).
+        get_calls = []
+        real_get = transcript_store.get
+        monkeypatch.setattr(
+            transcript_store, "get", lambda *a, **k: get_calls.append(a) or real_get(*a, **k)
+        )
+        m2 = _matcher(tmp_path)
+        model2 = FakeModel()
+        first = m2.transcribe_chunk_cached(video, 90, CHUNK_LEN, model2)
+        second = m2.transcribe_chunk_cached(video, 90, CHUNK_LEN, model2)
+
+        assert first == second
+        assert model2.calls == 0
+        assert len(get_calls) == 1
+
+    def test_l1_hit_short_circuits_same_instance(self, tmp_path):
+        video = _video(tmp_path)
+        m = _matcher(tmp_path)
+        model = FakeModel()
+        with patch.object(m, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            m.transcribe_chunk_cached(video, 90, CHUNK_LEN, model)
+            m.transcribe_chunk_cached(video, 90, CHUNK_LEN, model)
+        assert model.calls == 1
+
+    def test_empty_transcript_is_cached_not_a_perpetual_miss(self, tmp_path):
+        """{"text": None} → "" must be cached ("" is a valid value, only None misses)."""
+        video = _video(tmp_path)
+
+        class SilentModel(FakeModel):
+            def transcribe(self, audio_path):
+                self.calls += 1
+                return {"text": None}
+
+        m1 = _matcher(tmp_path)
+        model1 = SilentModel()
+        with patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            assert m1.transcribe_chunk_cached(video, 90, CHUNK_LEN, model1) == ""
+        assert model1.calls == 1
+
+        m2 = _matcher(tmp_path)
+        model2 = SilentModel()
+        assert m2.transcribe_chunk_cached(video, 90, CHUNK_LEN, model2) == ""
+        assert model2.calls == 0
+
+    def test_unstatable_file_degrades_to_compute(self, tmp_path):
+        """Missing file → file_key None → no persistence, but matching still works."""
+        ghost = tmp_path / "ghost.mkv"  # never created
+        for _ in range(2):  # two fresh instances: no cross-instance reuse, no raise
+            m = _matcher(tmp_path)
+            model = FakeModel()
+            with patch.object(m, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+                text = m.transcribe_chunk_cached(ghost, 90, CHUNK_LEN, model)
+            assert text
+            assert model.calls == 1
+
+    def test_temp_files_appended_only_on_compute(self, tmp_path):
+        """Cleanup semantics: a wav is tracked when extracted, never on a hit."""
+        video = _video(tmp_path)
+        m1 = _matcher(tmp_path)
+        model = FakeModel()
+        temp_files = []
+        with patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            m1.transcribe_chunk_cached(video, 90, CHUNK_LEN, model, temp_files=temp_files)
+            assert temp_files == [str(tmp_path / "chunk_90.wav")]
+            m1.transcribe_chunk_cached(video, 90, CHUNK_LEN, model, temp_files=temp_files)
+        assert len(temp_files) == 1  # L1 hit appended nothing
+
+        m2 = _matcher(tmp_path)
+        temp_files2 = []
+        m2.transcribe_chunk_cached(video, 90, CHUNK_LEN, FakeModel(), temp_files=temp_files2)
+        assert temp_files2 == []  # L2 hit appended nothing
+
+
+class TestModelKeySeparation:
+    """Transcripts must never be reused across different ASR model identities."""
+
+    def test_different_model_key_is_a_miss(self, tmp_path):
+        video = _video(tmp_path)
+
+        m1 = _matcher(tmp_path)
+        model1 = FakeModel()
+        with patch.object(m1, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            m1.transcribe_chunk_cached(
+                video, 90, CHUNK_LEN, model1, model_key="whisper_tiny_cpu_int8"
+            )
+        assert model1.calls == 1
+
+        # Fresh instance, same file/offset, DIFFERENT model identity → recompute.
+        m2 = _matcher(tmp_path)
+        model2 = FakeModel()
+        with patch.object(m2, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)):
+            m2.transcribe_chunk_cached(
+                video, 90, CHUNK_LEN, model2, model_key="whisper_large-v3_cpu_int8"
+            )
+        assert model2.calls == 1
+
+    def test_model_key_prefers_loaded_model_device(self, tmp_path):
+        """CUDA→CPU load fallback: the key follows the model's actual device,
+        so a transcript produced on cpu/int8 is never filed under cuda/float16."""
+        m = _matcher(tmp_path)
+        m.device = "cuda"  # matcher config claims cuda...
+        model = FakeModel()  # ...but the loaded model fell back to cpu
+        key = m._model_key_for(model)
+        assert "_cpu_" in key
+        assert "_cuda_" not in key
+
+    def test_model_key_falls_back_to_config_for_fakes_without_device(self, tmp_path):
+        m = _matcher(tmp_path)  # device="cpu"
+        key = m._model_key_for(object())  # no .device attribute
+        assert key == "whisper_tiny_cpu_int8"
+
+
+class TestEffectiveDeviceFix:
+    """EpisodeMatcher must honor the startup-pinned device, not the raw GPU probe."""
+
+    def test_pinned_cpu_wins_over_available_gpu(self, tmp_path):
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=1):
+            set_asr_device("cpu")  # user disabled GPU ASR / CUDA libs missing
+            m = EpisodeMatcher(cache_dir=tmp_path, show_name="X", model_name="tiny")
+            assert m.device == "cpu"
+            # _model_config feeds the L2 model_key — it must not claim cuda.
+            assert m._model_config()["device"] == "cpu"
+
+    def test_unpinned_falls_back_to_probe(self, tmp_path):
+        with patch("app.matcher.asr_models.ctranslate2.get_cuda_device_count", return_value=0):
+            m = EpisodeMatcher(cache_dir=tmp_path, show_name="X", model_name="tiny")
+        assert m.device == "cpu"
+
+
+class TestGoldenScanOffsets:
+    """Cache-stability guard: scan offsets are PERSISTED transcript-cache keys.
+
+    These exact values are baked into every user's ~/.engram/cache/
+    transcripts.sqlite as the start_s key component. Changing the lattice math
+    (canonical_scan_points) silently invalidates every existing transcript
+    cache — every chunk becomes a miss and gets re-transcribed. If this test
+    fails, you broke cache compatibility, not just a unit test: either revert
+    the lattice change or ship it knowingly as a cache-busting change.
+    """
+
+    def test_level_10_offsets_for_45min_episode(self):
+        assert canonical_scan_points(2700, skip_initial=90, num_points=10) == [
+            90, 366, 643, 920, 1196, 1473, 1750, 2026, 2303, 2580,
+        ]  # fmt: skip
+
+    def test_level_19_offsets_for_45min_episode(self):
+        assert canonical_scan_points(2700, skip_initial=90, num_points=19) == [
+            90, 228, 366, 505, 643, 781, 920, 1058, 1196, 1335,
+            1473, 1611, 1750, 1888, 2026, 2165, 2303, 2441, 2580,
+        ]  # fmt: skip

--- a/backend/tests/unit/test_transcript_cache_wiring.py
+++ b/backend/tests/unit/test_transcript_cache_wiring.py
@@ -11,6 +11,7 @@ matcher methods, ``transcript_store`` and the key derivation all run for real
 ``_isolate_transcript_store`` fixture).
 """
 
+import sqlite3
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -203,6 +204,33 @@ class TestLayering:
             assert text
             assert model.calls == 1
 
+    def test_transcribe_full_unlinks_computed_wav_but_not_on_hit(self, tmp_path):
+        """The full-file wav (tens of MB) must be deleted after a compute; an
+        L1 hit produces no wav and must not delete anything."""
+        video = _video(tmp_path)
+        m = _matcher(tmp_path)
+        # >=50 chars: transcribe_full rejects shorter transcripts as "too little text".
+        model = FakeModel(text_template="a long full-file transcript about {stem} " * 3)
+        wav = tmp_path / "full.wav"
+        wav.write_bytes(b"RIFF")
+
+        with (
+            patch.object(m, "extract_audio_chunk", return_value=str(wav)),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=model),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=1320),
+        ):
+            first = m.transcribe_full(video)
+            assert first is not None
+            assert not wav.exists()  # compute path: wav extracted, then removed
+
+            # L1 hit: no extraction, and a (recreated) wav is left untouched.
+            wav.write_bytes(b"RIFF")
+            second = m.transcribe_full(video)
+
+        assert second == first
+        assert model.calls == 1
+        assert wav.exists()
+
     def test_temp_files_appended_only_on_compute(self, tmp_path):
         """Cleanup semantics: a wav is tracked when extracted, never on a hit."""
         video = _video(tmp_path)
@@ -219,6 +247,73 @@ class TestLayering:
         temp_files2 = []
         m2.transcribe_chunk_cached(video, 90, CHUNK_LEN, FakeModel(), temp_files=temp_files2)
         assert temp_files2 == []  # L2 hit appended nothing
+
+
+class TestIdentifyEpisodeWiredPath:
+    """The L2 keys identify_episode precomputes and threads through its chunk loop.
+
+    ``transcribe_chunk_cached`` is covered directly above; this exercises the
+    WIRED path — identify_episode derives ``l2_file_key``/``l2_model_key`` once
+    per call and passes them into every chunk lookup — and proves the rows land
+    in the store under the file's real ``file_key_for`` key and the matcher's
+    model key (not under None, and not under a per-chunk re-derivation that
+    could drift).
+    """
+
+    def test_identify_episode_persists_chunk_rows_under_real_keys(self, tmp_path):
+        video = _video(tmp_path)
+        m = _matcher(tmp_path)
+        model = FakeModel()
+
+        # Lightest identify_episode drive (mirrors TestTranscriptionCache in
+        # test_episode_identification.py): the precomputed-season and TF-IDF
+        # seams are mocked so only extraction/ASR/L2 wiring run for real. The
+        # matrix/idf in the precomputed tuple are inert sentinels — the patched
+        # _get_tfidf_matcher never touches them.
+        tfidf = Mock()
+        tfidf.is_prepared = True
+        tfidf.match.return_value = [("S01E01", 0.9)]
+        precomputed = (object(), ["S01E01"], object())
+        fallback_guard = Mock(side_effect=AssertionError("full-file fallback must not run"))
+
+        with (
+            patch.object(m, "_get_tfidf_matcher", return_value=tfidf),
+            patch.object(m, "_load_precomputed_season", return_value=precomputed),
+            patch.object(m, "extract_audio_chunk", side_effect=_fake_extract(tmp_path)),
+            patch.object(m, "_match_full_file", fallback_guard),
+            patch("app.matcher.episode_identification.get_cached_model", return_value=model),
+            patch("app.matcher.episode_identification.get_video_duration", return_value=2700),
+        ):
+            result = m.identify_episode(video, tmp_path, season_number=1)
+
+        # Sanity: the decisive votes were accepted directly (no fallback row).
+        assert result is not None
+        assert result["episode"] == 1
+
+        offsets = canonical_scan_points(2700, skip_initial=90, num_points=10)
+        assert model.calls == len(offsets)
+
+        # Every scan offset is retrievable under the PRODUCTION keys: the
+        # file's stat-based file_key and the matcher's derived model key.
+        file_key = transcript_store.file_key_for(video)
+        assert file_key is not None
+        model_key = "whisper_tiny_cpu_int8"  # device="cpu" matcher + FakeModel.device="cpu"
+        assert m._model_key_for(model) == model_key
+        for off in offsets:
+            assert transcript_store.get(file_key, off, CHUNK_LEN, model_key) is not None
+
+        # ...and ONLY those rows: nothing landed under a None/drifted key and
+        # the accepted match never produced the (0, duration) full-file span.
+        conn = sqlite3.connect(transcript_store.CACHE_DB_PATH)
+        try:
+            rows = set(
+                conn.execute(
+                    "SELECT file_key, start_s, duration_s, model_key FROM transcripts"
+                ).fetchall()
+            )
+        finally:
+            conn.close()
+        assert rows == {(file_key, int(off), CHUNK_LEN, model_key) for off in offsets}
 
 
 class TestModelKeySeparation:

--- a/backend/tests/unit/test_transcript_store.py
+++ b/backend/tests/unit/test_transcript_store.py
@@ -1,0 +1,437 @@
+"""Tests for the disk-backed ASR transcript cache (transcript_store.py).
+
+Fixture strategy mirrors ``test_tmdb_persistent_cache.py``:
+- An autouse fixture redirects ``CACHE_DB_PATH`` to a per-test tmp_path file
+  via monkeypatch + ``close()``, so tests NEVER touch ``~/.engram/cache/``.
+- The fixture also resets the put-counter so LRU prune tests start clean.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import app.matcher.transcript_store as ts
+
+# ---------------------------------------------------------------------------
+# Isolation fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_transcript_store(tmp_path, monkeypatch):
+    """Redirect transcript_store to a per-test SQLite file in tmp_path."""
+    ts.close()
+    monkeypatch.setattr(ts, "CACHE_DB_PATH", tmp_path / "transcripts.sqlite")
+    # Reset the put counter so every test starts from 0.
+    monkeypatch.setattr(ts, "_put_counter", 0)
+    yield
+    ts.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MK = "faster-whisper_small_cpu_int8"  # a representative model_key
+
+
+def _put(fk: str, start: int = 0, dur: int = 30, mk: str = _MK, text: str = "hello") -> None:
+    ts.put(fk, start, dur, mk, text)
+
+
+def _get(fk: str, start: int = 0, dur: int = 30, mk: str = _MK) -> str | None:
+    return ts.get(fk, start, dur, mk)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRoundtrip:
+    def test_put_then_get_returns_text(self, tmp_path):
+        fk = "abc123"
+        ts.put(fk, 0, 30, _MK, "hello world")
+        assert ts.get(fk, 0, 30, _MK) == "hello world"
+
+    def test_miss_returns_none(self):
+        assert ts.get("no_such_key", 0, 30, _MK) is None
+
+    def test_cached_empty_string_returns_empty_not_none(self, tmp_path):
+        """Silent audio produces "" — must be distinguished from a cache miss."""
+        fk = "silent_file_key"
+        ts.put(fk, 0, 30, _MK, "")
+        result = ts.get(fk, 0, 30, _MK)
+        assert result == ""
+        assert result is not None
+
+    def test_put_replaces_existing_entry(self):
+        fk = "replace_me"
+        ts.put(fk, 0, 30, _MK, "first")
+        ts.put(fk, 0, 30, _MK, "second")
+        assert ts.get(fk, 0, 30, _MK) == "second"
+
+    def test_different_start_s_are_independent_entries(self):
+        fk = "multi_offset"
+        ts.put(fk, 0, 30, _MK, "zero")
+        ts.put(fk, 30, 30, _MK, "thirty")
+        assert ts.get(fk, 0, 30, _MK) == "zero"
+        assert ts.get(fk, 30, 30, _MK) == "thirty"
+
+    def test_different_model_keys_are_independent(self):
+        fk = "model_diff"
+        ts.put(fk, 0, 30, "model_a", "text-a")
+        ts.put(fk, 0, 30, "model_b", "text-b")
+        assert ts.get(fk, 0, 30, "model_a") == "text-a"
+        assert ts.get(fk, 0, 30, "model_b") == "text-b"
+
+    def test_different_duration_s_are_independent(self):
+        fk = "dur_diff"
+        ts.put(fk, 0, 30, _MK, "30s-text")
+        ts.put(fk, 0, 60, _MK, "60s-text")
+        assert ts.get(fk, 0, 30, _MK) == "30s-text"
+        assert ts.get(fk, 0, 60, _MK) == "60s-text"
+
+
+# ---------------------------------------------------------------------------
+# file_key_for tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFileKeyFor:
+    def test_same_file_same_key(self, tmp_path):
+        f = tmp_path / "audio.mkv"
+        f.write_bytes(b"x" * 1000)
+        k1 = ts.file_key_for(f)
+        k2 = ts.file_key_for(f)
+        assert k1 is not None
+        assert k1 == k2
+
+    def test_key_is_40_char_hex(self, tmp_path):
+        f = tmp_path / "audio.mkv"
+        f.write_bytes(b"data")
+        k = ts.file_key_for(f)
+        assert k is not None
+        assert len(k) == 40
+        assert all(c in "0123456789abcdef" for c in k)
+
+    def test_different_content_same_name_different_key(self, tmp_path):
+        """Changing file content (different size) → different key."""
+        f = tmp_path / "audio.mkv"
+        f.write_bytes(b"original_content")
+        k1 = ts.file_key_for(f)
+        # Write more bytes so st_size definitely changes.
+        f.write_bytes(b"original_content_plus_extra_bytes")
+        k2 = ts.file_key_for(f)
+        assert k1 != k2
+
+    def test_touch_mtime_gives_different_key(self, tmp_path):
+        """Touching mtime (re-rip same size) gives a new key."""
+        f = tmp_path / "audio.mkv"
+        f.write_bytes(b"x" * 100)
+        k1 = ts.file_key_for(f)
+        # Advance mtime by 2 seconds to ensure ns-level difference.
+        new_mtime = f.stat().st_mtime + 2
+        import os
+
+        os.utime(f, (new_mtime, new_mtime))
+        k2 = ts.file_key_for(f)
+        assert k1 != k2
+
+    def test_missing_file_returns_none(self, tmp_path):
+        missing = tmp_path / "does_not_exist.mkv"
+        assert ts.file_key_for(missing) is None
+
+    def test_missing_file_does_not_raise(self, tmp_path):
+        """file_key_for must be fail-safe — never raise on missing file."""
+        missing = tmp_path / "ghost.mkv"
+        try:
+            result = ts.file_key_for(missing)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"file_key_for raised unexpectedly: {exc}")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get bumps last_used_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLastUsedAt:
+    def test_get_bumps_last_used_at(self, monkeypatch):
+        """A cache hit must update last_used_at so LRU order reflects access."""
+        fake_time = {"value": 1_000_000}
+        monkeypatch.setattr(ts.time, "time", lambda: fake_time["value"])
+
+        fk = "lru_bump"
+        ts.put(fk, 0, 30, _MK, "text")
+
+        # Advance clock and perform a get — last_used_at must reflect the new time.
+        fake_time["value"] = 2_000_000
+        ts.get(fk, 0, 30, _MK)
+
+        conn = ts._get_conn()
+        row = conn.execute(
+            "SELECT last_used_at FROM transcripts "
+            "WHERE file_key=? AND start_s=0 AND duration_s=30 AND model_key=?",
+            (fk, _MK),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 2_000_000
+
+    def test_prune_keeps_recently_accessed_entry(self, monkeypatch):
+        """get() bumps last_used_at so the accessed entry survives pruning."""
+        # Override constants: cap = 2, check every put.
+        monkeypatch.setattr(ts, "_MAX_ROWS", 2)
+        monkeypatch.setattr(ts, "_PUT_PRUNE_INTERVAL", 1)
+
+        fake_time = {"value": 1000}
+        monkeypatch.setattr(ts.time, "time", lambda: fake_time["value"])
+
+        # Put entry A at t=1000.
+        ts.put("A", 0, 30, _MK, "a")
+
+        # Advance time and put entry B.
+        fake_time["value"] = 2000
+        ts.put("B", 0, 30, _MK, "b")
+
+        # Access A at t=3000 — bumps its last_used_at past B.
+        fake_time["value"] = 3000
+        ts.get("A", 0, 30, _MK)
+
+        # Put entry C at t=4000 — triggers prune; should evict B (oldest last_used_at).
+        fake_time["value"] = 4000
+        ts.put("C", 0, 30, _MK, "c")
+
+        # A and C survive; B is evicted.
+        assert ts.get("A", 0, 30, _MK) == "a"
+        assert ts.get("C", 0, 30, _MK) == "c"
+        assert ts.get("B", 0, 30, _MK) is None
+
+
+# ---------------------------------------------------------------------------
+# LRU prune tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLRUPrune:
+    def test_prune_removes_oldest_rows(self, monkeypatch):
+        """With cap=3 and interval=1, inserting 5 rows prunes down to 3 oldest."""
+        monkeypatch.setattr(ts, "_MAX_ROWS", 3)
+        monkeypatch.setattr(ts, "_PUT_PRUNE_INTERVAL", 1)
+
+        fake_time = {"value": 1000}
+        monkeypatch.setattr(ts.time, "time", lambda: fake_time["value"])
+
+        for i in range(5):
+            fake_time["value"] = 1000 + i
+            ts.put(f"key{i}", 0, 30, _MK, f"text{i}")
+
+        # key0 and key1 had lowest last_used_at and should be pruned.
+        assert ts.get("key0", 0, 30, _MK) is None
+        assert ts.get("key1", 0, 30, _MK) is None
+        # key2, key3, key4 survive.
+        assert ts.get("key2", 0, 30, _MK) == "text2"
+        assert ts.get("key3", 0, 30, _MK) == "text3"
+        assert ts.get("key4", 0, 30, _MK) == "text4"
+
+    def test_prune_not_triggered_until_interval(self, monkeypatch):
+        """With interval=5, prune fires only on every 5th put."""
+        monkeypatch.setattr(ts, "_MAX_ROWS", 2)
+        monkeypatch.setattr(ts, "_PUT_PRUNE_INTERVAL", 5)
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        fake_time = {"value": 1000}
+        monkeypatch.setattr(ts.time, "time", lambda: fake_time["value"])
+
+        # Insert 4 rows — prune should NOT fire yet (counter at 4, not divisible by 5).
+        for i in range(4):
+            fake_time["value"] = 1000 + i
+            ts.put(f"k{i}", 0, 30, _MK, f"t{i}")
+
+        conn = ts._get_conn()
+        (count,) = conn.execute("SELECT COUNT(*) FROM transcripts").fetchone()
+        assert count == 4  # no prune yet
+
+        # 5th put triggers prune — now capped at 2.
+        fake_time["value"] = 1004
+        ts.put("k4", 0, 30, _MK, "t4")
+        (count,) = conn.execute("SELECT COUNT(*) FROM transcripts").fetchone()
+        assert count == 2
+
+    def test_prune_is_no_op_when_under_cap(self, monkeypatch):
+        """_prune() is a no-op when row count is at or below _MAX_ROWS."""
+        monkeypatch.setattr(ts, "_MAX_ROWS", 100)
+        monkeypatch.setattr(ts, "_PUT_PRUNE_INTERVAL", 1)
+
+        for i in range(5):
+            ts.put(f"safe{i}", 0, 30, _MK, "x")
+
+        conn = ts._get_conn()
+        (count,) = conn.execute("SELECT COUNT(*) FROM transcripts").fetchone()
+        assert count == 5  # no rows deleted
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe / corruption tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFailSafe:
+    def test_corrupt_db_file_recovers_on_first_connect(self, tmp_path, monkeypatch):
+        """A corrupt DB is deleted and recreated; get/put work after recovery."""
+        corrupt_path = tmp_path / "bad.sqlite"
+        corrupt_path.write_bytes(b"THIS IS NOT A SQLITE DATABASE FILE")
+        ts.close()
+        monkeypatch.setattr(ts, "CACHE_DB_PATH", corrupt_path)
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        # Should not raise — module recovers by deleting and recreating.
+        ts.put("fk", 0, 30, _MK, "hello")
+        assert ts.get("fk", 0, 30, _MK) == "hello"
+
+    def test_get_on_missing_db_returns_none(self, tmp_path, monkeypatch):
+        """If _get_conn raises a sqlite3.Error, get() returns None without raising.
+
+        We simulate a broken DB by monkeypatching _get_conn to raise directly,
+        which covers any failure in the mkdir / schema-creation path without
+        depending on OS-specific path-collision behaviour.
+        """
+        ts.close()
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        def broken_conn():
+            raise sqlite3.OperationalError("simulated broken DB path")
+
+        monkeypatch.setattr(ts, "_get_conn", broken_conn)
+        result = ts.get("fk", 0, 30, _MK)
+        assert result is None
+
+    def test_put_on_missing_db_does_not_raise(self, tmp_path, monkeypatch):
+        """If _get_conn raises a sqlite3.Error, put() no-ops without raising."""
+        ts.close()
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        def broken_conn():
+            raise sqlite3.OperationalError("simulated broken DB path")
+
+        monkeypatch.setattr(ts, "_get_conn", broken_conn)
+        try:
+            ts.put("fk", 0, 30, _MK, "text")
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"put() raised unexpectedly: {exc}")
+
+    def test_get_does_not_raise_on_sqlite_error(self, monkeypatch):
+        """If the underlying connection raises sqlite3.Error, get() returns None."""
+
+        def bad_get_conn():
+            raise sqlite3.OperationalError("simulated DB error")
+
+        monkeypatch.setattr(ts, "_get_conn", bad_get_conn)
+        result = ts.get("fk", 0, 30, _MK)
+        assert result is None
+
+    def test_put_does_not_raise_on_sqlite_error(self, monkeypatch):
+        """If the underlying connection raises sqlite3.Error, put() no-ops."""
+
+        def bad_get_conn():
+            raise sqlite3.OperationalError("simulated DB error")
+
+        monkeypatch.setattr(ts, "_get_conn", bad_get_conn)
+        try:
+            ts.put("fk", 0, 30, _MK, "text")
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"put() raised unexpectedly: {exc}")
+
+    def test_file_key_for_does_not_raise_on_missing_file(self, tmp_path):
+        result = ts.file_key_for(tmp_path / "ghost.mkv")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestThreadSafety:
+    def test_concurrent_put_and_get(self):
+        """Multiple threads doing put/get on distinct keys must not error."""
+        errors: list[Exception] = []
+
+        def worker(thread_id: int) -> None:
+            try:
+                fk = f"thread_{thread_id}"
+                for i in range(10):
+                    ts.put(fk, i * 30, 30, _MK, f"text_{thread_id}_{i}")
+                for i in range(10):
+                    result = ts.get(fk, i * 30, 30, _MK)
+                    assert result == f"text_{thread_id}_{i}", (
+                        f"Thread {thread_id} offset {i}: expected text_{thread_id}_{i!r}, "
+                        f"got {result!r}"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(worker, range(16)))
+
+        assert not errors, f"Thread errors: {errors}"
+
+    def test_concurrent_put_shared_key(self):
+        """Multiple threads writing the same key must not raise (last-write wins)."""
+        errors: list[Exception] = []
+
+        def writer(thread_id: int) -> None:
+            try:
+                ts.put("shared_key", 0, 30, _MK, f"value_{thread_id}")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(writer, range(32)))
+
+        assert not errors
+        # The key must be readable (some value must have won).
+        result = ts.get("shared_key", 0, 30, _MK)
+        assert result is not None
+        assert result.startswith("value_")
+
+
+# ---------------------------------------------------------------------------
+# close() / reset_for_tests() helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCloseAndReset:
+    def test_close_allows_db_path_redirect(self, tmp_path, monkeypatch):
+        """After close(), a new CACHE_DB_PATH takes effect on next get/put."""
+        ts.put("original", 0, 30, _MK, "data")
+
+        new_db = tmp_path / "fresh.sqlite"
+        ts.close()
+        monkeypatch.setattr(ts, "CACHE_DB_PATH", new_db)
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        # The new DB is empty — the "original" key should not be found.
+        assert ts.get("original", 0, 30, _MK) is None
+
+    def test_reset_for_tests_resets_counter(self, tmp_path, monkeypatch):
+        """reset_for_tests() zeros the put counter."""
+        # Manually bump the counter.
+        with ts._put_counter_lock:
+            ts._put_counter = 99
+        new_db = tmp_path / "reset.sqlite"
+        monkeypatch.setattr(ts, "CACHE_DB_PATH", new_db)
+        ts.reset_for_tests(new_db)
+        with ts._put_counter_lock:
+            assert ts._put_counter == 0

--- a/backend/tests/unit/test_transcript_store.py
+++ b/backend/tests/unit/test_transcript_store.py
@@ -2,8 +2,10 @@
 
 Fixture strategy mirrors ``test_tmdb_persistent_cache.py``:
 - An autouse fixture redirects ``CACHE_DB_PATH`` to a per-test tmp_path file
-  via monkeypatch + ``close()``, so tests NEVER touch ``~/.engram/cache/``.
-- The fixture also resets the put-counter so LRU prune tests start clean.
+  via monkeypatch + ``reset_module_state_for_tests()``, so tests NEVER touch
+  ``~/.engram/cache/``.
+- The fixture also resets the put-counter and bootstrap-warning latch so every
+  test starts from a clean state.
 """
 
 from __future__ import annotations
@@ -23,12 +25,10 @@ import app.matcher.transcript_store as ts
 @pytest.fixture(autouse=True)
 def _isolate_transcript_store(tmp_path, monkeypatch):
     """Redirect transcript_store to a per-test SQLite file in tmp_path."""
-    ts.close()
     monkeypatch.setattr(ts, "CACHE_DB_PATH", tmp_path / "transcripts.sqlite")
-    # Reset the put counter so every test starts from 0.
-    monkeypatch.setattr(ts, "_put_counter", 0)
+    ts.reset_module_state_for_tests()
     yield
-    ts.close()
+    ts.reset_module_state_for_tests()
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +98,81 @@ class TestRoundtrip:
 
 
 # ---------------------------------------------------------------------------
+# Numeric key normalisation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNumericKeyNormalisation:
+    def test_float_duration_put_int_get_hits(self):
+        """put() with float duration, get() with truncated int → cache hit."""
+        fk = "float_dur"
+        ts.put(fk, 0, 1372.416, _MK, "float stored")
+        # 1372.416 rounds to 1372 — both ints and the rounded float should hit.
+        assert ts.get(fk, 0, 1372, _MK) == "float stored"
+        assert ts.get(fk, 0, 1372.0, _MK) == "float stored"
+
+    def test_float_duration_put_float_get_hits(self):
+        """put() and get() with the same float duration → cache hit."""
+        fk = "float_same"
+        ts.put(fk, 0, 1372.416, _MK, "roundtrip")
+        assert ts.get(fk, 0, 1372.416, _MK) == "roundtrip"
+
+    def test_float_start_s_normalised(self):
+        """put() with float start_s, get() with equivalent int → hit."""
+        fk = "float_start"
+        ts.put(fk, 30.7, 30, _MK, "offset text")
+        assert ts.get(fk, 31, 30, _MK) == "offset text"
+
+    def test_float_duration_slightly_different_rounds_to_same(self):
+        """Floats that round to the same integer resolve to the same row."""
+        fk = "float_rounding"
+        ts.put(fk, 0, 30.4, _MK, "text")
+        assert ts.get(fk, 0, 30.6, _MK) is None  # rounds to 31, not 30
+        assert ts.get(fk, 0, 30.3, _MK) == "text"  # rounds to 30
+
+
+# ---------------------------------------------------------------------------
+# file_key=None short-circuit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoneFileKey:
+    def test_get_with_none_file_key_returns_none(self):
+        """get() must return None silently when file_key is None."""
+        result = ts.get(None, 0, 30, _MK)
+        assert result is None
+
+    def test_put_with_none_file_key_does_not_raise(self):
+        """put() must be a no-op when file_key is None."""
+        try:
+            ts.put(None, 0, 30, _MK, "text")
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"put(None, ...) raised unexpectedly: {exc}")
+
+    def test_put_with_none_file_key_writes_nothing(self):
+        """After put(None, ...), the DB should have no rows."""
+        ts.put(None, 0, 30, _MK, "text")
+        conn = ts._get_conn()
+        (count,) = conn.execute("SELECT COUNT(*) FROM transcripts").fetchone()
+        assert count == 0
+
+    def test_get_with_none_does_not_touch_db(self, monkeypatch):
+        """get(None, ...) short-circuits before opening a DB connection."""
+        opened = []
+        original_get_conn = ts._get_conn
+
+        def tracking_get_conn():
+            opened.append(True)
+            return original_get_conn()
+
+        monkeypatch.setattr(ts, "_get_conn", tracking_get_conn)
+        ts.get(None, 0, 30, _MK)
+        assert not opened, "_get_conn should not be called when file_key is None"
+
+
+# ---------------------------------------------------------------------------
 # file_key_for tests
 # ---------------------------------------------------------------------------
 
@@ -146,15 +221,6 @@ class TestFileKeyFor:
     def test_missing_file_returns_none(self, tmp_path):
         missing = tmp_path / "does_not_exist.mkv"
         assert ts.file_key_for(missing) is None
-
-    def test_missing_file_does_not_raise(self, tmp_path):
-        """file_key_for must be fail-safe — never raise on missing file."""
-        missing = tmp_path / "ghost.mkv"
-        try:
-            result = ts.file_key_for(missing)
-        except Exception as exc:  # noqa: BLE001
-            pytest.fail(f"file_key_for raised unexpectedly: {exc}")
-        assert result is None
 
     def test_null_char_in_path_returns_none(self):
         """file_key_for must not raise on paths containing embedded null bytes."""
@@ -250,7 +316,6 @@ class TestLRUPrune:
         """With interval=5, prune fires only on every 5th put."""
         monkeypatch.setattr(ts, "_MAX_ROWS", 2)
         monkeypatch.setattr(ts, "_PUT_PRUNE_INTERVAL", 5)
-        monkeypatch.setattr(ts, "_put_counter", 0)
 
         fake_time = {"value": 1000}
         monkeypatch.setattr(ts.time, "time", lambda: fake_time["value"])
@@ -294,44 +359,12 @@ class TestFailSafe:
         """A corrupt DB is deleted and recreated; get/put work after recovery."""
         corrupt_path = tmp_path / "bad.sqlite"
         corrupt_path.write_bytes(b"THIS IS NOT A SQLITE DATABASE FILE")
-        ts.close()
         monkeypatch.setattr(ts, "CACHE_DB_PATH", corrupt_path)
-        monkeypatch.setattr(ts, "_put_counter", 0)
+        ts.reset_module_state_for_tests()
 
         # Should not raise — module recovers by deleting and recreating.
         ts.put("fk", 0, 30, _MK, "hello")
         assert ts.get("fk", 0, 30, _MK) == "hello"
-
-    def test_get_on_missing_db_returns_none(self, tmp_path, monkeypatch):
-        """If _get_conn raises a sqlite3.Error, get() returns None without raising.
-
-        We simulate a broken DB by monkeypatching _get_conn to raise directly,
-        which covers any failure in the mkdir / schema-creation path without
-        depending on OS-specific path-collision behaviour.
-        """
-        ts.close()
-        monkeypatch.setattr(ts, "_put_counter", 0)
-
-        def broken_conn():
-            raise sqlite3.OperationalError("simulated broken DB path")
-
-        monkeypatch.setattr(ts, "_get_conn", broken_conn)
-        result = ts.get("fk", 0, 30, _MK)
-        assert result is None
-
-    def test_put_on_missing_db_does_not_raise(self, tmp_path, monkeypatch):
-        """If _get_conn raises a sqlite3.Error, put() no-ops without raising."""
-        ts.close()
-        monkeypatch.setattr(ts, "_put_counter", 0)
-
-        def broken_conn():
-            raise sqlite3.OperationalError("simulated broken DB path")
-
-        monkeypatch.setattr(ts, "_get_conn", broken_conn)
-        try:
-            ts.put("fk", 0, 30, _MK, "text")
-        except Exception as exc:  # noqa: BLE001
-            pytest.fail(f"put() raised unexpectedly: {exc}")
 
     def test_get_does_not_raise_on_sqlite_error(self, monkeypatch):
         """If the underlying connection raises sqlite3.Error, get() returns None."""
@@ -363,9 +396,8 @@ class TestFailSafe:
         blocker.write_bytes(b"I am a file, not a directory")
         blocked_db = blocker / "transcripts.sqlite"
 
-        ts.close()
         monkeypatch.setattr(ts, "CACHE_DB_PATH", blocked_db)
-        monkeypatch.setattr(ts, "_put_counter", 0)
+        ts.reset_module_state_for_tests()
 
         assert ts.get("fk", 0, 30, _MK) is None
         # put() must not raise even though the directory cannot be created.
@@ -374,6 +406,36 @@ class TestFailSafe:
     def test_file_key_for_does_not_raise_on_missing_file(self, tmp_path):
         result = ts.file_key_for(tmp_path / "ghost.mkv")
         assert result is None
+
+    def test_degraded_mode_warns_once_then_latches(self, monkeypatch):
+        """First bootstrap failure sets the warning latch; subsequent calls do not reset it.
+
+        We verify the latch mechanics directly (rather than capturing loguru output,
+        which does not propagate to stdlib caplog by default).  The latch is the
+        mechanism that causes subsequent failures to log at DEBUG instead of WARNING.
+        """
+        call_count = [0]
+
+        def failing_get_conn():
+            call_count[0] += 1
+            raise sqlite3.OperationalError("simulated persistent failure")
+
+        monkeypatch.setattr(ts, "_get_conn", failing_get_conn)
+
+        # Before any failure the latch is off.
+        assert ts._bootstrap_warned is False
+
+        # First failure sets the latch.
+        ts.get("fk", 0, 30, _MK)
+        assert ts._bootstrap_warned is True
+
+        # Subsequent failures leave it set (no reset between calls in degraded mode).
+        ts.get("fk", 0, 30, _MK)
+        ts.get("fk", 0, 30, _MK)
+        assert ts._bootstrap_warned is True
+
+        # All 3 calls still attempted the DB (no early bail-out on failure).
+        assert call_count[0] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -438,9 +500,8 @@ class TestCloseAndReset:
         ts.put("original", 0, 30, _MK, "data")
 
         new_db = tmp_path / "fresh.sqlite"
-        ts.close()
         monkeypatch.setattr(ts, "CACHE_DB_PATH", new_db)
-        monkeypatch.setattr(ts, "_put_counter", 0)
+        ts.reset_module_state_for_tests()
 
         # The new DB is empty — the "original" key should not be found.
         assert ts.get("original", 0, 30, _MK) is None
@@ -455,3 +516,19 @@ class TestCloseAndReset:
         ts.reset_module_state_for_tests()
         with ts._put_counter_lock:
             assert ts._put_counter == 0
+
+    def test_reset_clears_bootstrap_warned_latch(self, monkeypatch):
+        """reset_module_state_for_tests() resets the warning latch so the next
+        failure emits a WARNING again (recovery possible after env fix)."""
+
+        def failing_get_conn():
+            raise sqlite3.OperationalError("persistent failure")
+
+        monkeypatch.setattr(ts, "_get_conn", failing_get_conn)
+        # Trigger a failure to set the latch.
+        ts.get("fk", 0, 30, _MK)
+        assert ts._bootstrap_warned is True
+
+        # Reset should clear the latch.
+        ts.reset_module_state_for_tests()
+        assert ts._bootstrap_warned is False

--- a/backend/tests/unit/test_transcript_store.py
+++ b/backend/tests/unit/test_transcript_store.py
@@ -423,16 +423,16 @@ class TestFailSafe:
         monkeypatch.setattr(ts, "_get_conn", failing_get_conn)
 
         # Before any failure the latch is off.
-        assert ts._bootstrap_warned is False
+        assert ts._bootstrap.warned is False
 
         # First failure sets the latch.
         ts.get("fk", 0, 30, _MK)
-        assert ts._bootstrap_warned is True
+        assert ts._bootstrap.warned is True
 
         # Subsequent failures leave it set (no reset between calls in degraded mode).
         ts.get("fk", 0, 30, _MK)
         ts.get("fk", 0, 30, _MK)
-        assert ts._bootstrap_warned is True
+        assert ts._bootstrap.warned is True
 
         # All 3 calls still attempted the DB (no early bail-out on failure).
         assert call_count[0] == 3
@@ -527,8 +527,8 @@ class TestCloseAndReset:
         monkeypatch.setattr(ts, "_get_conn", failing_get_conn)
         # Trigger a failure to set the latch.
         ts.get("fk", 0, 30, _MK)
-        assert ts._bootstrap_warned is True
+        assert ts._bootstrap.warned is True
 
         # Reset should clear the latch.
         ts.reset_module_state_for_tests()
-        assert ts._bootstrap_warned is False
+        assert ts._bootstrap.warned is False

--- a/backend/tests/unit/test_transcript_store.py
+++ b/backend/tests/unit/test_transcript_store.py
@@ -156,6 +156,10 @@ class TestFileKeyFor:
             pytest.fail(f"file_key_for raised unexpectedly: {exc}")
         assert result is None
 
+    def test_null_char_in_path_returns_none(self):
+        """file_key_for must not raise on paths containing embedded null bytes."""
+        assert ts.file_key_for("foo\x00bar") is None
+
 
 # ---------------------------------------------------------------------------
 # get bumps last_used_at
@@ -351,6 +355,22 @@ class TestFailSafe:
         except Exception as exc:  # noqa: BLE001
             pytest.fail(f"put() raised unexpectedly: {exc}")
 
+    def test_mkdir_failure_get_returns_none(self, tmp_path, monkeypatch):
+        """When the cache directory cannot be created (a regular file blocks mkdir),
+        get() returns None and put() does not raise — the fail-safe degrades gracefully."""
+        # Create a regular file at the path where the cache directory would go.
+        blocker = tmp_path / "blocker"
+        blocker.write_bytes(b"I am a file, not a directory")
+        blocked_db = blocker / "transcripts.sqlite"
+
+        ts.close()
+        monkeypatch.setattr(ts, "CACHE_DB_PATH", blocked_db)
+        monkeypatch.setattr(ts, "_put_counter", 0)
+
+        assert ts.get("fk", 0, 30, _MK) is None
+        # put() must not raise even though the directory cannot be created.
+        ts.put("fk", 0, 30, _MK, "text")
+
     def test_file_key_for_does_not_raise_on_missing_file(self, tmp_path):
         result = ts.file_key_for(tmp_path / "ghost.mkv")
         assert result is None
@@ -425,13 +445,13 @@ class TestCloseAndReset:
         # The new DB is empty — the "original" key should not be found.
         assert ts.get("original", 0, 30, _MK) is None
 
-    def test_reset_for_tests_resets_counter(self, tmp_path, monkeypatch):
-        """reset_for_tests() zeros the put counter."""
+    def test_reset_module_state_resets_counter(self, tmp_path, monkeypatch):
+        """reset_module_state_for_tests() zeros the put counter."""
         # Manually bump the counter.
         with ts._put_counter_lock:
             ts._put_counter = 99
         new_db = tmp_path / "reset.sqlite"
         monkeypatch.setattr(ts, "CACHE_DB_PATH", new_db)
-        ts.reset_for_tests(new_db)
+        ts.reset_module_state_for_tests()
         with ts._put_counter_lock:
             assert ts._put_counter == 0

--- a/backend/tests/unit/test_transcription_prewarm.py
+++ b/backend/tests/unit/test_transcription_prewarm.py
@@ -8,15 +8,16 @@ the production key shapes.
 
 import asyncio
 import importlib
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.matcher import transcript_store
 from app.matcher.asr_models import model_output_key
-from app.matcher.episode_identification import canonical_scan_points
+from app.matcher.episode_identification import EpisodeMatcher, canonical_scan_points
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.finalization_coordinator import FinalizationCoordinator
@@ -554,6 +555,137 @@ class TestPrewarmerTempNamespace:
         assert str(matcher.temp_dir) != default_dir, (
             "Prewarm temp_dir must differ from the shared whisper_chunks/ namespace"
         )
+
+
+class TestWalkAwayRematch:
+    """End-to-end Phase A guarantee, across a simulated restart.
+
+    A review-parked job's files are prewarmed by a REAL ``_prewarm_job`` run
+    (real EpisodeMatcher, real transcript_store redirected to tmp_path by the
+    conftest fixture; only Whisper and ffmpeg are faked). The store must then
+    hold exactly the 10 lattice rows per file — and a FRESH EpisodeMatcher
+    (= new process) must re-match every offset from the persistent cache with
+    ZERO ASR calls and ZERO audio extractions, even with a model that raises.
+    """
+
+    class _CountingWhisper:
+        device = "cpu"  # honest post-load device -> model_key matches CONFIG_KEY
+
+        def __init__(self):
+            self.calls = 0
+
+        def transcribe(self, audio_path):
+            self.calls += 1
+            return {"text": f"prewarmed speech from {Path(audio_path).stem} again and again"}
+
+    class _PoisonModel:
+        device = "cpu"
+
+        def transcribe(self, audio_path):
+            raise AssertionError("restart re-match must be served from the persistent cache")
+
+    @staticmethod
+    def _fake_extract(tmp_path):
+        """Per-(file, offset) wav path so transcripts are distinct per chunk."""
+
+        def _extract(mkv_file, start_time, duration=None):
+            return str(tmp_path / f"chunk_{Path(mkv_file).stem}_{start_time}.wav")
+
+        return _extract
+
+    def _expected_text(self, f: Path, off: int) -> str:
+        return f"prewarmed speech from chunk_{f.stem}_{off} again and again"
+
+    async def _seed_two_title_review_job(self, tmp_path) -> tuple[int, list[Path]]:
+        """Review-parked job with TWO titles whose output files exist on disk."""
+        files = []
+        for i in range(2):
+            f = tmp_path / f"show_t0{i}.mkv"
+            f.write_bytes(b"\x00" * 2048)
+            files.append(f)
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="SHOW_S1D1",
+                content_type=ContentType.TV,
+                state=JobState.REVIEW_NEEDED,
+                detected_title="Some Show",
+                detected_season=1,
+                staging_path=str(tmp_path),
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            for i, f in enumerate(files):
+                session.add(
+                    DiscTitle(
+                        job_id=job.id,
+                        title_index=i,
+                        duration_seconds=DURATION,
+                        state=TitleState.REVIEW,
+                        output_filename=str(f),
+                    )
+                )
+            await session.commit()
+            return job.id, files
+
+    async def test_prewarm_then_fresh_matcher_rematches_with_zero_asr(
+        self, tmp_path, duration_stub
+    ):
+        job_id, files = await self._seed_two_title_review_job(tmp_path)
+
+        # --- Leg 1: real prewarm run against the review-parked job. ---------
+        # Real EpisodeMatcher (default model_name="small", requested_workers=1,
+        # explicit device="cpu") so _model_config()/_model_key_for produce the
+        # SAME keys live matching uses — i.e. CONFIG_KEY.
+        prewarm_matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="__prewarm__", device="cpu")
+        whisper = self._CountingWhisper()
+        p = TranscriptionPrewarmer()  # no semaphore provider -> nullcontext per chunk
+        p._matcher = prewarm_matcher
+
+        with (
+            patch.object(prewarm_matcher, "extract_audio_chunk", self._fake_extract(tmp_path)),
+            patch("app.matcher.asr_models.get_cached_model", return_value=whisper),
+        ):
+            await p._prewarm_job(job_id, full_file=False)
+
+        assert whisper.calls == len(files) * len(OFFSETS)
+
+        # The store holds EXACTLY the 10 lattice rows per file, keyed under the
+        # production file_key/model_key — nothing extra (no full-file span, no
+        # rows under a drifted model identity).
+        expected_rows = set()
+        for f in files:
+            file_key = transcript_store.file_key_for(f)
+            assert file_key is not None
+            for off in OFFSETS:
+                assert transcript_store.get(file_key, off, CHUNK_LEN, CONFIG_KEY) is not None
+                expected_rows.add((file_key, int(off), CHUNK_LEN, CONFIG_KEY))
+        conn = sqlite3.connect(transcript_store.CACHE_DB_PATH)
+        try:
+            rows = set(
+                conn.execute(
+                    "SELECT file_key, start_s, duration_s, model_key FROM transcripts"
+                ).fetchall()
+            )
+        finally:
+            conn.close()
+        assert rows == expected_rows
+
+        # --- Leg 2: simulated restart — fresh matcher, poison model. ---------
+        # New EpisodeMatcher instance = empty L1; the poison model raises on any
+        # transcribe and extraction is forbidden, so every transcript MUST come
+        # from the persistent L2 store.
+        fresh_matcher = EpisodeMatcher(cache_dir=tmp_path, show_name="Some Show", device="cpu")
+        no_extract = MagicMock(side_effect=AssertionError("L2 hit must not extract a wav"))
+        with patch.object(fresh_matcher, "extract_audio_chunk", no_extract):
+            for f in files:
+                for off in OFFSETS:
+                    text = fresh_matcher.transcribe_chunk_cached(
+                        f, off, CHUNK_LEN, self._PoisonModel()
+                    )
+                    assert text == self._expected_text(f, int(off))
+        no_extract.assert_not_called()
 
 
 class TestFailSoftGranularity:

--- a/backend/tests/unit/test_transcription_prewarm.py
+++ b/backend/tests/unit/test_transcription_prewarm.py
@@ -503,3 +503,105 @@ class TestJobManagerWiring:
         await jm.job_manager.rematch_single_title(13, 1)
 
         mock_prewarmer.cancel_for_job.assert_called_once_with(13)
+
+    async def test_apply_review_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        monkeypatch.setattr(jm.job_manager._finalization, "apply_review", AsyncMock())
+
+        await jm.job_manager.apply_review(14, 100, episode_code="S01E03")
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(14)
+
+    async def test_apply_review_batch_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        monkeypatch.setattr(jm.job_manager._finalization, "apply_review_batch", AsyncMock())
+
+        await jm.job_manager.apply_review_batch(15, [{"title_id": 1, "episode_code": "S01E01"}])
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(15)
+
+
+class TestPrewarmerTempNamespace:
+    def test_prewarm_matcher_uses_isolated_temp_dir(self, monkeypatch):
+        """_build_matcher must give the prewarm matcher its own temp dir so that a
+        cancelled thread can't poison the shared whisper_chunks/ namespace."""
+        import tempfile
+
+        from app.services.transcription_prewarm import TranscriptionPrewarmer
+
+        # Stub out the heavy EpisodeMatcher constructor.
+        fake_matcher = FakeMatcher()
+        fake_matcher.temp_dir = None  # will be overwritten by _build_matcher
+
+        monkeypatch.setattr(
+            "app.matcher.episode_identification.EpisodeMatcher",
+            lambda **kwargs: fake_matcher,
+        )
+        monkeypatch.setattr(
+            "app.services.config_service.get_config_sync",
+            lambda: None,
+        )
+
+        matcher = TranscriptionPrewarmer._build_matcher()
+
+        default_dir = str(Path(tempfile.gettempdir()) / "whisper_chunks")
+        prewarm_dir = str(Path(tempfile.gettempdir()) / "whisper_chunks_prewarm")
+        assert str(matcher.temp_dir) == prewarm_dir, (
+            f"Expected prewarm namespace {prewarm_dir!r}, got {matcher.temp_dir!r}"
+        )
+        assert str(matcher.temp_dir) != default_dir, (
+            "Prewarm temp_dir must differ from the shared whisper_chunks/ namespace"
+        )
+
+
+class TestFailSoftGranularity:
+    async def test_single_chunk_failure_continues_remaining(
+        self, tmp_path, config_flags, model_loader, duration_stub
+    ):
+        """A failure in chunk N must not prevent chunks N+1 .. end from warming."""
+        fail_at_start = int(OFFSETS[2])  # chunk 3 (0-indexed: 2) raises
+
+        class PartialFailMatcher(FakeMatcher):
+            def transcribe_chunk_cached(
+                self,
+                video_file,
+                start,
+                length,
+                model,
+                *,
+                file_key=None,
+                model_key=None,
+                temp_files=None,
+            ):
+                if int(start) == fail_at_start:
+                    raise RuntimeError("simulated transcription failure")
+                return super().transcribe_chunk_cached(
+                    video_file,
+                    start,
+                    length,
+                    model,
+                    file_key=file_key,
+                    model_key=model_key,
+                    temp_files=temp_files,
+                )
+
+        fm = PartialFailMatcher()
+        p = TranscriptionPrewarmer(semaphore_provider=lambda: CountingSemaphore())
+        p._matcher = fm
+
+        job_id, f = await _seed_review_job(tmp_path)
+        await _run_to_completion(p, job_id)
+
+        succeeded = [s for s, _l, _k in fm.transcribe_calls]
+        # Every offset except the failing one should have been attempted.
+        expected_ok = [int(off) for off in OFFSETS if int(off) != fail_at_start]
+        assert succeeded == expected_ok, f"Expected {expected_ok}, got {succeeded}"
+        # The file_key entry for the failing chunk must be absent; all others present.
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS:
+            if int(off) == fail_at_start:
+                assert transcript_store.get(file_key, off, CHUNK_LEN, CONFIG_KEY) is None
+            else:
+                assert transcript_store.get(file_key, off, CHUNK_LEN, CONFIG_KEY) is not None

--- a/backend/tests/unit/test_transcription_prewarm.py
+++ b/backend/tests/unit/test_transcription_prewarm.py
@@ -181,7 +181,9 @@ async def _run_to_completion(p: TranscriptionPrewarmer, job_id: int) -> None:
     await p.start_for_job(job_id)
     task = p._tasks.get(job_id)
     if task is not None:
-        await task
+        # Bind the (None) result: a bare `await name` statement trips CodeQL's
+        # no-effect check even though the await drives the task to completion.
+        _ = await task
     await asyncio.sleep(0)  # let add_done_callback pop the dict entry
 
 
@@ -216,7 +218,7 @@ class TestStartForJob:
         assert starts == 1
 
         release.set()
-        await first_task
+        _ = await first_task  # bare `await name` trips CodeQL's no-effect check
         await asyncio.sleep(0)
         assert p._tasks == {}
 
@@ -355,7 +357,9 @@ class TestCancellation:
 
         p.cancel_for_job(job_id)
         with pytest.raises(asyncio.CancelledError):
-            await task
+            # Awaiting the cancelled task re-raises CancelledError; binding the
+            # result avoids CodeQL's no-effect FP on a bare `await name`.
+            _ = await task
 
         assert len(fake_matcher.transcribe_calls) == 1  # nothing after cancel
         assert p._tasks == {}
@@ -720,7 +724,7 @@ class TestFailSoftGranularity:
                 )
 
         fm = PartialFailMatcher()
-        p = TranscriptionPrewarmer(semaphore_provider=lambda: CountingSemaphore())
+        p = TranscriptionPrewarmer(semaphore_provider=CountingSemaphore)
         p._matcher = fm
 
         job_id, f = await _seed_review_job(tmp_path)

--- a/backend/tests/unit/test_transcription_prewarm.py
+++ b/backend/tests/unit/test_transcription_prewarm.py
@@ -1,0 +1,505 @@
+"""Unit tests for the TranscriptionPrewarmer background service.
+
+The matcher and Whisper model are faked; the transcript store is the real
+module redirected to a tmp SQLite file by the global conftest fixture
+(``_isolate_transcript_store``), so coverage checks and write-through exercise
+the production key shapes.
+"""
+
+import asyncio
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.matcher import transcript_store
+from app.matcher.asr_models import model_output_key
+from app.matcher.episode_identification import canonical_scan_points
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.finalization_coordinator import FinalizationCoordinator
+from app.services.job_state_machine import JobStateMachine
+from app.services.transcription_prewarm import TranscriptionPrewarmer
+from tests.unit.conftest import _unit_session_factory
+
+# Import via importlib: app/services/__init__.py re-exports the ``job_manager``
+# INSTANCE, shadowing the submodule on plain ``import app.services.job_manager``.
+jm = importlib.import_module("app.services.job_manager")
+
+DURATION = 600
+CHUNK_LEN = 30
+MODEL_CONFIG = {"type": "whisper", "name": "small", "device": "cpu", "requested_workers": 1}
+CONFIG_KEY = model_output_key(MODEL_CONFIG)
+OFFSETS = canonical_scan_points(DURATION, skip_initial=90, chunk_len=CHUNK_LEN, num_points=10)
+
+
+class FakeMatcher:
+    """Just enough EpisodeMatcher surface for the prewarmer."""
+
+    chunk_duration = CHUNK_LEN
+    skip_initial_duration = 90
+
+    def __init__(self):
+        self.audio_chunks = {}
+        self.transcribe_calls: list[tuple[int, int, str]] = []
+        self.honest_key: str | None = None  # None -> same as the config-derived key
+
+    def _model_config(self):
+        return dict(MODEL_CONFIG)
+
+    def _model_key_for(self, model):
+        return self.honest_key or CONFIG_KEY
+
+    @staticmethod
+    def _resolve_source(mkv_file):
+        return str(Path(mkv_file).resolve())
+
+    def transcribe_chunk_cached(
+        self, video_file, start, length, model, *, file_key=None, model_key=None, temp_files=None
+    ):
+        self.transcribe_calls.append((int(start), int(length), model_key))
+        transcript_store.put(file_key, start, length, model_key, f"text-{start}")
+        return f"text-{start}"
+
+
+class CountingSemaphore:
+    """Async-context-manager stub counting per-chunk acquire/release."""
+
+    def __init__(self):
+        self.acquires = 0
+        self.releases = 0
+        self.held = 0
+        self.max_held = 0
+
+    async def __aenter__(self):
+        self.acquires += 1
+        self.held += 1
+        self.max_held = max(self.max_held, self.held)
+
+    async def __aexit__(self, *exc):
+        self.releases += 1
+        self.held -= 1
+        return False
+
+
+class BlockingSemaphore(CountingSemaphore):
+    """Lets the first acquire through, blocks the second forever (cancel target)."""
+
+    def __init__(self):
+        super().__init__()
+        self.blocked = asyncio.Event()
+        self._proceed = asyncio.Event()  # never set
+
+    async def __aenter__(self):
+        await super().__aenter__()
+        if self.acquires > 1:
+            self.blocked.set()
+            await self._proceed.wait()
+
+
+@pytest.fixture
+def config_flags(monkeypatch):
+    """Stub config_service.get_config with mutable prewarm flags."""
+    flags = SimpleNamespace(
+        enable_background_pretranscription=True,
+        pretranscribe_full_file=False,
+    )
+
+    async def _get_config():
+        return flags
+
+    monkeypatch.setattr("app.services.config_service.get_config", _get_config)
+    return flags
+
+
+@pytest.fixture
+def model_loader(monkeypatch):
+    """Stub asr_models.get_cached_model, recording every load."""
+    calls = []
+
+    def _get_cached_model(cfg):
+        calls.append(cfg)
+        return SimpleNamespace(name="fake-model")
+
+    monkeypatch.setattr("app.matcher.asr_models.get_cached_model", _get_cached_model)
+    return calls
+
+
+@pytest.fixture
+def duration_stub(monkeypatch):
+    monkeypatch.setattr("app.matcher.episode_identification.get_video_duration", lambda f: DURATION)
+
+
+@pytest.fixture
+def fake_matcher():
+    return FakeMatcher()
+
+
+@pytest.fixture
+def prewarmer(fake_matcher):
+    sem = CountingSemaphore()
+    p = TranscriptionPrewarmer(semaphore_provider=lambda: sem)
+    p._matcher = fake_matcher  # skip the lazy heavy build
+    return p, sem
+
+
+async def _seed_review_job(tmp_path, *, title_state=TitleState.REVIEW) -> tuple[int, Path]:
+    """Job parked in review with one title whose output file exists on disk."""
+    f = tmp_path / "show_t00.mkv"
+    f.write_bytes(b"\x00" * 2048)
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1D1",
+            content_type=ContentType.TV,
+            state=JobState.REVIEW_NEEDED,
+            detected_title="Some Show",
+            detected_season=1,
+            staging_path=str(tmp_path),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        session.add(
+            DiscTitle(
+                job_id=job.id,
+                title_index=0,
+                duration_seconds=DURATION,
+                state=title_state,
+                output_filename=str(f),
+            )
+        )
+        await session.commit()
+        return job.id, f
+
+
+async def _run_to_completion(p: TranscriptionPrewarmer, job_id: int) -> None:
+    """start_for_job + await the spawned task + let done-callbacks run."""
+    await p.start_for_job(job_id)
+    task = p._tasks.get(job_id)
+    if task is not None:
+        await task
+    await asyncio.sleep(0)  # let add_done_callback pop the dict entry
+
+
+class TestStartForJob:
+    async def test_disabled_flag_is_a_no_op(self, config_flags, prewarmer, model_loader):
+        config_flags.enable_background_pretranscription = False
+        p, _sem = prewarmer
+
+        await p.start_for_job(123)
+
+        assert p._tasks == {}
+        assert model_loader == []
+
+    async def test_double_start_is_idempotent(self, config_flags):
+        p = TranscriptionPrewarmer()
+        starts = 0
+        release = asyncio.Event()
+
+        async def fake_job(job_id, *, full_file):
+            nonlocal starts
+            starts += 1
+            await release.wait()
+
+        p._prewarm_job = fake_job
+
+        await p.start_for_job(7)
+        first_task = p._tasks[7]
+        await p.start_for_job(7)
+
+        assert p._tasks[7] is first_task
+        await asyncio.sleep(0)
+        assert starts == 1
+
+        release.set()
+        await first_task
+        await asyncio.sleep(0)
+        assert p._tasks == {}
+
+
+class TestCoverageAndTranscription:
+    async def test_fully_cached_file_never_loads_model(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        p, sem = prewarmer
+        job_id, f = await _seed_review_job(tmp_path)
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS:
+            transcript_store.put(file_key, off, CHUNK_LEN, CONFIG_KEY, "cached")
+
+        await _run_to_completion(p, job_id)
+
+        assert model_loader == []
+        assert p._matcher.transcribe_calls == []
+        assert sem.acquires == 0
+        assert p._tasks == {}
+
+    async def test_partial_coverage_transcribes_only_missing(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        p, sem = prewarmer
+        job_id, f = await _seed_review_job(tmp_path)
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS[:4]:
+            transcript_store.put(file_key, off, CHUNK_LEN, CONFIG_KEY, "cached")
+
+        await _run_to_completion(p, job_id)
+
+        assert len(model_loader) == 1
+        expected = [(off, CHUNK_LEN, CONFIG_KEY) for off in OFFSETS[4:]]
+        assert p._matcher.transcribe_calls == expected
+        # Semaphore taken and released once PER CHUNK, never held across chunks.
+        assert sem.acquires == len(expected)
+        assert sem.releases == len(expected)
+        assert sem.max_held == 1
+        # Write-through landed in the store under the honest key.
+        for off in OFFSETS:
+            assert transcript_store.get(file_key, off, CHUNK_LEN, CONFIG_KEY) is not None
+
+    async def test_empty_string_transcript_counts_as_cached(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        """A cached "" (silent audio) is a hit, not a miss."""
+        p, _sem = prewarmer
+        job_id, f = await _seed_review_job(tmp_path)
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS:
+            transcript_store.put(file_key, off, CHUNK_LEN, CONFIG_KEY, "")
+
+        await _run_to_completion(p, job_id)
+
+        assert model_loader == []
+        assert p._matcher.transcribe_calls == []
+
+    async def test_full_file_flag_warms_full_span(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        config_flags.pretranscribe_full_file = True
+        p, _sem = prewarmer
+        job_id, f = await _seed_review_job(tmp_path)
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS:
+            transcript_store.put(file_key, off, CHUNK_LEN, CONFIG_KEY, "cached")
+
+        await _run_to_completion(p, job_id)
+
+        # Grid fully cached -> only the (0, duration) full-file span is warmed,
+        # keyed exactly as transcribe_full's L2 entry.
+        assert p._matcher.transcribe_calls == [(0, DURATION, CONFIG_KEY)]
+        assert transcript_store.get(file_key, 0, DURATION, CONFIG_KEY) is not None
+
+    async def test_full_file_off_does_not_warm_full_span(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        p, _sem = prewarmer
+        job_id, f = await _seed_review_job(tmp_path)
+
+        await _run_to_completion(p, job_id)
+
+        starts = [c[0] for c in p._matcher.transcribe_calls]
+        assert starts == list(OFFSETS)  # grid only, no (0, DURATION) span
+        file_key = transcript_store.file_key_for(f)
+        assert transcript_store.get(file_key, 0, DURATION, CONFIG_KEY) is None
+
+    async def test_honest_key_recheck_skips_transcription(
+        self, tmp_path, config_flags, prewarmer, model_loader, duration_stub
+    ):
+        """Config key misses, but the post-load (honest) key is fully cached."""
+        p, _sem = prewarmer
+        p._matcher.honest_key = "whisper_small_cuda_float16"
+        job_id, f = await _seed_review_job(tmp_path)
+        file_key = transcript_store.file_key_for(f)
+        for off in OFFSETS:
+            transcript_store.put(file_key, off, CHUNK_LEN, p._matcher.honest_key, "cached")
+
+        await _run_to_completion(p, job_id)
+
+        # The model HAD to load (config-derived key looked uncovered), but the
+        # honest-key recheck found full coverage -> zero transcriptions.
+        assert len(model_loader) == 1
+        assert p._matcher.transcribe_calls == []
+
+    async def test_no_candidate_files_skips_matcher_build(
+        self, tmp_path, config_flags, model_loader
+    ):
+        """Organized/failed titles and missing files never touch the matcher."""
+        p = TranscriptionPrewarmer()
+        built = MagicMock()
+        p._build_matcher = built
+        job_id, f = await _seed_review_job(tmp_path, title_state=TitleState.COMPLETED)
+
+        await _run_to_completion(p, job_id)
+
+        built.assert_not_called()
+        assert model_loader == []
+
+
+class TestCancellation:
+    async def test_cancel_mid_fill_stops_promptly(
+        self, tmp_path, config_flags, fake_matcher, model_loader, duration_stub
+    ):
+        sem = BlockingSemaphore()
+        p = TranscriptionPrewarmer(semaphore_provider=lambda: sem)
+        p._matcher = fake_matcher
+        job_id, _f = await _seed_review_job(tmp_path)
+
+        await p.start_for_job(job_id)
+        task = p._tasks[job_id]
+        # First chunk transcribes; the second acquire blocks -> cancel there.
+        await asyncio.wait_for(sem.blocked.wait(), timeout=5)
+        assert len(fake_matcher.transcribe_calls) == 1
+
+        p.cancel_for_job(job_id)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert len(fake_matcher.transcribe_calls) == 1  # nothing after cancel
+        assert p._tasks == {}
+
+    async def test_cancel_for_job_absent_is_safe(self):
+        TranscriptionPrewarmer().cancel_for_job(424242)  # must not raise
+
+    async def test_on_job_terminal_cancels_task(self):
+        p = TranscriptionPrewarmer()
+        fake_task = MagicMock()
+        fake_task.done.return_value = False
+        p._tasks[5] = fake_task
+
+        await p.on_job_terminal(5, JobState.COMPLETED)
+
+        fake_task.cancel.assert_called_once()
+        assert 5 not in p._tasks
+
+    async def test_cancel_all_sweeps_every_task(self):
+        p = TranscriptionPrewarmer()
+        tasks = {}
+        for jid in (1, 2):
+            t = MagicMock()
+            t.done.return_value = False
+            tasks[jid] = t
+            p._tasks[jid] = t
+
+        p.cancel_all()
+
+        for t in tasks.values():
+            t.cancel.assert_called_once()
+        assert p._tasks == {}
+
+
+class TestJobManagerWiring:
+    def test_review_trigger_and_terminal_hook_registered(self):
+        assert jm.job_manager._start_prewarm_on_review in jm.state_machine._on_transition_callbacks
+        assert jm.job_manager._prewarmer.on_job_terminal in jm.state_machine._on_terminal_callbacks
+
+    async def test_review_transition_kicks_off_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+
+        jm.job_manager._start_prewarm_on_review(7, JobState.REVIEW_NEEDED)
+        mock_prewarmer.kickoff.assert_called_once_with(7)
+
+        jm.job_manager._start_prewarm_on_review(7, JobState.MATCHING)
+        mock_prewarmer.kickoff.assert_called_once()  # unchanged: review-only
+
+    async def test_finalization_review_parking_triggers_prewarm(self, tmp_path, monkeypatch):
+        """check_job_completion parking a TV job in review flows through the
+        on_transition chokepoint into prewarmer.kickoff."""
+        broadcaster = MagicMock()
+        broadcaster.broadcast_job_completed = AsyncMock()
+        broadcaster.broadcast_job_failed = AsyncMock()
+        broadcaster.broadcast_job_state_changed = AsyncMock()
+        sm = JobStateMachine(broadcaster)
+        coord = FinalizationCoordinator(broadcaster, sm)
+        coord.finalize_disc_job = AsyncMock()
+
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        sm.on_transition(jm.job_manager._start_prewarm_on_review)
+
+        async with _unit_session_factory() as session:
+            job = DiscJob(
+                drive_id="E:",
+                volume_label="SHOW_S1D1",
+                content_type=ContentType.TV,
+                state=JobState.MATCHING,
+                detected_title="Some Show",
+                detected_season=1,
+                staging_path=str(tmp_path),
+                subtitle_status="completed",
+            )
+            session.add(job)
+            await session.commit()
+            await session.refresh(job)
+            job_id = job.id
+            session.add(
+                DiscTitle(
+                    job_id=job_id,
+                    title_index=0,
+                    duration_seconds=DURATION,
+                    matched_episode="S01E01",
+                    match_confidence=0.8,
+                    state=TitleState.MATCHED,
+                )
+            )
+            session.add(
+                DiscTitle(
+                    job_id=job_id,
+                    title_index=1,
+                    duration_seconds=DURATION,
+                    state=TitleState.REVIEW,
+                )
+            )
+            await session.commit()
+
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+
+        mock_prewarmer.kickoff.assert_called_once_with(job_id)
+
+    async def test_set_name_and_resume_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        monkeypatch.setattr(jm.job_manager._identification, "set_name_and_resume", AsyncMock())
+        run_ripping = AsyncMock()
+        monkeypatch.setattr(jm.job_manager, "_run_ripping", run_ripping)
+
+        await jm.job_manager.set_name_and_resume(11, "Show", "tv")
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(11)
+        await jm.job_manager._active_jobs.pop(11)
+
+    async def test_re_identify_job_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        monkeypatch.setattr(
+            jm.job_manager._identification,
+            "re_identify",
+            AsyncMock(return_value={"has_ripped": True}),
+        )
+        monkeypatch.setattr(jm.job_manager, "_rerun_matching", AsyncMock())
+
+        await jm.job_manager.re_identify_job(12, "Show", "tv")
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(12)
+        await jm.job_manager._active_jobs.pop(12)
+
+    async def test_rerun_matching_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+
+        # Nonexistent job: _rerun_matching returns right after the cancel seam.
+        await jm.job_manager._rerun_matching(999_999)
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(999_999)
+
+    async def test_rematch_single_title_cancels_prewarm(self, monkeypatch):
+        mock_prewarmer = MagicMock()
+        monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
+        monkeypatch.setattr(jm.job_manager._matching, "rematch_single_title", AsyncMock())
+
+        await jm.job_manager.rematch_single_title(13, 1)
+
+        mock_prewarmer.cancel_for_job.assert_called_once_with(13)

--- a/docs/superpowers/specs/2026-06-10-walk-away-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-10-walk-away-workflow-design.md
@@ -1,0 +1,170 @@
+# Walk-Away Workflow: Rip-First Deferral + Transcript Cache + Disc-Hash Recognition
+
+## Context
+
+[Issue #370's comment](https://github.com/Jsakkos/engram/issues/370#issuecomment-4673060578) (craigthings, 2026-06-10): the #370 fix added a **pre-rip** season prompt, so a headless-server user now visits the web app twice — once at disc insert (season prompt), once at job end (review). They propose ripping everything first and pooling all human-in-the-loop moments into a single end-of-job review: "drop a disc and walk away, check in once at the end if needed."
+
+We agree, and go further. The friction in the commenter's version — "user still waits for matching after answering at review" — is solved by caching ASR transcripts: re-matching with corrected metadata becomes a ~ms TF-IDF operation instead of a 5–10 min Whisper re-run. Three workstreams, in order:
+
+- **Phase A** — persistent ASR transcript cache + nested scan grid + background pre-transcription (makes deferred review *fast*)
+- **Phase B** — rip-first deferral of all identity prompts (makes review *pooled*, often *zero-touch*)
+- **Phase C** — disc-hash recognition in the fingerprint network (makes review *unnecessary* for discs the network has seen)
+
+### Key facts established by exploration
+
+- **Ripping needs almost nothing.** Only TV-vs-movie content type influences title selection; `tmdb_id`/`season` are pure matching-time inputs. Four conditions park a job in REVIEW_NEEDED *before* ripping today (`identification_coordinator.py`): (A) unreadable label, (B) TV + TMDB lookup failed, (C) same-name no-year collision, (D) the #370 unknown-season gate (`_gate_unknown_season_disc`, line 519). The ambiguous-movie flow (lines ~448-477) already rips first — precedent exists.
+- **ASR transcripts are metadata-independent.** A track's Whisper output is identical regardless of candidate show/season. Today it's memoized only in-memory (`EpisodeMatcher.transcriptions`, session-only, lost on restart). Whisper is ~5–10 min/file; TF-IDF matching is ~1ms/chunk.
+- **Scan grids don't nest today.** 10-point standard scan and 25-point deep re-match (`STRICT_SCAN_POINTS`) compute *different* offsets, so cached chunk transcripts can't be reused across depths without grid alignment.
+- **The disc hash already flows.** `compute_content_hash` (extractor.py:147-202, BD `BDMV/STREAM` + DVD `VIDEO_TS`) runs unconditionally at insert and rides along with every fingerprint contribution; the server already counts `(pseudonym, disc_content_hash)` pairs in promotion. Missing: per-title scan metadata in the payload, a `disc_canonical` aggregate, and a lookup endpoint.
+
+### Decisions (user-confirmed)
+
+1. **Unknown season** → rip + auto cross-season match (machinery exists: all-seasons subtitle prefetch + `_match_across_seasons`); review only if inconclusive. Season-prompt CTA stays available as an optional shortcut.
+2. **Ambiguous TV-vs-movie** → rip permissively (all titles ≥ 15 min, else longest), decide at review.
+3. **One plan, phases A → B → C, each its own PR** (C is two PRs: server first, then client).
+
+### Push-backs incorporated (vs. the original proposal)
+
+- Cache **transcripts (text)**, not extracted audio segments: tiny (≤1 KB/chunk), skips *both* ffmpeg and Whisper; WAVs stay ephemeral temp files.
+- "Index the audio tracks" needs nothing new — chromaprint blobs are already persisted per `DiscTitle`.
+- "Extract remaining segments on review" requires the nested grid (below); with it, "remaining" is well-defined and the deep re-match ladder reuses everything.
+
+---
+
+## Phase A — Transcript cache + nested scan grid + prewarm (PR 1)
+
+### A1. Canonical nested scan grid
+
+`episode_identification.py` (~line 1528): replace the inline scan-point loop with a module-level `canonical_scan_points(video_duration, *, skip_initial, skip_final=120, chunk_len=30, num_points=10)`. Levels `n_k = 9·2^k + 1` → 10, 19, 37, 73, 145; each level inserts midpoints of the previous, so **every shallower level is a strict subset of every deeper one**. `num_points` snaps UP to the nearest level.
+
+**Use integer arithmetic**: `point = skip_initial + (i * available) // (n - 1)` (multiply before divide). Rationally, level-k point `i` ≡ level-k+1 point `2i`; integer floor division preserves this exactly, where per-level float `interval` can differ in the last ulp and break the subset property after truncation. Offsets may shift ≤1 s vs today's float path — immaterial for 30 s chunks; don't write a regression test pinning today's exact float offsets.
+
+Snap depth constants to the lattice: `STRICT_SCAN_POINTS` 25 → **37** (`matching_coordinator.py:34`); `_CONFLICT_FIXED_DEPTHS` (25, 50) → **(37, 73)** and snap the full-coverage tier to the largest level ≤ `_full_coverage_points` (`finalization_coordinator.py:132`, `:212`). Risk to note in PR: escalation passes get ~48% denser but fully reuse the shallower pass's transcripts.
+
+### A2. Persistent transcript store
+
+New `backend/app/matcher/transcript_store.py`, modeled on `tmdb_persistent_cache.py` (per-thread sqlite3 + WAL + init lock — matcher is sync code in threads). DB: `~/.engram/cache/transcripts.sqlite`.
+
+```sql
+CREATE TABLE transcripts (
+  file_key TEXT NOT NULL,      -- sha1(f"{resolved_path}|{size_bytes}|{mtime_ns}")
+  start_s INTEGER NOT NULL, duration_s INTEGER NOT NULL,
+  model_key TEXT NOT NULL,     -- output-affecting ASR identity
+  text TEXT NOT NULL, created_at INTEGER NOT NULL, last_used_at INTEGER NOT NULL,
+  PRIMARY KEY (file_key, start_s, duration_s, model_key));
+```
+
+- `model_key`: new helper `model_output_key()` in `asr_models.py` = `f"{type}_{name}_{device}_{compute_type}"` (compute_type IS output-affecting — int8 vs float16; worker counts are NOT, keep them out).
+- File identity via path+size+mtime_ns: re-rips get fresh keys automatically; no hashing of 30 GB files.
+- Eviction: size-capped LRU (~100k rows, prune by `last_used_at` every ~200 puts). Do **not** evict on staging cleanup — rows are tiny, dead rows are harmless, and surviving restarts is the headline win.
+- Every get/put in try/except: cache failure degrades to "just transcribe", never breaks matching.
+
+Wire into `EpisodeMatcher`: factor the memoized-transcribe block (lines 1595-1613) into `transcribe_chunk_cached()` with lookup order L1 dict → store → ffmpeg+Whisper (write-through both). Same layering in `transcribe_full` (line ~1277) — full-file transcripts persist when produced, just not prewarmed.
+
+### A3. Background pre-transcription ("fill the grid")
+
+New `backend/app/services/transcription_prewarm.py`: `TranscriptionPrewarmer` with a dedicated `EpisodeMatcher` (constructor args matching `EpisodeCurator._ensure_initialized` so `model_key`s align), per-job `asyncio.Task` dict, and the `MatchingCoordinator._match_semaphore`.
+
+- `start_for_job(job_id)`: for each ripped title's file, walk the 10-point lattice; for each missing store row: **acquire the match semaphore per chunk**, `asyncio.to_thread(transcribe_chunk_cached)`, release. Per-chunk acquisition means a live match waits at most one chunk — no priority queue needed. Idempotent (get-before-compute).
+- `cancel_for_job(job_id)`: wired to `JobStateMachine.on_terminal_state` plus the entry of `re_identify` / `set_name_and_resume` / rerun-matching (the real match owns the GPU; it reuses whatever got cached).
+- Full-file prewarm gated behind config flag, default **off** (grid is what re-match needs; full-file is 5–10 min of speculative GPU per file).
+- Phase A triggers: TV job parks in REVIEW_NEEDED with rematchable titles (`check_job_completion`), ambiguous-movie post-rip review. Phase B adds the awaiting-identity trigger.
+
+Config: `enable_background_pretranscription: bool = True`, `pretranscribe_full_file: bool = False` — **three-way sync** (AppConfig model + ConfigUpdate + ConfigResponse/GET + ConfigWizard) + Alembic migration with server_default (frozen builds converge via `_add_missing_columns`).
+
+### A4. Tests
+
+- Unit: lattice subset/coverage property tests; store round-trip, invalidation on size/mtime change, LRU prune, corrupt-DB resilience; prewarm scheduler (per-chunk acquire/release, cancellation) with stub semaphore; fake ASR model counting `transcribe()` calls — a *fresh matcher instance* (simulated restart) re-matching the same file does **zero** ASR calls.
+- Integration: park a job in review with real fixture MKVs → prewarm fills exactly 10 rows → re-identify completes with mocked-ASR never invoked.
+- Manual: `POST /api/simulate/insert-disc-from-staging` with real MKVs → land in review → watch `transcripts.sqlite` rows → `POST /api/jobs/{id}/re-identify` → log shows cache hits, sub-second per-title match.
+
+---
+
+## Phase B — Rip-first deferral of identity prompts (PR 2)
+
+### B1. State/UX model
+
+New nullable `DiscJob.identity_prompt_json` (`disc_job.py` + migration): `{"kind": "name"|"season"|"reidentify", "reason": "<text>"}`. Do **not** overload `review_reason` while RIPPING — too much code couples it to REVIEW_NEEDED. `identity_prompt_json` = non-blocking CTA; `review_reason` = blocking pooled review. At rip end an unanswered prompt converts into `review_reason`; answering clears it.
+
+Gate rework in `identify_disc` (`identification_coordinator.py`):
+
+| Today's pre-rip park | New behavior |
+|---|---|
+| (A) unreadable label (~:339) | prompt `kind=name`, permissive title selection, → RIPPING |
+| (B) TV + tmdb_id None (~:394) | prompt `kind=name` (keep "merged without separators" literal — frontend contract), skip prefetch, → RIPPING |
+| (C) no-year/ambiguous collision (~:371) | prompt `kind=reidentify` (keep `candidates_json`), skip prefetch, → RIPPING |
+| (D) unknown season (`_gate_unknown_season_disc` :519) | no park: all-seasons subtitle prefetch (existing `detected_season is None` path, :585-608), prompt `kind=season` ("select a season" literal preserved) as optional shortcut, → RIPPING, cross-season matching runs automatically |
+
+Permissive selection helper (content type UNKNOWN/ambiguous): select all titles ≥ 900 s, else longest. Ambiguous-movie flow unchanged.
+
+### B2. Matching gate + convergence
+
+- `JobManager._on_title_ripped` (job_manager.py:2411-2424): dispatch `match_single_file` only when identity ready (`detected_title` set AND `identity_prompt_json is None`; season may be unknown — cross-season handles it). Otherwise leave title `QUEUED` (already counts as active in `check_job_completion`, so no premature finalize). On a mid-rip answer, dispatch matching for every QUEUED title with `output_filename` (mirror the dispatch loop in `identify_from_staging`).
+- `_run_ripping` post-rip (job_manager.py:~2120): **re-read `content_type` from DB** (the captured local goes stale after a mid-rip answer). Identity ready → MATCHING (today). Pending → REVIEW_NEEDED with `review_reason` from the prompt + `prewarmer.start_for_job()`.
+- `set_name_and_resume` / `re_identify` accept `state == RIPPING`: update metadata (+ existing `_resolve_missing_tmdb_id`), clear prompt, kick subtitle prefetch, dispatch ripped QUEUED titles, **no state change, no new rip task** — `JobManager.set_name_and_resume` (:798-810) must branch instead of unconditionally spawning `_run_ripping` (double-rip hazard). Extend `re_identify`'s has_ripped branch: a "movie" answer routes to the multi-title movie resolution path, not MATCHING.
+- Season pinning in `MatchingCoordinator._match_single_file_inner`: when `job.detected_season is None` and **≥2 MATCHED titles agree on a season with zero MATCHED disagreement**, pin `job.detected_season` (persist + broadcast) so later titles take the cheap single-season path and chromaprint prepass re-engages. Per-title "review only if inconclusive" falls out of the existing calibrated-confidence gate (< 0.7 → review) — no new threshold.
+
+### B3. Frontend
+
+- `Job` type gains `identity_prompt`; include it in REST jobs payload AND `broadcast_job_update` (remember the REST/WS serializer-drift hazard — both sides or the UI silently defaults).
+- `promptSelection.ts`: `classifyPromptJob` checks `identity_prompt.kind` first (any non-terminal state), falls back to `review_reason` substrings; `selectPromptJobs` widens to `ripping || review_needed`. `shouldAutoOpenPrompt` (only-active-job rule, P13) unchanged.
+- `adapters.ts`: `promptKind` for ripping jobs; `App.tsx` routes `'reidentify'` → ReIdentifyModal; verify modals don't optimistically assume state flips to RIPPING on submit.
+- `simulation_service.py`: add `identity_pending` param so sims can produce a RIPPING job carrying a prompt (sim bypasses `identify_disc`; required for E2E).
+
+### B4. Tests
+
+- Backend unit: each gate reaches RIPPING with the right prompt; `_on_title_ripped` gating + retroactive dispatch; mid-rip `set_name_and_resume` mutates without state change/second rip; post-rip pending → pooled REVIEW_NEEDED; season pinning (2-agree/0-disagree; conflict → no pin).
+- Frontend unit: `promptSelection.test.ts` ripping-state classification + auto-open + dismissal.
+- Integration: unreadable label → rip → mid-rip answer → matching → zero review stops; and no-answer → exactly one pooled REVIEW_NEEDED.
+- Manual sim: insert with `identity_pending=name` → assert ripping + CTA → `set-name` mid-rip → still ripping, prompt cleared → MATCHING at rip end. Caveat (state in PR): sim bypasses `identify_disc`, so gate rewiring is covered by integration tests only.
+- Risks to note: junk discs now consume rip time/staging space before identity confirmation (accepted); ambiguous-type discs rip more titles; `review_reason` is now strictly "blocking review".
+
+---
+
+## Phase C — Disc-hash recognition (PR 3: server repo; PR 4: engram client)
+
+Server work on a **branch** in `C:\Github\engram-fingerprint-server` (main auto-deploys to prod).
+
+### C1. Server (engram-fingerprint-server)
+
+- `migrations/003_disc_recognition.sql`: `disc_contribution` (pseudonym, disc_content_hash BLOB, tmdb_id, content_type, season, canonical `titles_json` + sha256 `titles_digest`, dedupe unique index on (pseudonym, hash, digest)) and `disc_canonical` (hash PK, tmdb_id, content_type, season, titles_json, tier, unique_contributors, mean_confidence).
+- `POST /v1/contribute-disc` (new route + zod schema; per-title rows mirror `DiscDbTitleMapping`: title_index, duration_seconds, size_bytes, assignment {episode|main_movie|extra|discarded, season, episode}, match_confidence, match_source). Separate endpoint, not a `/v1/contribute` field — avoids a wire_format_version bump for every client.
+- `GET /v1/identify-disc?hash=<b64url>` → `{disc: null}` or `{disc: {tmdb_id, content_type, season, tier, unique_contributors, mean_confidence, titles}}`. Single indexed point read.
+- `disc_promotion.ts` in the nightly cron: group by (hash, digest), latest row per pseudonym, exclude flagged contributors and mean confidence < 0.7; tiers per the existing ladder (≥3 pseudonyms + mean ≥0.85 → canonical, ≥2 → confirmed, ≥1 → candidate); conflicting digests → most-contributors wins, runner-up with ≥2 caps tier at confirmed. **Anti-feedback rule: exclude `match_source == "network_disc"` rows from counting** — a client that applied a network mapping must not confirm it.
+- `/v1/forget` cascades to `disc_contribution`.
+- Vitest: validation, dedupe, tiering incl. digest conflict + network_disc exclusion, identify hit/miss, forget.
+
+### C2. Client (engram)
+
+- **Read path**: new `backend/app/core/fingerprint_disc_classifier.py` — `identify_disc_via_network(content_hash, server_url)`, 3–5 s timeout, best-effort. Called in `_run_classification` **before** the TheDiscDB block, gated on `enable_fingerprint_identification` (same trust domain, no new flag) + `job.content_hash`.
+  - `canonical`: override like the DiscDB ≥0.90 path — set content_type/tmdb_id/name, confidence 0.99, `classification_source="fingerprint_network"`, no review; convert titles → `DiscDbTitleMapping` list **filtered to titles whose (duration ±2 s, size ±1%) match a scanned title** (guards MakeMKV-version drift), feed through existing `_set_discdb_mappings` + `discdb_mappings_json` so `try_discdb_assignment` auto-assigns episodes at rip time, zero ASR. Parameterize `try_discdb_assignment`'s hardcoded `"discdb"` source → `"network_disc"`.
+  - `confirmed`: identity only (skips all Phase B prompts); chromaprint/ASR verify episodes as today. `candidate`: ignore.
+- **Write path**: `DiscContributionQueue` model (mirror `FingerprintContribution`) + migration. Enqueue on COMPLETED via `on_terminal_state`: require content_hash + tmdb_id + known type + ≥1 real assignment; build rows from `DiscTitle` fields; **skip enqueue when every assignment's source is `network_disc`**. Drain inside `ContributionUploader._drain` after the episode sweep — same consent gates (`enable_fingerprint_contributions` + `fingerprint_disclosure_accepted`), retry semantics, and audit JSONL (`kind: "disc"`).
+- **Privacy**: disc records are release-level (pressed-disc layout), not personal; pseudonym remains the only identifier, `/v1/forget` covers it. Update JIT disclosure copy + settings text + docs privacy page; no new toggle.
+
+### C3. Tests / verification
+
+- Client unit: per-tier override behavior; tolerance rejection; enqueue payload golden test; network_disc skip rule; consent gating.
+- Integration: mocked httpx canonical response → zero `match_single_file` dispatches, all mapped titles pre-assigned.
+- Manual: `fingerprint_server_url` → local `wrangler dev`; contribute the same disc under 2–3 pseudonyms, run promotion, re-insert → no prompts, no matching. Caveat: sim jobs never get `content_hash` (sim bypasses `_create_job_for_disc`) — optionally add a `content_hash` sim param.
+
+---
+
+## What does NOT change
+
+Chromaprint prepass + 0.90 gate; organizer; review-queue episode-assignment UX (only adds identity/type prompts, removes pre-rip parks); subtitle download mechanics (only *when* prefetch starts); episode fingerprint contributions; pack serving; `compute_content_hash`.
+
+## Verification (end-to-end, after all phases)
+
+1. Backend `uv run pytest` (unit/integration/pipeline tiers), frontend `npm run test:unit` + `npm run test:e2e` (DEBUG=true backend; use worktree-isolated ports per CLAUDE.md).
+2. Walk-away scenario, real or staged disc: insert season-less multi-season disc → rips with CTA visible, no modal block → no user action → single REVIEW_NEEDED at end (or zero if cross-season decisive) → answer season → titles match in seconds (transcript cache hits in log).
+3. Mid-rip answer scenario: answer the CTA during rip → matching dispatches for already-ripped titles → job completes with zero review stops.
+4. Network scenario (Phase C): second insert of a community-known disc → identified + episode-assigned with no prompts and no ASR.
+5. Kill this session's servers before each PR (CLAUDE.md rule).
+
+## Follow-ups (out of scope)
+
+- Reply on issue #370 summarizing the direction (offer after plan approval).
+- Push/ntfy notification when a job lands in review (headless UX complement).
+- Speculative both-candidate matching for same-name twins using cached transcripts (noise-floor disambiguation — show-identity-collision item 3).
+- On implementation start: copy this plan into `docs/superpowers/specs/2026-06-10-walk-away-workflow-design.md` per repo convention.

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -163,3 +163,30 @@ describe('ConfigWizard — deep-linking (M2)', () => {
         expect(screen.queryByText('Max Concurrent Matches')).not.toBeInTheDocument();
     });
 });
+
+describe('ConfigWizard — background pre-transcription toggles', () => {
+    it('renders both toggles with defaults and sends the flipped value on save', async () => {
+        const onComplete = vi.fn();
+        render(<ConfigWizard {...noop} onComplete={onComplete} isOnboarding={false} initialSection="preferences" />);
+
+        // Master switch ships enabled; the expensive full-file option ships off.
+        const master = await screen.findByRole('checkbox', { name: /background pre-transcription/i });
+        expect(master).toBeChecked();
+        const fullFile = screen.getByRole('checkbox', { name: /pre-transcribe entire files/i });
+        expect(fullFile).not.toBeChecked();
+
+        // Disabling the master switch hides the dependent full-file option.
+        fireEvent.click(master);
+        expect(screen.queryByRole('checkbox', { name: /pre-transcribe entire files/i })).not.toBeInTheDocument();
+
+        // The flipped value reaches the PUT payload (three-way sync, frontend leg).
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+        await waitFor(() => expect(onComplete).toHaveBeenCalled());
+        const putCall = (fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls.find(
+            (c) => c[1]?.method === 'PUT',
+        );
+        const body = JSON.parse(putCall?.[1]?.body as string);
+        expect(body.enable_background_pretranscription).toBe(false);
+        expect(body.pretranscribe_full_file).toBe(false);
+    });
+});

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -189,4 +189,45 @@ describe('ConfigWizard — background pre-transcription toggles', () => {
         expect(body.enable_background_pretranscription).toBe(false);
         expect(body.pretranscribe_full_file).toBe(false);
     });
+
+    it('reads snake_case GET fields and does not fall back to defaults when values are present', async () => {
+        // Verifies the camelCase←snake_case GET mapping: a typo in the reader key would
+        // let the ?? fallback silently paper over the bug and this test would fail.
+        mockApi({ enable_background_pretranscription: false, pretranscribe_full_file: true });
+        const onComplete = vi.fn();
+        render(<ConfigWizard {...noop} onComplete={onComplete} isOnboarding={false} initialSection="preferences" />);
+
+        // Master off — GET value (false) must win over the ?? true default.
+        const master = await screen.findByRole('checkbox', { name: /background pre-transcription/i });
+        expect(master).not.toBeChecked();
+
+        // Sub-toggle is hidden while master is off; re-enable master to reveal it.
+        fireEvent.click(master);
+        const fullFile = await screen.findByRole('checkbox', { name: /pre-transcribe entire files/i });
+        // GET value (true) must win over the ?? false default — not just the default.
+        expect(fullFile).toBeChecked();
+    });
+
+    it('sends pretranscribe_full_file=true in PUT when sub-toggle is explicitly enabled', async () => {
+        // Pins the non-default value on the PUT leg (camelCase→snake_case serialisation).
+        const onComplete = vi.fn();
+        render(<ConfigWizard {...noop} onComplete={onComplete} isOnboarding={false} initialSection="preferences" />);
+
+        // Master is on by default; turn on the sub-toggle (ships off).
+        await screen.findByRole('checkbox', { name: /background pre-transcription/i });
+        const fullFile = screen.getByRole('checkbox', { name: /pre-transcribe entire files/i });
+        expect(fullFile).not.toBeChecked();
+        fireEvent.click(fullFile);
+        expect(fullFile).toBeChecked();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+        await waitFor(() => expect(onComplete).toHaveBeenCalled());
+        const putCall = (fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls.find(
+            (c) => c[1]?.method === 'PUT',
+        );
+        const body = JSON.parse(putCall?.[1]?.body as string);
+        // Both fields sent; sub-toggle carries non-default true value.
+        expect(body.enable_background_pretranscription).toBe(true);
+        expect(body.pretranscribe_full_file).toBe(true);
+    });
 });

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -108,6 +108,8 @@ interface ConfigData {
     libraryTvPath: string;
     tmdbApiKey: string;
     maxConcurrentMatches: number;
+    enableBackgroundPretranscription: boolean;
+    pretranscribeFullFile: boolean;
     ffmpegPath: string;
     conflictResolutionDefault: string;
     episodeOrderingPreference: 'aired' | 'dvd';
@@ -184,6 +186,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         libraryTvPath: '',
         tmdbApiKey: '',
         maxConcurrentMatches: 2,
+        enableBackgroundPretranscription: true,
+        pretranscribeFullFile: false,
         ffmpegPath: '',
         conflictResolutionDefault: 'ask',
         episodeOrderingPreference: 'aired',
@@ -293,6 +297,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     libraryTvPath: data.library_tv_path || '',
                     tmdbApiKey: data.tmdb_api_key === '***' ? '' : (data.tmdb_api_key || ''),
                     maxConcurrentMatches: data.max_concurrent_matches ?? 2,
+                    enableBackgroundPretranscription: data.enable_background_pretranscription ?? true,
+                    pretranscribeFullFile: data.pretranscribe_full_file ?? false,
                     ffmpegPath: data.ffmpeg_path || '',
                     conflictResolutionDefault: data.conflict_resolution_default || 'ask',
                     episodeOrderingPreference: data.episode_ordering_preference || 'aired',
@@ -450,6 +456,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     library_tv_path: config.libraryTvPath,
                     tmdb_api_key: config.tmdbApiKey,
                     max_concurrent_matches: config.maxConcurrentMatches,
+                    enable_background_pretranscription: config.enableBackgroundPretranscription,
+                    pretranscribe_full_file: config.pretranscribeFullFile,
                     ffmpeg_path: config.ffmpegPath,
                     conflict_resolution_default: config.conflictResolutionDefault,
                     episode_ordering_preference: config.episodeOrderingPreference,
@@ -1327,6 +1335,40 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                         <div id={GPU_ANCHOR_ID}>
                             <GpuAccelerationSetting />
                         </div>
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    checked={config.enableBackgroundPretranscription}
+                                    onChange={(e) => handleInputChange('enableBackgroundPretranscription', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>Background Pre-Transcription</strong>
+                                    <span className="checkbox-hint">
+                                        While a job waits in the review queue, transcribe its unresolved tracks in the background so re-matching after your review is near-instant. Uses idle CPU/GPU time; transcripts are cached locally.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
+
+                        {config.enableBackgroundPretranscription && (
+                            <div className="form-group checkbox-group">
+                                <label className="checkbox-label">
+                                    <input
+                                        type="checkbox"
+                                        checked={config.pretranscribeFullFile}
+                                        onChange={(e) => handleInputChange('pretranscribeFullFile', e.target.checked)}
+                                    />
+                                    <span className="checkbox-text">
+                                        <strong>Pre-Transcribe Entire Files</strong>
+                                        <span className="checkbox-hint">
+                                            Also transcribe each unresolved track end-to-end, not just the scan points. Expensive (roughly 5&ndash;10 minutes of GPU time per file) &mdash; worth it if your GPU sits idle and matches often fall back to full-file transcription.
+                                        </span>
+                                    </span>
+                                </label>
+                            </div>
+                        )}
 
                         <div className="form-group">
                             <label htmlFor="conflictResolution">Default Conflict Resolution</label>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1346,7 +1346,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 <span className="checkbox-text">
                                     <strong>Background Pre-Transcription</strong>
                                     <span className="checkbox-hint">
-                                        While a job waits in the review queue, transcribe its unresolved tracks in the background so re-matching after your review is near-instant. Uses idle CPU/GPU time; transcripts are cached locally.
+                                        While a job waits in the review queue, transcribe its unresolved tracks in the background so re-matching after your review is near-instant. Runs in the background while jobs wait for your review; transcripts are cached locally.
                                     </span>
                                 </span>
                             </label>
@@ -1363,7 +1363,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                     <span className="checkbox-text">
                                         <strong>Pre-Transcribe Entire Files</strong>
                                         <span className="checkbox-hint">
-                                            Also transcribe each unresolved track end-to-end, not just the scan points. Expensive (roughly 5&ndash;10 minutes of GPU time per file) &mdash; worth it if your GPU sits idle and matches often fall back to full-file transcription.
+                                            Also transcribe each unresolved track end-to-end, not just short samples. Expensive (roughly 5&ndash;10 minutes of GPU time per file, substantially longer on CPU) &mdash; worth it when matches often fall back to full-file transcription.
                                         </span>
                                     </span>
                                 </label>


### PR DESCRIPTION
## Summary

Phase A (1 of 3) of the walk-away workflow rework prompted by the [#370 follow-up comment](https://github.com/Jsakkos/engram/issues/370#issuecomment-4673060578): make deferred/pooled review *fast* by never re-running Whisper for work already done. Spec: `docs/superpowers/specs/2026-06-10-walk-away-workflow-design.md` (committed in this PR). Phases B (rip-first deferral of identity prompts) and C (disc-hash recognition via the fingerprint network) follow as separate PRs.

- **Persistent transcript cache** (`~/.engram/cache/transcripts.sqlite`): Whisper output keyed by (file identity, offset, duration, ASR model identity). Re-matching a track — review decision, re-identify, re-match, or full app restart — reuses transcripts instead of re-transcribing; minutes → seconds. Fail-safe (a broken cache degrades to "just transcribe"), LRU-pruned, re-rips auto-invalidate via mtime/size keys.
- **Nested scan-point lattice** (10/19/37/73/145, integer math): every shallow scan's offsets are a strict subset of every deeper scan's, so deep re-match escalation reuses all prior transcripts. Deep-rematch depths aligned (`STRICT_SCAN_POINTS` 37; conflict ladder 37/73 with full-coverage floored as a cost ceiling; wrong-show confirming pass snapped up as a coverage floor).
- **Background pre-transcription**: while a job waits in review, a `TranscriptionPrewarmer` fills the cache for its tracks (state-machine trigger on REVIEW_NEEDED; per-chunk sharing of the global match semaphore so live matches preempt; cancelled at every user-action seam; isolated temp-wav namespace). Config: `enable_background_pretranscription` (default on) + `pretranscribe_full_file` (default off), three-way synced (model/API/UI) with migration.
- **Fix**: the matcher resolved its ASR device from a raw GPU probe instead of the startup-pinned effective device — disabling GPU acceleration now genuinely applies to episode matching (and to cached-transcript identity).

## Cost note (for release notes accuracy)

Requested scan depths now equal realized depths — 25/50 already realized as 37/73 since the lattice snap. The net change is a cost *reduction*: the escalation ladder's final tier floors to the lattice, dropping a redundant deeper pass on typical-length episodes (e.g. realized [37, 73, 145] → [37, 73]). Do not describe this as "denser escalation".

## Test plan

- [x] Unit tier: 2,145 passed (incl. ~150 new: lattice subset/golden-offset pins, store contract, cache wiring restart-survival, prewarmer scheduling/cancellation, config three-way sync)
- [x] Integration tier: 209 passed, 1 skipped
- [x] Pipeline tier: 95 passed
- [x] Frontend: lint clean, 244 vitest passed, production build OK
- [x] ruff check + format clean; Alembic migration live-verified on a scratch DB (upgrade/downgrade + frozen-build `_add_missing_columns` convergence)
- [x] Walk-away e2e: real prewarm run over a review-parked job leaves exactly the 10 lattice rows per file; a fresh matcher (simulated restart) re-matches every offset with a poison ASR model — zero transcriptions, zero extractions

🤖 Generated with [Claude Code](https://claude.com/claude-code)