### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-06-15
+
+_Highlights: a fixes-focused release that sharpens TV disc identification — fan-style abbreviated labels (e.g. `DS9`) now resolve to the full show name, a legitimately feature-length episode is no longer mistaken for a "Play All" track and discarded, and a disc whose identity can't be corroborated goes to Needs Review instead of completing under a guessed name._
+
+### Changed
+
+- **Multi-disc box sets identify a little faster** — ripping several discs of the same season no longer re-fetches identical episode-runtime data from TMDB once per disc; the runtime lookup is now cached for the life of the app, trimming redundant network calls during identification. (#404)
+
 ### Fixed
 
 - **Abbreviated TV disc labels now resolve to the right show name** — a disc whose label is a fan-style abbreviation (e.g. `DS9` for *Star Trek: Deep Space Nine*) used to keep the raw label as the show name even when TMDB had identified the series correctly, filing episodes under a name like `DS9S1D1`. Engram now matches the abbreviation against the TMDB title — including number-words, so `DS9` corroborates "Deep Space **Nine**" — and adopts the proper show name. (#403)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.0"
+__version__ = "0.21.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.0"
+version = "0.21.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.0"
+version = "0.21.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.0",
+            "version": "0.21.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.0",
+    "version": "0.21.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.21.1

Patch release — TV disc identification fixes plus a small identification speedup. No new features, so this is a patch bump from `0.21.0`.

Bumps the version across all six version files (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json` ×2) and promotes the `[Unreleased]` changelog entries into the `## [0.21.1] - 2026-06-15` section. The date is the **UTC** publish day (a day ahead of the local Pacific date).

### Changed
- **Multi-disc box sets identify a little faster** — ripping several discs of the same season no longer re-fetches identical episode-runtime data from TMDB once per disc; the runtime lookup is now cached for the life of the app. (#404)

### Fixed
- **Abbreviated TV disc labels now resolve to the right show name** — a fan-style abbreviation (e.g. `DS9`) is now matched against the TMDB title (including number-words) and the proper show name is adopted instead of filing under the raw label. (#403)
- **Feature-length episodes are no longer discarded as a "Play All" track** — a long episode whose runtime happened to equal the combined length of the other episodes is now checked against expected TMDB runtimes before being flagged. (#403)
- **Discs whose identity can't be confirmed now go to review instead of completing under a guessed name** — when the TMDB show name can't be corroborated by anything on the disc, the job goes to Needs Review with the suggested title. (#403)

### Release mechanics
- `changelog-version-check` verified locally: `extract_changelog.py --version 0.21.1 --check` → `ok`.
- `CONTRIBUTORS.md` regenerated — no change (no new external contributors this window; #401/#402 are dependency bots, excluded).
- Squash-merging this PR (title prefix `chore: release v`) triggers `tag-release.yml` → tag `v0.21.1` → `release.yml` (binaries + GitHub release) and `docker.yml` (GHCR image).

> Leaving the merge to you — merging publishes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
