### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-02
+
+_Highlights: Discord webhook notifications for job completion, plus fixes for a Docker subtitle-cache permission error, migrations getting stuck behind duplicate columns, and modal keyboard focus order._
+
 ### Added
 
 - **Discord webhook notifications for job completion.** Configure a webhook URL in Settings → Preferences → Notifications; Engram posts a color-coded embed when a disc job reaches COMPLETED (green) or FAILED (red). The URL is stored as a credential (redacted in API responses, SSRF-validated on write). Embed content is hard-coded for now — a future PR will add customizable message templates. (#482)
+
 ### Fixed
 
-- **Subtitle cache directory no longer fails to create with a permission-denied warning on startup.** `ensure_paths_exist()` checked `is_absolute()` before expanding `~`, so the default `subtitles_cache_path` of `~/.engram/cache` was never tilde-expanded and instead resolved to a literal `~` folder under the backend source directory, which is unwritable in Docker. `~` is now expanded before the absolute-path check, matching every other consumer of this setting. (#459)
-- **Database migrations no longer get stuck behind a "duplicate column name" error.** `_add_missing_columns()` (the frozen-build fallback) and Alembic both converge the schema toward the same model on every startup; if a column a pending Alembic migration wanted to add had already been added out-of-band, the migration failed and was silently swallowed, leaving `alembic_version` permanently one revision behind and blocking every later migration on every subsequent restart. Alembic upgrades now apply one revision at a time and self-heal past a revision whose only failure is a column that already exists. (#459)
+- **Subtitle cache directory no longer fails to create with a permission-denied warning on startup.** `ensure_paths_exist()` checked `is_absolute()` before expanding `~`, so the default `subtitles_cache_path` of `~/.engram/cache` was never tilde-expanded and instead resolved to a literal `~` folder under the backend source directory, which is unwritable in Docker. `~` is now expanded before the absolute-path check, matching every other consumer of this setting. (#481)
+- **Database migrations no longer get stuck behind a "duplicate column name" error.** `_add_missing_columns()` (the frozen-build fallback) and Alembic both converge the schema toward the same model on every startup; if a column a pending Alembic migration wanted to add had already been added out-of-band, the migration failed and was silently swallowed, leaving `alembic_version` permanently one revision behind and blocking every later migration on every subsequent restart. Alembic upgrades now apply one revision at a time and self-heal past a revision whose only failure is a column that already exists. (#483)
+- **Modal dismiss button now receives keyboard focus when the modal opens, and focus returns to the triggering element when it closes.** Addresses a WCAG 2.4.3 (Focus Order) gap: keyboard and screen-reader users previously had to tab in from wherever focus last landed, and lost their place in the page when the modal closed. (#479)
 
 ## [0.22.2] - 2026-06-30
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.22.2"
+__version__ = "0.23.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.22.2"
+version = "0.23.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.22.2"
+version = "0.23.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.22.2",
+    "version": "0.23.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.22.2",
+            "version": "0.23.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.22.2",
+    "version": "0.23.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- Minor release: adds Discord webhook notifications for job completion (#482), plus three fixes — Docker subtitle-cache permission error (#481), Alembic migrations stuck behind duplicate columns (#483), and modal keyboard focus order (#479).
- Bumps version to 0.23.0 in `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json` (both self-version fields).
- Moves `[Unreleased]` changelog entries into a dated `[0.23.0] - 2026-07-02` section (UTC publish day); corrected two entries that referenced the tracking issue (#459) instead of their actual PRs (#481, #483); added the missing entry for #479.
- Regenerated `CONTRIBUTORS.md` (no changes — already current).

## Test plan
- [x] `uv run python scripts/extract_changelog.py --version 0.23.0 --check` confirms the CHANGELOG section resolves
- [x] `uv run ruff check` passes on touched backend files
- [x] Pre-commit hooks (ruff, ruff format, whitespace, EOF, toml/yaml checks) passed on commit
- [ ] User to merge — squash-merge triggers `tag-release.yml` → `release.yml` (binaries) + `docker.yml` (GHCR image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)