### PR TITLE
chore: release v0.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.4] - 2026-06-18
+
+_Highlights: disc titles that carry a season or box-set subtitle in their AI-guessed name now resolve on TMDB correctly instead of stalling on an identity prompt._
+
 ### Fixed
 
-- Disc titles that include a season/box-set subtitle (e.g. an AI-guessed "Avatar: The Last Airbender Book One: Water") now resolve their TMDB id by stripping the trailing Book/Volume/Part/Season subtitle. Previously the over-specified name matched nothing on TMDB, which left the job without a tmdb_id — forcing an identity prompt and failing subtitle download.
+- **Disc titles carrying a season or box-set subtitle now find their TMDB match** — when the AI resolved a title like "Avatar: The Last Airbender Book One: Water", the over-specified name matched nothing on TMDB, leaving the job without a `tmdb_id` and forcing an identity prompt while subtitle download failed. Engram now strips the trailing Book/Volume/Part/Season qualifier before the TMDB lookup, so the disc identifies cleanly and episode matching proceeds without interruption. (#420)
 
 ## [0.21.3] - 2026-06-16
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.3"
+__version__ = "0.21.4"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.3"
+version = "0.21.4"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.3"
+version = "0.21.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.3",
+    "version": "0.21.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.3",
+            "version": "0.21.4",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.3",
+    "version": "0.21.4",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bumps version to 0.21.4 across all 6 version files
- Moves `[Unreleased]` CHANGELOG entry to `[0.21.4] - 2026-06-18`
- Regenerates CONTRIBUTORS.md (no new external contributors this cycle)

## Changes since v0.21.3

**Fixed**
- Disc titles carrying a season or box-set subtitle (e.g. AI-guessed "Avatar: The Last Airbender Book One: Water") now strip the qualifier before the TMDB lookup, so the disc identifies cleanly instead of stalling on an identity prompt and failing subtitle download. (#420)

**Deps** (no user-facing impact)
- `@types/node` → `^25.9.3` (#418)
- `eslint-plugin-react-refresh` → `^0.5.3` (#419)

## Test Plan
- [x] Unit tests: 2384 passed
- [x] `extract_changelog.py --version 0.21.4` produces correct release notes
- [x] All 6 version files updated to 0.21.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)