### PR TITLE
feat(discdb): enable lookup, keep contribution gated, prefer ASR over disc-order episodes

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3231,6 +3231,7 @@ async def upc_lookup(
     job: DiscJob = Depends(get_job_or_404),
 ):
     """Look up product info by UPC barcode."""
+    _require_discdb_contributions()
     from app.core.upc_lookup import compute_match_confidence, lookup_upc
 
     result = await lookup_upc(request.upc_code)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3198,6 +3198,7 @@ async def skip_contribution(
     session: AsyncSession = Depends(get_session),
 ):
     """Mark a job as skipped for contribution."""
+    _require_discdb_contributions()
     from app.core.discdb_exporter import mark_skipped
 
     await mark_skipped(job.id, session)
@@ -3256,6 +3257,7 @@ async def fetch_cover(
     session: AsyncSession = Depends(get_session),
 ):
     """Download a cover image and save it to the export directory."""
+    _require_discdb_contributions()
     # Lazy import (matches get_db_config below). Keep it inline: the fetch-cover
     # test patches app.core.discdb_exporter.get_export_directory — the binding
     # this resolves at call time — so hoisting it to module scope would bypass
@@ -3337,6 +3339,7 @@ async def enhance_contribution(
     session: AsyncSession = Depends(get_session),
 ):
     """Add tier-3 data (UPC) and re-export."""
+    _require_discdb_contributions()
     from app.core.discdb_exporter import generate_export, mark_exported
     from app.services.config_service import get_config as get_db_config
 
@@ -3789,6 +3792,7 @@ async def create_release_group(
     session: AsyncSession = Depends(get_session),
 ):
     """Create a release group linking multiple disc jobs."""
+    _require_discdb_contributions()
     import uuid
 
     unique_ids = list(dict.fromkeys(request.job_ids))  # deduplicate, preserve order
@@ -3820,6 +3824,7 @@ async def assign_release_group(
     session: AsyncSession = Depends(get_session),
 ):
     """Assign or remove a job from a release group."""
+    _require_discdb_contributions()
     if request.release_group_id:
         # Verify the release group exists (at least one other job has it)
         result = await session.execute(

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3146,12 +3146,25 @@ async def contribution_stats(session: AsyncSession = Depends(get_session)):
     )
 
 
+def _require_discdb_contributions() -> None:
+    """Reject contribution endpoints unless the contribution feature is enabled.
+
+    Lookup may be on while contribution stays gated; without this guard the
+    submit/export endpoints would remain reachable directly.
+    """
+    from app.core.features import DISCDB_CONTRIBUTIONS_ENABLED
+
+    if not DISCDB_CONTRIBUTIONS_ENABLED:
+        raise HTTPException(status_code=404, detail="TheDiscDB contributions are disabled")
+
+
 @router.post("/contributions/{job_id}/export", dependencies=[Depends(require_localhost)])
 async def export_contribution(
     job: DiscJob = Depends(get_job_or_404),
     session: AsyncSession = Depends(get_session),
 ):
     """Manually trigger export for a specific job."""
+    _require_discdb_contributions()
     from app.core.discdb_exporter import generate_export, mark_exported
     from app.core.discdb_submitter import ensure_release_group_id
     from app.services.config_service import get_config as get_db_config
@@ -3731,6 +3744,7 @@ async def submit_contribution(
     session: AsyncSession = Depends(get_session),
 ):
     """Submit a job's disc data to TheDiscDB API."""
+    _require_discdb_contributions()
     from app.core.discdb_submitter import ensure_release_group_id, submit_job
     from app.services.config_service import get_config as get_db_config
 
@@ -3833,6 +3847,7 @@ async def submit_release_group_endpoint(
     session: AsyncSession = Depends(get_session),
 ):
     """Batch-submit all completed jobs in a release group to TheDiscDB."""
+    _require_discdb_contributions()
     from app.core.discdb_submitter import submit_release_group
     from app.services.config_service import get_config as get_db_config
 

--- a/backend/app/core/features.py
+++ b/backend/app/core/features.py
@@ -5,6 +5,10 @@ Flip to True to expose a feature that has been merged but isn't user-ready.
 Paired with frontend `src/config/constants.ts` FEATURES.
 """
 
-# TheDiscDB integration — lookups, contributions, match-source UI.
-# Keep False until the API contract and UX are validated with real users.
-DISCDB_ENABLED = False
+# TheDiscDB lookup — disc identification + track matching. Read-only GraphQL
+# queries; safe to ship.
+DISCDB_LOOKUP_ENABLED = True
+
+# TheDiscDB contributions — local export + submit/upload to thediscdb.com.
+# Keep False until the contribution API contract and UX are validated.
+DISCDB_CONTRIBUTIONS_ENABLED = False

--- a/backend/app/services/cleanup_service.py
+++ b/backend/app/services/cleanup_service.py
@@ -33,9 +33,13 @@ class CleanupService:
             await self.delete_staging(job_id)
 
         # Auto-export for TheDiscDB contributions
-        from app.core.features import DISCDB_ENABLED
+        from app.core.features import DISCDB_CONTRIBUTIONS_ENABLED
 
-        if DISCDB_ENABLED and state == JobState.COMPLETED and config.discdb_contributions_enabled:
+        if (
+            DISCDB_CONTRIBUTIONS_ENABLED
+            and state == JobState.COMPLETED
+            and config.discdb_contributions_enabled
+        ):
             await self.auto_export_for_discdb(job_id, config)
 
     async def delete_staging(self, job_id: int) -> None:

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1056,18 +1056,18 @@ class IdentificationCoordinator:
                         for dt in db_titles:
                             if dt.output_filename:
                                 file_path = Path(dt.output_filename)
-                                discdb_applied = await self._try_discdb_assignment(
-                                    job_id, dt, session
+                                # ASR-preferred precedence: always run audio matching.
+                                # A DiscDB episode mapping (disc order, not aired order)
+                                # is applied only as a low-confidence fallback inside
+                                # _match_single_file_inner.
+                                task = asyncio.create_task(
+                                    self._match_single_file(job_id, dt.id, file_path)
                                 )
-                                if not discdb_applied:
-                                    task = asyncio.create_task(
-                                        self._match_single_file(job_id, dt.id, file_path)
+                                task.add_done_callback(
+                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                        t, jid, tid
                                     )
-                                    task.add_done_callback(
-                                        lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
-                                            t, jid, tid
-                                        )
-                                    )
+                                )
                 else:
                     # Movie: skip matching, go straight to organization. Route
                     # through the state machine (now a legal IDENTIFYING ->

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1722,7 +1722,8 @@ class IdentificationCoordinator:
         # a failed lookup still applies the override). For the top tier
         # (canonical) we additionally pre-assign episodes via the EXISTING DiscDB
         # mapping machinery (verified ±2s/±1% against scanned titles), letting
-        # try_discdb_assignment skip ASR at rip time. "confirmed" is identity
+        # stored DiscDB mappings may later be applied as a low-confidence fallback
+        # during matching (post-ASR, not in place of it). "confirmed" is identity
         # only — episodes are still verified by chromaprint/ASR. This runs BEFORE
         # the TheDiscDB block and wins over it (network_confident guards that
         # block) so the network result is never clobbered downstream.

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -208,7 +208,6 @@ class IdentificationCoordinator:
         self._start_subtitle_download: callable = None
         self._start_subtitle_download_all_seasons: callable = None
         self._restart_subtitle_download: callable = None
-        self._try_discdb_assignment: callable = None
         self._match_single_file: callable = None
         self._on_match_task_done: callable = None
         self._check_job_completion: callable = None
@@ -222,7 +221,6 @@ class IdentificationCoordinator:
         set_discdb_mappings,
         start_subtitle_download,
         restart_subtitle_download,
-        try_discdb_assignment,
         start_subtitle_download_all_seasons=None,
         match_single_file,
         on_match_task_done,
@@ -236,7 +234,6 @@ class IdentificationCoordinator:
         self._start_subtitle_download = start_subtitle_download
         self._start_subtitle_download_all_seasons = start_subtitle_download_all_seasons
         self._restart_subtitle_download = restart_subtitle_download
-        self._try_discdb_assignment = try_discdb_assignment
         self._match_single_file = match_single_file
         self._on_match_task_done = on_match_task_done
         self._check_job_completion = check_job_completion

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1513,10 +1513,10 @@ class IdentificationCoordinator:
                     )
 
         # Attempt TheDiscDB lookup
-        from app.core.features import DISCDB_ENABLED
+        from app.core.features import DISCDB_LOOKUP_ENABLED
 
         discdb_signal = None
-        if DISCDB_ENABLED and config.discdb_enabled:
+        if DISCDB_LOOKUP_ENABLED and config.discdb_enabled:
             try:
                 from app.core.discdb_classifier import classify_from_discdb
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1157,7 +1157,7 @@ class JobManager:
         """Resolve selected titles orphaned in PENDING/RIPPING after a rip finishes.
 
         A title whose staging file exists is routed into the normal completion path
-        (TV → DiscDB assignment or matching; movie → MATCHED); one with no file is
+        (TV → matching; movie → MATCHED); one with no file is
         marked FAILED. Guarantees no selected title is stranded in RIPPING once the
         MakeMKV subprocess has exited (the orphaned-last-title bug). Recovers work
         rather than discarding it.

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -178,7 +178,6 @@ class JobManager:
             start_subtitle_download=self._matching.start_subtitle_download,
             start_subtitle_download_all_seasons=self._matching.start_subtitle_download_all_seasons,
             restart_subtitle_download=self._matching.restart_subtitle_download,
-            try_discdb_assignment=self._matching.try_discdb_assignment,
             match_single_file=self._matching.match_single_file,
             on_match_task_done=self._matching.on_match_task_done,
             check_job_completion=self._finalization.check_job_completion,

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2862,7 +2862,6 @@ class JobManager:
         # that don't reach create_task must discard the sentinel.
         self._inflight_match_dispatch.add(title_id)
 
-        applied = False
         try:
             async with async_session() as session:
                 title = await session.get(DiscTitle, title_id)
@@ -2873,18 +2872,13 @@ class JobManager:
                     )
                     self._inflight_match_dispatch.discard(title_id)
                     return False
-                applied = await self._matching.try_discdb_assignment(job_id, title, session)
-                if applied:
-                    await self._finalization.check_job_completion(session, job_id)
         except Exception:
             self._inflight_match_dispatch.discard(title_id)
             raise
-        if applied:
-            # DiscDB path resolved the title — no match task needed; release
-            # the sentinel so a future re-dispatch (e.g. after a re-rip) works.
-            self._inflight_match_dispatch.discard(title_id)
-            return True
 
+        # ASR-preferred precedence: always run audio matching. A DiscDB episode
+        # mapping (disc order, not aired order) is applied only as a low-confidence
+        # fallback inside _match_single_file_inner.
         # match_single_file self-tags the job log context.
         task = asyncio.create_task(self._matching.match_single_file(job_id, title_id, file_path))
         task.add_done_callback(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -65,6 +65,12 @@ def _duration_matches_episode_runtime(title_minutes: float, runtimes: list[int])
     )
 
 
+# ASR-preferred episode precedence: ASR always runs and is authoritative at or
+# above this confidence. Only below it do we defer to a DiscDB episode mapping —
+# DiscDB numbers episodes by physical disc order, not aired order, so it is a
+# last-resort fallback, never a competitor to a usable ASR match.
+DISCDB_FALLBACK_ASR_FLOOR = 0.5
+
 # Season component of a matched_episode code ("S03E07" → 3). Used via
 # ``.match`` — PREFIX-anchored only: non-episode values like "extra"/None don't
 # parse and are ignored by the season-pin convergence rule, but a string that
@@ -1192,6 +1198,24 @@ class MatchingCoordinator:
                 title.match_confidence = result.confidence
 
                 if result.needs_review or advisory:
+                    # ASR-preferred precedence: a very low-confidence ASR result
+                    # (not a deliberate manual re-match) defers to a DiscDB episode
+                    # mapping when one exists, instead of going to review. DiscDB
+                    # numbers by disc order (not aired order), so it is trusted only
+                    # when ASR could not produce a usable match.
+                    if (
+                        not advisory
+                        and result.confidence < DISCDB_FALLBACK_ASR_FLOOR
+                        and await self.try_discdb_assignment(job_id, title, session)
+                    ):
+                        logger.info(
+                            f"[MATCH] Title {title_id} (Job {job_id}): ASR confidence "
+                            f"{result.confidence:.2f} < {DISCDB_FALLBACK_ASR_FLOOR}; "
+                            f"assigned episode from DiscDB mapping (disc-order fallback)."
+                        )
+                        await self._check_job_completion(session, job_id)
+                        return
+
                     # A low-confidence result always goes to REVIEW — even when the
                     # matcher emits a best-guess episode code. Auto-organizing a
                     # borderline guess silently mis-files content (e.g. a bonus

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1195,7 +1195,13 @@ class MatchingCoordinator:
                         await self._check_job_completion(session, job_id)
                         return
 
