### PR TITLE
chore: release v0.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.5] - 2026-06-18
+
+_Highlights: the in-app update restart button no longer incorrectly blocks when a job is parked in Needs Review or when dismissed cards are still in the database._
+
+### Fixed
+
+- **Update restart no longer false-fires "disc operation in progress" for parked or dismissed jobs** — two bugs caused the restart button to refuse even when no disc I/O was happening: `REVIEW_NEEDED` was counted as a blocking state even though the disc is already out and the job is waiting for user input, and jobs dismissed from the dashboard (`cleared_at` set) were not excluded from the active-job check, so an invisible ghost card could permanently block the button. Both are now fixed. (#422)
+
 ## [0.21.4] - 2026-06-18
 
 _Highlights: disc titles that carry a season or box-set subtitle in their AI-guessed name now resolve on TMDB correctly instead of stalling on an identity prompt._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.4"
+__version__ = "0.21.5"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.4"
+version = "0.21.5"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.4"
+version = "0.21.5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.4",
+    "version": "0.21.5",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to `0.21.5` in `backend/pyproject.toml` and `frontend/package.json`
- Add `## [0.21.5]` CHANGELOG entry for the updater fix shipped in #422

## What's in this release

**Fixed**: Update restart no longer false-fires "disc operation in progress" for parked or dismissed jobs — `REVIEW_NEEDED` was incorrectly counted as a blocking state (the disc is already out at that point), and jobs cleared from the dashboard were not excluded from the active-job check. (#422)

## Test plan

- [ ] `python backend/scripts/extract_changelog.py --version 0.21.5` prints the correct release body
- [ ] CI `changelog-version-check` passes
- [ ] Squash-merge → tag `v0.21.5` → release workflow publishes binaries with the extracted notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKPK1uwM5Bc5Pdv2Qwqtn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKPK1uwM5Bc5Pdv2Qwqtn2)_