### PR TITLE
fix(sentinel): use ioctl(CDROM_DRIVE_STATUS) to detect disc presence in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker).** In some container environments `/sys/block/sr0/size` freezes at the previous disc's block count after ejection and never drops to zero. This caused two compounding bugs: a ghost FAILED job fired on every cycle (spurious "inserted" event from the frozen sysfs), and the next real disc insertion was silently ignored until the container restarted. The sentinel now verifies disc presence via `ioctl(CDROM_DRIVE_STATUS)` when sysfs reports a non-zero size, querying drive firmware directly. (#477, thanks @katelovescode!)
+
 ## [0.22.1] - 2026-06-29
 
 _Highlights: two UI polish fixes — the bug-report icon no longer causes a layout shift on hover, and selecting a `Season NN` folder in the import picker is now identified correctly._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Engram will be documented in this file.
 
 ### Fixed
 
-- **Disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker).** In some container environments `/sys/block/sr0/size` freezes at the previous disc's block count after ejection and never drops to zero. This caused two compounding bugs: a ghost FAILED job fired on every cycle (spurious "inserted" event from the frozen sysfs), and the next real disc insertion was silently ignored until the container restarted. The sentinel now verifies disc presence via `ioctl(CDROM_DRIVE_STATUS)` when sysfs reports a non-zero size, querying drive firmware directly. (#477, thanks @katelovescode!)
+- **Disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker).** In some container environments `/sys/block/sr0/size` freezes at the previous disc's block count after ejection and never drops to zero. This caused two compounding bugs: a ghost FAILED job fired on every cycle (spurious "inserted" event from the frozen sysfs), and the next real disc insertion was silently ignored until the container restarted. The sentinel now verifies disc presence via `ioctl(CDROM_DRIVE_STATUS)` when sysfs reports a non-zero size, querying drive firmware directly. (#477)
 
 ## [0.22.1] - 2026-06-29
 

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -9,6 +9,7 @@ import asyncio
 import glob
 import logging
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Callable
@@ -145,6 +146,9 @@ def _get_volume_label_linux(drive: str) -> str:
         return ""
 
 
+_OPTICAL_DRIVE_RE = re.compile(r"^/dev/sr\d+$")
+
+
 def _is_disc_present_linux(drive: str) -> bool:
     """Check if a disc is present on Linux.
 
@@ -153,6 +157,8 @@ def _is_disc_present_linux(drive: str) -> bool:
     queries drive firmware directly — this handles containers where sysfs is
     frozen and never drops to 0 after disc removal.
     """
+    if not _OPTICAL_DRIVE_RE.match(drive):
+        return False
     try:
         dev_name = os.path.basename(drive)
         with open(f"/sys/block/{dev_name}/size") as f:

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -2,7 +2,7 @@
 
 Detects disc insertion/removal using platform-specific APIs:
 - Windows: kernel32 ctypes (GetDriveTypeW, GetVolumeInformationW)
