### PR TITLE
chore: release v0.21.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.7] - 2026-06-21
+
+_Highlights: TheDiscDB lookup is now on by default — Engram checks the community disc database during identification and uses its episode mappings as a low-confidence fallback, while audio matching (ASR) remains the primary and preferred signal._
+
+### Added
+
+- **TheDiscDB lookup is now enabled by default** — when a disc's content hash matches an entry in TheDiscDB, Engram now uses the community-contributed title-to-episode mapping as a fallback when audio-recognition confidence is low (below 0.5). ASR always runs first and wins when confident; a DiscDB mapping steps in only when the audio match is weak. Previously, a DiscDB hit would short-circuit ASR entirely and stamp 0.99 confidence using disc-order numbering — which frequently disagreed with aired order and produced worse results than the audio match. Contribution of new disc layouts remains gated off by default. (#430)
+
 ## [0.21.6] - 2026-06-19
 
 _Highlights: two disc-handling fixes — the Identify prompt no longer pops a blocking modal over a disc that is already ripping, and box-set TV discs now pin their TMDB lookup to the TV namespace instead of picking a fuzzy movie match._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.6"
+__version__ = "0.21.7"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.6"
+version = "0.21.7"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.6",
+    "version": "0.21.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.6",
+            "version": "0.21.7",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.6",
+    "version": "0.21.7",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bumps version from 0.21.6 → 0.21.7
- Enables TheDiscDB lookup by default (PR #430)
- Writes CHANGELOG section for 0.21.7

## Changes since 0.21.6

- **feat(discdb):** enable lookup, keep contribution gated, prefer ASR over disc-order episodes (#430)
- **chore(deps):** update vite to ^8.0.16 (#428)
- **chore(deps):** update tailwindcss monorepo to v4.3.1 (#429)
- **test(discdb):** remove inert mocks after ASR-precedence refactor (#431)

## Test plan
- [x] Unit tests: 2400 passed
- [x] `extract_changelog.py --version 0.21.7` produces clean output
- [x] Version bumped in 4 files (both `package-lock.json` entries included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)