### PR TITLE
chore: release v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-06-30
+
+_Highlights: disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker)._
+
 ### Fixed
 
 - **Disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker).** In some container environments `/sys/block/sr0/size` freezes at the previous disc's block count after ejection and never drops to zero. This caused two compounding bugs: a ghost FAILED job fired on every cycle (spurious "inserted" event from the frozen sysfs), and the next real disc insertion was silently ignored until the container restarted. The sentinel now verifies disc presence via `ioctl(CDROM_DRIVE_STATUS)` when sysfs reports a non-zero size, querying drive firmware directly. (#477)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.22.1"
+__version__ = "0.22.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.22.1"
+version = "0.22.2"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.22.1"
+version = "0.22.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.22.1",
+    "version": "0.22.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.22.1",
+            "version": "0.22.2",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.22.1",
+    "version": "0.22.2",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- Moves the `[Unreleased]` CHANGELOG entry into a new `## [0.22.2] - 2026-06-30` section (containerized disc auto-detection fix, #477)
- Bumps version to `0.22.2` in `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and `frontend/package-lock.json`

## Test plan
- [x] `backend/scripts/extract_changelog.py --version 0.22.2 --check` passes
- [x] `uv run ruff check` passes
- [x] `package.json`/`package-lock.json` parse as valid JSON
- [ ] CI green (changelog-version-check, build/release pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MowstQxYXCLDPmtfQd8kdL)_