### PR TITLE
fix(history): pin Reassign Track dropdown to the disc's season

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reassign Track episode dropdown now uses the disc's actual season.** When reassigning a track on a completed multi-season disc from the History detail panel, the episode picker was pinned to Season 1 (`S01E01`, `S01E02`, …) because it derived the season from the track's current match instead of the job's identified season. It now uses the job's detected season, so a Season 2+ disc correctly offers `S02E…` episodes.
+
 ## [0.21.10] - 2026-06-22
 
 _Highlights: TheDiscDB ContentHash lookups are fixed after a server-side schema change that was silently causing every hash query to fail, plus dependency maintenance and subtitle-cache refresh._

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -400,6 +400,14 @@ function JobDetailPanel({
     };
   }, [onClose]);
 
+  // Season for the reassign modal: the disc's detected season is authoritative;
+  // fall back to the matched episode's season, then 1, only when it's unknown.
+  const effectiveAmendSeason =
+    detail?.detected_season ??
+    (amendTarget?.matchedEpisode?.match(/^S(\d{2})E/)?.[1]
+      ? parseInt(amendTarget.matchedEpisode.match(/^S(\d{2})E/)![1], 10)
+      : 1);
+
   return (
     <motion.div
       ref={panelRef}
@@ -841,21 +849,20 @@ function JobDetailPanel({
             matchedEpisode: amendTarget.matchedEpisode,
             titleIndex: amendTarget.titleIndex,
           }}
+          season={effectiveAmendSeason}
           seasonEpisodes={(() => {
-            // Build episode list from sibling matched_episode codes on the same season,
-            // or fall back to a 1..26 range when that's not available.
-            const season = amendTarget.matchedEpisode?.match(/^S(\d{2})E/)?.[1];
-            if (season) {
-              const eps = detail.titles
-                .filter((t) => t.matched_episode?.startsWith(`S${season}E`))
-                .map((t) => {
-                  const m = t.matched_episode?.match(/E(\d{2,})$/);
-                  return m ? parseInt(m[1], 10) : null;
-                })
-                .filter((n): n is number => n !== null);
-              const unique = Array.from(new Set(eps)).sort((a, b) => a - b);
-              if (unique.length > 0) return unique;
-            }
+            // Build episode list from sibling matched_episode codes on the disc's
+            // season, or fall back to a 1..26 range when that's not available.
+            const seasonCode = String(effectiveAmendSeason).padStart(2, "0");
+            const eps = detail.titles
+              .filter((t) => t.matched_episode?.startsWith(`S${seasonCode}E`))
+              .map((t) => {
+                const m = t.matched_episode?.match(/E(\d{2,})$/);
+                return m ? parseInt(m[1], 10) : null;
+              })
+              .filter((n): n is number => n !== null);
+            const unique = Array.from(new Set(eps)).sort((a, b) => a - b);
+            if (unique.length > 0) return unique;
             return Array.from({ length: 26 }, (_, i) => i + 1);
           })()}
           onSubmit={async (target) => {

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -402,11 +402,9 @@ function JobDetailPanel({
 
   // Season for the reassign modal: the disc's detected season is authoritative;
   // fall back to the matched episode's season, then 1, only when it's unknown.
+  const matchedSeason = amendTarget?.matchedEpisode?.match(/^S(\d{2})E/);
   const effectiveAmendSeason =
-    detail?.detected_season ??
-    (amendTarget?.matchedEpisode?.match(/^S(\d{2})E/)?.[1]
-      ? parseInt(amendTarget.matchedEpisode.match(/^S(\d{2})E/)![1], 10)
-      : 1);
+    detail?.detected_season ?? (matchedSeason ? parseInt(matchedSeason[1], 10) : 1);
 
   return (
     <motion.div

--- a/frontend/src/components/HistoryPage/AmendTitleModal.test.tsx
+++ b/frontend/src/components/HistoryPage/AmendTitleModal.test.tsx
@@ -8,6 +8,7 @@ describe("AmendTitleModal", () => {
     render(
       <AmendTitleModal
         title={{ id: 2265, matchedEpisode: "S03E10", titleIndex: 24 }}
+        season={3}
         seasonEpisodes={[10, 11, 12, 13]}
         onSubmit={onSubmit}
         onClose={() => {}}
@@ -16,5 +17,26 @@ describe("AmendTitleModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /mark as extra/i }));
     fireEvent.click(screen.getByRole("button", { name: /apply/i }));
     expect(onSubmit).toHaveBeenCalledWith({ kind: "extra" });
+  });
+
+  it("labels options and submits episode codes using the season prop, not the matched episode", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AmendTitleModal
+        // Track is (wrongly) matched to S01 — the modal must still offer S02.
+        title={{ id: 1, matchedEpisode: "S01E01", titleIndex: 6 }}
+        season={2}
+        seasonEpisodes={[1, 2, 3]}
+        onSubmit={onSubmit}
+        onClose={() => {}}
+      />,
+    );
+    // Dropdown options reflect the disc's season, not the matched episode.
+    expect(screen.getByRole("option", { name: /S02E01/ })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /S01E01/ })).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Episode"), { target: { value: "3" } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onSubmit).toHaveBeenCalledWith({ kind: "episode", episode_code: "S02E03" });
   });
 });

--- a/frontend/src/components/HistoryPage/AmendTitleModal.tsx
+++ b/frontend/src/components/HistoryPage/AmendTitleModal.tsx
@@ -5,6 +5,8 @@ import type { AmendKind } from "../../api/client";
 
 export interface AmendTitleModalProps {
   title: { id: number; matchedEpisode: string | null; titleIndex: number };
+  /** The disc/job's season — drives the episode codes, NOT the (possibly wrong) matched episode. */
+  season: number;
   seasonEpisodes: number[];
   hasUploadedFingerprint?: boolean;
   onSubmit: (target: { kind: AmendKind; episode_code?: string }) => Promise<void>;
@@ -13,6 +15,7 @@ export interface AmendTitleModalProps {
 
 export function AmendTitleModal({
   title,
+  season,
   seasonEpisodes,
   hasUploadedFingerprint,
   onSubmit,
@@ -38,7 +41,7 @@ export function AmendTitleModal({
     return () => document.removeEventListener("keydown", handler);
   }, [handleClose]);
 
-  const season = title.matchedEpisode?.match(/^S(\d{2})E/)?.[1] ?? "01";
+  const seasonCode = String(season).padStart(2, "0");
 
   async function apply() {
     setBusy(true);
@@ -48,7 +51,7 @@ export function AmendTitleModal({
         if (episode == null) throw new Error("Pick an episode");
         await onSubmit({
           kind: "episode",
-          episode_code: `S${season}E${String(episode).padStart(2, "0")}`,
+          episode_code: `S${seasonCode}E${String(episode).padStart(2, "0")}`,
         });
       } else {
         await onSubmit({ kind });
@@ -222,7 +225,7 @@ export function AmendTitleModal({
                         >
                           {seasonEpisodes.map((ep) => (
                             <option key={ep} value={ep}>
-                              S{season}E{String(ep).padStart(2, "0")} — Episode {ep}
+                              S{seasonCode}E{String(ep).padStart(2, "0")} — Episode {ep}
                             </option>
                           ))}
                         </select>


### PR DESCRIPTION
## Problem

On the History detail panel, the **Reassign Track** modal's episode dropdown was pinned to **Season 1** (`S01E01`, `S01E02`, …) regardless of the disc's actual season. On a Season 2+ disc this made it impossible to reassign a track to the correct episode.

### Root cause

`AmendTitleModal` derived the season from the track's *currently matched episode* rather than the job's identity:

```ts
const season = title.matchedEpisode?.match(/^S(\d{2})E/)?.[1] ?? "01";
```

If the track was unmatched or mis-matched to S01, the modal (and the `seasonEpisodes` list built the same way in `HistoryPage`) locked to season `"01"` — so the fix surface inherited the very error it was meant to correct.

## Fix

Flow the job's authoritative `detected_season` down to `AmendTitleModal` as a new `season: number` prop, and build the episode list from siblings on that season. This mirrors the pattern already used by the live `ReviewQueue` (`detected_season ?? override ?? 1`) and the backend season-roster endpoint.

- `AmendTitleModal.tsx` — add `season` prop; remove the `matchedEpisode` regex; use the prop for option labels and the submitted `episode_code`.
- `HistoryPage.tsx` — compute `effectiveAmendSeason` (`detail.detected_season ?? matched-episode season ?? 1`), pass it in, and build `seasonEpisodes` from siblings on that season.

Jobs with unknown season fall back to the matched-episode season, then `1` — same as before, but a *known* season is never overridden.

## Verification

- **Unit test** (`AmendTitleModal.test.tsx`): with a track wrongly matched to `S01E01` but `season={2}`, the dropdown offers `S02E…` (not `S01E…`) and submitting yields `episode_code: "S02E03"`. `npm run test:unit` passes.
- `npm run build` (tsc + vite) and `npm run lint` clean.
- **Manual**: simulated a Season 2 TV disc to completion, opened History → job detail → Reassign track t06. The dropdown now lists `S02E01`–`S02E08` (screenshot below).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