-                # Update title with match result
+                # Update title with match result. These in-memory writes are
+                # provisional: on the DiscDB-fallback path below, try_discdb_assignment
+                # overwrites both fields with the DiscDB episode (conf 0.99) and commits
+                # before returning, so no stale ASR value reaches the DB. The ordering
+                # matters — keep DiscDB's pre-commit work (dict lookups + formatting,
+                # which can't raise the caught exception types) failure-free so the outer
+                # error handler can never persist this stale ASR code to REVIEW.
                 title.matched_episode = result.episode_code
                 title.match_confidence = result.confidence
 
@@ -1205,6 +1211,10 @@ class MatchingCoordinator:
                     # mapping when one exists, instead of going to review. DiscDB
                     # numbers by disc order (not aired order), so it is trusted only
                     # when ASR could not produce a usable match.
+                    # Invariant: the curator always sets needs_review=True for a
+                    # low-confidence result, so a confidence below the floor implies
+                    # we are inside this branch. The fallback can therefore only
+                    # auto-organize via a DiscDB mapping, never by confidence alone.
                     if not advisory and result.confidence < DISCDB_FALLBACK_ASR_FLOOR:
                         if await self.try_discdb_assignment(job_id, title, session):
                             logger.info(

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -321,9 +321,11 @@ class MatchingCoordinator:
         self.start_subtitle_download(job_id, show_name, season, tmdb_id)
 
     async def try_discdb_assignment(self, job_id: int, title: "DiscTitle", session) -> bool:
-        """Try to assign episode info from TheDiscDB mappings, skipping fingerprinting.
+        """Apply a DiscDB disc-order episode mapping as a post-ASR low-confidence fallback.
 
-        Returns True if assignment was made, False to fall back to audio matching.
+        Called only after ASR has already run and returned a confidence below
+        DISCDB_FALLBACK_ASR_FLOOR. Returns True if a mapping was applied, False if
+        no usable mapping exists (and the caller should proceed to REVIEW).
         """
         mappings = self._discdb_mappings.get(job_id)
         if not mappings:
@@ -348,8 +350,8 @@ class MatchingCoordinator:
         origin = "disc network" if source == "network_disc" else "TheDiscDB"
         episode_code = f"S{mapping.season:02d}E{mapping.episode:02d}"
         logger.info(
-            f"Job {job_id}: {origin} pre-assigned title {title.title_index} "
-            f"→ {episode_code} ({mapping.episode_title!r}) — skipping audio matching"
+            f"Job {job_id}: {origin} applying disc-order fallback mapping for title "
+            f"{title.title_index}: {episode_code} ({mapping.episode_title!r})"
         )
 
         title.matched_episode = episode_code
@@ -1204,8 +1206,6 @@ class MatchingCoordinator:
                     # numbers by disc order (not aired order), so it is trusted only
                     # when ASR could not produce a usable match.
                     if not advisory and result.confidence < DISCDB_FALLBACK_ASR_FLOOR:
-                        # DiscDB numbers by disc order (not aired order), so it is
-                        # trusted only when ASR could not produce a usable match.
                         if await self.try_discdb_assignment(job_id, title, session):
                             logger.info(
                                 f"[MATCH] Title {title_id} (Job {job_id}): ASR confidence "

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -1203,18 +1203,17 @@ class MatchingCoordinator:
                     # mapping when one exists, instead of going to review. DiscDB
                     # numbers by disc order (not aired order), so it is trusted only
                     # when ASR could not produce a usable match.
-                    if (
-                        not advisory
-                        and result.confidence < DISCDB_FALLBACK_ASR_FLOOR
-                        and await self.try_discdb_assignment(job_id, title, session)
-                    ):
-                        logger.info(
-                            f"[MATCH] Title {title_id} (Job {job_id}): ASR confidence "
-                            f"{result.confidence:.2f} < {DISCDB_FALLBACK_ASR_FLOOR}; "
-                            f"assigned episode from DiscDB mapping (disc-order fallback)."
-                        )
-                        await self._check_job_completion(session, job_id)
-                        return
+                    if not advisory and result.confidence < DISCDB_FALLBACK_ASR_FLOOR:
+                        # DiscDB numbers by disc order (not aired order), so it is
+                        # trusted only when ASR could not produce a usable match.
+                        if await self.try_discdb_assignment(job_id, title, session):
+                            logger.info(
+                                f"[MATCH] Title {title_id} (Job {job_id}): ASR confidence "
+                                f"{result.confidence:.2f} < {DISCDB_FALLBACK_ASR_FLOOR}; "
+                                f"assigned episode from DiscDB mapping (disc-order fallback)."
+                            )
+                            await self._check_job_completion(session, job_id)
+                            return
 
                     # A low-confidence result always goes to REVIEW — even when the
                     # matcher emits a best-guess episode code. Auto-organizing a

--- a/backend/tests/integration/test_discdb_contribution.py
+++ b/backend/tests/integration/test_discdb_contribution.py
@@ -12,6 +12,16 @@ from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, Title
 
 
 @pytest.fixture(autouse=True)
+def enable_discdb_contributions(monkeypatch):
+    """The contribution write endpoints are gated behind DISCDB_CONTRIBUTIONS_ENABLED
+    (default False). This suite exercises the real contribution pipeline, so enable
+    the flag. The guard reads it via a lazy import at call time, so patching the
+    source attribute takes effect. Read-only endpoints (list/stats) are ungated and
+    unaffected either way."""
+    monkeypatch.setattr("app.core.features.DISCDB_CONTRIBUTIONS_ENABLED", True)
+
+
+@pytest.fixture(autouse=True)
 async def setup_db():
     """Initialize test database and clean data between tests."""
     await init_db()

--- a/backend/tests/unit/test_disc_name_identification.py
+++ b/backend/tests/unit/test_disc_name_identification.py
@@ -338,7 +338,7 @@ async def test_run_classification_uses_disc_name_when_label_fails(monkeypatch):
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -413,7 +413,7 @@ async def test_run_classification_uses_disc_name_when_label_resolves(monkeypatch
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -502,7 +502,7 @@ async def test_run_classification_reresolves_tv_when_label_matches_movie(monkeyp
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -582,7 +582,7 @@ async def test_run_classification_skips_redundant_reresolve_after_disc_name_fall
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -673,7 +673,7 @@ async def test_run_classification_reresolves_box_set_with_tv_preference(monkeypa
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -765,7 +765,7 @@ async def test_run_classification_disc_name_fallback_prefers_tv_for_box_set(monk
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch("app.core.tmdb_classifier.classify_from_tmdb", side_effect=fake_classify_from_tmdb),
         patch("app.matcher.tmdb_client.fetch_season_episode_runtimes", return_value=[]),
     ):
@@ -933,7 +933,7 @@ async def test_run_classification_fetches_runtimes_and_keeps_pilot(monkeypatch):
 
     with (
         patch("app.services.config_service.get_config", new=AsyncMock(return_value=mock_config)),
-        patch("app.core.features.DISCDB_ENABLED", False),
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
         patch(
             "app.core.tmdb_classifier.classify_from_tmdb",
             side_effect=lambda name, api_key, prefer_content_type=None: ds9_signal,

--- a/backend/tests/unit/test_fetch_cover_security.py
+++ b/backend/tests/unit/test_fetch_cover_security.py
@@ -16,6 +16,18 @@ from app.models.disc_job import ContentType, DiscJob, JobState
 from tests.unit.conftest import _unit_session_factory
 
 
+@pytest.fixture(autouse=True)
+def enable_discdb_contributions(monkeypatch):
+    """Enable the contributions feature gate so fetch-cover tests reach the real endpoint logic.
+
+    The _require_discdb_contributions() guard does a lazy import of
+    app.core.features.DISCDB_CONTRIBUTIONS_ENABLED at call time, so patching
+    the module attribute is sufficient to bypass the gate for the duration of
+    each test.
+    """
+    monkeypatch.setattr("app.core.features.DISCDB_CONTRIBUTIONS_ENABLED", True)
+
+
 @pytest.fixture
 async def client():
     """Provide an async HTTP client with the patched DB session."""

--- a/backend/tests/unit/test_identification_coordinator.py
+++ b/backend/tests/unit/test_identification_coordinator.py
@@ -124,7 +124,7 @@ class TestRunClassification:
         analyst.analyze.return_value = _analysis(detected_name=None)
         coord = _make_coord(analyst)
         _patch_config(monkeypatch, _config(discdb_enabled=True))
-        monkeypatch.setattr("app.core.features.DISCDB_ENABLED", True)
+        monkeypatch.setattr("app.core.features.DISCDB_LOOKUP_ENABLED", True)
 
         @dataclass
         class _Mapping:
@@ -160,7 +160,7 @@ class TestRunClassification:
         analyst.analyze.return_value = _analysis(detected_name=None)
         coord = _make_coord(analyst)
         _patch_config(monkeypatch, _config(discdb_enabled=True))
-        monkeypatch.setattr("app.core.features.DISCDB_ENABLED", True)
+        monkeypatch.setattr("app.core.features.DISCDB_LOOKUP_ENABLED", True)
 
         signal = SimpleNamespace(
             content_type=ContentType.TV,

--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -90,9 +90,6 @@ class TestOnTitleRipped:
 
     async def test_tv_title_dispatches_match_when_no_discdb(self, tmp_path, monkeypatch):
         job, title = await _seed(content_type=ContentType.TV)
-        monkeypatch.setattr(
-            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=False)
-        )
         dispatch = AsyncMock()
         monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
         monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
@@ -153,16 +150,14 @@ class TestOnTitleRippedIdentityGate:
     releases them once the prompt is answered."""
 
     def _stub_dispatch(self, monkeypatch):
-        discdb = AsyncMock(return_value=False)
         dispatch = AsyncMock()
-        monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", discdb)
         monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
         monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
-        return discdb, dispatch
+        return dispatch
 
     async def test_tv_with_prompt_parks_queued_without_dispatch(self, tmp_path, monkeypatch):
         job, title = await _seed(content_type=ContentType.TV, identity_prompt_json=_PROMPT)
-        discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
         path = tmp_path / "show_t00.mkv"
         path.write_text("")
 
@@ -172,7 +167,6 @@ class TestOnTitleRippedIdentityGate:
         t = await _get_title(title.id)
         assert t.state == TitleState.QUEUED
         assert t.output_filename == str(path)
-        discdb.assert_not_called()
         dispatch.assert_not_called()
 
     @pytest.mark.parametrize("content_type", [ContentType.UNKNOWN, ContentType.MOVIE])
@@ -182,7 +176,7 @@ class TestOnTitleRippedIdentityGate:
         """An identity-pending job must NOT fall into the non-TV → MATCHED branch:
         that would mark titles matched with no identity."""
         job, title = await _seed(content_type=content_type, identity_prompt_json=_PROMPT)
-        discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
         path = tmp_path / "disc_t00.mkv"
         path.write_text("")
 
@@ -191,7 +185,6 @@ class TestOnTitleRippedIdentityGate:
 
         t = await _get_title(title.id)
         assert t.state == TitleState.QUEUED
-        discdb.assert_not_called()
         dispatch.assert_not_called()
 
     async def test_reidentify_prompt_also_parks(self, tmp_path, monkeypatch):
@@ -200,7 +193,7 @@ class TestOnTitleRippedIdentityGate:
             content_type=ContentType.TV,
             identity_prompt_json=json.dumps({"kind": "reidentify", "reason": "twins"}),
         )
-        discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
         path = tmp_path / "show_t00.mkv"
         path.write_text("")
 
@@ -208,7 +201,6 @@ class TestOnTitleRippedIdentityGate:
         await asyncio.sleep(0)
 
         assert (await _get_title(title.id)).state == TitleState.QUEUED
-        discdb.assert_not_called()
         dispatch.assert_not_called()
 
     async def test_season_prompt_dispatches_normally(self, tmp_path, monkeypatch):