-- Linux: /sys/block/sr* enumeration, blkid, eject
+- Linux: /sys/block/sr* enumeration + ioctl(CDROM_DRIVE_STATUS), blkid, eject
 """
 
 import asyncio
@@ -17,6 +17,9 @@ from typing import Any
 if sys.platform == "win32":
     import ctypes
     import string
+
+if sys.platform != "win32":
+    import fcntl
 
 logger = logging.getLogger(__name__)
 
@@ -143,14 +146,31 @@ def _get_volume_label_linux(drive: str) -> str:
 
 
 def _is_disc_present_linux(drive: str) -> bool:
-    """Check if a disc is present on Linux by reading /sys/block size."""
+    """Check if a disc is present on Linux.
+
+    Reads /sys/block size first: if it's zero the drive is definitely empty.
+    If non-zero (or unreadable), falls back to ioctl(CDROM_DRIVE_STATUS) which
+    queries drive firmware directly — this handles containers where sysfs is
+    frozen and never drops to 0 after disc removal.
+    """
     try:
-        dev_name = os.path.basename(drive)  # "sr0" from "/dev/sr0"
-        size_path = f"/sys/block/{dev_name}/size"
-        with open(size_path) as f:
-            size = int(f.read().strip())
-        return size > 0
+        dev_name = os.path.basename(drive)
+        with open(f"/sys/block/{dev_name}/size") as f:
+            if int(f.read().strip()) == 0:
+                return False  # sysfs confirmed empty — trust it
     except (FileNotFoundError, ValueError, PermissionError, OSError):
+        pass
+
+    # sysfs non-zero or unavailable — verify via ioctl (handles frozen sysfs in containers)
+    try:
+        CDROM_DRIVE_STATUS = 0x5326
+        CDS_DISC_OK = 4
+        fd = os.open(drive, os.O_RDONLY | os.O_NONBLOCK)
+        try:
+            return fcntl.ioctl(fd, CDROM_DRIVE_STATUS) == CDS_DISC_OK
+        finally:
+            os.close(fd)
+    except OSError:
         return False
 
 

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -146,7 +146,7 @@ def _get_volume_label_linux(drive: str) -> str:
         return ""
 
 
-_OPTICAL_DRIVE_RE = re.compile(r"^/dev/sr\d+$")
+_OPTICAL_DRIVE_RE = re.compile(r"^/dev/sr(\d+)$")
 
 
 def _is_disc_present_linux(drive: str) -> bool:
@@ -157,10 +157,14 @@ def _is_disc_present_linux(drive: str) -> bool:
     queries drive firmware directly — this handles containers where sysfs is
     frozen and never drops to 0 after disc removal.
     """
-    if not _OPTICAL_DRIVE_RE.match(drive):
+    m = _OPTICAL_DRIVE_RE.match(drive)
+    if not m:
         return False
+    # Reconstruct paths from the captured digit group only — breaks taint flow
+    # from the original drive argument into any path expression.
+    dev_name = f"sr{m.group(1)}"
+    dev_path = f"/dev/{dev_name}"
     try:
-        dev_name = os.path.basename(drive)
         with open(f"/sys/block/{dev_name}/size") as f:
             if int(f.read().strip()) == 0:
                 return False  # sysfs confirmed empty — trust it
@@ -171,7 +175,7 @@ def _is_disc_present_linux(drive: str) -> bool:
     try:
         CDROM_DRIVE_STATUS = 0x5326
         CDS_DISC_OK = 4
-        fd = os.open(drive, os.O_RDONLY | os.O_NONBLOCK)
+        fd = os.open(dev_path, os.O_RDONLY | os.O_NONBLOCK)
         try:
             return fcntl.ioctl(fd, CDROM_DRIVE_STATUS) == CDS_DISC_OK
         finally:

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -149,20 +149,14 @@ def _get_volume_label_linux(drive: str) -> str:
 _OPTICAL_DRIVE_RE = re.compile(r"^/dev/sr(\d+)$")
 
 
-def _is_disc_present_linux(drive: str) -> bool:
-    """Check if a disc is present on Linux.
+def _check_sr_device(dev_num: int) -> bool:
+    """Check disc presence for /dev/srN by device number.
 
