### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-06-29
+
+_Highlights: two UI polish fixes — the bug-report icon no longer causes a layout shift on hover, and selecting a `Season NN` folder in the import picker is now identified correctly._
+
 ### Fixed
 
+- **Bug report icon no longer causes a layout shift on hover.** The icon was rendered inside `ActionButtons`, which appears after `StateIndicator` in the flex row, so revealing it on hover pushed all buttons rightward. It now lives before `StateIndicator` in the card, with reserved space via an opacity toggle, so the layout stays stable. (#465, thanks @katelovescode!)
 - **Manual import now identifies a picked `Season NN` folder correctly.** Selecting a season folder directly (e.g. `…\Seinfeld\Season 4`) created a job titled "Season 4" with no season and content type "unknown", because the scanner only handled picking a show folder or a parent-of-shows folder. It now recognizes a `Season NN` pick, taking the show name from the parent folder and the season from the folder's own name (and organizes in place beside the original show folder rather than nesting a second copy inside the season). (#474)
+
+### Changed
+
+- **Frontend dependency updates** — @radix-ui/react-scroll-area 1.2.3→1.2.12, @radix-ui/react-collapsible 1.1.3→1.1.14, @radix-ui/react-slot 1.1.2→1.3.0, @playwright/test 1.60.0→1.61.1. (#468, #470, #471, #472)
 
 ## [0.22.0] - 2026-06-28
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.22.0"
+version = "0.22.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.22.0"
+version = "0.22.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.22.0",
+            "version": "0.22.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.22.0",
+    "version": "0.22.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version to `0.22.1` across all 6 version files (pyproject.toml, \_\_init\_\_.py, uv.lock, package.json, package-lock.json ×2, CHANGELOG.md)
- Write CHANGELOG section for 0.22.1: two fixes (#465, #474) + four dep bumps (#468, #470, #471, #472)

## Changes since v0.22.0

**Fixed**
- Bug report icon no longer causes layout shift on hover — moved before `StateIndicator` with opacity-reserved space (#465, thanks @katelovescode!)
- Manual import correctly identifies a picked `Season NN` folder (#474)

**Changed**
- Frontend deps: @radix-ui/react-scroll-area 1.2.3→1.2.12, @radix-ui/react-collapsible 1.1.3→1.1.14, @radix-ui/react-slot 1.1.2→1.3.0, @playwright/test 1.60.0→1.61.1

## Test plan

- [ ] `python backend/scripts/extract_changelog.py --version 0.22.1 --check` returns `ok`
- [ ] All 6 version files read `0.22.1`
- [ ] CI passes (changelog-version-check, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)