### PR TITLE
feat: add auto-eject settings toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Settings toggle to disable automatic disc ejection.** A new "Auto-Eject Disc When Ripping Completes" checkbox in Settings → Preferences → Maintenance & watchdog controls whether Engram ejects the disc when ripping finishes. Enabled by default (preserving existing behavior); disable to keep the disc loaded for manual verification or re-ripping without re-inserting.
+
 ## [0.21.12] - 2026-06-23
 
 _Highlights: two small fixes — auto-detected extras stay visible in review so you can reassign them before they are filed, and the settings button now uses the universally-recognized gear icon instead of a sun/starburst._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -316,6 +316,8 @@ class ConfigResponse(BaseModel):
     timeout_ripping_seconds: int
     timeout_matching_seconds: int
     timeout_organizing_seconds: int
+    # Drive behavior
+    auto_eject_enabled: bool
     # Staging cleanup
     staging_cleanup_policy: str
     staging_cleanup_days: int
@@ -399,6 +401,8 @@ class ConfigUpdate(BaseModel):
     timeout_ripping_seconds: int | None = None
     timeout_matching_seconds: int | None = None
     timeout_organizing_seconds: int | None = None
+    # Drive behavior
+    auto_eject_enabled: bool | None = None
     # Staging cleanup
     staging_cleanup_policy: str | None = None
     staging_cleanup_days: int | None = None
@@ -1284,6 +1288,8 @@ async def get_config() -> ConfigResponse:
         timeout_ripping_seconds=config.timeout_ripping_seconds,
         timeout_matching_seconds=config.timeout_matching_seconds,
         timeout_organizing_seconds=config.timeout_organizing_seconds,
+        # Drive behavior
+        auto_eject_enabled=config.auto_eject_enabled,
         # Staging cleanup
         staging_cleanup_policy=config.staging_cleanup_policy,
         staging_cleanup_days=config.staging_cleanup_days,

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -20,7 +20,11 @@ DEFAULT_FINGERPRINT_SERVER_URL = "https://api.engramfp.com"
 
 
 class AppConfig(SQLModel, table=True):
-    """User-configurable application settings stored in database."""
+    """User-configurable application settings stored in database.
+
+    Covers paths, API keys, matching parameters, ripping coordination, staging
+    cleanup, extras policy, naming conventions, and drive behavior (auto-eject).
+    """
 
     __tablename__ = "app_config"
 
@@ -117,6 +121,9 @@ class AppConfig(SQLModel, table=True):
     timeout_organizing_seconds: int = Field(
         default=600, sa_column_kwargs={"server_default": text("600")}
     )
+
+    # Drive behavior
+    auto_eject_enabled: bool = Field(default=True, sa_column_kwargs={"server_default": text("1")})
 
     # Staging Cleanup
     staging_cleanup_policy: str = (

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2012,13 +2012,14 @@ class JobManager:
                         )
 
         # Free the drive for the next disc.
-        try:
-            from app.core.sentinel import eject_disc
+        if cfg and cfg.auto_eject_enabled:
+            try:
+                from app.core.sentinel import eject_disc
 
