### PR TITLE
chore: release v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-06-30
+
+_Highlights: the cancel-job confirmation now uses an animated Synapse v2 modal instead of the browser's native `window.confirm` dialog, eliminating the accidental-tap risk on the previous single-click confirm._
+
+### Fixed
+
+- **Cancel confirmation now uses the Synapse v2 modal instead of `window.confirm`.** The native browser dialog was a single-click confirm with no animation or design context, making accidental disc-cancel easy. The new modal matches the app's design language (SvPanel, mono uppercase, red glow on the confirm button) and is covered by unit tests for open/dismiss and confirm paths. (#466)
+
 ## [0.22.1] - 2026-06-29
 
 _Highlights: two UI polish fixes — the bug-report icon no longer causes a layout shift on hover, and selecting a `Season NN` folder in the import picker is now identified correctly._

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.22.1"
+__version__ = "0.22.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.22.1"
+version = "0.22.2"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.22.1"
+version = "0.22.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.22.1",
+    "version": "0.22.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.22.1",
+            "version": "0.22.2",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.22.1",
+    "version": "0.22.2",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump version `0.22.1` → `0.22.2` in all 6 required locations (pyproject.toml, \_\_init\_\_.py, uv.lock, package.json, package-lock.json ×2, CHANGELOG.md)
- Add CHANGELOG section for `[0.22.2]`

## What's in this release

**PR #466** — Replace `window.confirm` cancel with Synapse v2 modal. Single-click cancel was an accidental-tap risk; the new animated modal matches the app's design language (SvPanel, mono uppercase, red glow on confirm) and is covered by unit tests.

## Test plan

- [x] `changelog-version-check` CI validates `CHANGELOG.md` has a `[0.22.2]` section matching `pyproject.toml`
- [x] Changelog extraction verified locally: `python scripts/extract_changelog.py --version 0.22.2 --check` → `ok`
- [x] All 6 version locations updated in lockstep
- [ ] Squash-merge triggers `tag-release.yml` → pushes `v0.22.2` tag → `release.yml` builds binaries + GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)