### PR TITLE
chore: bump CI Claude workflows to Sonnet 5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,4 +39,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -27,7 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Bump `model:` in `.github/workflows/claude.yml` (interactive Claude Code assistant) from `claude-sonnet-4-6` to `claude-sonnet-5`
- Bump `model:` in `.github/workflows/code-review.yml` (automated PR code-review bot) from `claude-sonnet-4-6` to `claude-sonnet-5`

## Test plan
- [ ] Confirm the `claude` workflow (triggered via `@claude` mention) runs successfully with the new model
- [ ] Confirm the `code-review` workflow posts a review on the next PR using the new model


---
_Generated by [Claude Code](https://claude.ai/code/session_015iUwyT5tVLymqgpuYVLHAY)_