### PR TITLE
perf(tmdb): memoize fetch_season_episode_runtimes per (show_id, season)

### DIFF
--- a/backend/app/matcher/tmdb_client.py
+++ b/backend/app/matcher/tmdb_client.py
@@ -761,17 +761,56 @@ def _fetch_season_details_cached(show_id: str, season_number: int) -> int:
     return len(season_data.get("episodes", []))
 
 
-@retry_network_operation(max_retries=3, base_delay=1.0)
 def fetch_season_episode_runtimes(show_id: str, season_number: int) -> list[int]:
+    """Public entry; short-circuits without caching when API key absent.
+
+    The disc-identification classifier calls this once per TV disc, so a
+    multi-disc box-set rip of the same season re-requests identical runtime
+    data per disc. The @lru_cache lives on the inner
+    ``_fetch_season_episode_runtimes_cached`` (mirroring ``fetch_season_details``)
+    so (1) the no-key early-return isn't cached — otherwise a first-boot user
+    who later sets a key in ConfigWizard would keep getting the cached empty
+    list — and (2) a transient network failure propagates to
+    ``@retry_network_operation`` and is caught HERE, returning ``[]`` without
+    ``@lru_cache`` pinning an empty list on the show/season key for the rest of
+    the process.
+
+    Returns a fresh ``list`` copy on every call so a caller mutating the result
+    can't corrupt the shared cached list (the ints inside are immutable, so a
+    shallow copy suffices — no deepcopy needed).
     """
-    Fetch episode runtimes for a given show and season from the TMDB API.
+    from app.services.config_service import get_config_sync
 
-    Args:
-        show_id: The TMDB show ID.
-        season_number: The season number to fetch runtimes for.
+    if not get_config_sync().tmdb_api_key:
+        logger.warning("TMDB API key not configured")
+        return []
 
-    Returns:
-        list[int]: Episode runtimes in minutes, or empty list if the request failed.
+    try:
+        result = _fetch_season_episode_runtimes_cached(show_id, season_number)
+    # See fetch_show_id wrapper for why the catch widens to match the
+    # retry decorator's tuple (RequestException + builtin Connection/Timeout).
+    except (requests.exceptions.RequestException, ConnectionError, TimeoutError) as e:
+        logger.error(
+            f"Failed to fetch episode runtimes for show {show_id} Season {season_number}: {e}",
+            exc_info=True,
+        )
+        return []
+
+    return list(result)
+
+
+@lru_cache(maxsize=_TMDB_LRU_MAXSIZE)
+@retry_network_operation(max_retries=3, base_delay=1.0)
+def _fetch_season_episode_runtimes_cached(show_id: str, season_number: int) -> list[int]:
+    """Cached implementation. Caller (the public wrapper) guarantees the API
+    key is present and catches the post-retry exception.
+
+    Like ``_fetch_season_details_cached``, this does NOT route through
+    ``_tmdb_get_json`` — that helper swallows ``RequestException`` and returns
+    None, which would let ``@lru_cache`` pin an empty-list sentinel on the
+    show/season key after a transient failure. Letting ``raise_for_status()``
+    propagate keeps transient failures out of the cache (``lru_cache`` never
+    caches exceptions; only successful return values get stored).
     """
     logger.info(f"Fetching episode runtimes for show {show_id} Season {season_number}...")
     from app.services.config_service import get_config_sync
@@ -779,13 +818,18 @@ def fetch_season_episode_runtimes(show_id: str, season_number: int) -> list[int]
     config = get_config_sync()
     tmdb_api_key = config.tmdb_api_key
     if not tmdb_api_key:
-        logger.warning("TMDB API key not configured")
-        return []
+        raise RuntimeError(
+            "_fetch_season_episode_runtimes_cached called without a TMDB API key; "
+            "use the public fetch_season_episode_runtimes wrapper"
+        )
 
     url = f"https://api.themoviedb.org/3/tv/{show_id}/season/{season_number}"
-    season_data = _tmdb_get_json(url, tmdb_api_key)
-    if season_data is None:
-        return []
+
+    headers, params = _tmdb_auth(tmdb_api_key)
+
+    response = requests.get(url, headers=headers, params=params, timeout=30)
+    response.raise_for_status()
+    season_data = response.json()
     episodes = season_data.get("episodes", [])
     runtimes = [ep.get("runtime", 0) or 0 for ep in episodes]
     logger.info(f"Got {len(runtimes)} episode runtimes for Season {season_number}: {runtimes}")
@@ -1039,4 +1083,5 @@ def clear_caches() -> None:
     _fetch_show_details_cached.cache_clear()
     _fetch_movie_details_cached.cache_clear()
     _fetch_season_details_cached.cache_clear()
+    _fetch_season_episode_runtimes_cached.cache_clear()
     tmdb_persistent_cache.clear()

--- a/backend/tests/unit/test_tmdb_client.py
+++ b/backend/tests/unit/test_tmdb_client.py
@@ -479,6 +479,50 @@ class TestFetchSeasonDetails:
 
 
 @pytest.mark.unit
