### PR TITLE
fix(finalization): guard against organizing a terminal job

### DIFF
--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -627,6 +627,18 @@ class FinalizationCoordinator:
         if not job:
             return
 
+        # Guard: never re-enter finalization logic on a terminal job. A concurrent
+        # watchdog call or a late-completing match task can race the normal path
+        # and call check_job_completion after the job is already COMPLETED/FAILED.
+        # Without this guard, finalize_disc_job runs on a dead job, organizes
+        # files, and then produces an "Invalid state transition: failed→completed"
+        # warning when Phase 3 can't move the terminal state forward.
+        if job.state in (JobState.COMPLETED, JobState.FAILED):
+            logger.debug(
+                f"Job {job_id}: already terminal ({job.state.value}), skipping completion check"
+            )
+            return
+
         statement = select(DiscTitle).where(DiscTitle.job_id == job_id)
         result = await session.execute(statement)
         titles = result.scalars().all()
@@ -979,10 +991,18 @@ class FinalizationCoordinator:
             # and the watchdog clock is reset off this transition. Same-state (the
             # movie staging-import path is already ORGANIZING) re-broadcasts
             # harmlessly. The transition's commit also flushes the conflict-loop
-            # reassignments. If somehow rejected, log and organize anyway — staged
-            # files must still be moved.
+            # reassignments. If the transition is rejected because the job is
+            # already terminal (COMPLETED/FAILED), abort — organizing files for a
+            # dead job produces the "failed→completed" invalid-transition warning
+            # and moves files without updating the DB correctly.
             organizing_ok = await self._state_machine.transition_to_organizing(job, session)
             if not organizing_ok:
+                if job.state in (JobState.COMPLETED, JobState.FAILED):
+                    logger.warning(
+                        f"Job {job_id}: job is already {job.state.value}; "
+                        "aborting finalization to avoid organizing a terminal job"
+                    )
+                    return
                 logger.warning(
                     f"Job {job_id}: could not enter ORGANIZING from {job.state.value}; "
                     "organizing anyway"

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -1003,6 +1003,9 @@ class FinalizationCoordinator:
                         "aborting finalization to avoid organizing a terminal job"
                     )
                     return
+                # Non-terminal fallback: still organize. REVIEW_NEEDED→ORGANIZING is
+                # blocked by the state machine, but REVIEW_NEEDED→COMPLETED is valid,
+                # so Phase 2 + 3 can close the job cleanly without entering ORGANIZING.
                 logger.warning(
                     f"Job {job_id}: could not enter ORGANIZING from {job.state.value}; "
                     "organizing anyway"

--- a/backend/tests/unit/test_finalization_coordinator.py
+++ b/backend/tests/unit/test_finalization_coordinator.py
@@ -563,6 +563,44 @@ class TestCheckJobCompletion:
         assert job.state == JobState.FAILED
         coord.finalize_disc_job.assert_not_called()
 
+    async def test_already_completed_job_skips_finalization(self, tmp_path):
+        """check_job_completion must not call finalize on an already-COMPLETED job.
+
+        Regression guard for the watchdog-race bug (job 228): when a concurrent
+        reconcile_and_advance races the normal completion path, check_job_completion
+        can be called after the job is already terminal.  Without the guard it would
+        see has_matched=True and call finalize_disc_job on a dead job.
+        """
+        job_id = await _seed_job([(0, "S01E01", None, TitleState.MATCHED)], staging=str(tmp_path))
+        async with _unit_session_factory() as s:
+            job = await s.get(DiscJob, job_id)
+            job.state = JobState.COMPLETED
+            await s.commit()
+
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+        coord.finalize_disc_job.assert_not_called()
+
+    async def test_already_failed_job_skips_finalization(self, tmp_path):
+        """check_job_completion must not call finalize on an already-FAILED job.
+
+        Same watchdog-race guard: a FAILED job with some MATCHED titles (e.g.
+        deferred extras) must not re-enter finalize_disc_job.
+        """
+        job_id = await _seed_job([(0, "S01E01", None, TitleState.MATCHED)], staging=str(tmp_path))
+        async with _unit_session_factory() as s:
+            job = await s.get(DiscJob, job_id)
+            job.state = JobState.FAILED
+            await s.commit()
+
+        coord = _make_coord()
+        coord.finalize_disc_job = AsyncMock()
+        async with _unit_session_factory() as session:
+            await coord.check_job_completion(session, job_id)
+        coord.finalize_disc_job.assert_not_called()
+
     async def test_conflict_escalation_short_circuits_finalize(self, tmp_path):
         job_id = await _seed_job(
             [


### PR DESCRIPTION
## Summary

- Fixes job 228 regression: disc triggered stall timeout, matched episodes were organized, but job ended in wrong state with `"Invalid state transition: failed→completed"` warning
- Root cause: two compounding bugs in `finalization_coordinator.py` allowed `finalize_disc_job` to run on an already-terminal job
- Both bugs were exposed by the deferred-extras change (1b916538) that routes extras through `finalize_disc_job`

## Root Cause

**Bug 1 — `check_job_completion` missing terminal-state guard:**
When a watchdog reconcile races the normal matching completion path, `check_job_completion` could be called on a job already in COMPLETED or FAILED state. Without a guard, it would read titles, see `has_matched=True` (from MATCHED extras/episodes), and call `finalize_disc_job` on a dead job.

**Bug 2 — "organizing anyway" fallback in `finalize_disc_job` Phase 1:**
When `transition_to_organizing` was rejected because the job was FAILED, the code logged a warning and continued to Phase 2 anyway. This organized the file successfully, but Phase 3 then called `transition_to_completed(FAILED→COMPLETED)` — invalid, rejected, producing the warning. The file was moved to the library but the DB was left inconsistent.

**Why 1b916538 triggered this:** Before that commit, `_handle_extras` for "keep" policy organized extras immediately and set them COMPLETED. The `all_failed` branch would fire if all non-extra titles failed. After the commit, extras stay MATCHED, so `has_matched=True` routes through `finalize_disc_job` instead — exposing the latent terminal-state race.

## Changes

`backend/app/services/finalization_coordinator.py`:
1. `check_job_completion`: early-return if `job.state in (COMPLETED, FAILED)` before reading titles or deciding to finalize
2. `finalize_disc_job` Phase 1: when `transition_to_organizing` fails because the job is terminal, log a warning and `return` instead of falling through to Phase 2

## Test plan

- [ ] All existing unit + pipeline tests pass (2512 tests, verified locally)
- [ ] All 163 extras-related tests pass (verified locally)
- [ ] Manual: trigger a stall timeout on a disc with MATCHED episodes — job should go to REVIEW_NEEDED or COMPLETED cleanly, no "failed→completed" warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)