### PR TITLE
fix(identify): rip-first for uncorroborated TV identity (don't block the rip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A disc Engram can't quite confirm now rips first instead of waiting on you** — when TMDB finds the show but nothing on the disc corroborates the name (for example a label like `DS9S3D2 ok`, where a stray annotation broke the match), the disc used to stop and ask you to confirm the title *before* ripping anything. It now rips immediately and carries a **Confirm title** prompt you can answer any time — or it pools into the single Needs Review visit at the end — restoring the walk-away workflow for this case. Engram also strips common trailing rip annotations (`ok`, `done`, `rip`, …) from disc labels so these discs usually identify cleanly with no prompt at all. (#414)
+
 ## [0.21.2] - 2026-06-15
 
 _Highlights: subtitle-cache harvesting is now hardened against two real-world OpenSubtitles data quality problems that caused entire TV seasons to match at "no clear vote" confidence and route to Needs Review._

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -117,6 +117,15 @@ _NUMBER_WORDS: dict[str, str] = {  # 1-10; sufficient for fan-style abbreviation
 _ACRONYM_STOPWORDS: frozenset[str] = frozenset({"of", "and", "a", "an"})
 
 
+# Trailing annotation tokens users append to a finished rip's label
+# (e.g. "DS9S3D2 ok"). Stripped trailing-only in _parse_volume_label so the
+# show name still corroborates against TMDB; an unlisted token is caught by the
+# rip-first reidentify gate instead, so this list only needs the common ones.
+_LABEL_JUNK_TOKENS: frozenset[str] = frozenset(
+    {"OK", "DONE", "RIP", "RIPPED", "COPY", "BACKUP", "BAK", "FINAL"}
+)
+
+
 def _abbreviation_matches(label: str, full_name: str) -> bool:
     """True if ``label`` is an initialism/abbreviation of ``full_name``.
 
@@ -1016,6 +1025,14 @@ class DiscAnalyst:
         # Remove common disc indicators that aren't disc numbers
         label = re.sub(r"\b(DVD|BLURAY|BD)\s*\d*\b", "", label)
         label = label.strip()
+
+        # Drop trailing rip-annotation tokens (e.g. "DS9 OK" -> "DS9"). Trailing
+        # only, and never empties the name (the > 1 guard): an unstripped junk
+        # token still rips-first via the reidentify gate.
+        tokens = label.split()
+        while len(tokens) > 1 and tokens[-1] in _LABEL_JUNK_TOKENS:
+            tokens.pop()
+        label = " ".join(tokens)
 
         # Convert to title case
         name = label.title() if label else None

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -233,6 +233,11 @@ class DiscAnalysisResult:
     classification_source: str = "heuristic"
     play_all_title_indices: list[int] = field(default_factory=list)
     is_ambiguous_movie: bool = False
+    # TV identity found on TMDB but not corroborated by the on-disc label — a
+    # best-guess identity the user confirms later. Routes the job to the
+    # rip-first reidentify gate (walk-away) instead of a pre-rip park. Set only
+    # at the two _uncorroborated_review_reason sites below.
+    identity_unconfirmed: bool = False
 
 
 # Main-feature selection tuning. A movie disc only needs review when 2+ titles
@@ -584,6 +589,7 @@ class DiscAnalyst:
             ):
                 tmdb_only.needs_review = True
                 tmdb_only.review_reason = _uncorroborated_review_reason(effective_name, tmdb_signal)
+                tmdb_only.identity_unconfirmed = True
             return tmdb_only
 
         # Ambiguous - needs human review
@@ -735,6 +741,7 @@ class DiscAnalyst:
                 result.review_reason = _uncorroborated_review_reason(
                     result.detected_name, tmdb_signal
                 )
+                result.identity_unconfirmed = True
 
         return result
 

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -121,9 +121,10 @@ _ACRONYM_STOPWORDS: frozenset[str] = frozenset({"of", "and", "a", "an"})
 # (e.g. "DS9S3D2 ok"). Stripped trailing-only in _parse_volume_label so the
 # show name still corroborates against TMDB; an unlisted token is caught by the
 # rip-first reidentify gate instead, so this list only needs the common ones.
-_LABEL_JUNK_TOKENS: frozenset[str] = frozenset(
-    {"OK", "DONE", "RIP", "RIPPED", "COPY", "BACKUP", "BAK", "FINAL"}
-)
+# Deliberately excludes dictionary words that are plausibly a real trailing
+# title token (e.g. "Final", "Copy") — those rely on the identity_unconfirmed
+# gate rather than risk mangling a legitimate name like "The Final".
+_LABEL_JUNK_TOKENS: frozenset[str] = frozenset({"OK", "DONE", "RIP", "RIPPED", "BACKUP", "BAK"})
 
 
 def _abbreviation_matches(label: str, full_name: str) -> bool:

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -558,14 +558,16 @@ class IdentificationCoordinator:
                         await self._run_ripping(job_id)
                         return
 
-                    # Gate C (walk-away B2): same-name collision (ambiguous
-                    # identity / no-year twin) — identity is uncertain but the
-                    # twins are persisted (candidates_json, set above) for the
-                    # ReIdentifyModal quick-pick, so rip first with a
-                    # reidentify prompt instead of parking. Prefetch was
-                    # already skipped for collisions (downloading by the
-                    # tentative name would fetch the wrong show's subtitles).
-                    if _collision:
+                    # Gate C (walk-away B2): identity is uncertain but we have a
+                    # best guess — rip first with a reidentify prompt instead of
+                    # parking. Two cases: a same-name collision (twins persisted
+                    # in candidates_json for the ReIdentifyModal quick-pick;
+                    # prefetch already skipped) OR an uncorroborated single TMDB
+                    # identity (analysis.identity_unconfirmed; tmdb_id is real, so
+                    # the prefetch above ran). The user confirms via the
+                    # "Confirm title" CTA any time, or it converges to the pooled
+                    # review at rip end (B4).
+                    if _collision or analysis.identity_unconfirmed:
                         await self._rip_first_with_prompt(
                             job,
                             session,

--- a/backend/tests/unit/test_analyst.py
+++ b/backend/tests/unit/test_analyst.py
@@ -663,3 +663,43 @@ class TestParseVolumeLabelJunkTokens:
         # A label that is only a junk token keeps it rather than becoming None.
         name, season, disc = DiscAnalyst._parse_volume_label("OK_S1D1")
         assert name == "Ok"
+
+
+class TestUncorroboratedIdentityFlag:
+    """Uncorroborated TV identity sets identity_unconfirmed for the rip-first gate."""
+
+    def _ds9_signal(self):
+        return TmdbSignal(ContentType.TV, 0.7, tmdb_id=580, tmdb_name="Star Trek: Deep Space Nine")
+
+    def test_uncorroborated_tv_identity_sets_flag(self):
+        analyst = DiscAnalyst(config=_default_config())
+        titles = _make_titles([45, 45, 45, 45])
+        # 'ZZZJUNK' is neither similar to nor an initialism of the TMDB name,
+        # so corroboration fails and the identity is unconfirmed.
+        result = analyst.analyze(
+            titles,
+            volume_label="ZZZJUNK_S3D2",
+            tmdb_signal=self._ds9_signal(),
+            disc_title="ZZZJUNK",
+        )
+        assert result.content_type == ContentType.TV
+        assert result.needs_review is True
+        assert result.identity_unconfirmed is True
+
+    def test_corroborated_identity_not_flagged(self):
+        analyst = DiscAnalyst(config=_default_config())
+        titles = _make_titles([45, 45, 45, 45])
+        # 'DS9' is the digit-initialism of 'Deep Space Nine' -> corroborated.
+        result = analyst.analyze(
+            titles,
+            volume_label="DS9S2D4",
+            tmdb_signal=self._ds9_signal(),
+            disc_title="DS9S2D4",
+        )
+        assert result.needs_review is False
+        assert result.identity_unconfirmed is False
+
+    def test_default_result_flag_is_false(self):
+        from app.core.analyst import DiscAnalysisResult
+
+        assert DiscAnalysisResult(content_type=ContentType.TV).identity_unconfirmed is False

--- a/backend/tests/unit/test_analyst.py
+++ b/backend/tests/unit/test_analyst.py
@@ -640,3 +640,26 @@ class TestNamesAreSimilar:
         # Jaccard is 0 here ("startrekpicard" is a single token with no overlap),
         # so this only passes via the whitespace-insensitive collapsed path.
         assert _names_are_similar("Startrekpicard", "Star Trek: Picard") is True
+
+
+class TestParseVolumeLabelJunkTokens:
+    """Trailing rip-annotation tokens (e.g. 'ok') are stripped from the name."""
+
+    def test_strips_trailing_ok(self):
+        assert DiscAnalyst._parse_volume_label("DS9S3D2 ok") == ("Ds9", 3, 2)
+
+    def test_clean_label_unchanged(self):
+        assert DiscAnalyst._parse_volume_label("DS9S2D4") == ("Ds9", 2, 4)
+
+    def test_strips_multiple_trailing_junk_tokens(self):
+        assert DiscAnalyst._parse_volume_label("DS9S3D2 ok done") == ("Ds9", 3, 2)
+
+    def test_preserves_non_trailing_junk_token(self):
+        # A leading 'OK' that is part of the real title must survive.
+        name, season, disc = DiscAnalyst._parse_volume_label("OK_KO_S1D1")
+        assert name == "Ok Ko"
+
+    def test_all_junk_label_not_emptied(self):
+        # A label that is only a junk token keeps it rather than becoming None.
+        name, season, disc = DiscAnalyst._parse_volume_label("OK_S1D1")
+        assert name == "Ok"

--- a/backend/tests/unit/test_identify_rip_first_gates.py
+++ b/backend/tests/unit/test_identify_rip_first_gates.py
@@ -527,3 +527,5 @@ class TestGateCUncorroboratedIdentity:
         coord._run_ripping.assert_awaited_once_with(job_id)
         # Never parked.
         assert not any(state == JobState.REVIEW_NEEDED.value for state, _ in gate_env)
+        # identity_unconfirmed is not a collision, so subtitle prefetch ran.
+        coord._start_subtitle_download.assert_called_once_with(job_id, "Ds9 Ok", 3, 580)

--- a/backend/tests/unit/test_identify_rip_first_gates.py
+++ b/backend/tests/unit/test_identify_rip_first_gates.py
@@ -494,3 +494,36 @@ class TestUnreadableDiscWalkAwayChain:
         assert len(review) == 1
         assert review[0]["review_reason"] == UNREADABLE_REASON
         assert review[0]["identity_prompt_json"] == ""
+
+
+@pytest.mark.unit
+class TestGateCUncorroboratedIdentity:
+    async def test_uncorroborated_identity_rips_first_with_reidentify(self, gate_env):
+        """An uncorroborated-but-known TV identity rips first with a reidentify
+        prompt (walk-away) instead of parking — like a same-name collision."""
+        job_id = await _seed_identifying_job("DS9S3D2_OK")
+        reason = (
+            "Couldn't confirm disc 'Ds9 Ok' is 'Star Trek: Deep Space Nine' "
+            "(TMDB #580). Confirm or correct the title."
+        )
+        analysis = _make_analysis(
+            ContentType.TV,
+            "Ds9 Ok",
+            season=3,
+            tmdb_id=580,
+            needs_review=True,
+            review_reason=reason,
+        )
+        analysis.identity_unconfirmed = True
+        coord = _bare_coord(analysis, _GATE_TITLES, "DS9S3D2_OK")
+
+        await coord.identify_disc(job_id)
+
+        job = await _reload_job(job_id)
+        assert job.state == JobState.RIPPING
+        assert job.review_reason is None
+        prompt = json.loads(job.identity_prompt_json)
+        assert prompt == {"kind": "reidentify", "reason": reason}
+        coord._run_ripping.assert_awaited_once_with(job_id)
+        # Never parked.
+        assert not any(state == JobState.REVIEW_NEEDED.value for state, _ in gate_env)

--- a/docs/superpowers/plans/2026-06-15-uncorroborated-identity-ripfirst.md
+++ b/docs/superpowers/plans/2026-06-15-uncorroborated-identity-ripfirst.md
@@ -1,0 +1,399 @@
+# Uncorroborated TV Identity Rip-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A TV disc whose TMDB identity is found but not corroborated by the on-disc label rips-first with a non-blocking "Confirm title" prompt (deferred to the pooled end-of-run review) instead of parking in `REVIEW_NEEDED` before ripping.
+
+**Architecture:** Two fixes. (1) Safety net — the analyst flags the uncorroborated-identity case with a typed `identity_unconfirmed` flag, and the identification coordinator routes that flag through the existing walk-away Gate C `_rip_first_with_prompt(kind="reidentify")` path. (2) Optimization — `_parse_volume_label` strips trailing rip-annotation tokens (e.g. `ok`) so common cases corroborate cleanly and show no prompt at all.
+
+**Tech Stack:** Python 3.11, FastAPI/SQLModel, pytest (`uv run pytest`), ruff. Spec: `docs/superpowers/specs/2026-06-15-uncorroborated-identity-ripfirst-design.md`.
+
+All commands run from `backend/`.
+
+---
+
+### Task 1: Strip trailing rip-annotation tokens in `_parse_volume_label`
+
+**Files:**
+- Modify: `backend/app/core/analyst.py` (add `_LABEL_JUNK_TOKENS` constant near `_ACRONYM_STOPWORDS` ~line 117; add strip block in `_parse_volume_label` after `label = label.strip()` ~line 1018)
+- Test: `backend/tests/unit/test_analyst.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/tests/unit/test_analyst.py` (the module already imports `DiscAnalyst`):
+
+```python
+class TestParseVolumeLabelJunkTokens:
+    """Trailing rip-annotation tokens (e.g. 'ok') are stripped from the name."""
+
+    def test_strips_trailing_ok(self):
+        assert DiscAnalyst._parse_volume_label("DS9S3D2 ok") == ("Ds9", 3, 2)
+
+    def test_clean_label_unchanged(self):
+        assert DiscAnalyst._parse_volume_label("DS9S2D4") == ("Ds9", 2, 4)
+
+    def test_strips_multiple_trailing_junk_tokens(self):
+        assert DiscAnalyst._parse_volume_label("DS9S3D2 ok done") == ("Ds9", 3, 2)
+
+    def test_preserves_non_trailing_junk_token(self):
+        # A leading 'OK' that is part of the real title must survive.
+        name, season, disc = DiscAnalyst._parse_volume_label("OK_KO_S1D1")
+        assert name == "Ok Ko"
+
+    def test_all_junk_label_not_emptied(self):
+        # A label that is only a junk token keeps it rather than becoming None.
+        name, season, disc = DiscAnalyst._parse_volume_label("OK_S1D1")
+        assert name == "Ok"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_analyst.py::TestParseVolumeLabelJunkTokens -v`
+Expected: `test_strips_trailing_ok` and `test_strips_multiple_trailing_junk_tokens` FAIL on the assertion (e.g. `("Ds9 Ok", 3, 2) != ("Ds9", 3, 2)`); the clean-label / non-trailing / all-junk tests already pass (they don't depend on the strip). No `NameError` — `_LABEL_JUNK_TOKENS` isn't referenced until Step 4.
+
+- [ ] **Step 3: Add the constant**
+
+In `backend/app/core/analyst.py`, immediately after the `_ACRONYM_STOPWORDS` definition (~line 117):
+
+```python
+# Trailing annotation tokens users append to a finished rip's label
+# (e.g. "DS9S3D2 ok"). Stripped trailing-only in _parse_volume_label so the
+# show name still corroborates against TMDB; an unlisted token is caught by the
+# rip-first reidentify gate instead, so this list only needs the common ones.
+_LABEL_JUNK_TOKENS: frozenset[str] = frozenset(
+    {"OK", "DONE", "RIP", "RIPPED", "COPY", "BACKUP", "BAK", "FINAL"}
+)
+```
+
+- [ ] **Step 4: Add the strip block**
+
+In `_parse_volume_label`, between `label = label.strip()` (~line 1018) and `name = label.title() if label else None` (~line 1021), insert:
+
+```python
+        # Drop trailing rip-annotation tokens (e.g. "DS9 OK" -> "DS9"). Trailing
+        # only, and never empties the name (the > 1 guard): an unstripped junk
+        # token still rips-first via the reidentify gate.
+        tokens = label.split()
+        while len(tokens) > 1 and tokens[-1] in _LABEL_JUNK_TOKENS:
+            tokens.pop()
+        label = " ".join(tokens)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_analyst.py::TestParseVolumeLabelJunkTokens -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/core/analyst.py tests/unit/test_analyst.py
+git commit -m "fix(analyst): strip trailing rip-annotation tokens from volume labels
+
+A label like 'DS9S3D2 ok' parsed the show name as 'Ds9 Ok', breaking TMDB
+corroboration. Strip a small denylist of trailing tokens (ok/done/rip/...) so
+the disc corroborates cleanly. Trailing-only, never empties the name.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add `identity_unconfirmed` flag to the analyst result
+
+**Files:**
+- Modify: `backend/app/core/analyst.py` (add field to `DiscAnalysisResult` ~line 226; set it at the two `_uncorroborated_review_reason` sites ~line 577 and ~line 727)
+- Test: `backend/tests/unit/test_analyst.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `backend/tests/unit/test_analyst.py` (module already imports `TmdbSignal`, `ContentType`, `_make_titles`, `_default_config`):
+
+```python
+class TestUncorroboratedIdentityFlag:
+    """Uncorroborated TV identity sets identity_unconfirmed for the rip-first gate."""
+
+    def _ds9_signal(self):
+        return TmdbSignal(
+            ContentType.TV, 0.7, tmdb_id=580, tmdb_name="Star Trek: Deep Space Nine"
+        )
+
+    def test_uncorroborated_tv_identity_sets_flag(self):
+        analyst = DiscAnalyst(config=_default_config())
+        titles = _make_titles([45, 45, 45, 45])
+        # 'ZZZJUNK' is neither similar to nor an initialism of the TMDB name,
+        # so corroboration fails and the identity is unconfirmed.
+        result = analyst.analyze(
+            titles,
+            volume_label="ZZZJUNK_S3D2",
+            tmdb_signal=self._ds9_signal(),
+            disc_title="ZZZJUNK",
+        )
+        assert result.content_type == ContentType.TV
+        assert result.needs_review is True
+        assert result.identity_unconfirmed is True
+
+    def test_corroborated_identity_not_flagged(self):
+        analyst = DiscAnalyst(config=_default_config())
+        titles = _make_titles([45, 45, 45, 45])
+        # 'DS9' is the digit-initialism of 'Deep Space Nine' -> corroborated.
+        result = analyst.analyze(
+            titles,
+            volume_label="DS9S2D4",
+            tmdb_signal=self._ds9_signal(),
+            disc_title="DS9S2D4",
+        )
+        assert result.needs_review is False
+        assert result.identity_unconfirmed is False
+
+    def test_default_result_flag_is_false(self):
+        from app.core.analyst import DiscAnalysisResult
+
+        assert DiscAnalysisResult(content_type=ContentType.TV).identity_unconfirmed is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_analyst.py::TestUncorroboratedIdentityFlag -v`
+Expected: FAIL with `AttributeError: 'DiscAnalysisResult' object has no attribute 'identity_unconfirmed'`
+
+- [ ] **Step 3: Add the dataclass field**
+
+In `backend/app/core/analyst.py`, in `DiscAnalysisResult`, immediately after `is_ambiguous_movie: bool = False` (~line 226):
+
+```python
+    # TV identity found on TMDB but not corroborated by the on-disc label — a
+    # best-guess identity the user confirms later. Routes the job to the
+    # rip-first reidentify gate (walk-away) instead of a pre-rip park. Set only
+    # at the two _uncorroborated_review_reason sites below.
+    identity_unconfirmed: bool = False
+```
+
+- [ ] **Step 4: Set the flag at the TMDB-only escalation site**
+
+In `analyze`, find the block (~line 576):
+
+```python
+                tmdb_only.needs_review = True
+                tmdb_only.review_reason = _uncorroborated_review_reason(effective_name, tmdb_signal)
+            return tmdb_only
+```
+
+Change to:
+
+```python
+                tmdb_only.needs_review = True
+                tmdb_only.review_reason = _uncorroborated_review_reason(effective_name, tmdb_signal)
+                tmdb_only.identity_unconfirmed = True
+            return tmdb_only
+```
+
+- [ ] **Step 5: Set the flag in `_apply_tmdb_signal`**
+
+In `_apply_tmdb_signal`, find the block (~line 724):
+
+```python
+            elif not result.needs_review and result.content_type == ContentType.TV:
+                result.needs_review = True
+                result.review_reason = _uncorroborated_review_reason(
+                    result.detected_name, tmdb_signal
+                )
+```
+
+Change to:
+
+```python
+            elif not result.needs_review and result.content_type == ContentType.TV:
+                result.needs_review = True
+                result.review_reason = _uncorroborated_review_reason(
+                    result.detected_name, tmdb_signal
+                )
+                result.identity_unconfirmed = True
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_analyst.py::TestUncorroboratedIdentityFlag -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 7: Run the full analyst test file (no regressions)**
+
+Run: `uv run pytest tests/unit/test_analyst.py -v`
+Expected: PASS (all existing + new tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/core/analyst.py tests/unit/test_analyst.py
+git commit -m "feat(analyst): flag uncorroborated TV identity with identity_unconfirmed
+
+Typed flag (mirrors is_ambiguous_movie) set at the two uncorroborated-identity
+escalation sites. Lets the identification coordinator route these to the
+rip-first reidentify gate instead of parking, without string-matching the
+review reason.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Route `identity_unconfirmed` through Gate C in the coordinator
+
+**Files:**
+- Modify: `backend/app/services/identification_coordinator.py` (the `if _collision:` branch ~line 568)
+- Test: `backend/tests/unit/test_identify_rip_first_gates.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `backend/tests/unit/test_identify_rip_first_gates.py` (helpers `_make_analysis`, `_bare_coord`, `_seed_identifying_job`, `_reload_job`, `gate_env`, `_GATE_TITLES` already exist in this file):
+
+```python
+@pytest.mark.unit
+class TestGateCUncorroboratedIdentity:
+    async def test_uncorroborated_identity_rips_first_with_reidentify(self, gate_env):
+        """An uncorroborated-but-known TV identity rips first with a reidentify
+        prompt (walk-away) instead of parking — like a same-name collision."""
+        job_id = await _seed_identifying_job("DS9S3D2_OK")
+        reason = (
+            "Couldn't confirm disc 'Ds9 Ok' is 'Star Trek: Deep Space Nine' "
+            "(TMDB #580). Confirm or correct the title."
+        )
+        analysis = _make_analysis(
+            ContentType.TV,
+            "Ds9 Ok",
+            season=3,
+            tmdb_id=580,
+            needs_review=True,
+            review_reason=reason,
+        )
+        analysis.identity_unconfirmed = True
+        coord = _bare_coord(analysis, _GATE_TITLES, "DS9S3D2_OK")
+
+        await coord.identify_disc(job_id)
+
+        job = await _reload_job(job_id)
+        assert job.state == JobState.RIPPING
+        assert job.review_reason is None
+        prompt = json.loads(job.identity_prompt_json)
+        assert prompt == {"kind": "reidentify", "reason": reason}
+        coord._run_ripping.assert_awaited_once_with(job_id)
+        # Never parked.
+        assert not any(state == JobState.REVIEW_NEEDED.value for state, _ in gate_env)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_identify_rip_first_gates.py::TestGateCUncorroboratedIdentity -v`
+Expected: FAIL — the job parks: `assert job.state == JobState.RIPPING` fails with `JobState.REVIEW_NEEDED` (the analysis falls into the catch-all park branch).
+
+- [ ] **Step 3: Extend the Gate C branch**
+
+In `backend/app/services/identification_coordinator.py`, replace the Gate C block (~lines 561-576). Find:
+
+```python
+                    # Gate C (walk-away B2): same-name collision (ambiguous
+                    # identity / no-year twin) — identity is uncertain but the
+                    # twins are persisted (candidates_json, set above) for the
+                    # ReIdentifyModal quick-pick, so rip first with a
+                    # reidentify prompt instead of parking. Prefetch was
+                    # already skipped for collisions (downloading by the
+                    # tentative name would fetch the wrong show's subtitles).
+                    if _collision:
+                        await self._rip_first_with_prompt(
+                            job,
+                            session,
+                            job_id,
+                            kind="reidentify",
+                            reason=analysis.review_reason,
+                        )
+                        return
+```
+
+Replace with:
+
+```python
+                    # Gate C (walk-away B2): identity is uncertain but we have a
+                    # best guess — rip first with a reidentify prompt instead of
+                    # parking. Two cases: a same-name collision (twins persisted
+                    # in candidates_json for the ReIdentifyModal quick-pick;
+                    # prefetch already skipped) OR an uncorroborated single TMDB
+                    # identity (analysis.identity_unconfirmed; tmdb_id is real, so
+                    # the prefetch above ran). The user confirms via the
+                    # "Confirm title" CTA any time, or it converges to the pooled
+                    # review at rip end (B4).
+                    if _collision or analysis.identity_unconfirmed:
+                        await self._rip_first_with_prompt(
+                            job,
+                            session,
+                            job_id,
+                            kind="reidentify",
+                            reason=analysis.review_reason,
+                        )
+                        return
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_identify_rip_first_gates.py::TestGateCUncorroboratedIdentity -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole rip-first gates file (the still-parks pin must hold)**
+
+Run: `uv run pytest tests/unit/test_identify_rip_first_gates.py -v`
+Expected: PASS — in particular `TestOtherReviewPathsStillPark::test_type_conflict_review_still_parks_before_ripping` still parks (its analysis has `identity_unconfirmed=False`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/identification_coordinator.py tests/unit/test_identify_rip_first_gates.py
+git commit -m "fix(identify): rip-first for uncorroborated TV identity instead of parking
+
+Route analysis.identity_unconfirmed through the walk-away Gate C reidentify
+path so a disc with a found-but-uncorroborated TMDB identity (e.g. label
+'DS9S3D2 ok') rips immediately and defers the 'Confirm title' to the pooled
+end-of-run review, restoring the walk-away guarantee. Content-type conflicts
+still park.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Verify the broader suite and lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the analyst + identification + state-machine unit tests**
+
+Run: `uv run pytest tests/unit/test_analyst.py tests/unit/test_analyst_ambiguity.py tests/unit/test_analyst_name_number.py tests/unit/test_identify_rip_first_gates.py -v`
+Expected: PASS (no regressions)
+
+- [ ] **Step 2: Run the identity-collision integration test (Gate C end-to-end pin)**
+
+Run: `uv run pytest tests/integration/test_show_identity_collision.py -v`
+Expected: PASS (the collision seam is unchanged by the OR extension)
+
+- [ ] **Step 3: Lint and format**
+
+Run: `uv run ruff check app/core/analyst.py app/services/identification_coordinator.py tests/unit/test_analyst.py tests/unit/test_identify_rip_first_gates.py`
+Then: `uv run ruff format app/core/analyst.py app/services/identification_coordinator.py tests/unit/test_analyst.py tests/unit/test_identify_rip_first_gates.py`
+Expected: no lint errors; format reports files unchanged or formats them.
+
+- [ ] **Step 4: Commit any format changes (if ruff format changed files)**
+
+```bash
+git add -A
+git commit -m "style: ruff format uncorroborated-identity changes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+(If ruff format changed nothing, skip this step.)
+
+---
+
+## Notes for the implementer
+
+- **Empty worktree DB:** these are unit tests using the in-memory `_unit_session_factory`; they do not need `backend/engram.db`. If integration tests in Task 4 Step 2 fail with `no such table: app_config`, run `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first (a known worktree env gap, not a regression).
+- **Line numbers are approximate** — anchor on the quoted code, not the line number.
+- **Do not** touch the four existing gates, `_rip_first_with_prompt`, or `BLOCKING_KINDS` — `reidentify` is already a blocking kind, so the B3 QUEUED-parking and B4 convergence already cover the new routing.

--- a/docs/superpowers/specs/2026-06-15-uncorroborated-identity-ripfirst-design.md
+++ b/docs/superpowers/specs/2026-06-15-uncorroborated-identity-ripfirst-design.md
@@ -1,0 +1,121 @@
+# Uncorroborated TV identity should rip-first, not block
+
+**Date:** 2026-06-15
+**Status:** Approved (design)
+**Area:** `backend/app/core/analyst.py`, `backend/app/services/identification_coordinator.py`
+
+## Problem
+
+A disc whose TMDB identity is found but cannot be textually corroborated against
+the on-disc label parks in `REVIEW_NEEDED` *before* ripping, waiting for the user
+to confirm the title. This contradicts the walk-away workflow (Phase B, #398),
+whose promise is "drop a disc and walk away, one pooled review at the end."
+
+### Live repro
+
+User ripping Star Trek: Deep Space Nine, 2026-06-15, jobs 164–170 (same binary):
+
+| Job | Label | Outcome |
+|-----|-------|---------|
+| 164 | `DS9S2D3 ok` | parked → `identifying -> review_needed`, user re-identified 15 min later, then ripped |
+| 165 | `DS9S2D4` | ripped immediately |
+| 166–169 | `DS9S2D5`…`DS9S3D1` | ripped immediately |
+| 170 | `DS9S3D2 ok` | parked → blocked the rip until the user manually re-identified |
+
+Only the two `" ok"`-suffixed labels blocked.
+
+## Root cause
+
+Two mechanisms, both introduced by PR #403 (`35b293ac`, *fix(analyst):
+abbreviation-aware naming, runtime-aware Play-All, review escalation*), which
+landed **after** the walk-away Phase B rip-first gates (#398):
+
+1. **The `" ok"` suffix breaks corroboration.** `_parse_volume_label` strips the
+   `S3D2` season/disc tokens but leaves the trailing `ok`, yielding the show name
+   `Ds9 Ok`. That collapses to `ds9ok`, which is not equal to the strict
+   initialism `ds9` of "Deep Space **Nine**" (`_abbreviation_matches`,
+   `nine→9`). Clean labels parse to `Ds9`, which corroborates and is renamed to
+   the canonical "Star Trek: Deep Space Nine". Failed corroboration keeps the raw
+   label name.
+
+2. **The uncorroborated-identity review reason isn't a rip-first gate.** When
+   corroboration fails for a TV disc, `_apply_tmdb_signal` escalates to
+   `needs_review=True` with `_uncorroborated_review_reason` ("Couldn't confirm
+   disc '…' is '…'. Confirm or correct the title."). The walk-away rip-first set
+   is exactly four gates — (A) unreadable-label, (B) TV-without-TMDB, (C)
+   same-name-collision, (D) unknown-season — and "every OTHER review path still
+   parks before ripping" (`test_identify_rip_first_gates.py` docstring). The #403
+   escalation is `_collision=False` (no `ambiguous_identity`, no no-year twin), so
+   it falls into the catch-all park branch
+   (`identification_coordinator.py` ~578-589).
+
+## Design
+
+### Fix 1 — Route uncorroborated-but-known TV identity through Gate C (rip-first)
+
+The fix's safety net. Uses a typed flag rather than matching the reason string,
+mirroring the existing `is_ambiguous_movie` flag on `DiscAnalysisResult`.
+
+- **`analyst.py`** — add `identity_unconfirmed: bool = False` to
+  `DiscAnalysisResult`. Set it `True` at the two sites that assign
+  `_uncorroborated_review_reason`:
+  - the TMDB-only path (`analyze`, ~576-577)
+  - `_apply_tmdb_signal` (~724-728)
+
+  Both sites are already TV-scoped and carry a `tmdb_id`, so the flag implies
+  "known content type + best-guess identity."
+
+- **`identification_coordinator.py`** — extend the Gate C branch from
+  `if _collision:` to `if _collision or analysis.identity_unconfirmed:`, routing
+  to `_rip_first_with_prompt(kind="reidentify", reason=analysis.review_reason)`.
+
+  Keying off `identity_unconfirmed` *separately* from `_collision` is deliberate:
+  collisions skip subtitle prefetch, but an uncorroborated single identity has a
+  real `tmdb_id`, so the existing `not _collision` prefetch block still runs.
+
+Because `reidentify` is a `BLOCKING_KIND`, ripped titles park in `QUEUED` (B3
+matching gate) and converge to a pooled `REVIEW_NEEDED` at rip end (B4) if the
+user never answers — reproducing today's review UX without blocking the rip.
+
+A genuine content-type conflict (heuristic-movie vs TMDB-tv) never sets
+`identity_unconfirmed`, so it still parks. No behavior change for movie discs
+(both escalation sites are TV-only).
+
+### Fix 2 — Strip trailing rip-annotation tokens in `_parse_volume_label`
+
+The optimization. After season/disc extraction and the existing `strip()`
+(`analyst.py` ~1018), drop trailing tokens from a small explicit denylist so the
+disc corroborates cleanly and shows no prompt at all:
+
+```python
+_LABEL_JUNK_TOKENS = frozenset({"OK", "DONE", "RIP", "RIPPED", "COPY", "BACKUP", "BAK", "FINAL"})
+```
+
+- **Trailing-only**, and only while a non-junk token remains (a pathological
+  `OK`-only label is not nuked; a legitimate leading token like `OK K.O.!` is
+  untouched).
+
+Framing: **Fix 1 is the safety net, Fix 2 is the optimization.** Because Fix 1
+guarantees any uncorroborated disc rips-first, the denylist need not be
+exhaustive — an unlisted junk token still rips-first-and-defers; it just shows the
+"Confirm title" CTA the user can ignore until the pooled review.
+
+## Testing (TDD)
+
+- **Analyst unit** (`tests/unit/test_analyst*.py`):
+  - `_parse_volume_label("DS9S3D2 ok")` → name `"Ds9"` (or `"DS9"` pre-title-case), season 3, disc 2.
+  - Trailing junk strip preserves leading/embedded tokens; `OK`-only label not emptied.
+  - Analysis of an uncorroborated TV disc sets `identity_unconfirmed=True`; a
+    corroborated clean label sets it `False`.
+- **Coordinator unit** (`tests/unit/test_identify_rip_first_gates.py`):
+  - an `identity_unconfirmed` analysis routes to
+    `_rip_first_with_prompt(kind="reidentify")` and does **not** park.
+  - a content-type-conflict review (no `identity_unconfirmed`) still parks.
+
+## Out of scope
+
+- Re-tuning `_abbreviation_matches` strictness.
+- The pre-#403 mis-organization of job 153 (`DS9S1D1 (1993)` folder) — already
+  fixed by #403's abbreviation-aware naming for clean labels.
+- Disc-hash (Phase C) recognition interactions.
+```


### PR DESCRIPTION
## Summary

A TV disc whose TMDB identity is found but **not corroborated** by the on-disc label was blocking the rip — it parked in `REVIEW_NEEDED` at identification and waited for the user to confirm the title before ripping a single title. That contradicts the walk-away workflow (#398/#370), whose promise is "drop a disc and walk away, one pooled review at the end."

This restores the walk-away guarantee for that case:

- **Rip-first gate (safety net):** the analyst now flags the uncorroborated-identity case with a typed `DiscAnalysisResult.identity_unconfirmed` (mirroring `is_ambiguous_movie`), and the identification coordinator routes it through the existing Gate C `_rip_first_with_prompt(kind="reidentify")` path. The disc rips immediately and the "Confirm title" prompt defers to the pooled end-of-run review (or the user answers any time). Genuine content-type conflicts still park.
- **Junk-label strip (optimization):** `_parse_volume_label` now strips a small denylist of trailing rip-annotation tokens (`ok`, `done`, `rip`, …) so a label like `DS9S3D2 ok` parses to `DS9`, corroborates cleanly, and shows no prompt at all. Trailing-only, never empties the name.

## Root cause

Found from a live Star Trek: DS9 rip. On one binary (2026-06-15), discs with a stray `" ok"` suffix (`DS9S2D3 ok`, `DS9S3D2 ok`) blocked at identification while clean labels (`DS9S2D4` … `DS9S3D1`) ripped straight through.

PR #403 (shipped 0.21.1) added two things **after** the walk-away gates (#398): abbreviation-aware corroboration *and* an uncorroborated-identity review escalation. The `" ok"` suffix parses the show name as `Ds9 Ok` → collapses to `ds9ok` ≠ the strict initialism `ds9` of "Deep Space **Nine**" → corroboration fails → escalation fires. But that new review reason was never added to the four walk-away rip-first gates (unreadable-label / TV-without-TMDB / same-name-collision / unknown-season), so it fell into the "every other review path still parks before ripping" branch.

Full write-up: `docs/superpowers/specs/2026-06-15-uncorroborated-identity-ripfirst-design.md`.

## Test plan

- [x] `tests/unit/test_analyst.py::TestParseVolumeLabelJunkTokens` — trailing junk stripped; clean/leading/all-junk labels handled.
- [x] `tests/unit/test_analyst.py::TestUncorroboratedIdentityFlag` — uncorroborated TV identity sets the flag; corroborated clean label does not.
- [x] `tests/unit/test_identify_rip_first_gates.py::TestGateCUncorroboratedIdentity` — `identity_unconfirmed` rips first with a `reidentify` prompt and does not park.
- [x] `tests/unit/test_identify_rip_first_gates.py::TestOtherReviewPathsStillPark` — content-type conflicts still park (the pin holds).
- [x] `tests/integration/test_show_identity_collision.py` — Gate C collision seam unchanged (5 passed).
- [x] Full backend unit suite: 2353 passed; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
