### PR TITLE
chore: release v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.3] - 2026-06-16
+
+_Highlights: two disc-handling fixes — a disc whose label Engram can't quite confirm now rips immediately instead of blocking, and re-ripping a stalled track no longer misattributes a finished track as a duplicate._
+
 ### Fixed
 
 - **A disc Engram can't quite confirm now rips first instead of waiting on you** — when TMDB finds the show but nothing on the disc corroborates the name (for example a label like `DS9S3D2 ok`, where a stray annotation broke the match), the disc used to stop and ask you to confirm the title *before* ripping anything. It now rips immediately and carries a **Confirm title** prompt you can answer any time — or it pools into the single Needs Review visit at the end — restoring the walk-away workflow for this case. Engram also strips common trailing rip annotations (`ok`, `done`, `rip`, …) from disc labels so these discs usually identify cleanly with no prompt at all. (#414)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.2"
+__version__ = "0.21.3"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.2"
+version = "0.21.3"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.1"
+version = "0.21.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.2",
+    "version": "0.21.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.2",
+            "version": "0.21.3",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.2",
+    "version": "0.21.3",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to 0.21.3 across all version files (pyproject.toml, \_\_init\_\_.py, package.json, package-lock.json, uv.lock)
- Move [Unreleased] entries for #414 and #415 into [0.21.3] changelog section
- Also corrects a stale `uv.lock` entry that still referenced 0.21.1

## Changes in this release

**Fixed**
- Disc whose label Engram can't confirm now rips first instead of blocking on user confirmation (#414)
- Re-ripping a stalled track no longer misattributes a pre-existing staging file as the re-ripped track (#415)

## Test Plan
- [x] 2370 unit tests pass
- [x] `extract_changelog.py --version 0.21.3` extracts cleanly
- [ ] Squash-merge triggers `tag-release.yml` → binary build