### PR TITLE
chore: release v0.21.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.11] - 2026-06-23
+
+_Highlights: disc-hash fingerprint identification is now on by default for all installs, and the Reassign Track dropdown correctly shows the disc's actual season._
+
+### Added
+
+- **Disc-hash fingerprint identification is now enabled by default** — the fingerprint network's disc-hash identification path (`GET /v1/identify-disc`) now runs automatically for every install, including existing ones (migrated via Alembic). A `canonical` or `confirmed` match pre-assigns episodes with high confidence; `candidate`-tier hits are not applied as an override. Previously this path was gated off while the shared catalog was being seeded. The catalog is now large enough to be useful. (#445)
+
 ### Fixed
 
-- **Reassign Track episode dropdown now uses the disc's actual season.** When reassigning a track on a completed multi-season disc from the History detail panel, the episode picker was pinned to Season 1 (`S01E01`, `S01E02`, …) because it derived the season from the track's current match instead of the job's identified season. It now uses the job's detected season, so a Season 2+ disc correctly offers `S02E…` episodes.
+- **Reassign Track episode dropdown now uses the disc's actual season.** When reassigning a track on a completed multi-season disc from the History detail panel, the episode picker was pinned to Season 1 (`S01E01`, `S01E02`, …) because it derived the season from the track's current match instead of the job's identified season. It now uses the job's detected season, so a Season 2+ disc correctly offers `S02E…` episodes. (#447)
 
 ## [0.21.10] - 2026-06-22
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.10"
+__version__ = "0.21.11"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.10"
+version = "0.21.11"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.10"
+version = "0.21.11"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.10",
+    "version": "0.21.11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.10",
+            "version": "0.21.11",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.10",
+    "version": "0.21.11",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to 0.21.11 across all 6 version files
- Add `[0.21.11]` CHANGELOG section (moved from `[Unreleased]`, added missing #445 entry)

## Changes since v0.21.10

### Added
- **#445** — Disc-hash fingerprint identification on by default (new installs + Alembic migration for existing)

### Fixed
- **#447** — Reassign Track dropdown pinned to the disc's actual season

## Test Plan
- [x] All 2412 backend unit tests pass
- [x] `extract_changelog.py --version 0.21.11` extracts cleanly
- [ ] Squash-merge triggers `tag-release.yml` → binaries published