### PR TITLE
test(discdb): remove inert try_discdb_assignment mocks after ASR-precedence refactor

### DIFF
--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2835,15 +2835,17 @@ class JobManager:
         """Run the standard per-title match dispatch for a ripped file.
 
         Shared by ``_on_title_ripped``, ``reconcile_stuck_titles``, and
-        ``dispatch_pending_matches`` so the sites can't diverge: TheDiscDB
-        assignment first (then a completion check, since no match task will
-        run), otherwise a ``match_single_file`` task with the standard done
-        callback. Owns its session — match tasks must own their own sessions.
+        ``dispatch_pending_matches`` so the sites can't diverge: dispatches a
+        ``match_single_file`` task with the standard done callback. (DiscDB
+        episode assignment is no longer a pre-dispatch step; under ASR-preferred
+        precedence it runs only as a low-confidence fallback inside
+        ``_match_single_file_inner``.) Owns its session — match tasks must own
+        their own sessions.
 
         Skips a title that already has a live match task (see
         ``_inflight_match_dispatch``), making repeat dispatch safe. Returns
-        True when work was dispatched (DiscDB assignment or match task), False
-        when skipped (in-flight, or title vanished).
+        True when a match task was dispatched, False when skipped (in-flight,
+        or title vanished).
 
         TOCTOU note: the membership check and ``add`` are separated by NO
         awaits — both run in a single event-loop turn, so they are effectively

--- a/backend/tests/unit/test_identity_answer_midrip.py
+++ b/backend/tests/unit/test_identity_answer_midrip.py
@@ -326,9 +326,6 @@ class TestApplyIdentityResumeAction:
 
     def _stub_matching(self, monkeypatch):
         dispatch = AsyncMock()
-        monkeypatch.setattr(
-            job_manager._matching, "try_discdb_assignment", AsyncMock(return_value=False)
-        )
         monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
         monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
         return dispatch

--- a/backend/tests/unit/test_import_tmdb_resolution.py
+++ b/backend/tests/unit/test_import_tmdb_resolution.py
@@ -115,7 +115,6 @@ def _build_coordinator(analysis, monkeypatch, *, signal):
     )
 
     coordinator._run_classification = AsyncMock(return_value=analysis)
-    coordinator._try_discdb_assignment = AsyncMock(return_value=False)
     coordinator._match_single_file = AsyncMock(return_value=None)
     coordinator._on_match_task_done = Mock()
     coordinator._finalize_disc_job = AsyncMock(return_value=None)

--- a/backend/tests/unit/test_staging_import_state.py
+++ b/backend/tests/unit/test_staging_import_state.py
@@ -77,7 +77,6 @@ def _build_coordinator(content_type: ContentType, monkeypatch):
     # Stub the IO-heavy collaborators so the test stays a pure unit test.
     coordinator._probe_duration = AsyncMock(return_value=1200.0)
     coordinator._run_classification = AsyncMock(return_value=_fake_analysis(content_type))
-    coordinator._try_discdb_assignment = AsyncMock(return_value=False)
     coordinator._match_single_file = AsyncMock(return_value=None)
     coordinator._on_match_task_done = Mock()
     coordinator._finalize_disc_job = AsyncMock(return_value=None)

--- a/backend/tests/unit/test_stuck_job_recovery.py
+++ b/backend/tests/unit/test_stuck_job_recovery.py
@@ -118,13 +118,9 @@ async def test_reconcile_stuck_tv_with_file_queues_match(tmp_path, monkeypatch):
 
     called = {}
 
-    async def fake_discdb(jid, title, session):
-        return False
-
     async def fake_match(jid, title_id, path):
         called["match"] = (jid, title_id, str(path))
 
-    monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", fake_discdb)
     monkeypatch.setattr(job_manager._matching, "match_single_file", fake_match)
     monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
 
@@ -159,9 +155,7 @@ async def test_reconcile_stuck_identity_pending_parks_queued(tmp_path, monkeypat
 
     from unittest.mock import AsyncMock
 
-    discdb = AsyncMock(return_value=False)
     dispatch = AsyncMock()
-    monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", discdb)
     monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
     monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
 
@@ -169,7 +163,6 @@ async def test_reconcile_stuck_identity_pending_parks_queued(tmp_path, monkeypat
     await asyncio.sleep(0.05)
 
     assert (await _title(tid)).state == TitleState.QUEUED
-    discdb.assert_not_called()
     dispatch.assert_not_called()
 
 
@@ -191,9 +184,7 @@ async def test_reconcile_stuck_season_prompt_dispatches_normally(tmp_path, monke
 
     from unittest.mock import AsyncMock
 
-    discdb = AsyncMock(return_value=False)
     dispatch = AsyncMock()
-    monkeypatch.setattr(job_manager._matching, "try_discdb_assignment", discdb)
     monkeypatch.setattr(job_manager._matching, "match_single_file", dispatch)
     monkeypatch.setattr(job_manager._matching, "on_match_task_done", lambda *a, **k: None)
 


### PR DESCRIPTION
## What

Removes leftover **inert** DiscDB test scaffolding in four unit test files. These mocks/patches still reference `try_discdb_assignment` on code paths that no longer touch it after the ASR-preferred precedence refactor on this branch (PR #430).

| File | Removed |
|------|---------|
| `test_identity_answer_midrip.py` | `try_discdb_assignment` patch in `_stub_matching` |
| `test_stuck_job_recovery.py` | 3 reconcile-path patches + a `fake_discdb` def + a `discdb.assert_not_called()` |
| `test_import_tmdb_resolution.py` | dead `coordinator._try_discdb_assignment` attribute assignment |
| `test_staging_import_state.py` | dead `coordinator._try_discdb_assignment` attribute assignment |

## Why they are inert (on this base)

After #430:
- `JobManager._dispatch_title_match` goes straight to `match_single_file` (no pre-dispatch DiscDB short-circuit).
- `IdentificationCoordinator.identify_from_staging` no longer calls an injected `_try_discdb_assignment` (the injection was dropped); `IdentificationCoordinator` has no such attribute, so the assignments in items 3 & 4 are dead dynamic attributes nothing reads.
- DiscDB episode assignment now runs **only** as a low-confidence fallback inside `MatchingCoordinator._match_single_file_inner`.

The tests in scope mock `match_single_file`/dispatch directly, so the fallback path never executes — the `try_discdb_assignment` mocks were never exercised.

## What is NOT touched

- The live `MatchingCoordinator.try_discdb_assignment` method and its fallback call in `_match_single_file_inner` are untouched.
- No production code changes; no change to what any test fundamentally verifies (TV import / identity / stuck-recovery assertions are all preserved).

## Base note

Stacked on the #430 branch (`claude/trusting-booth-d64e49`) **on purpose**: the production call-site removal that makes these mocks inert lives there, not on `main`. On `main` these mocks are still load-bearing (verified: removing one yields `TypeError: 'NoneType' object is not callable` at the live `identify_from_staging` call site). Merge after / on top of #430.

## Verification

```
cd backend && uv run pytest tests/unit/test_identity_answer_midrip.py tests/unit/test_stuck_job_recovery.py tests/unit/test_import_tmdb_resolution.py tests/unit/test_staging_import_state.py -q
# 64 passed
```
ruff clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)