+class TestFetchSeasonEpisodeRuntimes:
+    """``fetch_season_episode_runtimes`` feeds the disc-identification
+    classifier one runtime list per TV disc. A multi-disc box-set rip of the
+    same season would otherwise re-fetch identical runtime data once per disc;
+    the @lru_cache inner (mirroring fetch_season_details) collapses those
+    repeats to a single TMDB round-trip for the lifetime of the process."""
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_repeat_call_same_args_hits_network_once(self, mock_get):
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"episodes": [{"runtime": 42}, {"runtime": 41}]},
+            raise_for_status=Mock(),
+        )
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test_key"
+            first = tmdb_client.fetch_season_episode_runtimes("4589", 1)
+            second = tmdb_client.fetch_season_episode_runtimes("4589", 1)
+
+        assert first == [42, 41]
+        assert first == second
+        # The second call for the same (show_id, season_number) must be served
+        # from the process-lifetime LRU — only one TMDB round-trip total.
+        assert mock_get.call_count == 1
+
+    @patch("app.matcher.tmdb_client.requests.get")
+    def test_clear_caches_flushes_runtimes(self, mock_get):
+        """``clear_caches()`` must flush this LRU too, otherwise a TMDB key
+        rotation would leave runtimes fetched with the revoked key pinned for
+        the rest of the process."""
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"episodes": [{"runtime": 42}]},
+            raise_for_status=Mock(),
+        )
+        with patch("app.services.config_service.get_config_sync") as cfg:
+            cfg.return_value.tmdb_api_key = "test_key"
+            tmdb_client.fetch_season_episode_runtimes("4589", 1)
+            clear_caches()
+            tmdb_client.fetch_season_episode_runtimes("4589", 1)
+        assert mock_get.call_count == 2
+
+
+@pytest.mark.unit
 class TestVariationEdgeCases:
     """Tests for edge cases in variation generation."""
 


### PR DESCRIPTION
## What

Add process-lifetime memoization to `fetch_season_episode_runtimes` in `backend/app/matcher/tmdb_client.py`, mirroring the existing `fetch_season_details` / `_fetch_season_details_cached` pattern.

## Why

Disc identification calls `fetch_season_episode_runtimes` once per TV disc during classification. For a multi-disc box-set rip of the same season, that re-fetched identical TMDB runtime data once per disc — a fresh HTTP round-trip every time, since (unlike its sibling `fetch_season_details`) the function had only `@retry_network_operation` and no memoization.

The existing per-job cache in `matching_coordinator` (`self._episode_runtimes[job.id]`) is keyed on `job.id`, so it does **not** dedupe across the separate jobs of a box set. A process-lifetime cache keyed on `(show_id, season_number)` is what collapses those cross-disc repeats.

## How

Inner/outer split rather than `@lru_cache` on the public function:

- **`_fetch_season_episode_runtimes_cached(show_id, season_number)`** — `@lru_cache(maxsize=_TMDB_LRU_MAXSIZE)` + `@retry_network_operation`. Uses `requests.get` + `raise_for_status()` directly (not `_tmdb_get_json`) and raises `RuntimeError` on a missing key, exactly like `_fetch_season_details_cached`.
- **`fetch_season_episode_runtimes(...)`** — public wrapper, **signature unchanged**. Short-circuits the no-key path *before* the cache, catches the post-retry network exception and returns `[]`, and returns a `list(result)` copy so callers can't mutate the shared cached list.
- **`clear_caches()`** — now also flushes `_fetch_season_episode_runtimes_cached`, so a TMDB key rotation drops runtimes fetched with the revoked key.

### Why the split (not `@lru_cache` on the public function)

Decorating the public function directly would poison the cache in two ways the codebase deliberately guards against:
1. The no-API-key early-return `[]` would get cached keyed on `(show_id, season)` — a first-boot user who sets their key in ConfigWizard afterward would keep getting the cached empty list until restart.
2. `_tmdb_get_json` swallows `RequestException` and returns `None` → `[]`, so a transient TMDB 429/5xx would pin an empty runtime list permanently.

Routing transient failures through `raise_for_status()` keeps them out of the cache — `lru_cache` never caches exceptions, only successful returns.

## Tests

New `TestFetchSeasonEpisodeRuntimes` in `backend/tests/unit/test_tmdb_client.py`:
- `test_repeat_call_same_args_hits_network_once` — two identical calls → `mock_get.call_count == 1`.
- `test_clear_caches_flushes_runtimes` — post-`clear_caches()` call re-hits the network.

## Verification

- `uv run pytest tests/unit/test_tmdb_client.py` → **43 passed** (2 new + all pre-existing).
- `uv run pytest tests/unit/test_matching_coordinator.py` (the caller) → **25 passed**.
- `uv run ruff check app/matcher/tmdb_client.py tests/unit/test_tmdb_client.py` → clean.

## Reviewer notes

- Public signature and return contract (`list[int]`, `[]` on no-key/failure) are unchanged, so the existing `matching_coordinator` call site — and the `fix/disc-identification` `_run_classification` call site once it lands — both benefit transparently.
- Thread-safe under the caller's `asyncio.to_thread` execution: CPython's `lru_cache` guards its internal dict with a lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
