### PR TITLE
Add ARM64 (Linux aarch64) build for NVIDIA Jetson

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,150 @@ jobs:
             engram-linux-x64.tar.gz
             engram-linux-x64.manifest.sha256
 
+  build-linux-arm64:
+    name: Build Linux Executable (arm64)
+    # GitHub-hosted aarch64 runner (free for public repos). Produces the native
+    # Linux arm64 bundle for NVIDIA Jetson and other aarch64 Linux devices. ASR
+    # is CPU-only here: the ctranslate2 aarch64 wheel on PyPI has no CUDA build,
+    # so GPU on Jetson is an opt-in on-device step (see docs/development/jetson.md).
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      # Build frontend
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      # Copy frontend build into backend for bundling
+      - name: Bundle frontend
+        run: cp -r frontend/dist backend/app/static
+
+      # Build backend executable
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsndfile1 ffmpeg
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          uv sync --no-install-project
+          # Pin the build toolchain so release artifacts are reproducible and a
+          # PyInstaller / hooks-contrib release can't silently change what gets
+          # bundled (a hooks-contrib change is what dropped certifi from 0.14.0).
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
+      - name: Build executable
+        working-directory: backend
+        run: uv run pyinstaller engram.spec
+
+      - name: Verify binary architecture
+        run: |
+          file backend/dist/engram/engram
+          file backend/dist/engram/engram | grep -q 'aarch64' \
+            || { echo "binary is not aarch64 as expected"; exit 1; }
+
+      - name: Smoke test built executable
+        env:
+          PORT: "8765"
+          HOST: "127.0.0.1"
+        run: |
+          ./backend/dist/engram/engram > smoke-stdout.log 2> smoke-stderr.log &
+          BACKEND_PID=$!
+          trap "kill $BACKEND_PID 2>/dev/null || true" EXIT
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8765/api/jobs > /dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "1" ]; then
+            echo "===== stdout ====="
+            cat smoke-stdout.log || true
+            echo "===== stderr ====="
+            cat smoke-stderr.log || true
+            echo "executable never became ready"
+            exit 1
+          fi
+          # Fork-bomb regression guard: a healthy onedir server is ~1 process;
+          # a spawn fork-bomb produces 10+ within seconds, so >2 is a safe trigger.
+          count=$(pgrep -f 'dist/engram/engram' | wc -l | tr -d ' ')
+          echo "engram process count: $count"
+          if [ "$count" -gt 2 ]; then
+            echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
+            exit 1
+          fi
+          # fpcalc must be bundled and detected — the whole point of shipping it.
+          # Retry with a generous per-attempt timeout: the endpoint shells out to
+          # ffmpeg/fpcalc subprocesses and the first call can be slow on a cold
+          # runner; a retry after warmup returns fast. The gate stays strict — it
+          # still requires found=True, it just tolerates transient first-run latency.
+          fpcalc_found=""
+          for i in $(seq 1 4); do
+            fpcalc_found=$(curl -fsS --max-time 15 http://127.0.0.1:8765/api/detect-tools \
+              | python3 -c "import sys, json; print(json.load(sys.stdin)['fpcalc']['found'])" 2>/dev/null) || true
+            if [ "$fpcalc_found" = "True" ]; then break; fi
+            if [ "$i" -lt 4 ]; then
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', retrying in 2s"
+              sleep 2
+            else
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', no more retries"
+            fi
+          done
+          echo "fpcalc detected: $fpcalc_found"
+          if [ "$fpcalc_found" != "True" ]; then
+            echo "bundled fpcalc was not detected"
+            exit 1
+          fi
+          echo "smoke test passed"
+
+      - name: Verify CA bundle + bundled fpcalc + TLS self-test
+        run: |
+          ca="backend/dist/engram/_internal/certifi/cacert.pem"
+          test -f "$ca" || { echo "certifi CA bundle missing from build ($ca)"; exit 1; }
+          size=$(stat -c%s "$ca")
+          [ "$size" -ge 50000 ] || { echo "certifi CA bundle suspiciously small ($size)"; exit 1; }
+          echo "certifi CA bundle present: $size bytes"
+          # Deterministic guard for the bundled fpcalc (_internal/bin/, the path
+          # detect_fpcalc() resolves via _MEIPASS) — independent of server timing.
+          fpc="backend/dist/engram/_internal/bin/fpcalc"
+          test -f "$fpc" || { echo "bundled fpcalc missing from build ($fpc)"; exit 1; }
+          echo "bundled fpcalc present: $fpc"
+          ./backend/dist/engram/engram --selftest || { echo "TLS self-test failed"; exit 1; }
+
+      - name: Generate file manifest
+        run: |
+          # sha256sum-style manifest, paths relative to the engram/ dir (no leading
+          # ./). The updater verifies every listed path exists after extraction.
+          ( cd backend/dist/engram && find . -type f -printf '%P\0' | sort -z | xargs -0 sha256sum ) \
+            > engram-linux-arm64.manifest.sha256
+          echo "manifest entries: $(wc -l < engram-linux-arm64.manifest.sha256)"
+
+      - name: Package
+        run: tar -czf engram-linux-arm64.tar.gz -C backend/dist engram
+      - uses: actions/upload-artifact@v7
+        with:
+          name: engram-linux-arm64
+          path: |
+            engram-linux-arm64.tar.gz
+            engram-linux-arm64.manifest.sha256
+
   build-macos:
     name: Build macOS Executable (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -456,7 +600,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [build-windows, build-linux, build-macos]
+    needs: [build-windows, build-linux, build-linux-arm64, build-macos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -472,10 +616,13 @@ jobs:
           name: engram-linux-x64
       - uses: actions/download-artifact@v8
         with:
+          name: engram-linux-arm64
+      - uses: actions/download-artifact@v8
+        with:
           name: engram-macos-arm64
       - name: Generate SHA256 checksums
         run: |
-          sha256sum engram-windows-x64.zip engram-linux-x64.tar.gz engram-macos-arm64.tar.gz > sha256sums.txt
+          sha256sum engram-windows-x64.zip engram-linux-x64.tar.gz engram-linux-arm64.tar.gz engram-macos-arm64.tar.gz > sha256sums.txt
           cat sha256sums.txt
       - name: Generate release notes from CHANGELOG
         env:
@@ -522,6 +669,8 @@ jobs:
             engram-windows-x64.manifest.sha256
             engram-linux-x64.tar.gz
             engram-linux-x64.manifest.sha256
+            engram-linux-arm64.tar.gz
+            engram-linux-arm64.manifest.sha256
             engram-macos-arm64.tar.gz
             engram-macos-arm64.manifest.sha256
             sha256sums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **ARM64 (Linux aarch64) build for NVIDIA Jetson and other aarch64 Linux devices** — releases now include `engram-linux-arm64.tar.gz`, built natively on a GitHub-hosted arm64 runner and validated by the same smoke test, TLS self-test, and bundled-`fpcalc` checks as the x86_64 build. ASR runs on the CPU out of the box (the PyPI `ctranslate2` aarch64 wheel has no CUDA build); GPU-accelerated transcription on a Jetson is an opt-in on-device step that compiles CTranslate2 against the device's JetPack CUDA toolkit (`backend/scripts/jetson_gpu_setup.sh`, documented in `docs/development/jetson.md`). The auto-updater now distinguishes x86_64 from aarch64 so each host downloads the matching bundle.
+
 ## [0.21.7] - 2026-06-21
 
 _Highlights: TheDiscDB lookup is now on by default — Engram checks the community disc database during identification and uses its episode mappings as a low-confidence fallback, while audio matching (ASR) remains the primary and preferred signal._

--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ No Python or Node.js required — the Config Wizard opens in your browser on fir
 |----------|----------|-----|
 | Windows | `engram-windows-x64.zip` | `engram.exe` |
 | Linux (x64) | `engram-linux-x64.tar.gz` | `./engram/engram` |
+| Linux (arm64 / Jetson) | `engram-linux-arm64.tar.gz` | `./engram/engram` |
 | macOS | `engram-macos-arm64.tar.gz` | `./engram/engram` |
+
+On Linux arm64 (e.g. NVIDIA Jetson), download `engram-linux-arm64.tar.gz`. ASR runs on the CPU out of the box; GPU acceleration needs an on-device build step — see [Jetson setup](docs/development/jetson.md).
 
 On macOS, download `engram-macos-arm64.tar.gz`. It runs natively on Apple Silicon (M1/M2/M3/M4) and transparently on Intel Macs via Rosetta 2. macOS has no automatic optical-drive detection — use the staging-folder workflow (see [Linux / macOS setup](docs/guide/linux-setup.md)).
 

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -13,6 +13,7 @@ Platform restart strategies:
 
 import hashlib
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -350,16 +351,26 @@ class UpdateChecker:
             await self._broadcast()
 
     def _select_asset(self, assets: list[dict]) -> dict | None:
-        """Return the platform-appropriate release asset, or None if not found."""
-        platform = sys.platform
+        """Return the platform-appropriate release asset, or None if not found.
+
+        On Linux the architecture matters: we ship both an x86_64 bundle
+        (``engram-linux-x64.tar.gz``) and an aarch64 bundle
+        (``engram-linux-arm64.tar.gz``), so an arm64 host (e.g. a Jetson) must
+        not pick up the x86_64 tarball and vice versa.
+        """
+        system = sys.platform
+        is_arm = platform.machine().lower() in ("aarch64", "arm64")
         for asset in assets:
             name = asset.get("name", "").lower()
-            if platform == "win32" and name.endswith(".zip") and "windows" in name:
+            if system == "win32" and name.endswith(".zip") and "windows" in name:
                 return asset
-            if platform == "linux" and name.endswith(".tar.gz") and "linux" in name:
-                return asset
+            if system == "linux" and name.endswith(".tar.gz") and "linux" in name:
+                name_is_arm = "arm64" in name or "aarch64" in name
+                if name_is_arm == is_arm:
+                    return asset
+                continue
             if (
-                platform == "darwin"
+                system == "darwin"
                 and name.endswith(".tar.gz")
                 and ("macos" in name or "darwin" in name)
             ):

--- a/backend/scripts/fetch_fpcalc.py
+++ b/backend/scripts/fetch_fpcalc.py
@@ -32,27 +32,59 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-CHROMAPRINT_VERSION = "1.5.1"
-_BASE = f"https://github.com/acoustid/chromaprint/releases/download/v{CHROMAPRINT_VERSION}"
+_RELEASES = "https://github.com/acoustid/chromaprint/releases/download"
 
-# Per-platform release asset + its SHA256. Hashes were computed from the
-# official v1.5.1 GitHub release assets. Bump all three together on a version
-# change. macOS uses the native arm64 build, matching the arm64-only release
-# matrix in .github/workflows/release.yml.
-_ASSETS: dict[str, tuple[str, str]] = {
+# Per-platform release asset (version, file name, SHA256). Hashes were computed
+# from the official GitHub release assets. macOS uses the native arm64 build,
+# matching the arm64-only macOS release matrix in .github/workflows/release.yml.
+#
+# Most platforms pin Chromaprint 1.5.1. Linux aarch64 pins 1.6.0 because 1.5.1
+# never shipped an arm64 fpcalc — the 1.6.0 release is the first with one
+# (`chromaprint-fpcalc-1.6.0-linux-arm64.tar.gz`). Each entry therefore carries
+# its own version so platforms can be bumped independently.
+_ASSETS: dict[str, tuple[str, str, str]] = {
     "windows": (
-        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-windows-x86_64.zip",
+        "1.5.1",
+        "chromaprint-fpcalc-1.5.1-windows-x86_64.zip",
         "36b478e16aa69f757f376645db0d436073a42c0097b6bb2677109e7835b59bbc",
     ),
-    "linux": (
-        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-linux-x86_64.tar.gz",
+    "linux_x86_64": (
+        "1.5.1",
+        "chromaprint-fpcalc-1.5.1-linux-x86_64.tar.gz",
         "4d7433a7f778e5946d7225230681cbcd634e153316ecac87c538c33ac32387a5",
     ),
+    "linux_aarch64": (
+        "1.6.0",
+        "chromaprint-fpcalc-1.6.0-linux-arm64.tar.gz",
+        "c8667f556f77d8ebbe08b75a968c0592bd2a67aaa696eff91715feb5083b1cd4",
+    ),
     "darwin": (
-        f"chromaprint-fpcalc-{CHROMAPRINT_VERSION}-macos-arm64.tar.gz",
+        "1.5.1",
+        "chromaprint-fpcalc-1.5.1-macos-arm64.tar.gz",
         "9c5d9565d2396dbcf0e1d797e1ffdf1e19242f3bed88ac3200e144286b57ede6",
     ),
 }
+
+
+def _platform_key() -> str | None:
+    """Map the running platform to an ``_ASSETS`` key (or ``None`` if unsupported).
+
+    Windows and macOS are single-arch in our release matrix (x86_64 and arm64
+    respectively); Linux distinguishes x86_64 from aarch64 so a Jetson / arm64
+    host gets the matching fpcalc rather than the x86_64 one.
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "windows":
+        return "windows"
+    if system == "darwin":
+        return "darwin"
+    if system == "linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux_x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux_aarch64"
+    return None
 
 
 def _target_path() -> Path:
@@ -104,17 +136,20 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    system = platform.system().lower()
-    if system not in _ASSETS:
-        raise SystemExit(f"error: no pinned fpcalc asset for platform {system!r}")
+    key = _platform_key()
+    if key is None:
+        raise SystemExit(
+            f"error: no pinned fpcalc asset for platform "
+            f"{platform.system()!r}/{platform.machine()!r}"
+        )
 
     dest = _target_path()
     if dest.is_file() and not args.force:
         print(f"fpcalc already present at {dest} (use --force to re-download)")
         return 0
 
-    asset, expected_sha = _ASSETS[system]
-    url = f"{_BASE}/{asset}"
+    version, asset, expected_sha = _ASSETS[key]
+    url = f"{_RELEASES}/v{version}/{asset}"
     print(f"downloading {url}")
     try:
         with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 - pinned https URL

--- a/backend/scripts/jetson_gpu_setup.sh
+++ b/backend/scripts/jetson_gpu_setup.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# jetson_gpu_setup.sh — enable CUDA-accelerated ASR for the Engram arm64 bundle
+# on an NVIDIA Jetson.
+#
+# WHY THIS EXISTS
+# ---------------
+# Engram transcribes episode audio with faster-whisper / CTranslate2. On x86_64
+# the PyPI `ctranslate2` wheel ships a CUDA-enabled build, so GPU "just works"
+# once cuDNN/cuBLAS are present. On aarch64 the PyPI wheel is **CPU-only** — there
+# is no CUDA aarch64 wheel — so the shipped `engram-linux-arm64.tar.gz` runs ASR
+# on the CPU. To get GPU on a Jetson you must compile CTranslate2 from source
+# against the device's JetPack CUDA toolkit and swap the result into the bundle.
+#
+# This script automates that. It is the on-device counterpart to the CPU-only CI
+# bundle, and it must be run ON THE JETSON (it compiles for the local GPU).
+#
+# IMPORTANT: this path requires validation on real Jetson hardware. Treat it as a
+# best-effort, well-signposted procedure rather than a turnkey guarantee.
+#
+# USAGE
+#   ./jetson_gpu_setup.sh /path/to/extracted/engram
+#
+#   where the argument is the extracted bundle directory that contains the
+#   `engram` launcher and the `_internal/` folder (i.e. the dir created by
+#   `tar xzf engram-linux-arm64.tar.gz`).
+#
+# OVERRIDES (environment variables)
+#   CUDA_ARCH   CUDA compute capability to target. Auto-detected when possible;
+#               defaults to 87 (Orin family). Use 72 for Xavier (AGX/NX/NANO),
+#               87 for Orin (AGX/NX/Nano), 53/62 for older TX/Nano.
+#   CT2_VERSION CTranslate2 git tag to build. Defaults to the version baked into
+#               the bundle (read from _internal/ctranslate2/version.py) so the
+#               compiled C++ library matches the bundled Python bindings.
+#   JOBS        Parallel build jobs (defaults to nproc).
+#
+set -euo pipefail
+
+err()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m==>\033[0m %s\n' "$*"; }
+
+# --- 1. Validate arguments + host -------------------------------------------
+BUNDLE_DIR="${1:-}"
+[ -n "$BUNDLE_DIR" ] || err "usage: $0 /path/to/extracted/engram"
+BUNDLE_DIR="$(cd "$BUNDLE_DIR" && pwd)" || err "bundle dir not found: $1"
+CT2_PKG_DIR="$BUNDLE_DIR/_internal/ctranslate2"
+[ -d "$CT2_PKG_DIR" ] || err "not an Engram bundle (missing $CT2_PKG_DIR)"
+
+[ "$(uname -m)" = "aarch64" ] || err "this script must run on the Jetson (aarch64); got $(uname -m)"
+
+# A Jetson exposes its integrated GPU via the Tegra device nodes / L4T release
+# file. Bail early with a clear message rather than building something unusable.
+if [ ! -e /etc/nv_tegra_release ] && [ ! -e /dev/nvgpu ] && [ ! -e /dev/nvhost-gpu ]; then
+  err "no Jetson/Tegra GPU detected (no /etc/nv_tegra_release or /dev/nvhost-gpu).
+     This script is for NVIDIA Jetson with JetPack installed."
+fi
+
+# --- 2. Locate the JetPack CUDA toolkit -------------------------------------
+CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+[ -x "$CUDA_HOME/bin/nvcc" ] || err "CUDA toolkit not found at $CUDA_HOME (set CUDA_HOME).
+     Install it with JetPack:  sudo apt-get install nvidia-jetpack"
+info "CUDA toolkit: $("$CUDA_HOME/bin/nvcc" --version | sed -n 's/.*release \([0-9.]*\).*/\1/p' | tr -d '\n') at $CUDA_HOME"
+
+# --- 3. Resolve target versions ---------------------------------------------
+# Match the CTranslate2 C++ library to the Python bindings shipped in the bundle,
+# otherwise the swapped-in libctranslate2.so won't match the frozen _ext module.
+BUNDLED_CT2="$(sed -n 's/^__version__ *= *["'"'"']\([0-9.]*\)["'"'"'].*/\1/p' \
+  "$CT2_PKG_DIR/version.py" 2>/dev/null || true)"
+CT2_VERSION="${CT2_VERSION:-${BUNDLED_CT2:-4.6.3}}"
+CUDA_ARCH="${CUDA_ARCH:-87}"   # Orin default; override for Xavier (72) etc.
+JOBS="${JOBS:-$(nproc)}"
+info "Building CTranslate2 v$CT2_VERSION for CUDA arch sm_$CUDA_ARCH (bundle has ${BUNDLED_CT2:-unknown})"
+if [ -n "$BUNDLED_CT2" ] && [ "$CT2_VERSION" != "$BUNDLED_CT2" ]; then
+  info "WARNING: building $CT2_VERSION but bundle ships $BUNDLED_CT2 — bindings may mismatch."
+fi
+
+# --- 4. Build dependencies ---------------------------------------------------
+# CTranslate2 defaults to Intel MKL (x86-only); on aarch64 use OpenBLAS instead.
+info "Installing build dependencies (sudo)..."
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  git build-essential cmake libopenblas-dev
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+# --- 5. Build CTranslate2 with CUDA -----------------------------------------
+info "Cloning CTranslate2 v$CT2_VERSION..."
+git clone --depth 1 --branch "v$CT2_VERSION" --recursive \
+  https://github.com/OpenNMT/CTranslate2.git
+cd CTranslate2
+
+info "Configuring (CUDA on, cuDNN on, MKL off, OpenBLAS)..."
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+  -DWITH_CUDA=ON -DWITH_CUDNN=ON \
+  -DWITH_MKL=OFF -DWITH_OPENBLAS=ON \
+  -DOPENMP_RUNTIME=COMP \
+  -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
+  -DCMAKE_INSTALL_PREFIX="$WORK/ct2-install"
+info "Compiling (this takes a while on a Jetson)..."
+cmake --build build --config Release -j "$JOBS"
+cmake --install build
+
+# --- 6. Build the matching Python bindings ----------------------------------
+# Build the bindings against the SAME CTranslate2 we just compiled so _ext.so
+# links the CUDA library. We target the bundle's interpreter (cp311) via a
+# disposable venv to avoid touching system Python.
+info "Building Python bindings..."
+python3 -m venv "$WORK/venv"
+# shellcheck disable=SC1091
+source "$WORK/venv/bin/activate"
+pip install --upgrade pip wheel setuptools pybind11
+export CTRANSLATE2_ROOT="$WORK/ct2-install"
+cd python
+pip wheel . -w "$WORK/wheel" --no-deps
+deactivate
+
+# --- 7. Swap the CUDA build into the Engram bundle --------------------------
+# Replace the CPU-only ctranslate2 in the bundle with the freshly built CUDA one:
+#   - libctranslate2.so*           -> _internal/ (next to the loader's rpath)
+#   - ctranslate2/_ext*.so + *.py  -> _internal/ctranslate2/
+info "Backing up the CPU-only ctranslate2 ($CT2_PKG_DIR.cpu-backup)..."
+rm -rf "$CT2_PKG_DIR.cpu-backup"
+cp -a "$CT2_PKG_DIR" "$CT2_PKG_DIR.cpu-backup"
+
+UNPACK="$WORK/unpack"
+mkdir -p "$UNPACK"
+( cd "$UNPACK" && unzip -q "$WORK"/wheel/ctranslate2-*.whl )
+
+info "Installing CUDA ctranslate2 into the bundle..."
+# Python package files (incl. the compiled _ext*.so).
+cp -a "$UNPACK"/ctranslate2/. "$CT2_PKG_DIR"/
+# The shared library: prefer the one the wheel bundles; fall back to the install tree.
+SO="$(find "$UNPACK" "$WORK/ct2-install" -name 'libctranslate2.so*' | head -n1)"
+[ -n "$SO" ] || err "could not locate built libctranslate2.so"
+cp -a "$SO"* "$BUNDLE_DIR/_internal/" 2>/dev/null || cp -a "$SO" "$BUNDLE_DIR/_internal/"
+
+cat <<EOF
+
+$(info "Done.")
+GPU CTranslate2 (v$CT2_VERSION, sm_$CUDA_ARCH) installed into:
+  $BUNDLE_DIR
+
+Next steps:
+  1. (Re)start Engram:        cd "$BUNDLE_DIR" && ./engram
+  2. Confirm the device:      curl localhost:8000/api/asr-status   # expect device:"cuda"
+  3. Run a match and watch GPU load with:  sudo tegrastats
+  4. ~/.engram/engram.log should show "Loaded ... on cuda" (no "Falling back to CPU").
+
+If ASR still reports CPU, see docs/development/jetson.md (device detection and
+JetPack version notes). To revert, restore $CT2_PKG_DIR.cpu-backup.
+EOF

--- a/backend/scripts/jetson_gpu_setup.sh
+++ b/backend/scripts/jetson_gpu_setup.sh
@@ -107,7 +107,14 @@ cmake --install build
 # links the CUDA library. We target the bundle's interpreter (cp311) via a
 # disposable venv to avoid touching system Python.
 info "Building Python bindings..."
-python3 -m venv "$WORK/venv"
+# Must match the bundle's cp311 ABI — a cp310 _ext.so (JetPack 6 ships Python
+# 3.10 as `python3`) won't import in the frozen 3.11 runtime. Fail loudly here
+# rather than producing an ImportError after the swap.
+PY311="${PYTHON:-python3.11}"
+command -v "$PY311" >/dev/null || err "python3.11 is required to match the bundle's cp311 ABI \
+(got $("$PY311" --version 2>&1 || echo none)). Install it (e.g. sudo apt-get install python3.11 \
+python3.11-venv) or set PYTHON."
+"$PY311" -m venv "$WORK/venv"
 # shellcheck disable=SC1091
 source "$WORK/venv/bin/activate"
 pip install --upgrade pip wheel setuptools pybind11
@@ -126,15 +133,21 @@ cp -a "$CT2_PKG_DIR" "$CT2_PKG_DIR.cpu-backup"
 
 UNPACK="$WORK/unpack"
 mkdir -p "$UNPACK"
-( cd "$UNPACK" && unzip -q "$WORK"/wheel/ctranslate2-*.whl )
+# A wheel is a zip; extract with the stdlib so we don't depend on `unzip` being
+# installed (a fresh L4T image doesn't ship it).
+WHEEL="$(echo "$WORK"/wheel/ctranslate2-*.whl)"
+( cd "$UNPACK" && "$PY311" -m zipfile -e "$WHEEL" . )
 
 info "Installing CUDA ctranslate2 into the bundle..."
 # Python package files (incl. the compiled _ext*.so).
 cp -a "$UNPACK"/ctranslate2/. "$CT2_PKG_DIR"/
-# The shared library: prefer the one the wheel bundles; fall back to the install tree.
-SO="$(find "$UNPACK" "$WORK/ct2-install" -name 'libctranslate2.so*' | head -n1)"
-[ -n "$SO" ] || err "could not locate built libctranslate2.so"
-cp -a "$SO"* "$BUNDLE_DIR/_internal/" 2>/dev/null || cp -a "$SO" "$BUNDLE_DIR/_internal/"
+# The shared library: prefer the one the wheel bundles; fall back to the install
+# tree. Copy the whole soname set from its directory (real file + version
+# symlinks, e.g. libctranslate2.so.4 -> libctranslate2.so.4.6.3) preserving
+# links — _ext links against the SONAME, so dropping the symlink breaks dlopen.
+SO_DIR="$(dirname "$(find "$UNPACK" "$WORK/ct2-install" -name 'libctranslate2.so*' | head -n1)")"
+[ -d "$SO_DIR" ] || err "could not locate built libctranslate2.so"
+cp -a "$SO_DIR"/libctranslate2.so* "$BUNDLE_DIR/_internal/"
 
 cat <<EOF
 

--- a/backend/tests/unit/test_updater.py
+++ b/backend/tests/unit/test_updater.py
@@ -370,6 +370,37 @@ class TestUpdateCheckerStates:
         assert asset["name"].endswith(".zip")
         assert "windows" in asset["name"]
 
+    # Linux ships both x86_64 and aarch64 bundles; the host arch must pick the
+    # right one (a Jetson must not download the x86_64 tarball, and vice versa).
+    _MULTIARCH_ASSETS = [
+        {"name": "engram-linux-x64.tar.gz", "browser_download_url": "https://e/x64"},
+        {"name": "engram-linux-arm64.tar.gz", "browser_download_url": "https://e/arm64"},
+        {"name": "engram-windows-x64.zip", "browser_download_url": "https://e/win"},
+        {"name": "sha256sums.txt", "browser_download_url": "https://e/sums"},
+    ]
+
+    def test_select_asset_linux_x86_64(self, monkeypatch):
+        """An x86_64 Linux host picks the x64 tarball, not arm64."""
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "platform", "linux")
+        monkeypatch.setattr("app.core.updater.platform.machine", lambda: "x86_64")
+        checker = UpdateChecker()
+        asset = checker._select_asset(self._MULTIARCH_ASSETS)
+        assert asset is not None
+        assert asset["name"] == "engram-linux-x64.tar.gz"
+
+    def test_select_asset_linux_aarch64(self, monkeypatch):
+        """An aarch64 Linux host (e.g. Jetson) picks the arm64 tarball, not x64."""
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "platform", "linux")
+        monkeypatch.setattr("app.core.updater.platform.machine", lambda: "aarch64")
+        checker = UpdateChecker()
+        asset = checker._select_asset(self._MULTIARCH_ASSETS)
+        assert asset is not None
+        assert asset["name"] == "engram-linux-arm64.tar.gz"
+
 
 def _make_build(root: Path, *, complete: bool = True) -> Path:
     """Create a fake extracted onedir build at root/engram. Returns the engram dir.

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.6"
+version = "0.21.7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/development/gpu.md
+++ b/docs/development/gpu.md
@@ -12,9 +12,15 @@ on the CPU with `int8`.
 |----|-----|--------|
 | Windows | NVIDIA (CC ≥ 7.0) | ✅ CUDA `float16` |
 | Windows | NVIDIA (Pascal, CC 6.x) | ✅ CUDA `int8_float16`/`float32` (auto-selected) |
-| Linux | NVIDIA | ✅ CUDA |
+| Linux (x86_64) | NVIDIA | ✅ CUDA |
+| Linux (aarch64 / Jetson) | NVIDIA | ⚙️ CUDA after an on-device build — see [jetson.md](./jetson.md) |
 | Windows/Linux | AMD / Intel / none | CPU `int8` |
 | macOS | Apple / AMD | CPU `int8` (no GPU path in the engine) |
+
+> **aarch64 caveat:** the PyPI `ctranslate2` wheel for aarch64 is **CPU-only** (no
+> CUDA build exists), so the shipped `engram-linux-arm64.tar.gz` runs ASR on the
+> CPU. GPU on Jetson requires compiling CTranslate2 against JetPack — see
+> [jetson.md](./jetson.md).
 
 ## Why the libraries aren't bundled
 

--- a/docs/development/jetson.md
+++ b/docs/development/jetson.md
@@ -1,0 +1,111 @@
+# NVIDIA Jetson (Linux arm64)
+
+Engram ships a native **Linux arm64 (aarch64)** build —
+`engram-linux-arm64.tar.gz` — that runs on NVIDIA Jetson and other aarch64 Linux
+devices. It is produced by the `build-linux-arm64` job in
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml) on a
+GitHub-hosted `ubuntu-24.04-arm` runner, so it goes through the same smoke test,
+CA-bundle / fpcalc / TLS self-test, and manifest checks as the x86_64 build.
+
+## Install (CPU ASR — works out of the box)
+
+1. Download **`engram-linux-arm64.tar.gz`** from the
+   [Releases](https://github.com/Jsakkos/engram/releases) page.
+2. Extract and run:
+
+   ```bash
+   tar xzf engram-linux-arm64.tar.gz
+   cd engram
+   ./engram
+   ```
+
+3. The Config Wizard opens in your browser. FFmpeg is required for episode
+   matching — install it with `sudo apt-get install ffmpeg`.
+
+The bundled `fpcalc` audio fingerprinter is the aarch64 Chromaprint 1.6.0 build
+(Chromaprint 1.5.1, used on other platforms, never shipped an arm64 binary).
+
+> **ASR runs on the CPU in this build.** That is a hard constraint of the
+> ecosystem, not a configuration choice — see below.
+
+## Why GPU ASR needs an extra on-device step
+
+Engram transcribes audio with faster-whisper, which runs on
+[CTranslate2](https://opennmt.net/CTranslate2/). CTranslate2 supports **NVIDIA
+CUDA only**. On x86_64 the PyPI `ctranslate2` wheel ships a CUDA-enabled build,
+so GPU works once cuDNN/cuBLAS are present (see [gpu.md](./gpu.md)).
+
+**On aarch64 the PyPI `ctranslate2` wheel is CPU-only** — there is no
+CUDA-enabled aarch64 wheel. So a generic CI bundle, and the GitHub arm64 runner
+that builds it (no JetPack/L4T/Tegra CUDA), can only produce a CPU build. GPU on
+Jetson requires compiling CTranslate2 from source against the device's JetPack
+CUDA toolkit, targeting the device's compute capability:
+
+| Jetson family | `CUDA_ARCH` |
+|---------------|-------------|
+| Orin (AGX / NX / Nano) | `87` |
+| Xavier (AGX / NX) | `72` |
+| TX2 / earlier | `62` / `53` |
+
+## Enable GPU ASR (`jetson_gpu_setup.sh`)
+
+> **Status: requires validation on real Jetson hardware.** This is a best-effort,
+> well-signposted procedure, not a turnkey guarantee. Build times on a Jetson are
+> long (tens of minutes).
+
+Prerequisites:
+
+- **JetPack 6.x** (CUDA 12.x, Ubuntu 22.04 base). The bundle is built against
+  Python 3.11; JetPack 6's system stack aligns with upstream CUDA 12, which is
+  what CTranslate2 4.6 targets. Older JetPack (5.x / CUDA 11.4) is **not**
+  supported by this path.
+- The extracted `engram-linux-arm64` bundle.
+
+Run the helper against the extracted bundle:
+
+```bash
+# from the extracted bundle's backend scripts, or download the script from the repo
+CUDA_ARCH=87 ./jetson_gpu_setup.sh /path/to/extracted/engram
+```
+
+What it does ([`backend/scripts/jetson_gpu_setup.sh`](../../backend/scripts/jetson_gpu_setup.sh)):
+
+1. Verifies it's running on a Jetson (Tegra device nodes / `/etc/nv_tegra_release`)
+   and locates the JetPack CUDA toolkit (`$CUDA_HOME`, default `/usr/local/cuda`).
+2. Reads the CTranslate2 version baked into the bundle
+   (`_internal/ctranslate2/version.py`) so the compiled C++ library matches the
+   bundled Python bindings.
+3. Builds CTranslate2 with
+   `-DWITH_CUDA=ON -DWITH_CUDNN=ON -DWITH_MKL=OFF -DWITH_OPENBLAS=ON`
+   (MKL is x86-only; OpenBLAS is the aarch64 equivalent) for the target
+   `CMAKE_CUDA_ARCHITECTURES`.
+4. Builds the matching Python bindings and swaps `libctranslate2.so*` +
+   `ctranslate2/_ext*.so` into the bundle, backing up the CPU-only build to
+   `_internal/ctranslate2.cpu-backup`.
+
+JetPack already provides cuDNN and cuBLAS system-wide, so the on-demand wheel
+download in `backend/app/matcher/cuda_runtime.py` (used on x86_64) is **not**
+needed here — it remains a fallback.
+
+## Confirm GPU is active
+
+```bash
+curl localhost:8000/api/asr-status      # expect device:"cuda"
+sudo tegrastats                         # watch GPU load while a match runs
+# ~/.engram/engram.log shows "Loaded ... on cuda" (no "Falling back to CPU")
+```
+
+The effective device is resolved once at startup (`job_manager.start()` →
+`set_asr_device()`), and every call site reads it through `detect_asr_device()`,
+so the `/api/asr-status` badge can't disagree with the model loader.
+
+### If it still reports CPU
+
+`gpu_detected()` in `cuda_runtime.py` is the raw hardware probe. On JetPack 6
+`nvidia-smi` exists; on some Jetson setups the probe may not see the integrated
+Tegra GPU. If ASR stays on CPU after the swap, this is the most likely cause —
+file an issue with `tegrastats`/`nvidia-smi` output so we can extend the probe
+with a Tegra check (e.g. `/etc/nv_tegra_release`).
+
+To revert to the CPU build, restore `_internal/ctranslate2.cpu-backup` over
+`_internal/ctranslate2`.


### PR DESCRIPTION
## Why

A user wants to run Engram on an **NVIDIA Jetson** (aarch64 / Linux for Tegra). Today releases only ship Windows x64, Linux x86_64, and macOS arm64 bundles, so there's no artifact a Jetson can run. This adds a native `engram-linux-arm64.tar.gz`.

## What

### Phase 1 — CPU-only arm64 release bundle (fully CI-tested)
- **`release.yml`**: new `build-linux-arm64` job on a GitHub-hosted `ubuntu-24.04-arm` runner. It mirrors the x86_64 job exactly — same frontend bundling, pinned PyInstaller, smoke test, CA-bundle / fpcalc / TLS self-test, and file manifest — only changing the arch assertion (`aarch64`) and artifact names. Wired into `create-release` (`needs`, artifact download, `sha256sums.txt`, and the release `files:` list).
- **`fetch_fpcalc.py`**: selects the fpcalc asset by `(system, machine)` instead of OS alone. Linux aarch64 uses **Chromaprint 1.6.0** (`chromaprint-fpcalc-1.6.0-linux-arm64.tar.gz`, SHA-pinned) because 1.5.1 never shipped an arm64 fpcalc; each asset entry now carries its own version so platforms bump independently. Verified the aarch64 binary is a valid `ARM aarch64` ELF containing `fpcalc`.
- **`updater.py`**: `_select_asset()` now distinguishes x86_64 from aarch64 so a Jetson downloads `engram-linux-arm64.tar.gz` and an x86_64 host stays on `engram-linux-x64.tar.gz`. New unit tests cover both.

### Phase 2 — On-device GPU ASR (documented + scripted; needs Jetson hardware to validate)
The PyPI `ctranslate2` aarch64 wheel is **CPU-only** — there is no CUDA aarch64 wheel — so a CI bundle (and the generic arm64 runner that builds it) can only produce a CPU build. GPU on Jetson requires compiling CTranslate2 from source against the device's JetPack CUDA toolkit.
- **`backend/scripts/jetson_gpu_setup.sh`**: builds CTranslate2 with `-DWITH_CUDA=ON -DWITH_CUDNN=ON -DWITH_MKL=OFF -DWITH_OPENBLAS=ON` for the target compute capability (Orin = 87, Xavier = 72), matching the bundle's CTranslate2 version, then swaps `libctranslate2.so*` + `ctranslate2/_ext*.so` into the bundle (backing up the CPU build).
- **`docs/development/jetson.md`**: install steps, the CPU/GPU split, prerequisites (JetPack 6.x), and how to confirm GPU is active. `gpu.md`, `README.md`, and `CHANGELOG.md` updated to reference the arm64 build and Jetson caveat.

## Testing
- `uv run pytest tests/unit/test_updater.py` — 55 passed, 2 skipped (incl. new arch-selection tests).
- `ruff check` + `ruff format --check` clean on changed files.
- `release.yml` YAML validated; `fetch_fpcalc.py` runs end-to-end on x86_64 (SHA verified) and resolves the correct key for aarch64/arm64.

## Status / caveats
- **Phase 1 is self-contained and shippable** (a runnable Jetson tarball with CPU ASR). It will be fully exercised by CI on the next release / a draft `workflow_dispatch` run.
- **Phase 2 (GPU) needs validation on real Jetson hardware** — it's signposted as best-effort in the script and docs. Device detection (`gpu_detected()`) may need a Tegra-specific check; flagged in the docs as a follow-up once hardware confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk2kqE9y5av9WJn6Bve5BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk2kqE9y5av9WJn6Bve5BB)_