### PR TITLE
chore: release v0.21.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.12] - 2026-06-23
+
+_Highlights: two small fixes — auto-detected extras stay visible in review so you can reassign them before they are filed, and the settings button now uses the universally-recognized gear icon instead of a sun/starburst._
+
 ### Fixed
 
-- Auto-detected extras are no longer filed away mid-rip and frozen in the review panel. They now stay with the rest of the disc's tracks and are organized at the end, so when a disc goes to review you can reassign a misdetected extra (e.g. a dual-episode track) to an episode before it is filed.
+- **Auto-detected extras are no longer filed away mid-rip and frozen in the review panel.** They now stay with the rest of the disc's tracks and are organized at the end, so when a disc goes to review you can reassign a misdetected extra (e.g. a dual-episode track) to an episode before it is filed. (#449)
+- **Settings button now shows a gear icon instead of a sun/starburst.** The previous `IcoSettings` icon drew evenly-spaced radial spokes — the universal symbol for brightness controls. It has been replaced with the standard Lucide gear (rounded 8-tab outer shell with a center bore), which is universally recognized as a settings trigger. (#451)
 
 ## [0.21.11] - 2026-06-23
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.11"
+__version__ = "0.21.12"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.11"
+version = "0.21.12"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.11",
+    "version": "0.21.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.11",
+            "version": "0.21.12",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.11",
+    "version": "0.21.12",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bumps version to 0.21.12 across all 5 files (6 version fields)
- Moves two post-v0.21.11 fixes from `[Unreleased]` into a new `[0.21.12]` section

## Changes since v0.21.11

- **#449** — Auto-detected extras stay visible in review so they can be reassigned before being filed
- **#451** — Settings button now uses the standard gear icon instead of a sun/starburst

## Test Plan

- [ ] CI changelog-version-check passes (pyproject version matches CHANGELOG section)
- [ ] CI build and tests pass
- [ ] Squash-merge with title `chore: release v0.21.12` to trigger tagging workflow