### PR TITLE
chore: release v0.21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.10] - 2026-06-22
+
+_Highlights: dependency maintenance and subtitle-cache refresh._
+
+### Changed
+
+- **Subtitle seed list pruned and refreshed** — removed 159 non-English and zero-disc shows that were consuming harvest quota with no benefit to English-language matching, and added 8 US/UK classics. (#437)
+- **Frontend dependency updates** — react-hook-form 7.55→7.80, react-router-dom 7.17→7.18, @radix-ui/react-checkbox 1.1→1.3, @radix-ui/react-select 2.1→2.3, @radix-ui/react-switch 1.1→1.3. (#439, #440, #441, #442, #443)
+
 ## [0.21.9] - 2026-06-22
 
 _Highlights: completed jobs are no longer locked — you can now reassign a misfiled track to the correct episode, mark it as an extra, or discard it directly from the History detail panel, and the fingerprint network self-corrects when a contributed fingerprint is retracted and re-submitted._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to Engram will be documented in this file.
 
 ## [0.21.10] - 2026-06-22
 
-_Highlights: dependency maintenance and subtitle-cache refresh._
+_Highlights: TheDiscDB ContentHash lookups are fixed after a server-side schema change that was silently causing every hash query to fail, plus dependency maintenance and subtitle-cache refresh._
+
+### Fixed
+
+- **TheDiscDB ContentHash lookups no longer fail with "Unexpected Execution Error"** — TheDiscDB restructured their GraphQL schema to insert a `ReleaseDisc` junction between `Release` and `Disc`. Our filter walked `releases.some.discs.some.contentHash`, which still passed schema validation but threw an execution error because the junction's `contentHash` property is not mapped to a SQL column. The filter now traverses the junction correctly (`disc { contentHash }`). In production this caused every hash-based lookup to fall through to name/TMDB matching, which could misfire badly (an Avatar: The Last Airbender disc matched Green Book, for example). (#444)
 
 ### Changed
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.9"
+__version__ = "0.21.10"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.9"
+version = "0.21.10"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.7"
+version = "0.21.10"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.9",
+    "version": "0.21.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.9",
+            "version": "0.21.10",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.9",
+    "version": "0.21.10",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to 0.21.10 across all 6 version files (pyproject.toml, uv.lock, app/__init__.py, package.json, package-lock.json x2)
- Add [0.21.10] CHANGELOG section

## Changes since v0.21.9

- Subtitle seed list pruned and refreshed: removed 159 non-English and zero-disc shows, added 8 US/UK classics (#437)
- Frontend dep updates: react-hook-form 7.55 to 7.80, react-router-dom 7.17 to 7.18, @radix-ui/react-checkbox 1.1 to 1.3, @radix-ui/react-select 2.1 to 2.3, @radix-ui/react-switch 1.1 to 1.3 (#439, #440, #441, #442, #443)

## Test Plan
- [ ] CI passes (changelog-version-check, build, smoke tests)
- [ ] Squash-merge with exact title "chore: release v0.21.10" to trigger tag-release workflow

Generated with Claude Code