-    Reads /sys/block size first: if it's zero the drive is definitely empty.
-    If non-zero (or unreadable), falls back to ioctl(CDROM_DRIVE_STATUS) which
-    queries drive firmware directly — this handles containers where sysfs is
-    frozen and never drops to 0 after disc removal.
+    Accepts an int so no tainted string reaches any path expression.
+    Reads /sys/block size first (zero = definitely empty), then falls back
+    to ioctl(CDROM_DRIVE_STATUS) for containers where sysfs is frozen.
     """
-    m = _OPTICAL_DRIVE_RE.match(drive)
-    if not m:
-        return False
-    # Reconstruct paths from the captured digit group only — breaks taint flow
-    # from the original drive argument into any path expression.
-    dev_name = f"sr{m.group(1)}"
+    dev_name = f"sr{dev_num}"
     dev_path = f"/dev/{dev_name}"
     try:
         with open(f"/sys/block/{dev_name}/size") as f:
@@ -182,6 +176,14 @@ def _is_disc_present_linux(drive: str) -> bool:
             os.close(fd)
     except OSError:
         return False
+
+
+def _is_disc_present_linux(drive: str) -> bool:
+    """Check if a disc is present on Linux."""
+    m = _OPTICAL_DRIVE_RE.match(drive)
+    if not m:
+        return False
+    return _check_sr_device(int(m.group(1)))
 
 
 def _eject_disc_linux(drive: str) -> bool:

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -174,6 +174,11 @@ def _check_sr_device(dev_num: int) -> bool:
             return fcntl.ioctl(fd, CDROM_DRIVE_STATUS) == CDS_DISC_OK
         finally:
             os.close(fd)
+    except PermissionError:
+        logger.warning(
+            f"ioctl({dev_path}) permission denied — add the runtime user to the drive's group"
+        )
+        return False
     except OSError:
         return False
 
@@ -224,6 +229,8 @@ def get_volume_label(drive: str) -> str:
     if sys.platform == "win32":
         return _get_volume_label_windows(drive)
     elif sys.platform == "linux":
+        if not _OPTICAL_DRIVE_RE.match(drive):
+            return ""
         return _get_volume_label_linux(drive)
     return ""
 
@@ -242,6 +249,8 @@ def eject_disc(drive: str) -> bool:
     if sys.platform == "win32":
         return _eject_disc_windows(drive)
     elif sys.platform == "linux":
+        if not _OPTICAL_DRIVE_RE.match(drive):
+            return False
         return _eject_disc_linux(drive)
     logger.warning(f"Disc eject not supported on {sys.platform}")
     return False

--- a/backend/tests/unit/test_linux_drives.py
+++ b/backend/tests/unit/test_linux_drives.py
@@ -75,7 +75,13 @@ class TestIsDiscPresentLinux:
     """Tests for _is_disc_present_linux."""
 
     def test_disc_present_nonzero_size(self):
-        with patch("builtins.open", mock_open(read_data="4194304\n")):
+        # sysfs non-zero → ioctl confirms disc present
+        with (
+            patch("builtins.open", mock_open(read_data="4194304\n")),
+            patch("os.open", return_value=5),
+            patch("os.close"),
+            patch("fcntl.ioctl", return_value=4),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is True
 
     def test_no_disc_zero_size(self):
@@ -83,11 +89,17 @@ class TestIsDiscPresentLinux:
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_no_device_file(self):
-        with patch("builtins.open", side_effect=FileNotFoundError):
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("os.open", side_effect=OSError),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_permission_denied(self):
-        with patch("builtins.open", side_effect=PermissionError):
+        with (
+            patch("builtins.open", side_effect=PermissionError),
+            patch("os.open", side_effect=OSError),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
 

--- a/backend/tests/unit/test_linux_drives.py
+++ b/backend/tests/unit/test_linux_drives.py
@@ -5,7 +5,10 @@ filesystem and subprocess calls. Also verifies Windows behavior
 is unchanged.
 """
 
+import sys
 from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
 
 from app.core import sentinel
 
@@ -71,6 +74,7 @@ class TestGetVolumeLabelLinux:
         assert label == ""
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl and O_NONBLOCK are Linux-only")
 class TestIsDiscPresentLinux:
     """Tests for _is_disc_present_linux."""
 

--- a/backend/tests/unit/test_sentinel.py
+++ b/backend/tests/unit/test_sentinel.py
@@ -164,6 +164,10 @@ class TestLinuxReaders:
         with patch.object(sentinel.glob, "glob", return_value=[]):
             assert sentinel._get_optical_drives_linux() == []
 
+    def test_is_disc_present_linux_invalid_path(self):
+        assert sentinel._is_disc_present_linux("/dev/sda") is False
+        assert sentinel._is_disc_present_linux("../../etc/passwd") is False
+
     def test_is_disc_present_linux_true(self):
         # sysfs shows non-zero → falls through to ioctl → CDS_DISC_OK (4)
         with patch("builtins.open", mock_open(read_data="2048\n")), \

--- a/backend/tests/unit/test_sentinel.py
+++ b/backend/tests/unit/test_sentinel.py
@@ -165,19 +165,47 @@ class TestLinuxReaders:
             assert sentinel._get_optical_drives_linux() == []
 
     def test_is_disc_present_linux_true(self):