-            await asyncio.to_thread(eject_disc, drive_id)
-            self._drive_monitor.notify_ejected(drive_id)
-        except (OSError, RuntimeError) as e:
-            logger.warning(f"Job {sanitize_log_value(job_id)}: eject after re-rip failed: {e}")
+                await asyncio.to_thread(eject_disc, drive_id)
+                self._drive_monitor.notify_ejected(drive_id)
+            except (OSError, RuntimeError) as e:
+                logger.warning(f"Job {sanitize_log_value(job_id)}: eject after re-rip failed: {e}")
 
     async def rerip_title_manual(self, job_id: int, title_id: int) -> None:
         """Manually re-rip one title using the disc currently in the drive.
@@ -2440,13 +2441,14 @@ class JobManager:
                         )
 
             # Eject disc and reset sentinel state so a new disc insert is detected
-            try:
-                from app.core.sentinel import eject_disc
+            if rip_config and rip_config.auto_eject_enabled:
+                try:
+                    from app.core.sentinel import eject_disc
 
-                await asyncio.to_thread(eject_disc, drive_id)
-                self._drive_monitor.notify_ejected(drive_id)
-            except (OSError, RuntimeError) as e:
-                logger.warning(f"Could not eject disc from {drive_id}: {e}")
+                    await asyncio.to_thread(eject_disc, drive_id)
+                    self._drive_monitor.notify_ejected(drive_id)
+                except (OSError, RuntimeError) as e:
+                    logger.warning(f"Could not eject disc from {drive_id}: {e}")
 
             # Post-rip convergence (walk-away Phase B4): re-read the job row —
             # the locals captured at setup go stale once mid-rip identity

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -350,6 +350,18 @@ class TestConfigEndpoints:
         assert config["enable_background_pretranscription"] is False
         assert config["pretranscribe_full_file"] is True
 
+    async def test_auto_eject_enabled_roundtrips(self, client):
+        """The auto-eject toggle must persist and read back correctly.
+
+        Gates disc ejection after ripping; if the API can't save/return it the
+        setting would silently reset to True on every reload.
+        """
+        await _seed_config()
+        r = await client.put("/api/config", json={"auto_eject_enabled": False})
+        assert r.status_code == 200
+        config = (await client.get("/api/config")).json()
+        assert config["auto_eject_enabled"] is False
+
     async def test_pretranscription_flags_unrelated_put_leaves_unchanged(self, client):
         """A PUT that omits both flags must not reset them to defaults."""
         await _seed_config()

--- a/backend/tests/unit/test_config_pretranscription_fields.py
+++ b/backend/tests/unit/test_config_pretranscription_fields.py
@@ -14,6 +14,7 @@ from app.models.app_config import AppConfig
 FIELDS_AND_DEFAULTS = [
     ("enable_background_pretranscription", True),
     ("pretranscribe_full_file", False),
+    ("auto_eject_enabled", True),
 ]
 
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -180,6 +180,14 @@ never deleted regardless of this setting (the source folder is yours). See
 | `staging_cleanup_policy` | `"on_success"`, `"on_completion"`, `"manual"`, or `"after_days"` | `"on_success"` |
 | `staging_cleanup_days` | Retention period when policy is `"after_days"` | `7` |
 
+### Drive Behavior
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `auto_eject_enabled` | Eject the disc automatically when ripping finishes | `true` |
+
+Disable `auto_eject_enabled` if you want to keep the disc in the drive after ripping — for example, to manually verify the output or to re-rip a title without re-inserting the disc. Applies to both normal rips and re-rips triggered from the review queue.
+
 ### Naming Conventions
 
 Organized files follow these naming patterns:

--- a/frontend/e2e/auto-eject-config.spec.ts
+++ b/frontend/e2e/auto-eject-config.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the "Auto-Eject Disc When Ripping Completes" toggle in ConfigWizard.
+ *
+ * These tests interact directly with the Settings modal (non-onboarding ConfigWizard).
+ * The toggle is in the Preferences section → Maintenance & watchdog subsection.
+ *
+ * Tests verify:
+ *   - The toggle is checked by default (auto-eject enabled).
+ *   - Unchecking and saving persists the false value across page reloads.
+ *   - Re-checking and saving restores the true value (full round-trip).
+ */
+
+async function openSettingsPreferences(page: import('@playwright/test').Page) {
+    await page.locator('[data-testid="sv-settings-btn"]').click();
+    await expect(page.getByRole('heading', { level: 2, name: 'Settings' })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.wizard-loading')).not.toBeVisible({ timeout: 10000 });
+    await page
+        .getByRole('navigation', { name: 'Settings sections' })
+        .getByRole('button', { name: 'Preferences' })
+        .click();
+    await expect(page.getByText(/How Engram matches, names, and tidies up/i)).toBeVisible({ timeout: 3000 });
+    // Expand Maintenance & watchdog if collapsed
+    const summary = page.getByRole('group').filter({ hasText: /Maintenance.*watchdog/i }).locator('summary');
+    const isOpen = await summary.evaluate((el) => (el.parentElement as HTMLDetailsElement).open);
+    if (!isOpen) {
+        await summary.click();
+    }
+}
+
+async function savePreferences(page: import('@playwright/test').Page) {
+    await page.getByRole('button', { name: /Save Changes/i }).click();
+    await expect(page.locator('[data-testid="sv-settings-btn"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Auto-eject disc toggle', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('toggle is checked by default (auto-eject on)', async ({ page }) => {
+        await openSettingsPreferences(page);
+
+        const checkbox = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await expect(checkbox).toBeVisible();
+        await expect(checkbox).toBeChecked();
+    });
+
+    test('unchecking and saving persists false across reload', async ({ page }) => {
+        await openSettingsPreferences(page);
+
+        const checkbox = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await expect(checkbox).toBeVisible();
+
+        if (await checkbox.isChecked()) {
+            await checkbox.uncheck();
+        }
+        await expect(checkbox).not.toBeChecked();
+        await savePreferences(page);
+
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+        await openSettingsPreferences(page);
+
+        const checkboxAfterReload = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await expect(checkboxAfterReload).not.toBeChecked();
+    });
+
+    test('re-checking and saving restores true (full round-trip)', async ({ page }) => {
+        // Step 1: uncheck and save (set to false)
+        await openSettingsPreferences(page);
+
+        let checkbox = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await expect(checkbox).toBeVisible();
+        if (await checkbox.isChecked()) {
+            await checkbox.uncheck();
+        }
+        await expect(checkbox).not.toBeChecked();
+        await savePreferences(page);
+
+        // Step 2: reload, re-open, re-check, and save (set to true)
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+        await openSettingsPreferences(page);
+
+        checkbox = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await checkbox.check();
+        await expect(checkbox).toBeChecked();
+        await savePreferences(page);
+
+        // Step 3: reload one more time and confirm it's checked
+        await page.reload();
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+        await openSettingsPreferences(page);
+
+        const checkboxFinal = page.getByRole('checkbox', { name: /Auto-Eject Disc When Ripping Completes/i });
+        await expect(checkboxFinal).toBeChecked();
+    });
+});

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1443,6 +1443,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                         Automatically eject the disc from the drive when ripping finishes.
                                         Disable if you want to keep the disc loaded after ripping — for
                                         manual verification or re-ripping without re-inserting the disc.
+                                        When disabled, after manually ejecting wait a few seconds before
+                                        inserting the next disc so it is reliably detected.
                                     </span>
                                 </span>
                             </label>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -113,6 +113,7 @@ interface ConfigData {
     ffmpegPath: string;
     conflictResolutionDefault: string;
     episodeOrderingPreference: 'aired' | 'dvd';
+    autoEjectEnabled: boolean;
     watchdogEnabled: boolean;
     timeoutIdentifyingSeconds: number;
     timeoutRippingSeconds: number;
@@ -191,6 +192,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         ffmpegPath: '',
         conflictResolutionDefault: 'ask',
         episodeOrderingPreference: 'aired',
+        autoEjectEnabled: true,
         watchdogEnabled: true,
         timeoutIdentifyingSeconds: 600,
         timeoutRippingSeconds: 1200,
@@ -302,6 +304,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     ffmpegPath: data.ffmpeg_path || '',
                     conflictResolutionDefault: data.conflict_resolution_default || 'ask',
                     episodeOrderingPreference: data.episode_ordering_preference || 'aired',
+                    autoEjectEnabled: data.auto_eject_enabled ?? true,
                     watchdogEnabled: data.watchdog_enabled ?? true,
                     timeoutIdentifyingSeconds: data.timeout_identifying_seconds ?? 600,
                     timeoutRippingSeconds: data.timeout_ripping_seconds ?? 1200,
@@ -461,6 +464,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     ffmpeg_path: config.ffmpegPath,
                     conflict_resolution_default: config.conflictResolutionDefault,
                     episode_ordering_preference: config.episodeOrderingPreference,
+                    auto_eject_enabled: config.autoEjectEnabled,
                     watchdog_enabled: config.watchdogEnabled,
                     timeout_identifying_seconds: config.timeoutIdentifyingSeconds,
                     timeout_ripping_seconds: config.timeoutRippingSeconds,
@@ -1425,6 +1429,24 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 <span className="wizard-group-chevron">▸</span>Maintenance &amp; watchdog
                             </summary>
                             <div className="wizard-group-body">
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label">
+                                <input
+                                    type="checkbox"
+                                    checked={config.autoEjectEnabled}
+                                    onChange={(e) => handleInputChange('autoEjectEnabled', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>Auto-Eject Disc When Ripping Completes</strong>
+                                    <span className="checkbox-hint">
+                                        Automatically eject the disc from the drive when ripping finishes.
+                                        Disable if you want to keep the disc loaded after ripping — for
+                                        manual verification or re-ripping without re-inserting the disc.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
 
                         <div className="form-group">
                             <label htmlFor="stagingCleanup">Staging Cleanup Policy</label>


### PR DESCRIPTION
## Summary

- Adds an **Auto-Eject Disc When Ripping Completes** toggle to Settings → Preferences → Maintenance & watchdog
- Default is **on** (preserves existing behavior — existing installs are unaffected)
- Applies to both normal rips and re-rips triggered from the review queue

## What changed

**Backend**
- `AppConfig.auto_eject_enabled: bool` — new field, `server_default="1"` so pre-existing DB rows stay enabled on upgrade
- `ConfigUpdate` + `ConfigResponse` wired for full API round-trip
- `_run_ripping()` and `rerip_titles()` in `job_manager.py`: eject blocks wrapped with `if <config>.auto_eject_enabled:` — both call sites already had config in scope, so no extra DB reads

**Frontend**
- `ConfigWizard.tsx`: `autoEjectEnabled` added to `ConfigData` interface, defaults, load mapping, and save payload
- Checkbox rendered in the **Maintenance & watchdog** collapsible section using the existing `checkbox-label` / `checkbox-hint` pattern (no new CSS)

**Tests (TDD — all tests written before implementation)**
- `test_config_pretranscription_fields.py`: `("auto_eject_enabled", True)` added to the three-way sync guard (AppConfig default, ConfigUpdate acceptance, ConfigResponse exposure)
- `test_api_routes.py`: `test_auto_eject_enabled_roundtrips` — PUT false, GET, assert false
- `frontend/e2e/auto-eject-config.spec.ts`: new E2E spec covering default state, uncheck-and-persist, and full round-trip; mirrors `fingerprint-toggle.spec.ts`

**Docs**
- `CHANGELOG.md`: `[Unreleased]` entry
- `docs/getting-started/configuration.md`: new Drive Behavior section with field table

## Reviewer notes

- No migration needed — `_add_missing_columns()` on startup adds the column with `server_default="1"`, so existing users get auto-eject on (the current behavior) without any action
- The `server_default` pattern matches `watchdog_enabled` and the other boolean prefs that shipped after the initial schema

🤖 Generated with [Claude Code](https://claude.ai/claude-code)