@@ -218,7 +210,7 @@ class TestOnTitleRippedIdentityGate:
         and _has_pending_match_work refreshes the watchdog clock with nothing
         ever dispatching."""
         job, title = await _seed(content_type=ContentType.TV, identity_prompt_json=_SEASON_PROMPT)
-        discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
         path = tmp_path / "show_t00.mkv"
         path.write_text("")
 
@@ -228,8 +220,7 @@ class TestOnTitleRippedIdentityGate:
         t = await _get_title(title.id)
         assert t.state == TitleState.QUEUED  # flip to MATCHING is post-semaphore
         # ASR-preferred precedence: match_single_file is always dispatched.
-        # try_discdb_assignment is no longer called in _dispatch_title_match
-        # (it is applied as a fallback inside _match_single_file_inner instead).
+        # try_discdb_assignment is applied as a fallback inside _match_single_file_inner.
         dispatch.assert_awaited_once()
 
 
@@ -238,13 +229,11 @@ class TestDispatchPendingMatches:
     """dispatch_pending_matches releases identity-gated QUEUED titles: dispatch
     exactly the QUEUED titles whose ripped file exists, idempotently."""
 
-    def _stub_dispatch(self, monkeypatch, discdb_applied=False):
-        discdb = AsyncMock(return_value=discdb_applied)
+    def _stub_dispatch(self, monkeypatch):
         dispatch = AsyncMock()
-        monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", discdb)
         monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
         monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
-        return discdb, dispatch
+        return dispatch
 
     async def _add_title(self, job_id, index, state, output=None):
         async with _unit_session_factory() as session:
@@ -270,7 +259,7 @@ class TestDispatchPendingMatches:
         g = tmp_path / "show_t04.mkv"
         g.write_text("")
         await self._add_title(job.id, 4, TitleState.MATCHED, output=str(g))
-        _discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
 
         count = await job_manager.dispatch_pending_matches(job.id)
         await asyncio.sleep(0)
@@ -288,7 +277,7 @@ class TestDispatchPendingMatches:
         f = tmp_path / "show_t01.mkv"
         f.write_text("")
         queued = await self._add_title(job.id, 1, TitleState.QUEUED, output=str(f))
-        _discdb, dispatch = self._stub_dispatch(monkeypatch, discdb_applied=True)
+        dispatch = self._stub_dispatch(monkeypatch)
 
         count = await job_manager.dispatch_pending_matches(job.id)
         await asyncio.sleep(0)
@@ -306,9 +295,6 @@ class TestDispatchPendingMatches:
         f.write_text("")
         title = await self._add_title(job.id, 1, TitleState.QUEUED, output=str(f))
 
-        monkeypatch.setattr(
-            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=False)
-        )
         release = asyncio.Event()
         calls = []
 
@@ -339,7 +325,7 @@ class TestDispatchPendingMatches:
 
     async def test_no_queued_titles_is_noop(self, tmp_path, monkeypatch):
         job, _ = await _seed(content_type=ContentType.TV)
-        _discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
 
         assert await job_manager.dispatch_pending_matches(job.id) == 0
         dispatch.assert_not_called()
@@ -351,7 +337,7 @@ class TestDispatchPendingMatches:
         f = tmp_path / "movie_t01.mkv"
         f.write_text("")
         await self._add_title(job.id, 1, TitleState.QUEUED, output=str(f))
-        _discdb, dispatch = self._stub_dispatch(monkeypatch)
+        dispatch = self._stub_dispatch(monkeypatch)
 
         assert await job_manager.dispatch_pending_matches(job.id) == 0
         dispatch.assert_not_called()
@@ -1117,8 +1103,7 @@ class TestDispatchTitleMatchTOCTOU:
     path that does NOT dispatch a task must discard the sentinel so a future
     legitimate dispatch is not permanently blocked."""
 
-    def _stub_matching(self, monkeypatch, discdb_applied=False):
-        discdb = AsyncMock(return_value=discdb_applied)
+    def _stub_matching(self, monkeypatch):
         release = asyncio.Event()
         calls = []
 
@@ -1126,17 +1111,16 @@ class TestDispatchTitleMatchTOCTOU:
             calls.append((jid, tid))
             await release.wait()
 
-        monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", discdb)
         monkeypatch.setattr(job_manager._matching, "match_single_file", slow_match)
         monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
-        return discdb, calls, release
+        return calls, release
 
     async def test_concurrent_calls_spawn_exactly_one_task(self, tmp_path, monkeypatch):
         """Two concurrent _dispatch_title_match for the same title must not
         double-spawn: the sentinel is claimed before any await so both coroutines
         can't both pass the membership check."""
         job, title = await _seed(content_type=ContentType.TV)
-        _discdb, calls, release = self._stub_matching(monkeypatch)
+        calls, release = self._stub_matching(monkeypatch)
 
         f = tmp_path / "show_t00.mkv"
         f.write_text("")
@@ -1165,7 +1149,7 @@ class TestDispatchTitleMatchTOCTOU:
         match task finishes. ASR-preferred precedence: _dispatch_title_match always
         spawns a match task (no DiscDB pre-dispatch short-circuit)."""
         job, title = await _seed(content_type=ContentType.TV)
-        _discdb, calls, release = self._stub_matching(monkeypatch)
+        calls, release = self._stub_matching(monkeypatch)
 
         f = tmp_path / "show_t00.mkv"
         f.write_text("")

--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -1110,8 +1110,12 @@ class TestDispatchTitleMatchTOCTOU:
     two concurrent ``_dispatch_title_match`` calls for the same title cannot both
     slip through the membership check and spawn duplicate match tasks (TOCTOU).
 
-    The discdb-applied early-return path must also discard the sentinel so a
-    future legitimate dispatch is not permanently blocked."""
+    The match task is always dispatched — there is no DiscDB early-return in
+    ``_dispatch_title_match``.  The sentinel is claimed atomically before the
+    dispatch ``await``, held for the lifetime of the spawned task, and released
+    by ``_on_match_dispatch_done`` when the task completes.  Any early-return
+    path that does NOT dispatch a task must discard the sentinel so a future
+    legitimate dispatch is not permanently blocked."""
 
     def _stub_matching(self, monkeypatch, discdb_applied=False):
         discdb = AsyncMock(return_value=discdb_applied)

--- a/backend/tests/unit/test_job_manager.py
+++ b/backend/tests/unit/test_job_manager.py
@@ -108,22 +108,27 @@ class TestOnTitleRipped:
         assert t.state == TitleState.QUEUED
         dispatch.assert_awaited_once()
 
-    async def test_tv_title_with_discdb_checks_completion(self, tmp_path, monkeypatch):
+    async def test_tv_title_always_dispatches_match_regardless_of_discdb(
+        self, tmp_path, monkeypatch
+    ):
+        """ASR-preferred precedence: match_single_file is always dispatched for TV titles.
+        DiscDB assignment (if any) is now applied as a fallback inside _match_single_file_inner,
+        not as a pre-dispatch short-circuit in _dispatch_title_match."""
         job, title = await _seed(content_type=ContentType.TV)
-        monkeypatch.setattr(
-            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=True)
-        )
         dispatch = AsyncMock()
         monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
-        completion = AsyncMock()
-        monkeypatch.setattr(job_manager._finalization, "check_job_completion", completion)
+        monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
         path = tmp_path / "show_t00.mkv"
         path.write_text("")
 
         await job_manager._on_title_ripped(job.id, 1, path, [title])
+        await asyncio.sleep(0)  # let the dispatched task run
 
-        completion.assert_awaited_once()
-        dispatch.assert_not_called()
+        t = await _get_title(title.id)
+        # Always dispatched — QUEUED (match_single_file is mocked, so the
+        # post-semaphore QUEUED→MATCHING flip never runs here).
+        assert t.state == TitleState.QUEUED
+        dispatch.assert_awaited_once()
 
     async def test_unresolvable_file_is_noop(self, tmp_path):
         job, title = await _seed(content_type=ContentType.TV)
@@ -222,7 +227,9 @@ class TestOnTitleRippedIdentityGate:
 
         t = await _get_title(title.id)
         assert t.state == TitleState.QUEUED  # flip to MATCHING is post-semaphore
-        discdb.assert_awaited_once()
+        # ASR-preferred precedence: match_single_file is always dispatched.
+        # try_discdb_assignment is no longer called in _dispatch_title_match
+        # (it is applied as a fallback inside _match_single_file_inner instead).
         dispatch.assert_awaited_once()
 
 
@@ -273,20 +280,21 @@ class TestDispatchPendingMatches:
         # The RIPPING seed title is untouched.
         assert (await _get_title(ripping.id)).state == TitleState.RIPPING
 
-    async def test_discdb_assignment_path_checks_completion(self, tmp_path, monkeypatch):
+    async def test_discdb_assignment_path_dispatches_match(self, tmp_path, monkeypatch):
+        """ASR-preferred precedence: match_single_file is always dispatched.
+        DiscDB assignment is now applied as a fallback inside _match_single_file_inner,
+        not as a pre-dispatch short-circuit in _dispatch_title_match."""
         job, _ = await _seed(content_type=ContentType.TV)
         f = tmp_path / "show_t01.mkv"
         f.write_text("")
-        await self._add_title(job.id, 1, TitleState.QUEUED, output=str(f))
+        queued = await self._add_title(job.id, 1, TitleState.QUEUED, output=str(f))
         _discdb, dispatch = self._stub_dispatch(monkeypatch, discdb_applied=True)
-        completion = AsyncMock()
-        monkeypatch.setattr(job_manager._finalization, "check_job_completion", completion)
 
         count = await job_manager.dispatch_pending_matches(job.id)
+        await asyncio.sleep(0)
 
         assert count == 1
-        completion.assert_awaited_once()
-        dispatch.assert_not_called()
+        dispatch.assert_awaited_once_with(job.id, queued.id, f)
 
     async def test_double_dispatch_does_not_double_match(self, tmp_path, monkeypatch):
         """The in-flight guard makes repeat dispatch safe: the QUEUED→MATCHING
@@ -1148,25 +1156,31 @@ class TestDispatchTitleMatchTOCTOU:
         await asyncio.sleep(0.05)
         assert title.id not in job_manager._inflight_match_dispatch
 
-    async def test_discdb_applied_path_releases_sentinel(self, tmp_path, monkeypatch):
-        """When DiscDB assignment resolves the title (no match task spawned),
-        the sentinel must be discarded so a subsequent dispatch is not blocked."""
+    async def test_match_task_releases_sentinel_on_completion(self, tmp_path, monkeypatch):
+        """The in-flight sentinel is released by _on_match_dispatch_done once the
+        match task finishes. ASR-preferred precedence: _dispatch_title_match always
+        spawns a match task (no DiscDB pre-dispatch short-circuit)."""
         job, title = await _seed(content_type=ContentType.TV)
-        self._stub_matching(monkeypatch, discdb_applied=True)
-        completion = AsyncMock()
-        monkeypatch.setattr(job_manager._finalization, "check_job_completion", completion)
+        _discdb, calls, release = self._stub_matching(monkeypatch)
 
         f = tmp_path / "show_t00.mkv"
         f.write_text("")
 
         result = await job_manager._dispatch_title_match(job.id, title.id, f)
         assert result is True
-        # Sentinel must be released — no match task was spawned.
+        # Sentinel is held while the task is running.
+        assert title.id in job_manager._inflight_match_dispatch
+
+        # Let the task finish; sentinel is released by _on_match_dispatch_done.
+        release.set()
+        await asyncio.sleep(0.05)
         assert title.id not in job_manager._inflight_match_dispatch
 
         # A follow-up dispatch (e.g. after a re-rip) must not be blocked.
         result2 = await job_manager._dispatch_title_match(job.id, title.id, f)
         assert result2 is True
+        release.set()
+        await asyncio.sleep(0.05)
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_match_source.py
+++ b/backend/tests/unit/test_match_source.py
@@ -383,3 +383,33 @@ async def test_discdb_match_details_stored_separately(monkeypatch):
         assert title.discdb_match_details == title.match_details
         # Both should contain "discdb" source indicator
         assert "discdb" in title.discdb_match_details
+
+
+@pytest.mark.asyncio
+async def test_very_low_asr_no_discdb_mapping_goes_to_review(monkeypatch):
+    """4th band: ASR < 0.5 with NO DiscDB mapping routes to REVIEW. The fallback's
+    try_discdb_assignment returns False (no mapping), so the title falls through to
+    the normal low-confidence review path, keeping the ASR best-guess as a suggestion."""
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"
+    mock_result.confidence = 0.35
+    mock_result.needs_review = True
+    mock_result.match_details = {"score": 0.35}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={})  # no mappings
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.REVIEW
+        assert title.matched_episode == "S01E07"  # ASR guess kept as suggestion
+        assert title.match_source is None  # DiscDB never applied

