### PR TITLE
fix(config): expand ~ before absolute-path check in ensure_paths_exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Subtitle cache directory no longer fails to create with a permission-denied warning on startup.** `ensure_paths_exist()` checked `is_absolute()` before expanding `~`, so the default `subtitles_cache_path` of `~/.engram/cache` was never tilde-expanded and instead resolved to a literal `~` folder under the backend source directory, which is unwritable in Docker. `~` is now expanded before the absolute-path check, matching every other consumer of this setting. (#459)
+
 ## [0.22.2] - 2026-06-30
 
 _Highlights: disc auto-detection no longer breaks after the first rip on containerized installs (TrueNAS, Docker)._

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -271,7 +271,7 @@ async def ensure_paths_exist(config: AppConfig) -> None:
 
     for path_str in paths_to_create:
         if path_str:
-            path = Path(path_str)
+            path = Path(path_str).expanduser()
             if not path.is_absolute():
                 # Make relative paths absolute based on backend directory
                 path = Path(__file__).parent.parent / path_str

--- a/backend/tests/unit/test_config_service.py
+++ b/backend/tests/unit/test_config_service.py
@@ -178,3 +178,22 @@ class TestEnsurePathsExist:
         )
         await ensure_paths_exist(config)
         assert (tmp_path / "staging").exists()
+
+    async def test_ensure_paths_exist_expands_tilde(self, tmp_path, monkeypatch):
+        """A '~'-prefixed path should resolve against the home dir, not the backend dir.
+
+        Path("~/foo").is_absolute() is False, so expanduser() must run before the
+        absolute-path check or the tilde is never resolved (issue #459).
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        config = AppConfig(
+            staging_path=str(tmp_path / "staging"),
+            library_movies_path=str(tmp_path / "movies"),
+            library_tv_path=str(tmp_path / "tv"),
+            subtitles_cache_path="~/.engram/cache",
+        )
+
+        await ensure_paths_exist(config)
+
+        assert (tmp_path / ".engram" / "cache").exists()


### PR DESCRIPTION
## Summary
- `ensure_paths_exist()` checked `Path.is_absolute()` before calling `.expanduser()`, but `Path("~/foo").is_absolute()` is always `False` in pathlib, so the default `subtitles_cache_path` (`~/.engram/cache`) was never tilde-expanded. It instead resolved to a literal `~` directory joined onto the backend source dir (e.g. `/app/app/~/.engram/cache` in Docker), which is unwritable for the unprivileged runtime user — producing a permission-denied warning on every startup/config save.
- Fixes by calling `.expanduser()` first, matching every other consumer of `subtitles_cache_path` (`curator.py`, `precomputed_cache_service.py`, `routes.py`, etc.).
- Found while triaging [#459](https://github.com/Jsakkos/engram/issues/459) — this bug is cosmetic there (staging/library paths were already absolute for that user), not the cause of the reported ripping issue, but worth fixing since it's a real defect.

## Test plan
- [x] Added `test_ensure_paths_exist_expands_tilde` regression test (fails on the old code, passes after the fix)
- [x] `uv run pytest tests/unit/test_config_service.py tests/unit/test_setup_gate.py` — 20 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)