### PR TITLE
feat: headless server build variants for Linux x64 and ARM64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,9 +45,9 @@ jobs:
           # When dispatched with an explicit tag, check out that tag's code.
           ref: ${{ inputs.tag || github.sha }}
 
-      - uses: docker/setup-buildx-action@v4
-
       - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v4
 
       - name: Compute image tags
         id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - name: Compute image tags
         id: meta
         uses: docker/metadata-action@v6
@@ -115,7 +117,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,6 +453,268 @@ jobs:
             engram-linux-arm64.tar.gz
             engram-linux-arm64.manifest.sha256
 
+  build-linux-headless:
+    name: Build Linux Executable (x64, headless/server)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Bundle frontend
+        run: cp -r frontend/dist backend/app/static
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsndfile1 ffmpeg
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          uv sync --no-install-project
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
+      - name: Build headless executable
+        working-directory: backend
+        env:
+          HEADLESS_BUILD: "1"
+        run: uv run pyinstaller engram.spec
+
+      - name: Verify binary architecture
+        run: |
+          file backend/dist/engram/engram
+          file backend/dist/engram/engram | grep -q 'x86-64' \
+            || { echo "binary is not x86-64 as expected"; exit 1; }
+
+      - name: Smoke test built executable
+        env:
+          PORT: "8765"
+          HOST: "127.0.0.1"
+        run: |
+          ./backend/dist/engram/engram > smoke-stdout.log 2> smoke-stderr.log &
+          BACKEND_PID=$!
+          trap "kill $BACKEND_PID 2>/dev/null || true" EXIT
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8765/api/jobs > /dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "1" ]; then
+            echo "===== stdout ====="
+            cat smoke-stdout.log || true
+            echo "===== stderr ====="
+            cat smoke-stderr.log || true
+            echo "executable never became ready"
+            exit 1
+          fi
+          count=$(pgrep -f 'dist/engram/engram' | wc -l | tr -d ' ')
+          echo "engram process count: $count"
+          if [ "$count" -gt 2 ]; then
+            echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
+            exit 1
+          fi
+          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
+          echo "allow_lan_access: $lan"
+          if [ "$lan" != "True" ]; then
+            echo "headless build did not seed allow_lan_access=True"
+            exit 1
+          fi
+          fpcalc_found=""
+          for i in $(seq 1 4); do
+            fpcalc_found=$(curl -fsS --max-time 15 http://127.0.0.1:8765/api/detect-tools \
+              | python3 -c "import sys, json; print(json.load(sys.stdin)['fpcalc']['found'])" 2>/dev/null) || true
+            if [ "$fpcalc_found" = "True" ]; then break; fi
+            if [ "$i" -lt 4 ]; then
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', retrying in 2s"
+              sleep 2
+            else
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', no more retries"
+            fi
+          done
+          if [ "$fpcalc_found" != "True" ]; then
+            echo "bundled fpcalc was not detected"
+            exit 1
+          fi
+          echo "smoke test passed"
+
+      - name: Verify CA bundle + bundled fpcalc + TLS self-test
+        run: |
+          ca="backend/dist/engram/_internal/certifi/cacert.pem"
+          test -f "$ca" || { echo "certifi CA bundle missing from build ($ca)"; exit 1; }
+          size=$(stat -c%s "$ca")
+          [ "$size" -ge 50000 ] || { echo "certifi CA bundle suspiciously small ($size)"; exit 1; }
+          echo "certifi CA bundle present: $size bytes"
+          fpc="backend/dist/engram/_internal/bin/fpcalc"
+          test -f "$fpc" || { echo "bundled fpcalc missing from build ($fpc)"; exit 1; }
+          echo "bundled fpcalc present: $fpc"
+          ./backend/dist/engram/engram --selftest || { echo "TLS self-test failed"; exit 1; }
+
+      - name: Generate file manifest
+        run: |
+          ( cd backend/dist/engram && find . -type f -printf '%P\0' | sort -z | xargs -0 sha256sum ) \
+            > engram-linux-x64-headless.manifest.sha256
+          echo "manifest entries: $(wc -l < engram-linux-x64-headless.manifest.sha256)"
+
+      - name: Package
+        run: tar -czf engram-linux-x64-headless.tar.gz -C backend/dist engram
+      - uses: actions/upload-artifact@v7
+        with:
+          name: engram-linux-x64-headless
+          path: |
+            engram-linux-x64-headless.tar.gz
+            engram-linux-x64-headless.manifest.sha256
+
+  build-linux-arm64-headless:
+    name: Build Linux Executable (arm64, headless/server)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Bundle frontend
+        run: cp -r frontend/dist backend/app/static
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsndfile1 ffmpeg
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          uv sync --no-install-project
+          uv pip install "pyinstaller==6.20.0" "pyinstaller-hooks-contrib==2026.5"
+      - name: Fetch fpcalc (bundled audio fingerprinter)
+        working-directory: backend
+        run: uv run python scripts/fetch_fpcalc.py
+
+      - name: Build headless executable
+        working-directory: backend
+        env:
+          HEADLESS_BUILD: "1"
+        run: uv run pyinstaller engram.spec
+
+      - name: Verify binary architecture
+        run: |
+          file backend/dist/engram/engram
+          file backend/dist/engram/engram | grep -q 'aarch64' \
+            || { echo "binary is not aarch64 as expected"; exit 1; }
+
+      - name: Smoke test built executable
+        env:
+          PORT: "8765"
+          HOST: "127.0.0.1"
+        run: |
+          ./backend/dist/engram/engram > smoke-stdout.log 2> smoke-stderr.log &
+          BACKEND_PID=$!
+          trap "kill $BACKEND_PID 2>/dev/null || true" EXIT
+          ready=0
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 2 http://127.0.0.1:8765/api/jobs > /dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "1" ]; then
+            echo "===== stdout ====="
+            cat smoke-stdout.log || true
+            echo "===== stderr ====="
+            cat smoke-stderr.log || true
+            echo "executable never became ready"
+            exit 1
+          fi
+          count=$(pgrep -f 'dist/engram/engram' | wc -l | tr -d ' ')
+          echo "engram process count: $count"
+          if [ "$count" -gt 2 ]; then
+            echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
+            exit 1
+          fi
+          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
+          echo "allow_lan_access: $lan"
+          if [ "$lan" != "True" ]; then
+            echo "headless build did not seed allow_lan_access=True"
+            exit 1
+          fi
+          fpcalc_found=""
+          for i in $(seq 1 4); do
+            fpcalc_found=$(curl -fsS --max-time 15 http://127.0.0.1:8765/api/detect-tools \
+              | python3 -c "import sys, json; print(json.load(sys.stdin)['fpcalc']['found'])" 2>/dev/null) || true
+            if [ "$fpcalc_found" = "True" ]; then break; fi
+            if [ "$i" -lt 4 ]; then
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', retrying in 2s"
+              sleep 2
+            else
+              echo "detect-tools attempt $i: fpcalc_found='$fpcalc_found', no more retries"
+            fi
+          done
+          if [ "$fpcalc_found" != "True" ]; then
+            echo "bundled fpcalc was not detected"
+            exit 1
+          fi
+          echo "smoke test passed"
+
+      - name: Verify CA bundle + bundled fpcalc + TLS self-test
+        run: |
+          ca="backend/dist/engram/_internal/certifi/cacert.pem"
+          test -f "$ca" || { echo "certifi CA bundle missing from build ($ca)"; exit 1; }
+          size=$(stat -c%s "$ca")
+          [ "$size" -ge 50000 ] || { echo "certifi CA bundle suspiciously small ($size)"; exit 1; }
+          echo "certifi CA bundle present: $size bytes"
+          fpc="backend/dist/engram/_internal/bin/fpcalc"
+          test -f "$fpc" || { echo "bundled fpcalc missing from build ($fpc)"; exit 1; }
+          echo "bundled fpcalc present: $fpc"
+          ./backend/dist/engram/engram --selftest || { echo "TLS self-test failed"; exit 1; }
+
+      - name: Generate file manifest
+        run: |
+          ( cd backend/dist/engram && find . -type f -printf '%P\0' | sort -z | xargs -0 sha256sum ) \
+            > engram-linux-arm64-headless.manifest.sha256
+          echo "manifest entries: $(wc -l < engram-linux-arm64-headless.manifest.sha256)"
+
+      - name: Package
+        run: tar -czf engram-linux-arm64-headless.tar.gz -C backend/dist engram
+      - uses: actions/upload-artifact@v7
+        with:
+          name: engram-linux-arm64-headless
+          path: |
+            engram-linux-arm64-headless.tar.gz
+            engram-linux-arm64-headless.manifest.sha256
+
   build-macos:
     name: Build macOS Executable (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
@@ -600,7 +862,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [build-windows, build-linux, build-linux-arm64, build-macos]
+    needs: [build-windows, build-linux, build-linux-arm64, build-macos, build-linux-headless, build-linux-arm64-headless]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -620,9 +882,15 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: engram-macos-arm64
+      - uses: actions/download-artifact@v8
+        with:
+          name: engram-linux-x64-headless
+      - uses: actions/download-artifact@v8
+        with:
+          name: engram-linux-arm64-headless
       - name: Generate SHA256 checksums
         run: |
-          sha256sum engram-windows-x64.zip engram-linux-x64.tar.gz engram-linux-arm64.tar.gz engram-macos-arm64.tar.gz > sha256sums.txt
+          sha256sum engram-windows-x64.zip engram-linux-x64.tar.gz engram-linux-arm64.tar.gz engram-macos-arm64.tar.gz engram-linux-x64-headless.tar.gz engram-linux-arm64-headless.tar.gz > sha256sums.txt
           cat sha256sums.txt
       - name: Generate release notes from CHANGELOG
         env:
@@ -673,4 +941,8 @@ jobs:
             engram-linux-arm64.manifest.sha256
             engram-macos-arm64.tar.gz
             engram-macos-arm64.manifest.sha256
+            engram-linux-x64-headless.tar.gz
+            engram-linux-x64-headless.manifest.sha256
+            engram-linux-arm64-headless.tar.gz
+            engram-linux-arm64-headless.manifest.sha256
             sha256sums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,13 +532,6 @@ jobs:
             echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
             exit 1
           fi
-          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
-            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
-          echo "allow_lan_access: $lan"
-          if [ "$lan" != "True" ]; then
-            echo "headless build did not seed allow_lan_access=True"
-            exit 1
-          fi
           fpcalc_found=""
           for i in $(seq 1 4); do
             fpcalc_found=$(curl -fsS --max-time 15 http://127.0.0.1:8765/api/detect-tools \
@@ -553,6 +546,13 @@ jobs:
           done
           if [ "$fpcalc_found" != "True" ]; then
             echo "bundled fpcalc was not detected"
+            exit 1
+          fi
+          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
+          echo "allow_lan_access: $lan"
+          if [ "$lan" != "True" ]; then
+            echo "headless build did not seed allow_lan_access=True"
             exit 1
           fi
           echo "smoke test passed"
@@ -663,13 +663,6 @@ jobs:
             echo "too many engram processes ($count) - possible multiprocessing fork-bomb"
             exit 1
           fi
-          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
-            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
-          echo "allow_lan_access: $lan"
-          if [ "$lan" != "True" ]; then
-            echo "headless build did not seed allow_lan_access=True"
-            exit 1
-          fi
           fpcalc_found=""
           for i in $(seq 1 4); do
             fpcalc_found=$(curl -fsS --max-time 15 http://127.0.0.1:8765/api/detect-tools \
@@ -684,6 +677,13 @@ jobs:
           done
           if [ "$fpcalc_found" != "True" ]; then
             echo "bundled fpcalc was not detected"
+            exit 1
+          fi
+          lan=$(curl -fsS --max-time 5 http://127.0.0.1:8765/api/config \
+            | python3 -c "import sys, json; print(json.load(sys.stdin)['allow_lan_access'])" 2>/dev/null) || true
+          echo "allow_lan_access: $lan"
+          if [ "$lan" != "True" ]; then
+            echo "headless build did not seed allow_lan_access=True"
             exit 1
           fi
           echo "smoke test passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,7 +505,6 @@ jobs:
       - name: Smoke test built executable
         env:
           PORT: "8765"
-          HOST: "127.0.0.1"
         run: |
           ./backend/dist/engram/engram > smoke-stdout.log 2> smoke-stderr.log &
           BACKEND_PID=$!
@@ -636,7 +635,6 @@ jobs:
       - name: Smoke test built executable
         env:
           PORT: "8765"
-          HOST: "127.0.0.1"
         run: |
           ./backend/dist/engram/engram > smoke-stdout.log 2> smoke-stderr.log &
           BACKEND_PID=$!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to Engram will be documented in this file.
 ### Added
 
 - **Settings toggle to disable automatic disc ejection.** A new "Auto-Eject Disc When Ripping Completes" checkbox in Settings → Preferences → Maintenance & watchdog controls whether Engram ejects the disc when ripping finishes. Enabled by default (preserving existing behavior); disable to keep the disc loaded for manual verification or re-ripping without re-inserting.
+- Headless server build variants for Linux: `engram-linux-x64-headless` and `engram-linux-arm64-headless`. These skip browser auto-launch and default `allow_lan_access` to `True` on first run so the dashboard is reachable from another machine without any manual configuration. Intended for NAS, Raspberry Pi, Jellyfin server, and other headless deployments.
+- Docker image now publishes both `linux/amd64` and `linux/arm64` layers.
 
 ## [0.21.12] - 2026-06-23
 

--- a/backend/app/core/network.py
+++ b/backend/app/core/network.py
@@ -40,19 +40,30 @@ def resolve_startup_host(default_host: str = LOCALHOST) -> str:
 
     Called before the event loop exists, so it uses the synchronous config
     reader. Any failure (e.g. DB tables not yet created on first run) falls
-    back to the safe default — the LAN toggle defaults off anyway.
+    back to the safe default.
+
+    Headless builds (ENGRAM_HEADLESS=1) default to binding all interfaces on
+    first run (when no config row exists yet). Once the row is seeded by
+    _seed_headless_defaults() inside init_db(), the persisted value is used on
+    subsequent runs — including if the user explicitly disables LAN access via
+    the settings UI.
     """
-    allow_lan = False
+    lan_setting: bool | None
     try:
         from app.services.config_service import read_allow_lan_sync
 
-        # Narrow single-column read: tolerates schema drift (a new AppConfig
-        # column not yet reconciled into an existing DB) that a full-row SELECT
-        # would choke on at this pre-init_db point.
-        allow_lan = read_allow_lan_sync()
+        lan_setting = read_allow_lan_sync()
     except Exception as e:  # noqa: BLE001 — startup must never crash on a config read
         logger.warning("Could not read LAN access setting, binding localhost: %s", e, exc_info=True)
-        allow_lan = False
+        lan_setting = False
+
+    if lan_setting is None:
+        # No config row yet. Headless builds default to LAN access so the UI
+        # is reachable from another machine on first run.
+        allow_lan = os.environ.get("ENGRAM_HEADLESS") == "1"
+    else:
+        allow_lan = lan_setting
+
     return compute_effective_host(
         allow_lan=allow_lan, env_host=_env_host(), default_host=default_host
     )

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,7 @@
 """Database setup with SQLModel and async SQLite."""
 
 import logging
+import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -309,8 +310,6 @@ async def _seed_headless_defaults() -> None:
     (row already present) are untouched, so a user who explicitly disabled
     LAN access via the settings UI keeps their preference.
     """
-    import os
-
     if os.environ.get("ENGRAM_HEADLESS") != "1":
         return
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -91,6 +91,8 @@ async def init_db() -> None:
     # but this preserves API keys/settings across breaking schema changes)
     await _migrate_app_config(engine)
 
+    await _seed_headless_defaults()
+
     logger.info("Database initialized successfully")
 
 
@@ -297,6 +299,29 @@ async def _migrate_app_config(target_engine: AsyncEngine | None = None) -> None:
                     insert_data,
                 )
                 logger.info(f"Restored app_config row with {len(insert_data)} fields")
+
+
+async def _seed_headless_defaults() -> None:
+    """Seed allow_lan_access=True on first headless install.
+
+    Runs after init_db() creates the app_config table. Only acts when
+    ENGRAM_HEADLESS=1 and no app_config row exists yet. Existing installs
+    (row already present) are untouched, so a user who explicitly disabled
+    LAN access via the settings UI keeps their preference.
+    """
+    import os
+
+    if os.environ.get("ENGRAM_HEADLESS") != "1":
+        return
+
+    async with async_session() as session:
+        row = (await session.execute(sa_text("SELECT id FROM app_config LIMIT 1"))).first()
+        if row is not None:
+            return  # config already exists, don't override
+
+        session.add(AppConfig(allow_lan_access=True))
+        await session.commit()
+        logger.info("Headless first-run: seeded app_config with allow_lan_access=True")
 
 
 async def reset_db() -> None:

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -153,7 +153,7 @@ def get_config_sync() -> AppConfig:
         return config
 
 
-def read_allow_lan_sync() -> bool:
+def read_allow_lan_sync() -> bool | None:
     """Read only the LAN toggle, before init_db()'s reconcilers have run.
 
     Called from ``resolve_startup_host`` at process start — *before* the lifespan
@@ -161,8 +161,15 @@ def read_allow_lan_sync() -> bool:
     hydrates every model column, so it trips on any column added since the user's
     DB was created (frozen builds skip Alembic and only reconcile schema later,
     inside ``init_db``). Read the single column we need via raw SQL, tolerant of a
-    missing column or table → ``False`` (the safe default; the LAN toggle is off
-    by default anyway).
+    missing column or table.
+
+    Returns:
+        True  — allow_lan_access is explicitly enabled in the database.
+        False — allow_lan_access is explicitly disabled, or an exception occurred
+                (safe fallback).
+        None  — no app_config row exists yet (fresh install). The caller may
+                apply a build-variant default instead of always falling back to
+                localhost.
     """
     from sqlalchemy import text
 
@@ -171,7 +178,9 @@ def read_allow_lan_sync() -> bool:
             row = conn.execute(text("SELECT allow_lan_access FROM app_config LIMIT 1")).first()
     except Exception:  # noqa: BLE001 — startup must never crash on a config read
         return False
-    return bool(row[0]) if row and row[0] is not None else False
+    if row is None:
+        return None  # no config row yet (fresh install)
+    return bool(row[0])
 
 
 async def update_config(**kwargs) -> AppConfig:

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -9,6 +9,11 @@ from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 block_cipher = None
 
+# Set HEADLESS_BUILD=1 in the build environment to produce the headless/server variant.
+# The runtime hook bakes ENGRAM_HEADLESS=1 into the frozen binary so no env var is
+# needed at runtime — the binary carries its own default.
+HEADLESS = os.environ.get("HEADLESS_BUILD", "0") == "1"
+
 # Collect ALL app.* submodules so PyInstaller doesn't miss any
 app_hidden = collect_submodules("app")
 
@@ -125,7 +130,7 @@ a = Analysis(
     hiddenimports=all_hidden,
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=["hooks/rthook_headless.py"] if HEADLESS else [],
     excludes=[],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/backend/hooks/rthook_headless.py
+++ b/backend/hooks/rthook_headless.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("ENGRAM_HEADLESS", "1")

--- a/backend/run.py
+++ b/backend/run.py
@@ -123,13 +123,16 @@ def main() -> None:
         app.state.bound_host = host
         app.state.bound_port = port
 
-        if frozen:
+        headless = os.environ.get("ENGRAM_HEADLESS") == "1"
+        if frozen and not headless:
             # Open browser after a short delay to let the server bind the port.
             # When bound to all interfaces, open localhost (http://0.0.0.0 is not
             # a valid client address); LAN clients use the address shown in the UI.
             browser_host = "localhost" if host == ALL_INTERFACES else host
             url = f"http://{browser_host}:{port}"
             _schedule_browser_open(url, updated="--updated" in sys.argv[1:])
+        elif frozen and headless:
+            logger.info(f"Headless mode: dashboard available at http://{host}:{port}")
 
         uvicorn.run(
             app,

--- a/backend/tests/unit/test_headless_seed.py
+++ b/backend/tests/unit/test_headless_seed.py
@@ -25,12 +25,11 @@ async def test_headless_seeds_allow_lan_on_empty_table(mem_engine, monkeypatch):
     """ENGRAM_HEADLESS=1 + empty app_config seeds allow_lan_access=True."""
     monkeypatch.setenv("ENGRAM_HEADLESS", "1")
     import app.database as db_module
-    from app.database import _seed_headless_defaults
 
     session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
     monkeypatch.setattr(db_module, "async_session", session_factory)
 
-    await _seed_headless_defaults()
+    await db_module._seed_headless_defaults()
 
     async with session_factory() as session:
         row = (
@@ -45,7 +44,6 @@ async def test_headless_does_not_overwrite_existing_config(mem_engine, monkeypat
     """ENGRAM_HEADLESS=1 + existing row with allow_lan=False leaves it unchanged."""
     monkeypatch.setenv("ENGRAM_HEADLESS", "1")
     import app.database as db_module
-    from app.database import _seed_headless_defaults
 
     session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
     monkeypatch.setattr(db_module, "async_session", session_factory)
@@ -55,7 +53,7 @@ async def test_headless_does_not_overwrite_existing_config(mem_engine, monkeypat
         session.add(AppConfig(allow_lan_access=False))
         await session.commit()
 
-    await _seed_headless_defaults()
+    await db_module._seed_headless_defaults()
 
     async with session_factory() as session:
         row = (
@@ -69,12 +67,11 @@ async def test_non_headless_does_not_seed(mem_engine, monkeypatch):
     """Without ENGRAM_HEADLESS=1, _seed_headless_defaults is a no-op."""
     monkeypatch.delenv("ENGRAM_HEADLESS", raising=False)
     import app.database as db_module
-    from app.database import _seed_headless_defaults
 
     session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
     monkeypatch.setattr(db_module, "async_session", session_factory)
 
-    await _seed_headless_defaults()
+    await db_module._seed_headless_defaults()
 
     async with session_factory() as session:
         row = (await session.execute(text("SELECT id FROM app_config LIMIT 1"))).first()

--- a/backend/tests/unit/test_headless_seed.py
+++ b/backend/tests/unit/test_headless_seed.py
@@ -1,0 +1,81 @@
+"""Tests for headless first-run seeding of allow_lan_access."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+
+from app.models import AppConfig
+
+
+@pytest_asyncio.fixture
+async def mem_engine():
+    """In-memory async SQLite with the full app schema."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_headless_seeds_allow_lan_on_empty_table(mem_engine, monkeypatch):
+    """ENGRAM_HEADLESS=1 + empty app_config seeds allow_lan_access=True."""
+    monkeypatch.setenv("ENGRAM_HEADLESS", "1")
+    import app.database as db_module
+    from app.database import _seed_headless_defaults
+
+    session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(db_module, "async_session", session_factory)
+
+    await _seed_headless_defaults()
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(text("SELECT allow_lan_access FROM app_config LIMIT 1"))
+        ).first()
+    assert row is not None
+    assert bool(row[0]) is True
+
+
+@pytest.mark.asyncio
+async def test_headless_does_not_overwrite_existing_config(mem_engine, monkeypatch):
+    """ENGRAM_HEADLESS=1 + existing row with allow_lan=False leaves it unchanged."""
+    monkeypatch.setenv("ENGRAM_HEADLESS", "1")
+    import app.database as db_module
+    from app.database import _seed_headless_defaults
+
+    session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(db_module, "async_session", session_factory)
+
+    # Pre-insert a row with allow_lan_access=False (simulates existing install)
+    async with session_factory() as session:
+        session.add(AppConfig(allow_lan_access=False))
+        await session.commit()
+
+    await _seed_headless_defaults()
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(text("SELECT allow_lan_access FROM app_config LIMIT 1"))
+        ).first()
+    assert bool(row[0]) is False  # existing setting preserved
+
+
+@pytest.mark.asyncio
+async def test_non_headless_does_not_seed(mem_engine, monkeypatch):
+    """Without ENGRAM_HEADLESS=1, _seed_headless_defaults is a no-op."""
+    monkeypatch.delenv("ENGRAM_HEADLESS", raising=False)
+    import app.database as db_module
+    from app.database import _seed_headless_defaults
+
+    session_factory = sessionmaker(mem_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(db_module, "async_session", session_factory)
+
+    await _seed_headless_defaults()
+
+    async with session_factory() as session:
+        row = (await session.execute(text("SELECT id FROM app_config LIMIT 1"))).first()
+    assert row is None  # no row seeded for non-headless builds

--- a/backend/tests/unit/test_network.py
+++ b/backend/tests/unit/test_network.py
@@ -84,6 +84,12 @@ class TestReadAllowLanSync:
         monkeypatch.setattr(config_service, "_get_sync_engine", lambda: engine)
         assert config_service.read_allow_lan_sync() is False
 
+    def test_returns_none_when_table_has_no_rows(self, tmp_path, monkeypatch):
+        """An empty table means 'not yet configured' — distinct from explicit False."""
+        engine = self._engine_with(tmp_path, value=None)  # table exists, no rows inserted
+        monkeypatch.setattr(config_service, "_get_sync_engine", lambda: engine)
+        assert config_service.read_allow_lan_sync() is None
+
 
 class TestResolveStartupHost:
     """Host resolution must never crash on a config read (the schema-drift bug)."""

--- a/backend/tests/unit/test_network.py
+++ b/backend/tests/unit/test_network.py
@@ -117,3 +117,30 @@ class TestResolveStartupHost:
             patch("app.services.config_service.read_allow_lan_sync", return_value=False),
         ):
             assert resolve_startup_host() == "127.0.0.1"
+
+    def test_headless_first_run_binds_all_interfaces(self, monkeypatch):
+        """ENGRAM_HEADLESS=1 + no config row (None) must bind 0.0.0.0."""
+        monkeypatch.setenv("ENGRAM_HEADLESS", "1")
+        with (
+            patch("app.core.network._env_host", return_value=None),
+            patch("app.services.config_service.read_allow_lan_sync", return_value=None),
+        ):
+            assert resolve_startup_host() == "0.0.0.0"
+
+    def test_headless_user_disabled_lan_respects_setting(self, monkeypatch):
+        """ENGRAM_HEADLESS=1 + explicit False in DB must still bind localhost."""
+        monkeypatch.setenv("ENGRAM_HEADLESS", "1")
+        with (
+            patch("app.core.network._env_host", return_value=None),
+            patch("app.services.config_service.read_allow_lan_sync", return_value=False),
+        ):
+            assert resolve_startup_host() == "127.0.0.1"
+
+    def test_non_headless_first_run_binds_localhost(self, monkeypatch):
+        """Without ENGRAM_HEADLESS, None from read_allow_lan_sync falls back to localhost."""
+        monkeypatch.delenv("ENGRAM_HEADLESS", raising=False)
+        with (
+            patch("app.core.network._env_host", return_value=None),
+            patch("app.services.config_service.read_allow_lan_sync", return_value=None),
+        ):
+            assert resolve_startup_host() == "127.0.0.1"

--- a/backend/tests/unit/test_run_browser.py
+++ b/backend/tests/unit/test_run_browser.py
@@ -18,6 +18,20 @@ class _FakeTimer:
         self.fn(*self.args, **self.kwargs)
 
 
+def test_headless_main_skips_schedule_browser_open(monkeypatch):
+    """main() must not call _schedule_browser_open when ENGRAM_HEADLESS=1."""
+    scheduled = []
+    monkeypatch.setenv("ENGRAM_HEADLESS", "1")
+    monkeypatch.setattr(run, "_schedule_browser_open", lambda url, **kw: scheduled.append(url))
+    monkeypatch.setattr("app.config.is_frozen", lambda: True)
+    monkeypatch.setattr("app.core.network.resolve_startup_host", lambda *a, **kw: "127.0.0.1")
+    import uvicorn
+
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
+    run.main()
+    assert scheduled == [], "headless build must not open a browser"
+
+
 def test_normal_launch_opens_tab(monkeypatch):
     opened = []
     monkeypatch.setattr(threading, "Timer", _FakeTimer)


### PR DESCRIPTION
## Summary

- Adds `engram-linux-x64-headless` and `engram-linux-arm64-headless` release artifacts — single-binary server builds that skip browser auto-launch and default `allow_lan_access` to `True` on first run so the dashboard is reachable from another machine without any manual configuration. Intended for NAS, Raspberry Pi, Jellyfin server, and other headless/SSH deployments.
- Docker image now publishes both `linux/amd64` and `linux/arm64` layers via QEMU + buildx.

## What changed

### Runtime hook (`backend/hooks/rthook_headless.py`)
PyInstaller runtime hook that bakes `ENGRAM_HEADLESS=1` into the frozen binary at build time. Uses `setdefault` so users can still override with `ENGRAM_HEADLESS=0` at runtime.

### Build flag (`backend/engram.spec`)
`HEADLESS_BUILD=1` env var at PyInstaller invocation conditionally includes the runtime hook. Normal builds are unchanged.

### Browser gate (`backend/run.py`)
`_schedule_browser_open` is skipped when `ENGRAM_HEADLESS=1`. Headless startup logs the dashboard URL instead.

### LAN-bind logic (`backend/app/services/config_service.py`, `backend/app/core/network.py`)
`read_allow_lan_sync()` now returns a 3-value sentinel: `True`/`False` (stored value) or `None` (no config row yet — fresh install). `resolve_startup_host()` uses `ENGRAM_HEADLESS` as the tie-breaker when the DB has no row, so headless first-run binds `0.0.0.0` without overriding an explicit user preference (`False`) set via the settings UI.

### First-run seed (`backend/app/database.py`)
`_seed_headless_defaults()` (called from `init_db()`) persists `allow_lan_access=True` when `ENGRAM_HEADLESS=1` and no config row exists yet, so the config UI reflects the actual bind behavior on subsequent runs.

### CI — headless build jobs (`.github/workflows/release.yml`)
Two new jobs mirror the existing Linux jobs with `HEADLESS_BUILD: "1"`:
- `build-linux-headless` on `ubuntu-latest` (x64)
- `build-linux-arm64-headless` on `ubuntu-24.04-arm` (native ARM64 runner)

Each job runs the full smoke test suite plus a headless-specific assertion that `allow_lan_access == True` after startup. `create-release` wires both artifacts into the release.

### CI — Docker ARM64 (`.github/workflows/docker.yml`)
Added `docker/setup-qemu-action@v3` and changed `platforms: linux/amd64` → `linux/amd64,linux/arm64` in the push step. The local-load smoke-test build remains amd64-only (required by Docker daemon).

## Test plan

- [x] 24 unit tests pass: `test_network.py` (8 tests including 4 new), `test_run_browser.py` (4 tests including 1 new), `test_headless_seed.py` (3 new tests)
- [ ] CI: `build-linux-headless` and `build-linux-arm64-headless` jobs build and pass smoke tests (validates `allow_lan_access=True` seeded on first run)
- [ ] CI: Docker push succeeds for both `linux/amd64` and `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)