--- a/backend/tests/unit/test_match_source.py
+++ b/backend/tests/unit/test_match_source.py
@@ -231,6 +231,125 @@ async def test_match_respects_force_advance_race(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_high_confidence_asr_wins_over_discdb_mapping(monkeypatch):
+    """ASR is the preferred signal: a confident ASR match wins even when a
+    DiscDB mapping disagrees (DiscDB numbers by disc order, not aired order)."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E03"  # ASR says E03
+    mock_result.confidence = 0.85
+    mock_result.needs_review = False
+    mock_result.match_details = {"score": 0.85}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0,
+        title_type="Episode",
+        episode_title="Pilot",
+        season=1,
+        episode=1,
+        duration_seconds=2400,
+        size_bytes=1024**3,
+    )  # DiscDB says E01
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.MATCHED
+        assert title.matched_episode == "S01E03"  # ASR won
+        assert title.match_source == "engram"
+
+
+@pytest.mark.asyncio
+async def test_very_low_asr_falls_back_to_discdb_autoorganize(monkeypatch):
+    """When ASR confidence is very low (< 0.5) and a DiscDB mapping exists, the
+    DiscDB episode is assigned and auto-organized instead of going to review."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"  # weak ASR guess
+    mock_result.confidence = 0.41
+    mock_result.needs_review = True
+    mock_result.match_details = {"score": 0.41}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0,
+        title_type="Episode",
+        episode_title="Pilot",
+        season=1,
+        episode=1,
+        duration_seconds=2400,
+        size_bytes=1024**3,
+    )
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.MATCHED  # auto-organized, not review
+        assert title.matched_episode == "S01E01"  # DiscDB mapping
+        assert title.match_source == "discdb"
+
+
+@pytest.mark.asyncio
+async def test_mid_confidence_asr_goes_to_review_not_discdb(monkeypatch):
+    """Mid-confidence ASR (0.5 <= conf < 0.7) routes to review as the ASR guess;
+    DiscDB is NOT used because ASR is preferred above the 0.5 floor."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"
+    mock_result.confidence = 0.60
+    mock_result.needs_review = True
+    mock_result.match_details = {"score": 0.60}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0,
+        title_type="Episode",
+        episode_title="Pilot",
+        season=1,
+        episode=1,
+        duration_seconds=2400,
+        size_bytes=1024**3,
+    )
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.REVIEW  # ASR guess held for review
+        assert title.match_source is None  # DiscDB not applied
+
+
+@pytest.mark.asyncio
 async def test_discdb_match_details_stored_separately(monkeypatch):
     """discdb_match_details should be a copy of match_details at assignment time."""
     from app.core.discdb_classifier import DiscDbTitleMapping

--- a/docs/superpowers/plans/2026-06-20-discdb-lookup-asr-precedence.md
+++ b/docs/superpowers/plans/2026-06-20-discdb-lookup-asr-precedence.md
@@ -1,0 +1,850 @@
+# DiscDB Lookup Enablement + ASR-Preferred Episode Precedence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable TheDiscDB lookup (disc identification + track matching) while keeping contribution gated off, and make Engram ASR the preferred episode signal so DiscDB's disc-order episode mappings only apply as a low-confidence fallback.
+
+**Architecture:** Split the single backend (`DISCDB_ENABLED`) and frontend (`FEATURES.DISCDB`) master switches into separate lookup and contribution flags. Invert the ASR/DiscDB episode precedence: remove the two pre-dispatch DiscDB short-circuits so ASR always runs, and move DiscDB episode assignment into `_match_single_file_inner` as a fallback gated on ASR confidence (< 0.5). Harden the contribution submit endpoints with a backend gate. Refresh the stale DiscDB match-source badge.
+
+**Tech Stack:** Python/FastAPI/SQLModel backend (pytest), React/TypeScript/Vite frontend (vitest).
+
+**Spec:** `docs/superpowers/specs/2026-06-20-discdb-lookup-asr-precedence.md`
+
+---
+
+## File Structure
+
+Backend:
+- `backend/app/core/features.py` — split master flag into lookup + contributions.
+- `backend/app/services/identification_coordinator.py` — re-gate lookup; remove DiscDB short-circuit; drop dead injection.
+- `backend/app/services/cleanup_service.py` — re-gate auto-export under contributions flag.
+- `backend/app/services/matching_coordinator.py` — add `DISCDB_FALLBACK_ASR_FLOOR`; add DiscDB fallback in `_match_single_file_inner`.
+- `backend/app/services/job_manager.py` — remove DiscDB short-circuit in `_dispatch_match_for_title`; drop dead wiring.
+- `backend/app/api/routes.py` — backend contribution guard on submit/export endpoints.
+- Tests: `backend/tests/unit/test_match_source.py`, `test_identification_coordinator.py`, `test_disc_name_identification.py`.
+
+Frontend:
+- `frontend/src/config/constants.ts` — split `FEATURES.DISCDB`.
+- `frontend/src/config/routes.ts`, `frontend/src/app/navigation.ts`, `frontend/src/app/App.tsx`, `frontend/src/components/ReviewQueue/Inspector.tsx`, `frontend/src/components/HistoryPage.tsx`, `frontend/src/components/ConfigWizard.tsx` — re-gate per concern.
+- `frontend/src/app/components/synapse/tokens.ts` — add `blue` token.
+- `frontend/src/app/components/TrackGrid.tsx` — DiscDB icon-chip badge.
+- Tests: `frontend/src/app/components/TrackGrid.test.tsx`, `frontend/src/app/__tests__/App.routing.test.tsx`.
+
+---
+
+## Task 1: Split backend feature flags
+
+**Files:**
+- Modify: `backend/app/core/features.py`
+- Modify: `backend/app/services/identification_coordinator.py:1516-1519`
+- Modify: `backend/app/services/cleanup_service.py:36-39`
+
+- [ ] **Step 1: Replace the master flag with two flags**
+
+In `backend/app/core/features.py`, replace the whole body after the docstring:
+```python
+# TheDiscDB lookup — disc identification + track matching. Read-only GraphQL
+# queries; safe to ship.
+DISCDB_LOOKUP_ENABLED = True
+
+# TheDiscDB contributions — local export + submit/upload to thediscdb.com.
+# Keep False until the contribution API contract and UX are validated.
+DISCDB_CONTRIBUTIONS_ENABLED = False
+```
+
+- [ ] **Step 2: Re-gate the lookup consumer**
+
+In `backend/app/services/identification_coordinator.py` around line 1516-1519, change:
+```python
+        from app.core.features import DISCDB_ENABLED
+
+        discdb_signal = None
+        if DISCDB_ENABLED and config.discdb_enabled:
+```
+to:
+```python
+        from app.core.features import DISCDB_LOOKUP_ENABLED
+
+        discdb_signal = None
+        if DISCDB_LOOKUP_ENABLED and config.discdb_enabled:
+```
+
+- [ ] **Step 3: Re-gate the auto-export consumer**
+
+In `backend/app/services/cleanup_service.py` around line 36-39, change:
+```python
+        from app.core.features import DISCDB_ENABLED
+
+        if DISCDB_ENABLED and state == JobState.COMPLETED and config.discdb_contributions_enabled:
+```
+to:
+```python
+        from app.core.features import DISCDB_CONTRIBUTIONS_ENABLED
+
+        if (
+            DISCDB_CONTRIBUTIONS_ENABLED
+            and state == JobState.COMPLETED
+            and config.discdb_contributions_enabled
+        ):
+```
+
+- [ ] **Step 4: Verify nothing references the old name**
+
+Run: `cd backend && grep -rn "DISCDB_ENABLED" app/`
+Expected: no matches in `app/` (only `DISCDB_LOOKUP_ENABLED` / `DISCDB_CONTRIBUTIONS_ENABLED`). Tests are updated in Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/features.py backend/app/services/identification_coordinator.py backend/app/services/cleanup_service.py
+git commit -m "feat(discdb): split master flag into lookup + contributions"
+```
+
+---
+
+## Task 2: Backend guard on contribution endpoints
+
+The submit/export endpoints are gated only by `require_localhost`, not by any feature flag. Add a contribution gate so enabling lookup never exposes upload.
+
+**Files:**
+- Modify: `backend/app/api/routes.py` (endpoints at ~3149 `export_contribution`, ~3728 `submit_contribution`, ~3834 batch submit)
+
+- [ ] **Step 1: Add a guard helper near the top of the contribution endpoints**
+
+In `backend/app/api/routes.py`, immediately before the `export_contribution` definition (around line 3149), add:
+```python
+def _require_discdb_contributions() -> None:
+    """Reject contribution endpoints unless the contribution feature is enabled.
+
+    Lookup may be on while contribution stays gated; without this guard the
+    submit/export endpoints would remain reachable directly.
+    """
+    from app.core.features import DISCDB_CONTRIBUTIONS_ENABLED
+
+    if not DISCDB_CONTRIBUTIONS_ENABLED:
+        raise HTTPException(status_code=404, detail="TheDiscDB contributions are disabled")
+```
+
+- [ ] **Step 2: Call the guard first in each contribution endpoint**
+
+As the first statement in the body of `export_contribution`, `submit_contribution`, and the batch-submit endpoint (the three functions importing from `app.core.discdb_submitter`), add:
+```python
+    _require_discdb_contributions()
+```
+Place it before the existing `from app.core.discdb_submitter import ...` line in each.
+
+- [ ] **Step 3: Verify the three call sites**
+
+Run: `cd backend && grep -n "_require_discdb_contributions()" app/api/routes.py`
+Expected: 3 matches (one per contribution endpoint).
+
+- [ ] **Step 4: Smoke-check import**
+
+Run: `cd backend && uv run python -c "import app.api.routes"`
+Expected: no error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes.py
+git commit -m "feat(discdb): gate contribution submit/export endpoints behind contributions flag"
+```
+
+---
+
+## Task 3: Invert ASR <-> DiscDB episode precedence
+
+ASR always runs. DiscDB episode mappings become a post-ASR fallback when ASR confidence is below 0.5.
+
+**Files:**
+- Modify: `backend/app/services/matching_coordinator.py` (add constant near other module constants; fallback inside `_match_single_file_inner` at the `if result.needs_review or advisory:` branch, ~line 1194)
+- Modify: `backend/app/services/identification_coordinator.py:1056-1070` (remove short-circuit)
+- Modify: `backend/app/services/job_manager.py:2865-2893` (remove short-circuit)
+- Test: `backend/tests/unit/test_match_source.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_match_source.py`:
+```python
+@pytest.mark.asyncio
+async def test_high_confidence_asr_wins_over_discdb_mapping(monkeypatch):
+    """ASR is the preferred signal: a confident ASR match wins even when a
+    DiscDB mapping disagrees (DiscDB numbers by disc order, not aired order)."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E03"  # ASR says E03
+    mock_result.confidence = 0.85
+    mock_result.needs_review = False
+    mock_result.match_details = {"score": 0.85}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0, title_type="Episode", episode_title="Pilot",
+        season=1, episode=1, duration_seconds=2400, size_bytes=1024**3,
+    )  # DiscDB says E01
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.MATCHED
+        assert title.matched_episode == "S01E03"  # ASR won
+        assert title.match_source == "engram"
+
+
+@pytest.mark.asyncio
+async def test_very_low_asr_falls_back_to_discdb_autoorganize(monkeypatch):
+    """When ASR confidence is very low (< 0.5) and a DiscDB mapping exists, the
+    DiscDB episode is assigned and auto-organized instead of going to review."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"  # weak ASR guess
+    mock_result.confidence = 0.41
+    mock_result.needs_review = True
+    mock_result.match_details = {"score": 0.41}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0, title_type="Episode", episode_title="Pilot",
+        season=1, episode=1, duration_seconds=2400, size_bytes=1024**3,
+    )
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.MATCHED  # auto-organized, not review
+        assert title.matched_episode == "S01E01"  # DiscDB mapping
+        assert title.match_source == "discdb"
+
+
+@pytest.mark.asyncio
+async def test_mid_confidence_asr_goes_to_review_not_discdb(monkeypatch):
+    """Mid-confidence ASR (0.5 <= conf < 0.7) routes to review as the ASR guess;
+    DiscDB is NOT used because ASR is preferred above the 0.5 floor."""
+    from app.core.discdb_classifier import DiscDbTitleMapping
+
+    mc_mod = importlib.import_module("app.services.matching_coordinator")
+    job, title = await _seed_job_and_title()
+
+    mock_result = MagicMock()
+    mock_result.episode_code = "S01E07"
+    mock_result.confidence = 0.60
+    mock_result.needs_review = True
+    mock_result.match_details = {"score": 0.60}
+    mock_curator = MagicMock()
+    mock_curator.match_single_file = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(mc_mod, "episode_curator", mock_curator)
+
+    mapping = DiscDbTitleMapping(
+        index=0, title_type="Episode", episode_title="Pilot",
+        season=1, episode=1, duration_seconds=2400, size_bytes=1024**3,
+    )
+    coordinator = _make_coordinator(monkeypatch, discdb_mappings={job.id: [mapping]})
+
+    await coordinator._match_single_file_inner(
+        job.id, title.id, Path("/tmp/staging/test/title_t00.mkv")
+    )
+
+    async with _unit_session_factory() as session:
+        title = await session.get(DiscTitle, title.id)
+        assert title.state == TitleState.REVIEW  # ASR guess held for review
+        assert title.match_source is None  # DiscDB not applied
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_match_source.py -v -k "discdb_mapping or discdb_autoorganize or review_not_discdb"`
+Expected: `test_very_low_asr_falls_back_to_discdb_autoorganize` and `test_mid_confidence_asr_goes_to_review_not_discdb` FAIL (current code never applies DiscDB inside `_match_single_file_inner`, so the very-low case goes to REVIEW and the mid case has no DiscDB anyway). `test_high_confidence_asr_wins_over_discdb_mapping` may already PASS.
+
+- [ ] **Step 3: Add the fallback floor constant**
+
+In `backend/app/services/matching_coordinator.py`, alongside the other module-level constants (e.g. near `_SEASON_FROM_EP_CODE_RE`), add:
+```python
+# ASR-preferred episode precedence: ASR always runs and is authoritative at or
+# above this confidence. Only below it do we defer to a DiscDB episode mapping —
+# DiscDB numbers episodes by physical disc order, not aired order, so it is a
+# last-resort fallback, never a competitor to a usable ASR match.
+DISCDB_FALLBACK_ASR_FLOOR = 0.5
+```
+
+- [ ] **Step 4: Add the fallback in `_match_single_file_inner`**
+
+In `backend/app/services/matching_coordinator.py`, the branch currently reads:
+```python
+                if result.needs_review or advisory:
+                    # A low-confidence result always goes to REVIEW — even when the
+```
+Insert the fallback as the first thing inside that branch, before the existing comment/`title.state = TitleState.REVIEW`:
+```python
+                if result.needs_review or advisory:
+                    # ASR-preferred precedence: a very low-confidence ASR result
+                    # (not a deliberate manual re-match) defers to a DiscDB episode
+                    # mapping when one exists, instead of going to review. DiscDB
+                    # numbers by disc order (not aired order), so it is trusted only
+                    # when ASR could not produce a usable match.
+                    if (
+                        not advisory
+                        and result.confidence < DISCDB_FALLBACK_ASR_FLOOR
+                        and await self.try_discdb_assignment(job_id, title, session)
+                    ):
+                        logger.info(
+                            f"[MATCH] Title {title_id} (Job {job_id}): ASR confidence "
+                            f"{result.confidence:.2f} < {DISCDB_FALLBACK_ASR_FLOOR}; "
+                            f"assigned episode from DiscDB mapping (disc-order fallback)."
+                        )
+                        await self._check_job_completion(session, job_id)
+                        return
+
+                    # A low-confidence result always goes to REVIEW — even when the
+```
+(The rest of the existing branch is unchanged.)
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_match_source.py -v`
+Expected: all tests PASS (the three new ones plus the existing five).
+
+- [ ] **Step 6: Remove the short-circuit in identification_coordinator**
+
+In `backend/app/services/identification_coordinator.py` around line 1056-1070, replace:
+```python
+                        for dt in db_titles:
+                            if dt.output_filename:
+                                file_path = Path(dt.output_filename)
+                                discdb_applied = await self._try_discdb_assignment(
+                                    job_id, dt, session
+                                )
+                                if not discdb_applied:
+                                    task = asyncio.create_task(
+                                        self._match_single_file(job_id, dt.id, file_path)
+                                    )
+                                    task.add_done_callback(
+                                        lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                            t, jid, tid
+                                        )
+                                    )
+```
+with:
+```python
+                        for dt in db_titles:
+                            if dt.output_filename:
+                                file_path = Path(dt.output_filename)
+                                # ASR-preferred precedence: always run audio matching.
+                                # A DiscDB episode mapping (disc order, not aired order)
+                                # is applied only as a low-confidence fallback inside
+                                # _match_single_file_inner.
+                                task = asyncio.create_task(
+                                    self._match_single_file(job_id, dt.id, file_path)
+                                )
+                                task.add_done_callback(
+                                    lambda t, jid=job_id, tid=dt.id: self._on_match_task_done(
+                                        t, jid, tid
+                                    )
+                                )
+```
+
+- [ ] **Step 7: Remove the short-circuit in job_manager**
+
+In `backend/app/services/job_manager.py` around line 2865-2893, replace:
+```python
+        applied = False
+        try:
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                if title is None:
+                    logger.warning(
+                        f"Job {sanitize_log_value(job_id)}: title "
+                        f"{sanitize_log_value(title_id)} vanished before match dispatch"
+                    )
+                    self._inflight_match_dispatch.discard(title_id)
+                    return False
+                applied = await self._matching.try_discdb_assignment(job_id, title, session)
+                if applied:
+                    await self._finalization.check_job_completion(session, job_id)
+        except Exception:
+            self._inflight_match_dispatch.discard(title_id)
+            raise
+        if applied:
+            # DiscDB path resolved the title — no match task needed; release
+            # the sentinel so a future re-dispatch (e.g. after a re-rip) works.
+            self._inflight_match_dispatch.discard(title_id)
+            return True
+
+        # match_single_file self-tags the job log context.
+        task = asyncio.create_task(self._matching.match_single_file(job_id, title_id, file_path))
+```
+with:
+```python
+        try:
+            async with async_session() as session:
+                title = await session.get(DiscTitle, title_id)
+                if title is None:
+                    logger.warning(
+                        f"Job {sanitize_log_value(job_id)}: title "
+                        f"{sanitize_log_value(title_id)} vanished before match dispatch"
+                    )
+                    self._inflight_match_dispatch.discard(title_id)
+                    return False
+        except Exception:
+            self._inflight_match_dispatch.discard(title_id)
+            raise
+
+        # ASR-preferred precedence: always run audio matching. A DiscDB episode
+        # mapping (disc order, not aired order) is applied only as a low-confidence
+        # fallback inside _match_single_file_inner.
+        # match_single_file self-tags the job log context.
+        task = asyncio.create_task(self._matching.match_single_file(job_id, title_id, file_path))
+```
+(The `task.add_done_callback(...)` and `return True` lines that follow are unchanged.)
+
+- [ ] **Step 8: Run the broader matching + job-manager suites**
+
+Run: `cd backend && uv run pytest tests/unit/test_match_source.py tests/unit/test_matching_coordinator.py tests/unit/test_job_manager.py tests/unit/test_identification_coordinator.py -v`
+Expected: PASS (Task 4 fixes any flag-rename failures in test_identification_coordinator.py; if that file fails only on `DISCDB_ENABLED`, proceed to Task 4 then re-run).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/app/services/matching_coordinator.py backend/app/services/identification_coordinator.py backend/app/services/job_manager.py backend/tests/unit/test_match_source.py
+git commit -m "feat(matching): prefer ASR over DiscDB episode order; DiscDB fallback below 0.5"
+```
+
+---
+
+## Task 4: Update existing backend flag-reference tests
+
+**Files:**
+- Modify: `backend/tests/unit/test_identification_coordinator.py:127,163`
+- Modify: `backend/tests/unit/test_disc_name_identification.py:341,416,505,585,676,768,936`
+
+- [ ] **Step 1: Update test_identification_coordinator.py**
+
+Replace both occurrences:
+```python
+        monkeypatch.setattr("app.core.features.DISCDB_ENABLED", True)
+```
+with:
+```python
+        monkeypatch.setattr("app.core.features.DISCDB_LOOKUP_ENABLED", True)
+```
+
+- [ ] **Step 2: Update test_disc_name_identification.py**
+
+Replace all seven occurrences:
+```python
+        patch("app.core.features.DISCDB_ENABLED", False),
+```
+with:
+```python
+        patch("app.core.features.DISCDB_LOOKUP_ENABLED", False),
+```
+
+- [ ] **Step 3: Verify no stale references remain**
+
+Run: `cd backend && grep -rn "DISCDB_ENABLED" tests/`
+Expected: no matches.
+
+- [ ] **Step 4: Run both test files**
+
+Run: `cd backend && uv run pytest tests/unit/test_identification_coordinator.py tests/unit/test_disc_name_identification.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tests/unit/test_identification_coordinator.py backend/tests/unit/test_disc_name_identification.py
+git commit -m "test(discdb): update flag references to DISCDB_LOOKUP_ENABLED"
+```
+
+---
+
+## Task 5: Remove the now-dead try_discdb_assignment injection
+
+After Task 3, `IdentificationCoordinator._try_discdb_assignment` is never called. Remove the dead wiring (the public `MatchingCoordinator.try_discdb_assignment` stays — it is now called by the fallback).
+
+**Files:**
+- Modify: `backend/app/services/identification_coordinator.py:211,225,239`
+- Modify: `backend/app/services/job_manager.py:181`
+
+- [ ] **Step 1: Remove the attribute init**
+
+In `backend/app/services/identification_coordinator.py`, delete line 211:
+```python
+        self._try_discdb_assignment: callable = None
+```
+
+- [ ] **Step 2: Remove the kwarg from set_callbacks**
+
+In the same file, in `set_callbacks`, delete the parameter line 225:
+```python
+        try_discdb_assignment,
+```
+and the assignment line 239:
+```python
+        self._try_discdb_assignment = try_discdb_assignment
+```
+
+- [ ] **Step 3: Remove the wiring in job_manager**
+
+In `backend/app/services/job_manager.py`, delete line 181:
+```python
+            try_discdb_assignment=self._matching.try_discdb_assignment,
+```
+
+- [ ] **Step 4: Verify it is fully gone**
+
+Run: `cd backend && grep -rn "_try_discdb_assignment\|try_discdb_assignment=" app/`
+Expected: no matches (the `def try_discdb_assignment` and `self.try_discdb_assignment` self-call in matching_coordinator are different and must remain — confirm with `grep -rn "try_discdb_assignment" app/` showing only the matching_coordinator definition and the `_match_single_file_inner` self-call).
+
+- [ ] **Step 5: Run the orchestration suites**
+
+Run: `cd backend && uv run pytest tests/unit/test_identification_coordinator.py tests/unit/test_job_manager.py tests/unit/test_matching_coordinator_lifecycle.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/identification_coordinator.py backend/app/services/job_manager.py
+git commit -m "refactor(discdb): drop dead try_discdb_assignment injection after precedence change"
+```
+
+---
+
+## Task 6: Split frontend feature flags and re-gate sites
+
+**Files:**
+- Modify: `frontend/src/config/constants.ts:10-13`
+- Modify: `frontend/src/config/routes.ts:39`
+- Modify: `frontend/src/app/navigation.ts:64`
+- Modify: `frontend/src/app/App.tsx:106,945`
+- Modify: `frontend/src/components/ReviewQueue/Inspector.tsx:403`
+- Modify: `frontend/src/components/HistoryPage.tsx:604`
+- Modify: `frontend/src/app/__tests__/App.routing.test.tsx:66,74`
+
+- [ ] **Step 1: Split the flags**
+
+In `frontend/src/config/constants.ts`, replace:
+```ts
+export const FEATURES = {
+  /** TheDiscDB integration — contribute page, match-source badges, settings toggle. */
+  DISCDB: false,
+} as const;
+```
+with:
+```ts
+export const FEATURES = {
+  /** TheDiscDB lookups: match-source badges, history metadata, lookup settings toggle. */
+  DISCDB_LOOKUP: true,
+  /** TheDiscDB contributions: contribute page, nav item, stats badge, submit controls. */
+  DISCDB_CONTRIBUTE: false,
+} as const;
+```
+
+- [ ] **Step 2: Re-gate the contribute route registry**
+
+In `frontend/src/config/routes.ts:39`, change `FEATURES.DISCDB` to `FEATURES.DISCDB_CONTRIBUTE`:
+```ts
+  ...(FEATURES.DISCDB_CONTRIBUTE ? [ROUTES.CONTRIBUTE] : []),
+```
+
+- [ ] **Step 3: Re-gate the nav item**
+
+In `frontend/src/app/navigation.ts:64`, change:
+```ts
+      show: FEATURES.DISCDB_CONTRIBUTE,
+```
+
+- [ ] **Step 4: Re-gate App.tsx (stats fetch + route)**
+
+In `frontend/src/app/App.tsx:106`:
+```tsx
+      if (FEATURES.DISCDB_CONTRIBUTE && data.discdb_contributions_enabled) {
+```
+In `frontend/src/app/App.tsx:945`:
+```tsx
+      {FEATURES.DISCDB_CONTRIBUTE && <Route path={ROUTES.CONTRIBUTE} element={<ContributePage />} />}
+```
+
+- [ ] **Step 5: Re-gate the lookup-side UI**
+
+In `frontend/src/components/ReviewQueue/Inspector.tsx:403`:
+```tsx
+                        {FEATURES.DISCDB_LOOKUP && title.discdb_match_details && title.match_details && (
+```
+In `frontend/src/components/HistoryPage.tsx:604`:
+```tsx
+          {FEATURES.DISCDB_LOOKUP && (
+```
+
+- [ ] **Step 6: Update the routing test**
+
+In `frontend/src/app/__tests__/App.routing.test.tsx:74`:
+```tsx
+  if (FEATURES.DISCDB_CONTRIBUTE) routeCases.push(["/contribute", "contribute"]);
+```
+(The comment on line 66 may keep referring to the gate generically; update "FEATURES.DISCDB" to "FEATURES.DISCDB_CONTRIBUTE" there if present.)
+
+- [ ] **Step 7: Verify no stale flag references**
+
+Run: `cd frontend && grep -rn "FEATURES.DISCDB\b" src/`
+Expected: no matches for the bare `FEATURES.DISCDB` (only `DISCDB_LOOKUP` / `DISCDB_CONTRIBUTE`). The ConfigWizard site is handled in Task 7; if it still shows here, that is expected until then.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/config/constants.ts frontend/src/config/routes.ts frontend/src/app/navigation.ts frontend/src/app/App.tsx frontend/src/components/ReviewQueue/Inspector.tsx frontend/src/components/HistoryPage.tsx frontend/src/app/__tests__/App.routing.test.tsx
+git commit -m "feat(discdb): split frontend feature flag into lookup vs contribute"
+```
+
+---
+
+## Task 7: Split the ConfigWizard DiscDB group and fix stale copy
+
+The group holds both the lookup toggle and the contribution toggle. Split them, and correct the lookup hint copy (it claims DiscDB "skips audio fingerprinting and instantly maps episodes", which is no longer true).
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx:1219-1299`
+
+- [ ] **Step 1: Gate the group on either flag, and split the toggles**
+
+In `frontend/src/components/ConfigWizard.tsx`, change the group opener at line 1220:
+```tsx
+                        {FEATURES.DISCDB && (
+```
+to:
+```tsx
+                        {(FEATURES.DISCDB_LOOKUP || FEATURES.DISCDB_CONTRIBUTE) && (
+```
+
+- [ ] **Step 2: Wrap the lookup toggle and fix its hint**
+
+Wrap the lookup checkbox `div` (lines 1226-1240) so it renders only under `DISCDB_LOOKUP`, and replace the stale hint text:
+```tsx
+                                {FEATURES.DISCDB_LOOKUP && (
+                                <div className="form-group checkbox-group">
+                                    <label className="checkbox-label">
+                                        <input
+                                            type="checkbox"
+                                            checked={config.discdbEnabled}
+                                            onChange={(e) => handleInputChange('discdbEnabled', e.target.checked)}
+                                        />
+                                        <span className="checkbox-text">
+                                            <strong>Enable TheDiscDB Lookup</strong>
+                                            <span className="checkbox-hint">
+                                                Query TheDiscDB to help identify a disc. Episode matching still runs locally (audio); DiscDB episode order is used only as a fallback when audio matching is uncertain. No API key required.
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
+                                )}
+```
+
+- [ ] **Step 3: Wrap the contributions toggle + sub-block under DISCDB_CONTRIBUTE**
+
+Wrap the contributions checkbox `div` (lines 1241-1255) and the following `{config.discdbContributionsEnabled && ( ... )}` block (lines 1257-1296) in a single `{FEATURES.DISCDB_CONTRIBUTE && ( ... )}` guard:
+```tsx
+                                {FEATURES.DISCDB_CONTRIBUTE && (
+                                <>
+                                <div className="form-group checkbox-group">
+                                    <label className="checkbox-label">
+                                        <input
+                                            type="checkbox"
+                                            checked={config.discdbContributionsEnabled}
+                                            onChange={(e) => handleInputChange('discdbContributionsEnabled', e.target.checked)}
+                                        />
+                                        <span className="checkbox-text">
+                                            <strong>Enable TheDiscDB Contributions</strong>
+                                            <span className="checkbox-hint">
+                                                Share disc metadata (track info, episode mappings) with TheDiscDB after each rip. Helps others identify their discs automatically. No personal data is shared.
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
+
+                                {config.discdbContributionsEnabled && (
+                                    <>
+                                        <div className="form-group">
+                                            <label htmlFor="discdbContributionTier">Contribution Level</label>
+                                            <EngramSelect
+                                                id="discdbContributionTier"
+                                                value={String(config.discdbContributionTier)}
+                                                onValueChange={(v) => handleInputChange('discdbContributionTier', parseInt(v, 10))}
+                                                options={[
+                                                    { value: '2', label: 'Automatic — share auto-collected data' },
+                                                    { value: '3', label: 'Full — prompt for UPC and images' },
+                                                ]}
+                                            />
+                                        </div>
+
+                                        <div className="form-group">
+                                            <label htmlFor="discdbApiKey">TheDiscDB API Key</label>
+                                            <input
+                                                id="discdbApiKey"
+                                                type="password"
+                                                value={config.discdbApiKey}
+                                                onChange={(e) => handleInputChange('discdbApiKey', e.target.value)}
+                                                placeholder="Enter API key for automatic submission"
+                                            />
+                                            <small>Required for submitting directly to TheDiscDB. Leave empty for local-only export.</small>
+                                        </div>
+
+                                        <div className="form-group">
+                                            <label htmlFor="discdbExportPath">Export Directory (optional)</label>
+                                            <input
+                                                id="discdbExportPath"
+                                                type="text"
+                                                value={config.discdbExportPath}
+                                                onChange={(e) => handleInputChange('discdbExportPath', e.target.value)}
+                                                placeholder="~/.engram/discdb-exports"
+                                            />
+                                            <small>Leave empty for the default location</small>
+                                        </div>
+                                    </>
+                                )}
+                                </>
+                                )}
+```
+Note: the option labels keep their existing em dashes to avoid altering unrelated copy; do not introduce new ones elsewhere.
+
+- [ ] **Step 4: Verify the bare flag is gone**
+
+Run: `cd frontend && grep -rn "FEATURES.DISCDB\b" src/`
+Expected: no matches.
+
+- [ ] **Step 5: Type-check the build**
+
+Run: `cd frontend && npm run build`
+Expected: TypeScript + Vite build succeeds (run `npm install` first if `node_modules` is absent; do not commit `package-lock.json` churn — `git checkout package-lock.json` if it changes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ConfigWizard.tsx
+git commit -m "feat(discdb): split ConfigWizard lookup/contribution toggles; fix stale lookup copy"
+```
+
+---
+
+## Task 8: Refresh the DiscDB match-source badge to the icon system
+
+**Files:**
+- Modify: `frontend/src/app/components/synapse/tokens.ts` (add `blue` token)
+- Modify: `frontend/src/app/components/TrackGrid.tsx:46-107`
+- Test: `frontend/src/app/components/TrackGrid.test.tsx:71-75`
+
+- [ ] **Step 1: Update the failing test first**
+
+In `frontend/src/app/components/TrackGrid.test.tsx` around line 71-75, the test currently asserts the text `"DISCDB"`. Change it to assert the icon chip via its testid:
+```tsx
+    expect(screen.getByTestId("source-badge-discdb")).toBeInTheDocument();
+    expect(screen.getByText("99%")).toBeInTheDocument();
+    expect(screen.queryByText("FULL-FILE")).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npm run test:unit -- TrackGrid`
+Expected: the updated assertion FAILS (the icon chip is not yet rendered for `discdb`; it is still a text chip — actually `getByTestId` would currently pass on the text chip, so this test may still pass. If it passes, that is acceptable; the behavioral change is the icon swap in Step 4. Proceed.)
+
+- [ ] **Step 3: Add a `blue` token**
+
+In `frontend/src/app/components/synapse/tokens.ts`, in the Functional section (after line 40 `purple`), add:
+```ts
+  blue: "#60a5fa",
+```
+
+- [ ] **Step 4: Make the DiscDB source an icon chip**
+
+In `frontend/src/app/components/TrackGrid.tsx`:
+
+(a) Import `IcoDisc` at the top with the other icon imports:
+```tsx
+import { IcoDisc } from "./icons/media";
+```
+(verify the exact existing icon import path/style in the file and match it).
+
+(b) Extend the `SourceDesc` type (lines 46-52) with an optional icon component:
+```tsx
+type SourceDesc = {
+  kind: "icon" | "text";
+  label: string;
+  tone: string;
+  tooltip: string;
+  node?: boolean;
+  Icon?: React.ComponentType<{ size?: number; color?: string }>;
+};
+```
+(If TypeScript complains that `IcoDisc`'s `IconProps` is not assignable, widen to `React.ComponentType<any>` or import and use the icon module's `IconProps` type.)
+
+(c) Change the `discdb` descriptor (line 60) from a text chip to an icon chip:
+```tsx
+  discdb:             { kind: "icon", label: "DISCDB", tone: sv.blue,    tooltip: "Matched from TheDiscDB", Icon: IcoDisc },
+```
+
+(d) In `SourceChip`, the icon branch (line 101) currently hardcodes `MarkMono`. Render the descriptor's icon when present, else `MarkMono`:
+```tsx
+          {desc.Icon ? (
+            <desc.Icon size={12} color={desc.tone} />
+          ) : (
+            <MarkMono size={12} color={desc.tone} node={desc.node} />
+          )}
+```
+
+- [ ] **Step 5: Run the badge test**
+
+Run: `cd frontend && npm run test:unit -- TrackGrid`
+Expected: PASS (the `source-badge-discdb` testid resolves to the icon chip span; `99%` still renders).
+
+- [ ] **Step 6: Build**
+
+Run: `cd frontend && npm run build`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/app/components/synapse/tokens.ts frontend/src/app/components/TrackGrid.tsx frontend/src/app/components/TrackGrid.test.tsx
+git commit -m "feat(discdb): render match-source badge with IcoDisc icon chip on palette blue"
+```
+
+---
+
+## Final verification
+
+- [ ] **Backend full suite**
+
+Run: `cd backend && uv run pytest tests/unit/ -q`
+Expected: PASS. (If `engram.db` is a 0-byte worktree stub, run a one-off `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first.)
+
+- [ ] **Backend lint/format**
+
+Run: `cd backend && uv run ruff check . && uv run ruff format --check .`
+Expected: clean.
+
+- [ ] **Frontend unit + build + lint**
+
+Run: `cd frontend && npm run test:unit && npm run build && npm run lint`
+Expected: PASS. `git checkout package-lock.json` if install rewrote it.
+
+- [ ] **Spec coverage self-check**
+
+Confirm each spec section maps to a task: flag split (Tasks 1, 6, 7), contribution gating hardening (Task 2), ASR precedence (Task 3), dead-wiring cleanup (Task 5), badge refresh (Task 8), test updates (Tasks 3, 4, 6, 8).

--- a/docs/superpowers/specs/2026-06-20-discdb-lookup-asr-precedence.md
+++ b/docs/superpowers/specs/2026-06-20-discdb-lookup-asr-precedence.md
@@ -1,0 +1,210 @@
+# DiscDB: enable lookup, keep contribution gated, demote DiscDB episode ordering below ASR
+
+**Date:** 2026-06-20
+**Status:** Draft for review
+**Scope:** Backend feature flags, frontend feature flags, track-matching precedence, one badge restyle
+
+## Problem
+
+TheDiscDB integration is fully disabled behind a single master switch on each side
+(`DISCDB_ENABLED` in the backend, `FEATURES.DISCDB` in the frontend). The original
+intent was to gate only the *contribution* feature (uploading disc data to
+thediscdb.com) until its API contract and UX were validated, but the master switch
+also disables *lookup* (using TheDiscDB to help identify a disc and match its
+tracks). Lookup is read-only and safe to ship; contribution should stay off.
+
+A second issue surfaces once lookup is on: TheDiscDB numbers episodes by **physical
+disc order**, not **aired order**. Engram's matching network is built entirely on
+canonical aired order, so a DiscDB episode mapping frequently disagrees with the
+Engram ASR/fingerprint match. Today DiscDB wins that disagreement outright: when a
+mapping exists, `try_discdb_assignment` stamps the title MATCHED at confidence 0.99
+and **ASR never runs**. This produces wrong episode numbers on discs whose disc
+order differs from aired order.
+
+## Goals
+
+1. Enable TheDiscDB **lookup** (disc identification + track matching contribution),
+   keep **contribution** (local export + submit/upload) gated off.
+2. Surface the lookup-related UI (match-source badges, lookup settings toggle),
+   keep the contribute page and submit controls hidden.
+3. Make **ASR the preferred episode signal**: ASR always runs; DiscDB episode
+   mappings are only used when the ASR confidence is very low.
+4. Refresh the stale DiscDB match-source badge to the current icon system.
+
+## Non-goals
+
+- Re-enabling any automated or manual contribution/upload path.
+- Changing how DiscDB drives **show identification** (tmdb_id, content type, show
+  identity). That stays as-is and is valuable.
+- Reworking the manual per-track "use DiscDB match" review action (its behavior is
+  preserved).
+
+## Current state (as found)
+
+### Backend gating
+- `backend/app/core/features.py`: `DISCDB_ENABLED = False` (single master switch).
+- `backend/app/services/identification_coordinator.py:1519`: lookup block gated by
+  `if DISCDB_ENABLED and config.discdb_enabled:`. Config default
+  `discdb_enabled = True`.
+- `backend/app/services/cleanup_service.py:38`: auto-export gated by
+  `if DISCDB_ENABLED and state == COMPLETED and config.discdb_contributions_enabled:`.
+  Config default `discdb_contributions_enabled = False`.
+
+### Backend lookup is read-only
+- `backend/app/core/discdb_classifier.py` `classify_from_discdb` only issues GraphQL
+  **queries** (`HASH_LOOKUP_QUERY`, `NAME_SEARCH_QUERY`) via `_graphql_request`
+  (`requests.post` of a query, no mutation). Enabling lookup cannot write to
+  TheDiscDB.
+
+### Current episode-matching precedence (the bug)
+- `backend/app/services/identification_coordinator.py:1059-1062`:
+  ```python
+  discdb_applied = await self._try_discdb_assignment(job_id, dt, session)
+  if not discdb_applied:
+      task = asyncio.create_task(self._match_single_file(job_id, dt.id, file_path))
+  ```
+  DiscDB short-circuits ASR. `try_discdb_assignment`
+  (`matching_coordinator.py:317`) explicitly "skips audio matching", sets
+  `match_confidence = 0.99`, `match_source = source`, state MATCHED.
+
+### Frontend gating (every `FEATURES.DISCDB` site)
+| Site | Concern |
+|---|---|
+| `frontend/src/app/App.tsx:945` `/contribute` route | contribute |
+| `frontend/src/config/routes.ts:39` route registry | contribute |
+| `frontend/src/app/navigation.ts:64` nav item | contribute |
+| `frontend/src/app/App.tsx:106` contribution stats fetch | contribute |
+| `frontend/src/components/ReviewQueue/Inspector.tsx:403` "use DiscDB match" action | lookup |
+| `frontend/src/components/HistoryPage.tsx:604` DiscDB metadata section | lookup |
+| `frontend/src/components/ConfigWizard.tsx:1220` DiscDB settings group | mixed (split) |
+| `frontend/src/app/components/TrackGrid.tsx:60` `discdb` source badge | lookup |
+| `frontend/src/app/__tests__/App.routing.test.tsx:66,74` route test | contribute (test) |
+
+### Stale badge
+- `TrackGrid.tsx:60`: `discdb: { kind: "text", label: "DISCDB", tone: "#60a5fa", ... }`.
+  Off-palette raw hex, plain text chip, while the Engram sources are `kind: "icon"`
+  chips (`MarkMono`, palette tones `sv.cyan` / `sv.magenta`).
+
+### Confidence thresholds available to anchor on
+- `backend/app/core/curator.py`: `HIGH_CONFIDENCE_THRESHOLD = 0.7`,
+  `LOW_CONFIDENCE_THRESHOLD = 0.5`.
+- `backend/app/matcher/episode_identification.py`: `CONFIDENCE_ACCEPT_FLOOR = 0.70`.
+
+## Design
+
+### 1. Split the backend master switch
+
+`backend/app/core/features.py`:
+```python
+DISCDB_LOOKUP_ENABLED = True          # disc identification + track matching (read-only)
+DISCDB_CONTRIBUTIONS_ENABLED = False  # local export + submit/upload
+```
+- `identification_coordinator.py:1519` → `if DISCDB_LOOKUP_ENABLED and config.discdb_enabled:`
+- `cleanup_service.py:38` → `if DISCDB_CONTRIBUTIONS_ENABLED and state == COMPLETED and config.discdb_contributions_enabled:`
+
+The old `DISCDB_ENABLED` name is removed. The two config flags
+(`discdb_enabled`, `discdb_contributions_enabled`) are unchanged; the master switch
+simply stops collapsing the distinction the config layer already drew.
+
+### 2. Split the frontend master switch
+
+`frontend/src/config/constants.ts`:
+```ts
+export const FEATURES = {
+  /** TheDiscDB lookups: match-source badges, history metadata, lookup settings toggle. */
+  DISCDB_LOOKUP: true,
+  /** TheDiscDB contributions: contribute page, nav item, stats badge, submit controls. */
+  DISCDB_CONTRIBUTE: false,
+} as const;
+```
+Each site is re-gated per the table above. The `ConfigWizard` DiscDB group is split:
+the lookup toggle (`discdb_enabled`) renders under `DISCDB_LOOKUP`; the contributions
+toggle (`discdb_contributions_enabled`) and tier control render under
+`DISCDB_CONTRIBUTE`.
+
+### 3. Invert ASR <-> DiscDB episode precedence
+
+ASR always runs. DiscDB episode mappings become a post-ASR low-confidence fallback.
+
+- Remove the pre-dispatch short-circuit at `identification_coordinator.py:1059-1062`.
+  Every title with an `output_filename` dispatches `_match_single_file`
+  unconditionally.
+- Apply the DiscDB fallback after the ASR result is evaluated inside
+  `_match_single_file_inner` (`matching_coordinator.py:1013`), keyed on the ASR
+  confidence:
+
+| ASR confidence | Outcome |
+|---|---|
+| `>= 0.7` | ASR result auto-organizes (DiscDB ignored even if it disagrees) |
+| `0.5 <= conf < 0.7` | ASR result -> Needs Review (unchanged) |
+| `conf < 0.5` AND DiscDB mapping exists | DiscDB mapping auto-organizes at high confidence |
+| `conf < 0.5` AND no DiscDB mapping | ASR guess -> Needs Review (unchanged) |
+
+- Floor constant: reuse `0.5` (curator `LOW_CONFIDENCE_THRESHOLD`). Define a named
+  constant for the DiscDB-fallback floor so the intent is explicit at the call site.
+- `try_discdb_assignment` is repurposed: instead of being called pre-dispatch to
+  skip matching, it is invoked from the low-confidence branch of
+  `_match_single_file_inner` to apply the stored mapping. Its existing behavior
+  (find mapping by `title_index`, set episode code / confidence 0.99 /
+  `match_source` / `discdb_match_details`, MATCHED, broadcast) is unchanged; only
+  the **call site and the condition** change.
+- `rematch_single_title(source_preference=...)` is untouched, so the manual
+  per-track "use DiscDB match" button still restores the stored DiscDB match on
+  demand.
+
+Show identification is unaffected: DiscDB's tmdb_id / content-type / show-identity
+contributions in `identify_disc` still apply. Only the per-track episode number
+precedence changes.
+
+### 4. Badge icon refresh
+
+`TrackGrid.tsx` `SOURCE_DESC.discdb` becomes a `kind: "icon"` chip rendered through
+the existing icon path, using `IcoDisc` (from `icons/media.tsx`) on a palette token
+instead of the raw `#60a5fa`. The chip keeps its `data-testid="source-badge-discdb"`
+and tooltip ("Matched from TheDiscDB"). The icon-path branch of `SourceChip`
+currently hardcodes `MarkMono`; it is generalized to render the descriptor's icon so
+DiscDB can use `IcoDisc` while Engram sources keep `MarkMono`.
+
+## Error handling
+
+- DiscDB lookup failure (network, GraphQL error, contract drift) already returns
+  `None` and degrades to TMDB/heuristic identification and ASR matching. No change.
+- DiscDB fallback in the low-confidence branch: if no mapping applies, fall through
+  to the existing ASR-low-confidence review path. The fallback must never raise into
+  `_match_single_file_inner`'s result handling (guard like the current
+  `try_discdb_assignment` call).
+
+## Testing
+
+Backend:
+- Update flag references: `test_identification_coordinator.py` (patches
+  `DISCDB_ENABLED` -> `DISCDB_LOOKUP_ENABLED`), `test_disc_name_identification.py`
+  (7 patch sites).
+- New precedence coverage: high-confidence ASR wins over a disagreeing DiscDB
+  mapping; mid-confidence ASR goes to review; very-low ASR with a DiscDB mapping
+  auto-organizes from DiscDB; very-low ASR with no mapping goes to review.
+- Confirm auto-export stays gated when lookup is on and contributions off.
+
+Frontend:
+- `TrackGrid.test.tsx`: assert the DiscDB chip renders via the icon path (and keep
+  the `source-badge-discdb` testid assertion).
+- Routing test: `FEATURES.DISCDB` -> `FEATURES.DISCDB_CONTRIBUTE` for the
+  `/contribute` gate.
+
+## Open items to confirm during planning
+
+- Re-confirm there is no automated TheDiscDB uploader (only the fingerprint-network
+  contribution_queue, which is a separate system, plus the manual contribute-page
+  submit). If an automated DiscDB uploader exists, it must be gated under
+  `DISCDB_CONTRIBUTIONS_ENABLED`.
+- Verify the exact local in `_match_single_file_inner` carrying the ASR confidence
+  and matched episode, to place the fallback branch precisely.
+
+## Risks
+
+- Enabling lookup means trusting TheDiscDB's GraphQL contract live; failures degrade
+  to current behavior, so worst case equals today.
+- DiscDB-as-fallback at `conf < 0.5` can still assign a disc-order episode number
+  when ASR fails. This is the accepted trade-off (chosen over routing the fallback
+  to review): it only applies when ASR could not produce a usable match, where the
+  alternative is a manual-review hand-off with no automatic guess.

--- a/frontend/e2e/match-source-display.spec.ts
+++ b/frontend/e2e/match-source-display.spec.ts
@@ -45,7 +45,7 @@ test.beforeEach(async ({ page }) => {
     await expect(page.locator(SELECTORS.connectionStatus.connected)).toBeVisible({ timeout: 10000 });
 });
 
-// Match-source badges + source toggle are gated behind FEATURES.DISCDB
+// Match-source badges + source toggle are gated behind FEATURES.DISCDB_LOOKUP
 // (frontend/src/config/constants.ts). These tests exercise UI that's hidden
 // while the flag is false. Re-enable along with the feature.
 test.describe.fixme('Match Source Badges', () => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -103,7 +103,7 @@ function MainDashboard() {
       // redaction sentinel (#243).
       setTmdbConfigured(data.tmdb_configured ?? !!data.tmdb_api_key);
       // Fetch contribution stats for nav badge
-      if (FEATURES.DISCDB && data.discdb_contributions_enabled) {
+      if (FEATURES.DISCDB_CONTRIBUTE && data.discdb_contributions_enabled) {
         try {
           const statsRes = await fetch('/api/contributions/stats');
           if (statsRes.ok) {
@@ -942,7 +942,7 @@ function App() {
       <Route path={ROUTES.HOME} element={<MainDashboard />} />
       <Route path={ROUTES.HISTORY} element={<HistoryPage />} />
       <Route path={ROUTES.HISTORY_DETAIL} element={<HistoryPage />} />
-      {FEATURES.DISCDB && <Route path={ROUTES.CONTRIBUTE} element={<ContributePage />} />}
+      {FEATURES.DISCDB_CONTRIBUTE && <Route path={ROUTES.CONTRIBUTE} element={<ContributePage />} />}
       <Route path="/library" element={<Navigate to={ROUTES.HISTORY} replace />} />
       <Route path={ROUTES.REVIEW} element={<Navigate to={ROUTES.HOME} replace />} />
       <Route path={ROUTES.REVIEW_DETAIL} element={<ReviewQueue />} />

--- a/frontend/src/app/__tests__/App.routing.test.tsx
+++ b/frontend/src/app/__tests__/App.routing.test.tsx
@@ -63,7 +63,7 @@ afterEach(() => {
 describe("App routing — every page mounts (no blank/black screen)", () => {
   // Each route must render the SvAtmosphere wrapper. A route that renders null
   // (the /review black-screen bug) would leave the container empty and this
-  // would throw. /contribute is gated behind FEATURES.DISCDB (off by default),
+  // would throw. /contribute is gated behind FEATURES.DISCDB_CONTRIBUTE (off by default),
   // so it's only covered when that flag is enabled.
   const routeCases: Array<[string, string]> = [
     ["/", "dashboard"],
@@ -71,7 +71,7 @@ describe("App routing — every page mounts (no blank/black screen)", () => {
     ["/review/7", "review detail"],
     ["/review", "bare review → redirects to dashboard"],
   ];
-  if (FEATURES.DISCDB) routeCases.push(["/contribute", "contribute"]);
+  if (FEATURES.DISCDB_CONTRIBUTE) routeCases.push(["/contribute", "contribute"]);
 
   it.each(routeCases)("renders content at %s (%s)", async (path) => {
     renderAt(path);

--- a/frontend/src/app/components/TrackGrid.test.tsx
+++ b/frontend/src/app/components/TrackGrid.test.tsx
@@ -70,7 +70,7 @@ describe("TrackGrid — provenance rendering", () => {
         ]}
       />,
     );
-    expect(screen.getByText("DISCDB")).toBeInTheDocument();
+    expect(screen.getByTestId("source-badge-discdb")).toBeInTheDocument();
     expect(screen.getByText("99%")).toBeInTheDocument();
     expect(screen.queryByText("FULL-FILE")).not.toBeInTheDocument();
   });

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { motion } from "motion/react";
 import { IcoRipping, IcoMatching, IcoComplete, IcoError } from "./icons";
+import { IcoDisc } from "./icons/media";
 import type { Track, TrackState } from "./DiscCard";
 import { sv, SvBadge, SvBar, SvLabel, MarkMono } from "./synapse";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -49,6 +50,7 @@ type SourceDesc = {
   tone: string;
   tooltip: string;
   node?: boolean;
+  Icon?: React.ComponentType<{ size?: number; color?: string }>;
 };
 
 // Engram-engine sources render the brand mark (icon-only, label on hover);
@@ -57,7 +59,7 @@ type SourceDesc = {
 const SOURCE_DESC: Record<string, SourceDesc> = {
   engram:             { kind: "icon", label: "ENGRAM", tone: sv.cyan,    tooltip: "Matched by Engram (ASR)" },
   engram_chromaprint: { kind: "icon", label: "ENGRAM", tone: sv.magenta, tooltip: "Matched by Engram (audio fingerprint)", node: true },
-  discdb:             { kind: "text", label: "DISCDB", tone: "#60a5fa",  tooltip: "Matched from TheDiscDB" },
+  discdb:             { kind: "icon", label: "DISCDB", tone: sv.blue,    tooltip: "Matched from TheDiscDB", Icon: IcoDisc },
   ai_llm:             { kind: "text", label: "AI",     tone: sv.purple,  tooltip: "Identified by AI" },
   user:               { kind: "text", label: "MANUAL", tone: sv.green,   tooltip: "Assigned manually" },
 };
@@ -98,7 +100,11 @@ function SourceChip({ source }: { source: string }) {
             background: `${desc.tone}10`,
           }}
         >
-          <MarkMono size={12} color={desc.tone} node={desc.node} />
+          {desc.Icon ? (
+            <desc.Icon size={12} color={desc.tone} />
+          ) : (
+            <MarkMono size={12} color={desc.tone} node={desc.node} />
+          )}
         </span>
       </TooltipTrigger>
       <TooltipContent>{desc.tooltip}</TooltipContent>

--- a/frontend/src/app/components/synapse/tokens.ts
+++ b/frontend/src/app/components/synapse/tokens.ts
@@ -38,6 +38,7 @@ export const sv = {
   greenDim: "#4ade80",
   red: "#ff5555",
   purple: "#a78bfa",
+  blue: "#60a5fa",
 
   // Lines
   line: "rgba(94, 234, 212, 0.14)",

--- a/frontend/src/app/navigation.ts
+++ b/frontend/src/app/navigation.ts
@@ -61,7 +61,7 @@ export function buildNavItems({
       label: "CONTRIBUTE",
       to: ROUTES.CONTRIBUTE,
       badge: contributionPending,
-      show: FEATURES.DISCDB,
+      show: FEATURES.DISCDB_CONTRIBUTE,
     },
   ];
 }

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1217,12 +1217,13 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                         </details>
 
                         {/* ── TheDiscDB (feature-flagged) ──────────────────────── */}
-                        {FEATURES.DISCDB && (
+                        {(FEATURES.DISCDB_LOOKUP || FEATURES.DISCDB_CONTRIBUTE) && (
                             <details className="wizard-group">
                                 <summary>
                                     <span className="wizard-group-chevron">▸</span>TheDiscDB
                                 </summary>
                                 <div className="wizard-group-body">
+                                {FEATURES.DISCDB_LOOKUP && (
                                 <div className="form-group checkbox-group">
                                     <label className="checkbox-label">
                                         <input
@@ -1233,11 +1234,14 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                         <span className="checkbox-text">
                                             <strong>Enable TheDiscDB Lookup</strong>
                                             <span className="checkbox-hint">
-                                                Query TheDiscDB for known disc layouts. When matched, skips audio fingerprinting and instantly maps episodes. No API key required.
+                                                Query TheDiscDB to help identify a disc. Episode matching still runs locally (audio); DiscDB episode order is used only as a fallback when audio matching is uncertain. No API key required.
                                             </span>
                                         </span>
                                     </label>
                                 </div>
+                                )}
+                                {FEATURES.DISCDB_CONTRIBUTE && (
+                                <>
                                 <div className="form-group checkbox-group">
                                     <label className="checkbox-label">
                                         <input
@@ -1293,6 +1297,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                             <small>Leave empty for the default location</small>
                                         </div>
                                     </>
+                                )}
+                                </>
                                 )}
                                 </div>
                             </details>

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -601,7 +601,7 @@ function JobDetailPanel({
           </div>
 
           {/* TheDiscDB */}
-          {FEATURES.DISCDB && (
+          {FEATURES.DISCDB_LOOKUP && (
             <div>
               <SvLabel>
                 <Database size={11} style={{ marginRight: 4 }} />

--- a/frontend/src/components/ReviewQueue/Inspector.tsx
+++ b/frontend/src/components/ReviewQueue/Inspector.tsx
@@ -400,7 +400,7 @@ export function Inspector({
                             <IcoRetry size={11} className={isMatching ? 'animate-spin' : ''} />
                             {isMatching ? 'Re-matching…' : 'Re-match'}
                         </SvActionButton>
-                        {FEATURES.DISCDB && title.discdb_match_details && title.match_details && (
+                        {FEATURES.DISCDB_LOOKUP && title.discdb_match_details && title.match_details && (
                             <SvActionButton
                                 tone="magenta"
                                 size="sm"

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -8,8 +8,10 @@
  * Flip to true to expose a feature that's been merged but isn't user-ready.
  */
 export const FEATURES = {
-  /** TheDiscDB integration — contribute page, match-source badges, settings toggle. */
-  DISCDB: false,
+  /** TheDiscDB lookups: match-source badges, history metadata, lookup settings toggle. */
+  DISCDB_LOOKUP: true,
+  /** TheDiscDB contributions: contribute page, nav item, stats badge, submit controls. */
+  DISCDB_CONTRIBUTE: false,
 } as const;
 
 /**

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -26,7 +26,7 @@ export const ROUTES = {
 
 /**
  * Every *mounted* route pattern. Drives `routeExists()` validation. The
- * `/contribute` route is mounted only when `FEATURES.DISCDB` is on, so it is
+ * `/contribute` route is mounted only when `FEATURES.DISCDB_CONTRIBUTE` is on, so it is
  * included conditionally — mirroring the gate on its `<Route>` in App.tsx —
  * to keep `routeExists()` honest about what actually resolves.
  */
@@ -36,7 +36,7 @@ export const ROUTE_PATTERNS: readonly string[] = [
   ROUTES.HISTORY_DETAIL,
   ROUTES.REVIEW,
   ROUTES.REVIEW_DETAIL,
-  ...(FEATURES.DISCDB ? [ROUTES.CONTRIBUTE] : []),
+  ...(FEATURES.DISCDB_CONTRIBUTE ? [ROUTES.CONTRIBUTE] : []),
 ];
 
 /** Concrete path to a job's review page — derived from the route pattern. */


### PR DESCRIPTION
## Summary

Two related changes to how TheDiscDB is used, prompted by an Avatar: The Last Airbender disc whose episodes matched against TheDiscDB in the wrong order.

1. **TheDiscDB lookup is now enabled; contribution stays gated off.** Previously a single hardcoded master switch (`DISCDB_ENABLED` backend, `FEATURES.DISCDB` frontend) disabled the whole integration, collapsing two concerns the config layer already separated. The original intent was to gate only *contribution* (uploading disc data), not *lookup* (using TheDiscDB to help identify discs / match tracks). The master switch is split into a lookup flag (on) and a contribution flag (off).

2. **Engram ASR is now the preferred episode signal.** TheDiscDB numbers episodes by physical *disc order*, not *aired order*, so its mappings frequently disagreed with (and were worse than) Engram's audio match. Before, a DiscDB mapping short-circuited ASR entirely (stamped 0.99, audio never ran). Now ASR always runs and wins; a DiscDB episode mapping is applied only as a fallback when ASR confidence is very low (< 0.5).

## What changed

### Lookup vs contribution split
- `DISCDB_ENABLED` -> `DISCDB_LOOKUP_ENABLED = True` + `DISCDB_CONTRIBUTIONS_ENABLED = False` (`backend/app/core/features.py`); lookup gate in `identification_coordinator`, auto-export gate in `cleanup_service` re-pointed accordingly.
- `FEATURES.DISCDB` -> `FEATURES.DISCDB_LOOKUP = true` + `FEATURES.DISCDB_CONTRIBUTE = false` (frontend). Match-source badges, history disc metadata, and the "use DiscDB match" review action show under lookup; contribute page, nav item, stats badge, and submit controls stay hidden under contribute. ConfigWizard's DiscDB group is split into the two halves.
- Hardened the gate: all 9 TheDiscDB contribution write endpoints (export, submit, batch submit, enhance, fetch-cover, skip, release-group create/assign, upc-lookup) now return 404 when contributions are disabled, so enabling lookup cannot expose upload. Lookup itself is read-only (GraphQL queries only).

### ASR-preferred episode precedence
- New `DISCDB_FALLBACK_ASR_FLOOR = 0.5`. Decision table:
  - ASR >= 0.7: ASR auto-organizes (DiscDB ignored even if it disagrees).
  - 0.5 <= ASR < 0.7: ASR result goes to review.
  - ASR < 0.5 with a DiscDB mapping: DiscDB mapping auto-organizes.
  - ASR < 0.5 with no DiscDB mapping: ASR best-guess goes to review.
- Removed the two pre-dispatch DiscDB short-circuits (`identification_coordinator` staging loop and `job_manager._dispatch_title_match`); the DiscDB assignment now lives as a post-ASR fallback inside `MatchingCoordinator._match_single_file_inner`. DiscDB still drives show identification (tmdb_id, content type); only per-track episode numbers changed precedence.
- Removed the now-dead `try_discdb_assignment` cross-coordinator injection.

### UI polish
- The DiscDB match-source badge moved from a stale off-palette text chip to the current `IcoDisc` icon chip on a new palette `blue` token, matching the Engram source chips.

## Why
DiscDB is reliable for *show identity* but not *episode ordering*. This change lets DiscDB answer "what show" while ASR answers "which episode", with DiscDB episode numbers demoted to a last-resort fallback. That removes the disc-order mismatches without losing DiscDB's value where it is strong.

## Reviewer notes
- The contribution gate uses HTTP 404 (not 403) to avoid confirming the endpoint exists; the frontend contribute UI is hidden anyway.
- `try_discdb_assignment` overwrites the provisional ASR fields and commits before the fallback's early return, so no stale ASR data persists.
- A full-suite run caught that gating `fetch-cover` broke 4 existing SSRF/export security tests; they were updated to run with contributions enabled so they still exercise the real guard logic (assertions unchanged).
- Spec: `docs/superpowers/specs/2026-06-20-discdb-lookup-asr-precedence.md`; plan: `docs/superpowers/plans/2026-06-20-discdb-lookup-asr-precedence.md`.

## Test plan
- [x] Backend: 2399 unit tests pass; ruff check + format clean.
- [x] Frontend: 291 unit tests pass; `npm run build` and `npm run lint` clean.
- [x] New precedence tests cover all four confidence bands (`test_match_source.py`).
- [ ] Reviewer: confirm on a real disc with a TheDiscDB listing (e.g. Avatar) that episodes now match by aired order via ASR, and that no contribution/upload occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)