-        with patch("builtins.open", mock_open(read_data="2048\n")):
+        # sysfs shows non-zero → falls through to ioctl → CDS_DISC_OK (4)
+        with patch("builtins.open", mock_open(read_data="2048\n")), \
+             patch("os.open", return_value=5), \
+             patch("os.close"), \
+             patch("fcntl.ioctl", return_value=4):
             assert sentinel._is_disc_present_linux("/dev/sr0") is True
 
     def test_is_disc_present_linux_zero_size(self):
         with patch("builtins.open", mock_open(read_data="0\n")):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
+    def test_is_disc_present_linux_frozen_sysfs_tray_open(self):
+        # The container bug: sysfs frozen at non-zero but tray is open (CDS_TRAY_OPEN=2)
+        with patch("builtins.open", mock_open(read_data="80398720\n")), \
+             patch("os.open", return_value=5), \
+             patch("os.close"), \
+             patch("fcntl.ioctl", return_value=2):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is False
+
+    def test_is_disc_present_linux_no_sysfs_ioctl_confirms(self):
+        # No sysfs (e.g. non-standard kernel) but ioctl confirms disc present
+        with patch("builtins.open", side_effect=FileNotFoundError), \
+             patch("os.open", return_value=5), \
+             patch("os.close"), \
+             patch("fcntl.ioctl", return_value=4):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is True
+
+    def test_is_disc_present_linux_ioctl_oserror(self):
+        # sysfs non-zero but ioctl fails (permission, no device) → safe False
+        with patch("builtins.open", mock_open(read_data="2048\n")), \
+             patch("os.open", side_effect=OSError("permission denied")):
+            assert sentinel._is_disc_present_linux("/dev/sr0") is False
+
     def test_is_disc_present_linux_missing_file(self):
-        with patch("builtins.open", side_effect=FileNotFoundError):
+        with patch("builtins.open", side_effect=FileNotFoundError), \
+             patch("os.open", side_effect=OSError):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_is_disc_present_linux_bad_value(self):
-        with patch("builtins.open", mock_open(read_data="notanumber")):
+        with patch("builtins.open", mock_open(read_data="notanumber")), \
+             patch("os.open", side_effect=OSError):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_get_volume_label_linux_success(self):

--- a/backend/tests/unit/test_sentinel.py
+++ b/backend/tests/unit/test_sentinel.py
@@ -170,10 +170,12 @@ class TestLinuxReaders:
 
     def test_is_disc_present_linux_true(self):
         # sysfs shows non-zero → falls through to ioctl → CDS_DISC_OK (4)
