### PR TITLE
fix(db): self-heal Alembic upgrades stuck behind a duplicate column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **Subtitle cache directory no longer fails to create with a permission-denied warning on startup.** `ensure_paths_exist()` checked `is_absolute()` before expanding `~`, so the default `subtitles_cache_path` of `~/.engram/cache` was never tilde-expanded and instead resolved to a literal `~` folder under the backend source directory, which is unwritable in Docker. `~` is now expanded before the absolute-path check, matching every other consumer of this setting. (#459)
+- **Database migrations no longer get stuck behind a "duplicate column name" error.** `_add_missing_columns()` (the frozen-build fallback) and Alembic both converge the schema toward the same model on every startup; if a column a pending Alembic migration wanted to add had already been added out-of-band, the migration failed and was silently swallowed, leaving `alembic_version` permanently one revision behind and blocking every later migration on every subsequent restart. Alembic upgrades now apply one revision at a time and self-heal past a revision whose only failure is a column that already exists. (#459)
 
 ## [0.22.2] - 2026-06-30
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -132,7 +132,7 @@ def _run_alembic_upgrade() -> None:
         logger.warning(f"Alembic migration failed (non-fatal): {e}", exc_info=True)
 
 
-def _upgrade_to_head_self_healing(alembic_cfg, sync_engine, max_steps: int = 25) -> None:
+def _upgrade_to_head_self_healing(alembic_cfg, sync_engine) -> None:
     """Apply pending Alembic migrations, healing revisions whose only failure
     is a column that already exists.
 
@@ -145,6 +145,13 @@ def _upgrade_to_head_self_healing(alembic_cfg, sync_engine, max_steps: int = 25)
     Since the schema already matches what that revision would produce, treat
     the failure as "already applied": stamp past just that one revision and
     keep going.
+
+    Safe only because _add_missing_columns() backfills *columns* for every
+    table before Alembic ever runs — it does not create indexes/constraints or
+    run data backfills. Stamping a revision "done" on a duplicate-column error
+    assumes the whole revision is a no-op, so a migration must not combine
+    add_column() with other DDL or data operations in the same upgrade(), or
+    that other work would be silently skipped whenever this self-heal fires.
     """
     from alembic import command
     from alembic.runtime.migration import MigrationContext
@@ -152,6 +159,10 @@ def _upgrade_to_head_self_healing(alembic_cfg, sync_engine, max_steps: int = 25)
     from sqlalchemy.exc import OperationalError
 
     script = ScriptDirectory.from_config(alembic_cfg)
+    # Upper bound on steps needed to walk from any revision to head — derived
+    # from the actual chain length rather than a fixed constant, so it never
+    # needs manual bumping as migrations accumulate.
+    max_steps = len(list(script.walk_revisions())) + 1
 
     for _ in range(max_steps):
         with sync_engine.connect() as conn:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -124,12 +124,58 @@ def _run_alembic_upgrade() -> None:
             logger.info("Alembic: stamped existing database at head")
         else:
             # Run any pending migrations
-            command.upgrade(alembic_cfg, "head")
+            _upgrade_to_head_self_healing(alembic_cfg, sync_engine)
             logger.info("Alembic: migrations up to date")
 
         sync_engine.dispose()
     except Exception as e:
         logger.warning(f"Alembic migration failed (non-fatal): {e}", exc_info=True)
+
+
+def _upgrade_to_head_self_healing(alembic_cfg, sync_engine, max_steps: int = 25) -> None:
+    """Apply pending Alembic migrations, healing revisions whose only failure
+    is a column that already exists.
+
+    _add_missing_columns() (the frozen-build fallback) and Alembic both run on
+    every startup and converge the schema toward the same SQLModel metadata.
+    If a column a pending migration wants to add was already added out-of-band,
+    its ADD COLUMN fails with "duplicate column name" and, left unhandled,
+    that leaves alembic_version stuck one revision behind forever — silently
+    blocking every later migration on every subsequent startup (issue #459).
+    Since the schema already matches what that revision would produce, treat
+    the failure as "already applied": stamp past just that one revision and
+    keep going.
+    """
+    from alembic import command
+    from alembic.runtime.migration import MigrationContext
+    from alembic.script import ScriptDirectory
+    from sqlalchemy.exc import OperationalError
+
+    script = ScriptDirectory.from_config(alembic_cfg)
+
+    for _ in range(max_steps):
+        with sync_engine.connect() as conn:
+            current = MigrationContext.configure(conn).get_current_revision()
+
+        if current == script.get_current_head():
+            return
+
+        try:
+            command.upgrade(alembic_cfg, "+1")
+        except OperationalError as e:
+            if "duplicate column name" not in str(e).lower():
+                raise
+            next_revs = script.get_revision(current).nextrev if current else None
+            next_rev = next(iter(next_revs)) if next_revs else None
+            if next_rev is None:
+                raise
+            logger.warning(
+                f"Alembic: revision {next_rev} adds a column that already exists "
+                "(added out-of-band); stamping as applied and continuing"
+            )
+            command.stamp(alembic_cfg, next_rev)
+
+    raise RuntimeError("Alembic upgrade did not reach head after self-healing retries")
 
 
 def _get_expected_columns(table_name: str) -> set[str]:

--- a/backend/tests/unit/test_database_migration.py
+++ b/backend/tests/unit/test_database_migration.py
@@ -568,3 +568,39 @@ class TestAlembicSelfHealing:
         finally:
             db_mod.settings.database_url = original_url
             sync_engine.dispose()
+
+    def test_self_heal_reraises_non_duplicate_column_errors(self, tmp_path, monkeypatch):
+        """An OperationalError unrelated to a duplicate column must propagate,
+        not be swallowed by the self-heal loop as if it were a no-op revision.
+        """
+        from alembic import command
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+        from sqlalchemy.exc import OperationalError
+
+        import app.database as db_mod
+
+        db_path = tmp_path / "propagate.db"
+        sync_engine = create_engine(f"sqlite:///{db_path}")
+
+        original_url = db_mod.settings.database_url
+        db_mod.settings.database_url = f"sqlite+aiosqlite:///{db_path}"
+        try:
+            SQLModel.metadata.create_all(sync_engine)
+
+            alembic_cfg = Config(str(db_mod._ALEMBIC_INI))
+            script = ScriptDirectory.from_config(alembic_cfg)
+            head = script.get_current_head()
+            down_revision = script.get_revision(head).down_revision or "base"
+            command.stamp(alembic_cfg, down_revision)
+
+            def fake_upgrade(_cfg, _rev):
+                raise OperationalError("SELECT 1", {}, Exception("no such table: unrelated_table"))
+
+            monkeypatch.setattr(command, "upgrade", fake_upgrade)
+
+            with pytest.raises(OperationalError, match="no such table"):
+                db_mod._upgrade_to_head_self_healing(alembic_cfg, sync_engine)
+        finally:
+            db_mod.settings.database_url = original_url
+            sync_engine.dispose()

--- a/backend/tests/unit/test_database_migration.py
+++ b/backend/tests/unit/test_database_migration.py
@@ -5,7 +5,7 @@ preserve app_config data, recreate transient tables, and remove obsolete columns
 """
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -510,3 +510,61 @@ class TestSchemaMigration:
             await session.commit()
             await session.refresh(job_no_prompt)
             assert job_no_prompt.identity_prompt_json is None
+
+
+class TestAlembicSelfHealing:
+    """Regression tests for issue #459: _add_missing_columns() (the frozen-build
+    fallback) and Alembic both run on every startup and converge toward the
+    same SQLModel metadata. If a column an Alembic migration wants to add was
+    already added out-of-band, ALTER TABLE ADD COLUMN fails with "duplicate
+    column name" and, previously, that failure was only logged — leaving
+    alembic_version stuck one revision behind forever and silently blocking
+    every later migration on every subsequent startup.
+    """
+
+    def test_upgrade_heals_when_head_column_already_present(self, tmp_path):
+        """A DB whose schema already matches head, but whose alembic_version
+        is one revision behind, must self-heal to head instead of getting
+        stuck retrying the same failing migration forever.
+        """
+        from alembic import command
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        import app.database as db_mod
+
+        db_path = tmp_path / "self_heal.db"
+        sync_engine = create_engine(f"sqlite:///{db_path}")
+
+        # migrations/env.py reads settings.database_url directly (ignores any
+        # connection passed via Config.attributes), so it must point at the
+        # temp DB before *any* Alembic command runs, including the stamp used
+        # to set up this scenario.
+        original_url = db_mod.settings.database_url
+        db_mod.settings.database_url = f"sqlite+aiosqlite:///{db_path}"
+        try:
+            # Simulate a DB that already has the full current schema (as if
+            # _add_missing_columns had already added every column, including
+            # the one the still-pending head migration wants to add).
+            SQLModel.metadata.create_all(sync_engine)
+
+            alembic_cfg = Config(str(db_mod._ALEMBIC_INI))
+            script = ScriptDirectory.from_config(alembic_cfg)
+            head = script.get_current_head()
+            down_revision = script.get_revision(head).down_revision or "base"
+
+            # Stamp alembic_version one revision behind head, so re-running
+            # the head migration's ADD COLUMN collides with the column that
+            # create_all() already put there.
+            command.stamp(alembic_cfg, down_revision)
+
+            db_mod._run_alembic_upgrade()
+
+            from alembic.runtime.migration import MigrationContext
+
+            with sync_engine.connect() as conn:
+                current_rev = MigrationContext.configure(conn).get_current_revision()
+            assert current_rev == head
+        finally:
+            db_mod.settings.database_url = original_url
+            sync_engine.dispose()


### PR DESCRIPTION
## Summary
- `_add_missing_columns()` (the frozen-build fallback) and Alembic both run on every startup and converge the schema toward the same SQLModel metadata. When `_add_missing_columns()` won the race and added a column first, Alembic's own migration for that same column failed with `duplicate column name` and was silently swallowed (`logger.warning(..., "non-fatal")`) — leaving `alembic_version` stuck one revision behind forever and silently blocking every later migration on every subsequent restart.
- Surfaced by a user's real-world startup log in [#459](https://github.com/Jsakkos/engram/issues/459) (`duplicate column name: import_manifest_json`), separate from the tilde-expansion bug already fixed there in #481.
- `_run_alembic_upgrade()` now applies pending migrations one revision at a time via a new `_upgrade_to_head_self_healing()`, and stamps past any single revision whose only failure is a column that already exists, instead of getting stuck.
- Note: `#459` itself remains open — this fixes a newly-found migration bug from the thread, not the originally reported "disc doesn't rip / jobs invisible in UI" symptom, which is still waiting on a requested debug log from the reporter.

## Test plan
- [x] Added `test_upgrade_heals_when_head_column_already_present` — reproduces the exact `duplicate column name` failure against the real Alembic migration chain, confirmed it fails on the old code before implementing the fix
- [x] `uv run pytest tests/unit/ tests/pipeline/` — 2511 passed, 19 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)