### PR TITLE
fix(ui): focus management in ConfirmModal (WCAG 2.4.3)

### DIFF
--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -17,7 +17,7 @@
  * promote it to the primary callout in that state.
  */
 
-import { useState, useEffect, type CSSProperties, type ReactNode, type MouseEvent } from "react";
+import { useState, useEffect, useRef, type CSSProperties, type ReactNode, type MouseEvent } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { IcoCancel, IcoError, IcoRetry, IcoPlay } from "../icons";
@@ -36,6 +36,14 @@ interface ConfirmModalProps {
 }
 
 function ConfirmModal({ titleId, title, body, confirmLabel, dismissLabel, confirmTone = "red", onConfirm, onDismiss }: ConfirmModalProps) {
+    const dismissRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        const trigger = document.activeElement as HTMLElement | null;
+        dismissRef.current?.focus();
+        return () => trigger?.focus();
+    }, []);
+
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onDismiss(); };
         document.addEventListener("keydown", onKey);
@@ -76,6 +84,7 @@ function ConfirmModal({ titleId, title, body, confirmLabel, dismissLabel, confir
                     </div>
                     <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
                         <button
+                            ref={dismissRef}
                             onClick={onDismiss}
                             style={{ fontFamily: sv.mono, fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", padding: "8px 14px", background: sv.bg0, border: `1px solid ${sv.lineMid}`, color: sv.inkDim, cursor: "pointer" }}
                         >


### PR DESCRIPTION
## Summary

- On modal open: captures `document.activeElement` (the trigger button), then focuses the dismiss button — the safer default per ARIA dialog pattern
- On modal close (both confirm and dismiss paths): restores focus to the captured trigger via the `useEffect` cleanup

Self-contained in `ConfirmModal` — no caller changes needed.

## Context

Addresses the focus management gap noted in the re-review of #466:
> When the modal opens, focus remains on the button that triggered it. When it closes, focus stays wherever it landed. WCAG 2.4.3 (Focus Order) and the ARIA dialog pattern both expect focus to move into the dialog on open, and return to the trigger on close.

## Test plan

- [ ] Open cancel modal → focus lands on "Keep Ripping" (dismiss) button
- [ ] Dismiss with keyboard (Enter/Space on dismiss, or Escape) → focus returns to Cancel button on the card
- [ ] Confirm cancel → focus returns to Cancel button (before card disappears)
- [ ] Same for Force-advance modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)