-        with patch("builtins.open", mock_open(read_data="2048\n")), \
-             patch("os.open", return_value=5), \
-             patch("os.close"), \
-             patch("fcntl.ioctl", return_value=4):
+        with (
+            patch("builtins.open", mock_open(read_data="2048\n")),
+            patch("os.open", return_value=5),
+            patch("os.close"),
+            patch("fcntl.ioctl", return_value=4),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is True
 
     def test_is_disc_present_linux_zero_size(self):
@@ -182,34 +184,44 @@ class TestLinuxReaders:
 
     def test_is_disc_present_linux_frozen_sysfs_tray_open(self):
         # The container bug: sysfs frozen at non-zero but tray is open (CDS_TRAY_OPEN=2)
-        with patch("builtins.open", mock_open(read_data="80398720\n")), \
-             patch("os.open", return_value=5), \
-             patch("os.close"), \
-             patch("fcntl.ioctl", return_value=2):
+        with (
+            patch("builtins.open", mock_open(read_data="80398720\n")),
+            patch("os.open", return_value=5),
+            patch("os.close"),
+            patch("fcntl.ioctl", return_value=2),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_is_disc_present_linux_no_sysfs_ioctl_confirms(self):
         # No sysfs (e.g. non-standard kernel) but ioctl confirms disc present
-        with patch("builtins.open", side_effect=FileNotFoundError), \
-             patch("os.open", return_value=5), \
-             patch("os.close"), \
-             patch("fcntl.ioctl", return_value=4):
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("os.open", return_value=5),
+            patch("os.close"),
+            patch("fcntl.ioctl", return_value=4),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is True
 
     def test_is_disc_present_linux_ioctl_oserror(self):
         # sysfs non-zero but ioctl fails (permission, no device) → safe False
-        with patch("builtins.open", mock_open(read_data="2048\n")), \
-             patch("os.open", side_effect=OSError("permission denied")):
+        with (
+            patch("builtins.open", mock_open(read_data="2048\n")),
+            patch("os.open", side_effect=OSError("permission denied")),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_is_disc_present_linux_missing_file(self):
-        with patch("builtins.open", side_effect=FileNotFoundError), \
-             patch("os.open", side_effect=OSError):
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("os.open", side_effect=OSError),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_is_disc_present_linux_bad_value(self):
-        with patch("builtins.open", mock_open(read_data="notanumber")), \
-             patch("os.open", side_effect=OSError):
+        with (
+            patch("builtins.open", mock_open(read_data="notanumber")),
+            patch("os.open", side_effect=OSError),
+        ):
             assert sentinel._is_disc_present_linux("/dev/sr0") is False
 
     def test_get_volume_label_linux_success(self):

--- a/backend/tests/unit/test_sentinel.py
+++ b/backend/tests/unit/test_sentinel.py
@@ -150,6 +150,7 @@ class TestNotify:
 
 
 @pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl and O_NONBLOCK are Linux-only")
 class TestLinuxReaders:
     """Linux /sys/block readers with mocked filesystem I/O."""
 


### PR DESCRIPTION
## Problem

In containerized deployments (confirmed on TrueNAS), `/sys/block/sr0/size` freezes at the last disc's block count after ejection and **never drops to zero**. This broke the sentinel in two compounding ways:

1. **Ghost jobs**: After auto-eject + `notify_ejected()`, the next two sentinel polls still read non-zero sysfs → debounce confirms a False→True transition → spurious "inserted" event fires → a FAILED job with no volume label is created.
2. **Stuck state**: `_drive_states` is now `True` again. When the user inserts a real disc, sysfs still shows the same frozen non-zero value → sentinel sees True→True → no state change → no "inserted" event → no new job until container restart.

## Investigation

Confirmed root cause by running `eject /dev/sr0` inside the container and immediately checking `/sys/block/sr0/size` — it still returned `80398720` (the old disc's block count) with the tray physically open. The kernel's sysfs view of the drive is frozen in this environment and cannot be used as the sole source of truth for disc presence.

## Fix

Two-stage detection in `_is_disc_present_linux`:

1. **sysfs size = 0 → return False immediately.** A zero is authoritative — the kernel is telling us the drive is empty, no need to go further.
2. **sysfs size > 0 (or unreadable) → verify via `ioctl(CDROM_DRIVE_STATUS)`.** This queries drive firmware directly through the kernel's CDROM subsystem and correctly returns the real tray/disc state even when sysfs is frozen. Only returns True when `CDS_DISC_OK (4)` is returned.

This also eliminates ghost jobs: immediately after eject, ioctl returns `CDS_TRAY_OPEN` or `CDS_NO_DISC` (not 4), so the spurious False→True debounce never triggers.

## Backward compatibility

- **Normal Linux (non-container)**: sysfs works correctly and returns 0 on empty drive → early-exits at step 1, ioctl never called. No behavior change.
- **Container/frozen sysfs**: sysfs non-zero → falls through to ioctl → correct result.
- **Non-sysfs systems**: sysfs raises `FileNotFoundError` → falls through to ioctl.
- **Windows**: unaffected, `_is_disc_present_linux` is never called on win32.
- `fcntl` imported under `sys.platform != "win32"` so the import is safe on both Linux (production) and macOS (test/dev).

## Testing

- 3 new unit tests covering: frozen sysfs + tray open (the bug case), no sysfs + ioctl confirms disc, sysfs non-zero + ioctl OSError safe-default
- Validated on TrueNAS Docker install: job completed → auto-eject → no ghost job fired → inserted next disc → new job started automatically, all without container restart