### PR TITLE
chore: release v0.21.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.6] - 2026-06-19
+
+_Highlights: two disc-handling fixes — the Identify prompt no longer pops a blocking modal over a disc that is already ripping, and box-set TV discs now pin their TMDB lookup to the TV namespace instead of picking a fuzzy movie match._
+
 ### Fixed
 
 - **The "Identify Disc" prompt no longer pops a blocking modal over a disc that is already ripping** — when a disc rips first with an open identity question (an unreadable label, or a title TMDB couldn't match), the prompt used to auto-open as a full-screen modal whose "Start Ripping →" button and "Awaiting Input" status made it look like the rip was blocked — so it was easy to hit **Cancel Job** and kill a healthy rip. The rip now stays visible with a **Name this disc** button on the card instead; the prompt only auto-opens once the rip finishes and the job is waiting for you. When the prompt is opened, its wording now reflects reality — it saves the title rather than "starting" a rip that's already underway, shows the actual reason TMDB couldn't match (instead of always claiming the label is unreadable), and reads "Ripping" while the disc is still ripping. (#424)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.5"
+__version__ = "0.21.6"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.5"
+version = "0.21.6"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.5"
+version = "0.21.6"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.4",
+    "version": "0.21.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.4",
+            "version": "0.21.6",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.5",
+    "version": "0.21.6",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Moves two fixes from `[Unreleased]` into the `[0.21.6]` CHANGELOG section
- Bumps version to 0.21.6 across `pyproject.toml`, `__init__.py`, `package.json`, `package-lock.json`, and `uv.lock`
- Catches up `package-lock.json` from 0.21.4 (both self-version fields were missed in the 0.21.5 release)

## What's in this release

- **#424** — The "Identify Disc" prompt no longer pops a blocking modal over a disc that is already ripping
- **#425** — Box-set TV discs now resolve to the TV series instead of a look-alike movie

## Test Plan

- [x] `uv run pytest tests/unit/` — 2396 passed
- [x] `extract_changelog.py --version 0.21.6` — extracts cleanly
- [ ] CI changelog-version-check must pass (version in pyproject.toml matches CHANGELOG section)