### PR TITLE
chore(ci): pin CI Claude actions to Sonnet to reduce usage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,3 +39,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: claude-sonnet-4-6

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: claude-sonnet-4-6
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Add `model: claude-sonnet-4-6` to `code-review.yml` and `claude.yml`
- Both workflows were defaulting to Opus (the action's default when no model is specified), which burns through subscription usage ~5x faster than Sonnet
- Code review quality with Sonnet is well within acceptable range for this use case

## Context

Every PR was generating two full agentic sessions against the subscription limit:
1. `code-review.yml` auto-triggers on PR `opened`
2. `claude.yml` triggers on `@claude` comments (posted manually after each `gh pr create`)

Pinning to Sonnet cuts the cost of both sessions significantly with no expected quality regression for code review tasks.

## Test plan

- [ ] Verify the `claude` check runs on the next PR with Sonnet (check action logs for model in use)
- [ ] Verify `code-review.yml` still posts inline comments as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)