### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-28
+
+_Highlights: manual media import replaces the background watch folder with a user-triggered folder picker, headless Linux server variants for NAS and Raspberry Pi, Docker multi-arch (amd64 + arm64) with properly versioned GHCR tags, and a new auto-eject toggle._
+
 ### Added
 
-- **Settings toggle to disable automatic disc ejection.** A new "Auto-Eject Disc When Ripping Completes" checkbox in Settings → Preferences → Maintenance & watchdog controls whether Engram ejects the disc when ripping finishes. Enabled by default (preserving existing behavior); disable to keep the disc loaded for manual verification or re-ripping without re-inserting.
-- Headless server build variants for Linux: `engram-linux-x64-headless` and `engram-linux-arm64-headless`. These skip browser auto-launch and default `allow_lan_access` to `True` on first run so the dashboard is reachable from another machine without any manual configuration. Intended for NAS, Raspberry Pi, Jellyfin server, and other headless deployments.
-- Docker image now publishes both `linux/amd64` and `linux/arm64` layers.
+- **Manual media import replaces the background watch folder.** Click **IMPORT** in the top bar, browse to a folder on the server, preview the discovered seasons and their file counts, then start one import job per (show, season). The new scanner walks `Disc/` subfolders transparently and infers the season from any `Season NN` path segment, fixing two reported bugs: `Show / Season / Disc / *.mkv` trees that previously imported nothing, and partial imports that required an app restart to re-scan. The import watch path and destination mode are repurposed as last-used defaults for the picker. (#463)
+- **Settings toggle to disable automatic disc ejection.** A new "Auto-Eject Disc When Ripping Completes" checkbox in Settings → Preferences → Maintenance & watchdog controls whether Engram ejects the disc when ripping finishes. Enabled by default (preserving existing behavior); disable to keep the disc loaded for manual verification or re-ripping without re-inserting. (#457)
+- Headless server build variants for Linux: `engram-linux-x64-headless` and `engram-linux-arm64-headless`. These skip browser auto-launch and default `allow_lan_access` to `True` on first run so the dashboard is reachable from another machine without any manual configuration. Intended for NAS, Raspberry Pi, Jellyfin server, and other headless deployments. (#460)
+- Docker image now publishes both `linux/amd64` and `linux/arm64` layers, and GHCR releases now carry four versioned tags (`v0.22.0`, `0.22.0`, `0.22`, and `latest`) for Renovate Bot pinning. (#460, #462)
 
 ## [0.21.12] - 2026-06-23
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.21.12"
+__version__ = "0.22.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.21.12"
+version = "0.22.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.21.12"
+version = "0.22.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.21.12",
+    "version": "0.22.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.21.12",
+            "version": "0.22.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.21.12",
+    "version": "0.22.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to `0.22.0` in all 6 version files (pyproject.toml, `__init__.py`, uv.lock, package.json, package-lock.json ×2, CHANGELOG.md)
- Move `[Unreleased]` entries to `## [0.22.0] - 2026-06-28`
- Add missing `[Unreleased]` entry for manual media import (#463)
- Update Docker changelog entry to include versioned GHCR tags detail (#462)

## Release notes preview

**Highlights:** manual media import replaces the background watch folder with a user-triggered folder picker, headless Linux server variants for NAS and Raspberry Pi, Docker multi-arch (amd64 + arm64) with properly versioned GHCR tags, and a new auto-eject toggle.

### Added
- Manual media import: IMPORT button → two-pane server browser → per-season jobs; fixes `Disc/` subfolder imports and partial-import restart bug (#463)
- Auto-eject toggle in Settings (#457)
- Headless Linux builds: `engram-linux-x64-headless`, `engram-linux-arm64-headless` (#460)
- Docker multi-arch + versioned GHCR tags (`v0.22.0`, `0.22.0`, `0.22`, `latest`) (#460, #462)

## Test plan

- [x] `uv run python backend/scripts/extract_changelog.py --version 0.22.0 --check` → `ok`
- [x] All 6 version files show `0.22.0`
- [x] Both `package-lock.json` self-version fields updated (lines 3 and 9)
- [ ] CI checks pass
- [ ] `changelog-version-check` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)