### PR TITLE
chore: release v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.2] - 2026-06-15
+
+_Highlights: subtitle-cache harvesting is now hardened against two real-world OpenSubtitles data quality problems that caused entire TV seasons to match at "no clear vote" confidence and route to Needs Review._
+
+### Fixed
+
+- **Subtitle providers that return one episode's dialogue under a different episode's code no longer corrupt the cache** — some providers re-time an episode's subtitle and save it under a different episode slot (e.g. DS9 S02E05 was a re-timed copy of S01E05 "Babel"). Two episodes then held byte-identical dialogue in the TF-IDF index, the matching scores scattered, and both episodes ended up in Needs Review. The harvester now hashes each downloaded subtitle's cleaned dialogue, detects cross-episode duplicates before they enter the cache, removes the contaminant file, and marks its slot as not-found so it can be re-fetched cleanly. On the affected DS9 Season 2, exactly the 12 contaminated episodes were flagged and cleared. (#407)
+- **OpenSubtitles results mislabeled to the wrong episode are now rejected before they reach the cache** — OpenSubtitles returns multiple candidates per episode number, and for some shows the metadata is wrong (e.g. DS9 Season 2 subtitles are tagged `season_number=1`, and within-season numbering is offset by the Emissary two-part pilot so "Episode 10 - Move Along Home" was returned for a request whose S01E10 is "The Nagus"). The harvester took the first candidate, saving the wrong episode's dialogue under the right code. Each candidate is now cross-checked against the requested episode's TMDB title (and episode numbers outside the season's real range are rejected outright); the harvester saves the first *valid* candidate per episode, falling through to the scraper sources when no valid OS result exists. On live DS9 data, the real Season 1 subtitles now harvest correctly — The Passenger at S01E08, Move Along Home at S01E09 — and that episode's audio now matches at 0.347 vs 0.058 runner-up where it previously scored ~0.067 scattered and went to review. (#407)
+
 ## [0.21.1] - 2026-06-15
 
 _Highlights: a fixes-focused release that sharpens TV disc identification — fan-style abbreviated labels (e.g. `DS9`) now resolve to the full show name, a legitimately feature-length episode is no longer mistaken for a "Play All" track and discarded, and a disc whose identity can't be corroborated goes to Needs Review instead of completing under a guessed name._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.1"
+__version__ = "0.21.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.1"
+version = "0.21.2"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.1",
+    "version": "0.21.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.1",
+            "version": "0.21.2",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.1",
+    "version": "0.21.2",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to `0.21.2` across all 5 version files (6 edits — both `package-lock.json` self-version fields)
- Add `## [0.21.2] - 2026-06-15` section to `CHANGELOG.md`

## Changes in this release

One PR merged after v0.21.1:

- **#407** `fix(subtitle-cache): validate harvested subtitles — dedup + OS mislabel rejection` — two subtitle cache corruption shapes (cross-episode content duplicates and OpenSubtitles wrong-episode mislabels) caused whole TV seasons to route to Needs Review; both are now rejected at harvest time before they enter the TF-IDF index.

## Release notes preview

Verified with `python backend/scripts/extract_changelog.py --version 0.21.2` — extraction is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)