### PR TITLE
feat: manual track skipping for queued tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Manual track skipping.** Skip a queued or not-yet-ripped track (for example a bogus "play all" title that slipped past auto-detection) straight from the dashboard, so MakeMKV does not waste time ripping it. Skipped tracks show a distinct SKIPPED badge, are excluded from the library, do not count as failures, and can be un-skipped until ripping reaches them. Skipping is best-effort during an in-progress full-disc rip (the file is written then deleted) and guaranteed for per-title rips. (#NNN)
+
 ### Fixed
 
 - **Jetson GPU setup script now works on real hardware, not just in theory.** A community member's field validation on a Jetson Orin NX (JetPack 6.2.2 / R36.5.0) found `jetson_gpu_setup.sh` was missing two steps: it didn't move the PyInstaller-bundled `libstdc++.so.6`/`libgcc_s.so.1` aside (causing `GLIBC_2.36`/`GLIBC_2.38 not found` on JetPack's older Ubuntu 22.04 base) and didn't populate the `~/.engram/cuda/` runtime cache from JetPack's system cuDNN/cuBLAS (so `/api/asr-status` never reported `gpu_runtime_installed: true`). Both are now automated by the script; `docs/development/jetson.md` is updated to "validated," and a new `docs/development/jetson-optical-drive.md` documents building the Blu-ray/DVD kernel modules JetPack doesn't ship for USB optical drives. (#485)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1015,6 +1015,47 @@ async def rerip_title(
     return {"status": "reripping", "job_id": job.id, "title_id": title_id}
 
 
+@router.post("/jobs/{job_id}/titles/{title_id}/skip-rip")
+async def skip_rip_title(
+    title_id: int,
+    job: DiscJob = Depends(get_job_or_404),
+) -> dict:
+    """Skip a queued/not-yet-ripped title so MakeMKV does not rip it."""
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    from app.services.job_manager import job_manager
+
+    ok = await job_manager.skip_rip_title(job.id, title_id)
+    if not ok:
+        raise HTTPException(
+            status_code=400,
+            detail="Title not found, not part of this job, or not skippable "
+            "(only queued/not-yet-ripped titles can be skipped)",
+        )
+    return {"status": "skipped", "job_id": job.id, "title_id": title_id}
+
+
+@router.post("/jobs/{job_id}/titles/{title_id}/unskip-rip")
+async def unskip_rip_title(
+    title_id: int,
+    job: DiscJob = Depends(get_job_or_404),
+) -> dict:
+    """Reverse a skip while the title's file has not been written yet."""
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    from app.services.job_manager import job_manager
+
+    ok = await job_manager.unskip_rip_title(job.id, title_id)
+    if not ok:
+        raise HTTPException(
+            status_code=400,
+            detail="Title not found or no longer un-skippable (already ripped)",
+        )
+    return {"status": "unskipped", "job_id": job.id, "title_id": title_id}
+
+
 @router.post("/jobs/{job_id}/review")
 async def submit_review(
     review: ReviewRequest,

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -384,6 +384,13 @@ class MakeMKVExtractor:
         # terminates the correct process.
         self._processes: dict[int, subprocess.Popen] = {}  # job_id -> process
         self._cancelled_jobs: set[int] = set()
+        # Per-job set of title_index values to skip. Checked before each
+        # per-title rip command so a queued-but-not-yet-ripped title can be
+        # dropped mid-rip. A full-disc "all" pass cannot honor this (one process
+        # rips everything); those skips are handled downstream by deleting the
+        # finished file. Single-writer per job under the rip thread + async
+        # skip calls; set mutation is atomic under the GIL.
+        self._skipped_indices: dict[int, set[int]] = {}
         # Per-drive locks prevent concurrent MakeMKV operations on the same drive.
         # Two makemkvcon processes fighting over one drive causes both to stall/fail.
         self._drive_locks: dict[str, asyncio.Lock] = {}
@@ -912,6 +919,7 @@ class MakeMKVExtractor:
                 return (-1, str(e), set())
             finally:
                 self._processes.pop(job_id, None)
+                self._skipped_indices.pop(job_id, None)
 
         try:
             # Start ripping in thread
@@ -989,6 +997,16 @@ class MakeMKVExtractor:
                 error_message=str(e),
             )
 
+    def skip_title_index(self, job_id: int, title_index: int) -> None:
+        """Register a title_index to skip in the per-title rip loop for a job."""
+        self._skipped_indices.setdefault(job_id, set()).add(title_index)
+
+    def unskip_title_index(self, job_id: int, title_index: int) -> None:
+        """Remove a previously-registered skip (no-op if absent)."""
+        s = self._skipped_indices.get(job_id)
+        if s:
+            s.discard(title_index)
+
     def cancel(self, job_id: int) -> None:
         """Cancel ripping for a specific job."""
         self._cancelled_jobs.add(job_id)
@@ -1021,6 +1039,7 @@ class MakeMKVExtractor:
         )
         self._processes.clear()
         self._cancelled_jobs.clear()
+        self._skipped_indices.clear()
 
     def _parse_disc_info(self, output: str) -> tuple[list[TitleInfo], str]:
         """Parse MakeMKV robot-mode output to extract title information and disc name.

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -106,6 +106,25 @@ def _files_to_ignore(output_dir: Path, title_indices: list[int] | None) -> set[s
     return ignore
 
 
+def _build_rip_commands(
+    makemkv_path: str,
+    drive_spec: str,
+    output_dir: str,
+    title_indices: list[int] | None,
+) -> list[tuple[int | None, list[str]]]:
+    """Build ``(title_index, argv)`` rip commands.
+
+    ``title_index`` is None for the single full-disc "all" pass (which rips
+    every title in one MakeMKV invocation and cannot drop an individual title);
+    otherwise each command carries the specific title index so the rip loop can
+    consult the live skip-set before starting it.
+    """
+    base = [makemkv_path, "-r", "--progress=-same", "mkv", drive_spec]
+    if not title_indices:
+        return [(None, [*base, "all", output_dir])]
+    return [(idx, [*base, str(idx), output_dir]) for idx in title_indices]
+
+
 def _safe_callback(cb: Callable, *args, label: str) -> None:
     """Invoke a user-supplied callback, logging (but not raising) any exception.
 
@@ -572,52 +591,16 @@ class MakeMKVExtractor:
         drive_spec = _to_drive_spec(drive)
 
         # Prepare commands to run
-        commands = []
-
+        commands = _build_rip_commands(
+            str(self.makemkv_path),
+            drive_spec,
+            str(output_dir),
+            title_indices,
+        )
         if not title_indices:
-            # Rip ALL titles (single command, most efficient)
             logger.info("Ripping ALL titles")
-            commands.append(
-                [
-                    str(self.makemkv_path),
-                    "-r",
-                    "--progress=-same",
-                    "mkv",
-                    drive_spec,
-                    "all",
-                    str(output_dir),
-                ]
-            )
-        elif len(title_indices) == 1:
-            # Rip single specific title
-            idx = title_indices[0]
-            logger.info(f"Ripping single title {idx}")
-            commands.append(
-                [
-                    str(self.makemkv_path),
-                    "-r",
-                    "--progress=-same",
-                    "mkv",
-                    drive_spec,
-                    str(idx),
-                    str(output_dir),
-                ]
-            )
         else:
-            # Rip multiple specific titles (must loop commands)
-            logger.info(f"Ripping {len(title_indices)} specific titles: {title_indices}")
-            for idx in title_indices:
-                commands.append(
-                    [
-                        str(self.makemkv_path),
-                        "-r",
-                        "--progress=-same",
-                        "mkv",
-                        drive_spec,
-                        str(idx),
-                        str(output_dir),
-                    ]
-                )
+            logger.info(f"Ripping {len(title_indices)} specific title(s): {title_indices}")
 
         # State tracking for progress
         current_title_idx = 0  # 0-based absolute index for progress reporting
@@ -779,11 +762,25 @@ class MakeMKVExtractor:
             try:
                 self._cancelled_jobs.discard(job_id)
 
-                for cmd in commands:
+                for title_index, cmd in commands:
                     if job_id in self._cancelled_jobs:
                         break
 
                     current_title_idx += 1
+
+                    # Live skip: a queued title the user skipped before MakeMKV
+                    # reached it is dropped here. (The "all" pass has
+                    # title_index None and cannot be skipped this way; those are
+                    # handled by deleting the finished file downstream.)
+                    if title_index is not None and title_index in self._skipped_indices.get(
+                        job_id, set()
+                    ):
+                        logger.info(
+                            f"Skipping title {title_index} (command "
+                            f"{current_title_idx}/{len(commands)}) - user-skipped"
+                        )
+                        continue
+
                     logger.info(
                         f"Executing rip command {current_title_idx}/{len(commands)}: "
                         f"{' '.join(cmd)}"

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -39,6 +39,7 @@ class TitleState(StrEnum):
     REVIEW = "review"  # Ripped successfully but needs human review for episode assignment
     COMPLETED = "completed"
     FAILED = "failed"
+    SKIPPED = "skipped"  # User skipped this track before ripping; excluded, not a failure
 
 
 class DiscJob(SQLModel, table=True):

--- a/backend/app/services/finalization_coordinator.py
+++ b/backend/app/services/finalization_coordinator.py
@@ -713,10 +713,21 @@ class FinalizationCoordinator:
         # All titles are terminal
         logger.info(f"All titles for job {job_id} effectively processed. Finalizing...")
 
-        has_matched = any(t.state == TitleState.MATCHED for t in titles)
-        has_review = any(t.state == TitleState.REVIEW for t in titles)
-        has_completed = any(t.state == TitleState.COMPLETED for t in titles)
-        all_failed = all(t.state == TitleState.FAILED for t in titles)
+        # SKIPPED titles are user-excluded and neutral to the outcome. If nothing
+        # else remains, the disc is done with nothing to organize.
+        matchable = [t for t in titles if t.state != TitleState.SKIPPED]
+        if not matchable:
+            logger.info(
+                f"Job {job_id}: all titles skipped by user, completing with nothing organized"
+            )
+            job.progress_percent = 100.0
+            await self._state_machine.transition_to_completed(job, session)
+            return
+
+        has_matched = any(t.state == TitleState.MATCHED for t in matchable)
+        has_review = any(t.state == TitleState.REVIEW for t in matchable)
+        has_completed = any(t.state == TitleState.COMPLETED for t in matchable)
+        all_failed = all(t.state == TitleState.FAILED for t in matchable)
 
         # Detect a same-name wrong-show pick up front (pure, no IO): EVERY episode
         # candidate matched nothing AND a same-name twin is persisted. Computed
@@ -724,7 +735,7 @@ class FinalizationCoordinator:
         # single confirming pass and (b) route to the re-identify review once that
         # pass also comes back empty. Titles aren't mutated within this call, so
         # the verdict stays valid down to the branch below.
-        wrong_show = _detect_wrong_show(job, titles)
+        wrong_show = _detect_wrong_show(job, matchable)
 
         # No reference subtitles ever arrived (#370): matching could not have
         # succeeded, and deep re-match escalation would just burn ASR passes
@@ -733,7 +744,7 @@ class FinalizationCoordinator:
         # A still-"downloading" status lands here too, deliberately: titles only
         # go all-terminal mid-download via force-advance or the subtitle-wait
         # timeout, and in both cases "retry the download" is the right advice.
-        if _no_reference_subtitles(job, titles):
+        if _no_reference_subtitles(job, matchable):
             show = job.tmdb_name or job.detected_title or "this show"
             reason = (
                 f"Episode matching couldn't run: no reference subtitles were "
@@ -751,7 +762,7 @@ class FinalizationCoordinator:
         # breaks or the whole track has been transcribed. Runs BEFORE the
         # has_review short-circuit so a pass that leaves one title unmatched
         # doesn't abort escalation of the titles still colliding.
-        if await self._maybe_escalate_conflicts(session, job, titles):
+        if await self._maybe_escalate_conflicts(session, job, matchable):
             return
 
         # Then give plain low-confidence reviews (no collision) escalating deep
@@ -760,7 +771,7 @@ class FinalizationCoordinator:
         # confirming pass instead of the full ladder — so a disc identified as the
         # wrong same-named show doesn't burn 3 ASR passes against the wrong corpus.
         if await self._maybe_escalate_reviews(
-            session, job, titles, wrong_show_suspected=bool(wrong_show)
+            session, job, matchable, wrong_show_suspected=bool(wrong_show)
         ):
             return
 
@@ -789,7 +800,7 @@ class FinalizationCoordinator:
             await self._park_in_review(
                 session,
                 job,
-                f"{sum(1 for t in titles if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
+                f"{sum(1 for t in matchable if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
             )
         elif has_matched:
             try:
@@ -1478,7 +1489,9 @@ class FinalizationCoordinator:
             select(DiscTitle).where(
                 DiscTitle.job_id == job_id,
                 DiscTitle.matched_episode.is_(None),
-                DiscTitle.state.notin_([TitleState.COMPLETED, TitleState.FAILED]),
+                DiscTitle.state.notin_(
+                    [TitleState.COMPLETED, TitleState.FAILED, TitleState.SKIPPED]
+                ),
             )
         )
         unresolved = result.scalars().all()
@@ -1686,7 +1699,9 @@ class FinalizationCoordinator:
                     DiscTitle.job_id == job_id,
                     DiscTitle.matched_episode.isnot(None),
                     DiscTitle.matched_episode != "skip",
-                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
+                    DiscTitle.state.not_in(
+                        [TitleState.COMPLETED, TitleState.FAILED, TitleState.SKIPPED]
+                    ),
                 )
             )
             matched_titles = result.scalars().all()
@@ -1795,7 +1810,9 @@ class FinalizationCoordinator:
             unresolved_result = await session.execute(
                 select(DiscTitle).where(
                     DiscTitle.job_id == job_id,
-                    DiscTitle.state.not_in([TitleState.COMPLETED, TitleState.FAILED]),
+                    DiscTitle.state.not_in(
+                        [TitleState.COMPLETED, TitleState.FAILED, TitleState.SKIPPED]
+                    ),
                     DiscTitle.matched_episode.is_(None),
                 )
             )

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2978,18 +2978,21 @@ class JobManager:
 
             if title.state == TitleState.SKIPPED:
                 # Mid-"all"-pass skip: MakeMKV wrote this title before we could
-                # drop it. Best-effort: delete the file and do not match it.
-                # path.name derives from the disc-supplied output filename, so
-                # sanitize it before logging (py/log-injection).
-                safe_name = sanitize_log_value(path.name)
+                # drop it. Best-effort: delete the file and do not match it. Log
+                # by title_index only (the disc-derived filename is a log-injection
+                # sink, py/log-injection); e.strerror is the OS reason without the
+                # path.
                 try:
                     path.unlink(missing_ok=True)
                     logger.info(
                         f"Job {job_id}: title {title.title_index} skipped by user, "
-                        f"deleted ripped file {safe_name}"
+                        f"deleted its ripped file"
                     )
                 except OSError as e:
-                    logger.warning(f"Job {job_id}: could not delete skipped file {safe_name}: {e}")
+                    logger.warning(
+                        f"Job {job_id}: could not delete skipped file for title "
+                        f"{title.title_index}: {e.strerror}"
+                    )
                 await self._finalization.check_job_completion(session, job_id)
                 return
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2978,20 +2978,20 @@ class JobManager:
 
             if title.state == TitleState.SKIPPED:
                 # Mid-"all"-pass skip: MakeMKV wrote this title before we could
-                # drop it. Best-effort: delete the file and do not match it. Log
-                # by title_index only (the disc-derived filename is a log-injection
-                # sink, py/log-injection); e.strerror is the OS reason without the
-                # path.
+                # drop it. Best-effort: delete the file and do not match it.
+                # title_index and strerror derive from the disc scan, so sanitize
+                # them inline before logging (py/log-injection), matching this
+                # file's established sanitize_log_value pattern.
                 try:
                     path.unlink(missing_ok=True)
                     logger.info(
-                        f"Job {job_id}: title {title.title_index} skipped by user, "
-                        f"deleted its ripped file"
+                        f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
+                        f"skipped by user, deleted its ripped file"
                     )
                 except OSError as e:
                     logger.warning(
                         f"Job {job_id}: could not delete skipped file for title "
-                        f"{title.title_index}: {e.strerror}"
+                        f"{sanitize_log_value(title.title_index)}: {sanitize_log_value(e.strerror)}"
                     )
                 await self._finalization.check_job_completion(session, job_id)
                 return

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2985,13 +2985,15 @@ class JobManager:
                 try:
                     path.unlink(missing_ok=True)
                     logger.info(
-                        f"Job {job_id}: title {sanitize_log_value(title.title_index)} "
-                        f"skipped by user, deleted its ripped file"
+                        f"Job {sanitize_log_value(job_id)}: title "
+                        f"{sanitize_log_value(title.title_index)} skipped by user, "
+                        f"deleted its ripped file"
                     )
                 except OSError as e:
                     logger.warning(
-                        f"Job {job_id}: could not delete skipped file for title "
-                        f"{sanitize_log_value(title.title_index)}: {sanitize_log_value(e.strerror)}"
+                        f"Job {sanitize_log_value(job_id)}: could not delete skipped "
+                        f"file for title {sanitize_log_value(title.title_index)}: "
+                        f"{sanitize_log_value(e.strerror)}"
                     )
                 await self._finalization.check_job_completion(session, job_id)
                 return

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2196,10 +2196,14 @@ class JobManager:
                     titles_to_rip = [dt for dt in disc_titles if dt.is_selected]
 
                 # Safety net: transition deselected PENDING titles to terminal state
+                # SKIPPED titles are already terminal, leave them alone. Only a
+                # deselected-but-still-PENDING title needs the safety-net nudge.
                 deselected_ids = [
                     dt.id
                     for dt in disc_titles
-                    if not dt.is_selected and dt.state == TitleState.PENDING
+                    if not dt.is_selected
+                    and dt.state == TitleState.PENDING
+                    and dt.state != TitleState.SKIPPED
                 ]
                 if deselected_ids:
                     async with async_session() as cleanup_session:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1307,6 +1307,71 @@ class JobManager:
             await self._finalization.check_job_completion(session, job_id)
         return True
 
+    async def skip_rip_title(self, job_id: int, title_id: int) -> bool:
+        """Skip a queued/not-yet-ripped title so MakeMKV does not rip it.
+
+        Acts only on PENDING or QUEUED titles (never one actively RIPPING or
+        already terminal). Marks the title SKIPPED + deselected, registers its
+        index in the extractor's live skip-set (honored by the per-title rip
+        loop), then re-checks job completion. Returns False if the title is not
+        in a skippable state.
+        """
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                return False
+            if title.state not in (TitleState.PENDING, TitleState.QUEUED):
+                return False
+
+            title.state = TitleState.SKIPPED
+            title.is_selected = False
+            title.match_details = json.dumps({"reason": "Skipped by user", "skipped": True})
+            session.add(title)
+            await session.commit()
+            title_index = title.title_index
+
+            # Live skip for an in-progress per-title rip loop.
+            self._extractor.skip_title_index(job_id, title_index)
+
+            logger.info(
+                f"Job {sanitize_log_value(job_id)}: title "
+                f"{sanitize_log_value(title_index)} skipped by user -> SKIPPED"
+            )
+            await ws_manager.broadcast_title_update(job_id, title_id, TitleState.SKIPPED.value)
+            await self._finalization.check_job_completion(session, job_id)
+        return True
+
+    async def unskip_rip_title(self, job_id: int, title_id: int) -> bool:
+        """Reverse a skip while the title's file has not been written yet.
+
+        Allowed only while the title is still SKIPPED and no output file exists.
+        Restores PENDING + selected and clears the extractor skip-set entry.
+        """
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                return False
+            if title.state != TitleState.SKIPPED:
+                return False
+            if title.output_filename:
+                return False
+
+            title.state = TitleState.PENDING
+            title.is_selected = True
+            title.match_details = None
+            session.add(title)
+            await session.commit()
+            title_index = title.title_index
+
+            self._extractor.unskip_title_index(job_id, title_index)
+
+            logger.info(
+                f"Job {sanitize_log_value(job_id)}: title "
+                f"{sanitize_log_value(title_index)} un-skipped -> PENDING"
+            )
+            await ws_manager.broadcast_title_update(job_id, title_id, TitleState.PENDING.value)
+        return True
+
     @staticmethod
     def _forced_review_details(existing: str | None, reason: str) -> str:
         """Tag a title's match_details as force-advanced/skipped to REVIEW.

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2972,6 +2972,20 @@ class JobManager:
             if not title:
                 return
 
+            if title.state == TitleState.SKIPPED:
+                # Mid-"all"-pass skip: MakeMKV wrote this title before we could
+                # drop it. Best-effort: delete the file and do not match it.
+                try:
+                    path.unlink(missing_ok=True)
+                    logger.info(
+                        f"Job {job_id}: title {title.title_index} skipped by user, "
+                        f"deleted ripped file {path.name}"
+                    )
+                except OSError as e:
+                    logger.warning(f"Job {job_id}: could not delete skipped file {path.name}: {e}")
+                await self._finalization.check_job_completion(session, job_id)
+                return
+
             title.output_filename = str(path)
 
             job = await session.get(DiscJob, job_id)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2979,14 +2979,17 @@ class JobManager:
             if title.state == TitleState.SKIPPED:
                 # Mid-"all"-pass skip: MakeMKV wrote this title before we could
                 # drop it. Best-effort: delete the file and do not match it.
+                # path.name derives from the disc-supplied output filename, so
+                # sanitize it before logging (py/log-injection).
+                safe_name = sanitize_log_value(path.name)
                 try:
                     path.unlink(missing_ok=True)
                     logger.info(
                         f"Job {job_id}: title {title.title_index} skipped by user, "
-                        f"deleted ripped file {path.name}"
+                        f"deleted ripped file {safe_name}"
                     )
                 except OSError as e:
-                    logger.warning(f"Job {job_id}: could not delete skipped file {path.name}: {e}")
+                    logger.warning(f"Job {job_id}: could not delete skipped file {safe_name}: {e}")
                 await self._finalization.check_job_completion(session, job_id)
                 return
 

--- a/backend/tests/integration/test_track_skipping.py
+++ b/backend/tests/integration/test_track_skipping.py
@@ -1,0 +1,83 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _seed():
+    async with async_session() as s:
+        job = DiscJob(
+            drive_id="Z:",
+            volume_label="T",
+            state=JobState.RIPPING,
+            content_type=ContentType.TV,
+            staging_path="/tmp/x",
+        )
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        # Seed two titles: skipping one must not auto-complete the job, so the
+        # un-skip round-trip stays exercisable against a still-running job.
+        t = DiscTitle(
+            job_id=job.id,
+            title_index=4,
+            duration_seconds=300,
+            state=TitleState.PENDING,
+            is_selected=True,
+        )
+        other = DiscTitle(
+            job_id=job.id,
+            title_index=5,
+            duration_seconds=300,
+            state=TitleState.PENDING,
+            is_selected=True,
+        )
+        s.add(t)
+        s.add(other)
+        await s.commit()
+        await s.refresh(t)
+        return job.id, t.id
+
+
+async def test_skip_and_unskip_endpoints(client):
+    job_id, title_id = await _seed()
+
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/skip-rip")
+    assert r.status_code == 200
+    assert r.json()["status"] == "skipped"
+    async with async_session() as s:
+        assert (await s.get(DiscTitle, title_id)).state == TitleState.SKIPPED
+
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/unskip-rip")
+    assert r.status_code == 200
+    async with async_session() as s:
+        assert (await s.get(DiscTitle, title_id)).state == TitleState.PENDING
+
+
+async def test_skip_rejects_terminal_job(client):
+    job_id, title_id = await _seed()
+    async with async_session() as s:
+        job = await s.get(DiscJob, job_id)
+        job.state = JobState.COMPLETED
+        await s.commit()
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/skip-rip")
+    assert r.status_code == 400

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -176,6 +176,13 @@ async def isolate_database(monkeypatch):
     # — a stale entry would silently skip an unrelated test's dispatch.
     _jm_inst._inflight_match_dispatch.clear()
 
+    # Same hazard for the extractor's per-job skip-set: skip_rip_title registers a
+    # job_id -> {title_index} entry that is only cleared at rip end / shutdown
+    # (neither runs in unit tests). With job ids restarting at 1 per in-memory DB,
+    # a stale entry would make an unrelated test's per-title rip silently skip a
+    # title. Clear it so each test starts with an empty skip-set.
+    _jm_inst._extractor._skipped_indices.clear()
+
     yield
 
     async with _unit_engine.begin() as conn:

--- a/backend/tests/unit/test_completion_skipped.py
+++ b/backend/tests/unit/test_completion_skipped.py
@@ -12,6 +12,24 @@ def async_session():
 
 
 @pytest.fixture(autouse=True)
+def _no_discord_task(monkeypatch):
+    """These tests drive jobs to COMPLETED/FAILED, whose terminal hook
+    fire-and-forgets a Discord notification via asyncio.create_task. That
+    detached task opens an async_session on the StaticPool in-memory DB and can
+    outlive the test's event loop, leaking a connection and intermittently
+    locking the shared DB for a later test. Stub the sender so completion here is
+    side-effect-free. (_send_discord_notification is resolved on self at call
+    time, so patching the instance attribute is honored even though
+    _notify_discord_on_terminal is a pre-registered terminal callback.)
+    """
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(job_manager, "_send_discord_notification", _noop)
+
+
+@pytest.fixture(autouse=True)
 async def _clean_db():
     await init_db()
     async with async_session() as s:

--- a/backend/tests/unit/test_completion_skipped.py
+++ b/backend/tests/unit/test_completion_skipped.py
@@ -1,0 +1,73 @@
+import pytest
+from sqlalchemy import text
+
+import app.database as _db
+from app.database import init_db
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.services.job_manager import job_manager
+
+
+def async_session():
+    return _db.async_session()
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _job_with_titles(states):
+    async with async_session() as s:
+        job = DiscJob(
+            drive_id="Z:",
+            volume_label="T",
+            state=JobState.MATCHING,
+            content_type=ContentType.MOVIE,
+            staging_path="/tmp/x",
+        )
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        for i, st in enumerate(states):
+            s.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=i,
+                    duration_seconds=100,
+                    state=st,
+                    is_selected=(st != TitleState.SKIPPED),
+                    matched_episode=("S01E01" if st == TitleState.MATCHED else None),
+                )
+            )
+        await s.commit()
+        return job.id
+
+
+async def _final_state(job_id):
+    async with async_session() as s:
+        return (await s.get(DiscJob, job_id)).state
+
+
+async def test_all_skipped_completes():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.SKIPPED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.COMPLETED
+
+
+async def test_skipped_plus_completed_completes():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.COMPLETED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.COMPLETED
+
+
+async def test_skipped_plus_failed_is_failed():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.FAILED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.FAILED

--- a/backend/tests/unit/test_completion_skipped.py
+++ b/backend/tests/unit/test_completion_skipped.py
@@ -2,7 +2,6 @@ import pytest
 from sqlalchemy import text
 
 import app.database as _db
-from app.database import init_db
 from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
 from app.services.job_manager import job_manager
 
@@ -31,7 +30,7 @@ def _no_discord_task(monkeypatch):
 
 @pytest.fixture(autouse=True)
 async def _clean_db():
-    await init_db()
+    await _db.init_db()
     async with async_session() as s:
         await s.execute(text("DELETE FROM disc_titles"))
         await s.execute(text("DELETE FROM disc_jobs"))

--- a/backend/tests/unit/test_extractor_skip.py
+++ b/backend/tests/unit/test_extractor_skip.py
@@ -1,4 +1,4 @@
-from app.core.extractor import MakeMKVExtractor
+from app.core.extractor import MakeMKVExtractor, _build_rip_commands
 
 
 def test_skip_set_registration_and_clear():
@@ -14,3 +14,18 @@ def test_skip_set_registration_and_clear():
     ext.unskip_title_index(999, 1)
     ext.unskip_title_index(5, 999)
     assert ext._skipped_indices[5] == {7}
+
+
+def test_build_rip_commands_all_selected_uses_all_pass():
+    cmds = _build_rip_commands("makemkvcon", "dev:F:", "/out", None)
+    assert len(cmds) == 1
+    title_index, cmd = cmds[0]
+    assert title_index is None  # "all" pass has no single title index
+    assert cmd[-1] == "/out"
+    assert "all" in cmd
+
+
+def test_build_rip_commands_subset_is_per_title_with_indices():
+    cmds = _build_rip_commands("makemkvcon", "dev:F:", "/out", [2, 4])
+    assert [ti for ti, _ in cmds] == [2, 4]
+    assert all(str(ti) in cmd for ti, cmd in cmds)

--- a/backend/tests/unit/test_extractor_skip.py
+++ b/backend/tests/unit/test_extractor_skip.py
@@ -1,0 +1,16 @@
+from app.core.extractor import MakeMKVExtractor
+
+
+def test_skip_set_registration_and_clear():
+    ext = MakeMKVExtractor()
+    ext.skip_title_index(5, 3)
+    ext.skip_title_index(5, 7)
+    assert ext._skipped_indices[5] == {3, 7}
+
+    ext.unskip_title_index(5, 3)
+    assert ext._skipped_indices[5] == {7}
+
+    # Unknown job / index is a no-op, never raises.
+    ext.unskip_title_index(999, 1)
+    ext.unskip_title_index(5, 999)
+    assert ext._skipped_indices[5] == {7}

--- a/backend/tests/unit/test_skip_rip_title.py
+++ b/backend/tests/unit/test_skip_rip_title.py
@@ -1,6 +1,79 @@
-from app.models.disc_job import TitleState
+import pytest
+from sqlalchemy import text
+
+import app.database as _db
+from app.database import init_db
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.services.job_manager import job_manager
 
 
 def test_skipped_state_exists_and_is_distinct():
     assert TitleState.SKIPPED == "skipped"
     assert TitleState.SKIPPED not in (TitleState.COMPLETED, TitleState.FAILED)
+
+
+def async_session():
+    # Resolve dynamically so the unit conftest's monkeypatch of
+    # app.database.async_session (in-memory engine) is honored; a module-level
+    # `from app.database import async_session` would bind the real engine and
+    # diverge from the session job_manager uses.
+    return _db.async_session()
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _make_job(state=JobState.RIPPING, title_state=TitleState.PENDING):
+    async with async_session() as s:
+        job = DiscJob(
+            drive_id="Z:",
+            volume_label="TEST",
+            state=state,
+            content_type=ContentType.TV,
+            staging_path="/tmp/none",
+        )
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        title = DiscTitle(
+            job_id=job.id, title_index=3, duration_seconds=1200, state=title_state, is_selected=True
+        )
+        s.add(title)
+        await s.commit()
+        await s.refresh(title)
+        return job.id, title.id
+
+
+async def test_skip_rip_pending_title_marks_skipped():
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    ok = await job_manager.skip_rip_title(job_id, title_id)
+    assert ok is True
+    async with async_session() as s:
+        t = await s.get(DiscTitle, title_id)
+        assert t.state == TitleState.SKIPPED
+        assert t.is_selected is False
+    assert 3 in job_manager._extractor._skipped_indices.get(job_id, set())
+
+
+async def test_skip_rip_rejects_ripping_title():
+    job_id, title_id = await _make_job(title_state=TitleState.RIPPING)
+    ok = await job_manager.skip_rip_title(job_id, title_id)
+    assert ok is False
+
+
+async def test_unskip_restores_pending():
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    await job_manager.skip_rip_title(job_id, title_id)
+    ok = await job_manager.unskip_rip_title(job_id, title_id)
+    assert ok is True
+    async with async_session() as s:
+        t = await s.get(DiscTitle, title_id)
+        assert t.state == TitleState.PENDING
+        assert t.is_selected is True
+    assert 3 not in job_manager._extractor._skipped_indices.get(job_id, set())

--- a/backend/tests/unit/test_skip_rip_title.py
+++ b/backend/tests/unit/test_skip_rip_title.py
@@ -47,6 +47,18 @@ async def _make_job(state=JobState.RIPPING, title_state=TitleState.PENDING):
             job_id=job.id, title_index=3, duration_seconds=1200, state=title_state, is_selected=True
         )
         s.add(title)
+        # A second, always-active guard title so skipping `title` never leaves the
+        # job all-terminal — that would fire job completion (and its terminal-state
+        # hooks) inside the skip, an unwanted side effect for these unit tests. The
+        # all-skipped completion path is covered directly in test_completion_skipped.
+        guard = DiscTitle(
+            job_id=job.id,
+            title_index=99,
+            duration_seconds=1200,
+            state=TitleState.PENDING,
+            is_selected=True,
+        )
+        s.add(guard)
         await s.commit()
         await s.refresh(title)
         return job.id, title.id

--- a/backend/tests/unit/test_skip_rip_title.py
+++ b/backend/tests/unit/test_skip_rip_title.py
@@ -1,0 +1,6 @@
+from app.models.disc_job import TitleState
+
+
+def test_skipped_state_exists_and_is_distinct():
+    assert TitleState.SKIPPED == "skipped"
+    assert TitleState.SKIPPED not in (TitleState.COMPLETED, TitleState.FAILED)

--- a/backend/tests/unit/test_skip_rip_title.py
+++ b/backend/tests/unit/test_skip_rip_title.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from sqlalchemy import text
 
@@ -77,3 +79,22 @@ async def test_unskip_restores_pending():
         assert t.state == TitleState.PENDING
         assert t.is_selected is True
     assert 3 not in job_manager._extractor._skipped_indices.get(job_id, set())
+
+
+async def test_on_title_ripped_deletes_skipped_file(tmp_path):
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    await job_manager.skip_rip_title(job_id, title_id)
+
+    fake = tmp_path / "TEST_t03.mkv"
+    fake.write_bytes(b"x" * 1024)
+
+    async with async_session() as s:
+        title = await s.get(DiscTitle, title_id)
+        sorted_titles = [title]
+
+    await job_manager._on_title_ripped(job_id, 1, Path(fake), sorted_titles)
+
+    assert not fake.exists()
+    async with async_session() as s:
+        t = await s.get(DiscTitle, title_id)
+        assert t.state == TitleState.SKIPPED

--- a/backend/tests/unit/test_skip_rip_title.py
+++ b/backend/tests/unit/test_skip_rip_title.py
@@ -4,7 +4,6 @@ import pytest
 from sqlalchemy import text
 
 import app.database as _db
-from app.database import init_db
 from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
 from app.services.job_manager import job_manager
 
@@ -24,7 +23,7 @@ def async_session():
 
 @pytest.fixture(autouse=True)
 async def _clean_db():
-    await init_db()
+    await _db.init_db()
     async with async_session() as s:
         await s.execute(text("DELETE FROM disc_titles"))
         await s.execute(text("DELETE FROM disc_jobs"))

--- a/docs/superpowers/plans/2026-07-03-track-skipping.md
+++ b/docs/superpowers/plans/2026-07-03-track-skipping.md
@@ -1,0 +1,1262 @@
+# Manual Track Skipping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users manually skip a queued / not-yet-ripped track so MakeMKV does not waste rip time on it (e.g. a bogus play-all concatenation), with a distinct reversible `SKIPPED` disposition.
+
+**Architecture:** A new terminal `TitleState.SKIPPED`, paired with the existing `is_selected` flag. Pre-rip skips shrink the selection and route to the per-title rip loop automatically. Mid-rip skips register in a live skip-set the extractor checks before each per-title command (guaranteed skip); during a full-disc `all` pass the file is written anyway and deleted at completion (best-effort). `SKIPPED` is neutral to job completion: it never blocks, never counts as a failure.
+
+**Tech Stack:** Python 3.11 / FastAPI / SQLModel / aiosqlite (backend), pytest; React 18 / TypeScript / Vite (frontend), Playwright.
+
+**Design spec:** `docs/superpowers/specs/2026-07-03-track-skipping-design.md`
+
+**Conventions:**
+- Backend commands run from `backend/` with `uv run` (e.g. `uv run pytest ...`). Never bare `python`/`pytest`.
+- Frontend commands run from `frontend/`.
+- Worktree DB may be a 0-byte stub; if a pipeline/integration test errors with "no such table", run `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first.
+- Do not use em dashes in code comments or changelog prose (project style).
+
+---
+
+## File Structure
+
+**Backend (modify):**
+- `backend/app/models/disc_job.py` — add `TitleState.SKIPPED`.
+- `backend/app/core/extractor.py` — live per-job skip-set; per-title loop honors it; `commands` become `(title_index, cmd)` tuples.
+- `backend/app/services/job_manager.py` — `skip_rip_title` / `unskip_rip_title`; `_on_title_ripped` deletes a SKIPPED file; `_run_ripping` treats SKIPPED as deselected.
+- `backend/app/services/finalization_coordinator.py` — SKIPPED excluded from the unresolved query; all-skipped short-circuit to COMPLETED; outcome booleans computed over non-skipped titles.
+- `backend/app/api/routes.py` — `skip-rip` / `unskip-rip` endpoints.
+
+**Frontend (modify):**
+- `frontend/src/types/index.ts` — `'skipped'` in `TitleState`.
+- `frontend/src/types/adapters.ts` — `'skipped'` in the state map.
+- `frontend/src/app/components/DiscCard.tsx` — `'skipped'` in `TrackState`; `onSkipTrack` / `onUnskipTrack` props threaded to `TrackGrid`.
+- `frontend/src/app/components/TrackGrid.tsx` — `skipped` STATE entry; skip / un-skip controls.
+- `frontend/src/api/client.ts` — `skipRipTitle` / `unskipRipTitle`.
+- `frontend/src/app/App.tsx` (+ `hooks/useJobManagement.ts` if that is where per-track handlers live) — wire handlers.
+
+**Tests (create/modify):**
+- `backend/tests/unit/test_extractor_skip.py` (create)
+- `backend/tests/unit/test_skip_rip_title.py` (create)
+- `backend/tests/integration/test_track_skipping.py` (create)
+- `backend/tests/unit/test_completion_skipped.py` (create)
+- `frontend/e2e/track-skipping.spec.ts` (create)
+
+---
+
+## Task 1: Add the `SKIPPED` title state
+
+**Files:**
+- Modify: `backend/app/models/disc_job.py:31-41`
+- Test: `backend/tests/unit/test_skip_rip_title.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/unit/test_skip_rip_title.py
+from app.models.disc_job import TitleState
+
+
+def test_skipped_state_exists_and_is_distinct():
+    assert TitleState.SKIPPED == "skipped"
+    assert TitleState.SKIPPED not in (TitleState.COMPLETED, TitleState.FAILED)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py::test_skipped_state_exists_and_is_distinct -v`
+Expected: FAIL with `AttributeError: SKIPPED`.
+
+- [ ] **Step 3: Add the enum value**
+
+In `backend/app/models/disc_job.py`, add to `TitleState` (after `FAILED`):
+
+```python
+class TitleState(StrEnum):
+    """State of an individual title."""
+
+    PENDING = "pending"
+    RIPPING = "ripping"
+    QUEUED = "queued"  # Ripped/on disk, waiting for a matching slot (subtitle + semaphore wait)
+    MATCHING = "matching"
+    MATCHED = "matched"  # Intermediate state: matched but not yet organized
+    REVIEW = "review"  # Ripped successfully but needs human review for episode assignment
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"  # User skipped this track before ripping; excluded, not a failure
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py::test_skipped_state_exists_and_is_distinct -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models/disc_job.py backend/tests/unit/test_skip_rip_title.py
+git commit -m "feat(model): add TitleState.SKIPPED for manual track skipping"
+```
+
+---
+
+## Task 2: Extractor honors a live skip-set in the per-title loop
+
+The extractor loops one command per title for subset rips. Register skipped `title_index` values so a title whose command has not started yet is dropped. Refactor `commands` to carry the title index.
+
+**Files:**
+- Modify: `backend/app/core/extractor.py` (`__init__` ~382-389; `_rip_titles_unlocked` command build ~567-613 and loop ~775-783)
+- Test: `backend/tests/unit/test_extractor_skip.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/unit/test_extractor_skip.py
+from app.core.extractor import MakeMKVExtractor
+
+
+def test_skip_set_registration_and_clear():
+    ext = MakeMKVExtractor()
+    ext.skip_title_index(5, 3)
+    ext.skip_title_index(5, 7)
+    assert ext._skipped_indices[5] == {3, 7}
+
+    ext.unskip_title_index(5, 3)
+    assert ext._skipped_indices[5] == {7}
+
+    # Unknown job / index is a no-op, never raises.
+    ext.unskip_title_index(999, 1)
+    ext.unskip_title_index(5, 999)
+    assert ext._skipped_indices[5] == {7}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_extractor_skip.py::test_skip_set_registration_and_clear -v`
+Expected: FAIL with `AttributeError: 'MakeMKVExtractor' object has no attribute 'skip_title_index'`.
+
+- [ ] **Step 3: Add the skip-set state and methods**
+
+In `MakeMKVExtractor.__init__`, after `self._cancelled_jobs: set[int] = set()`:
+
+```python
+        self._cancelled_jobs: set[int] = set()
+        # Per-job set of title_index values to skip. Checked before each
+        # per-title rip command so a queued-but-not-yet-ripped title can be
+        # dropped mid-rip. A full-disc "all" pass cannot honor this (one process
+        # rips everything); those skips are handled downstream by deleting the
+        # finished file. Single-writer per job under the rip thread + async
+        # skip calls; set mutation is atomic under the GIL.
+        self._skipped_indices: dict[int, set[int]] = {}
+```
+
+Add these methods (near `cancel`):
+
+```python
+    def skip_title_index(self, job_id: int, title_index: int) -> None:
+        """Register a title_index to skip in the per-title rip loop for a job."""
+        self._skipped_indices.setdefault(job_id, set()).add(title_index)
+
+    def unskip_title_index(self, job_id: int, title_index: int) -> None:
+        """Remove a previously-registered skip (no-op if absent)."""
+        s = self._skipped_indices.get(job_id)
+        if s:
+            s.discard(title_index)
+```
+
+Also clear the set on job end. In the `finally` block of `run_rip_with_streaming` (currently `self._processes.pop(job_id, None)`), add alongside it:
+
+```python
+            finally:
+                self._processes.pop(job_id, None)
+                self._skipped_indices.pop(job_id, None)
+```
+
+And in `shutdown`, after `self._cancelled_jobs.clear()`:
+
+```python
+        self._processes.clear()
+        self._cancelled_jobs.clear()
+        self._skipped_indices.clear()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_extractor_skip.py::test_skip_set_registration_and_clear -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/core/extractor.py backend/tests/unit/test_extractor_skip.py
+git commit -m "feat(extractor): add per-job skip-set state + accessors"
+```
+
+---
+
+## Task 3: Extractor per-title loop skips registered indices
+
+Refactor `commands` to `(title_index, cmd)` tuples and check the skip-set before starting each command.
+
+**Files:**
+- Modify: `backend/app/core/extractor.py` (command build ~567-613; loop ~775-783)
+- Test: `backend/tests/unit/test_extractor_skip.py`
+
+- [ ] **Step 1: Write the failing test**
+
+This test drives the loop's command-building + skip logic without spawning MakeMKV, by asserting on the command list shape the refactor produces. Add a small pure helper so the mapping is testable.
+
+Add to `backend/tests/unit/test_extractor_skip.py`:
+
+```python
+from app.core.extractor import _build_rip_commands
+
+
+def test_build_rip_commands_all_selected_uses_all_pass():
+    cmds = _build_rip_commands("makemkvcon", "dev:F:", "/out", None)
+    assert len(cmds) == 1
+    title_index, cmd = cmds[0]
+    assert title_index is None  # "all" pass has no single title index
+    assert cmd[-1] == "/out"
+    assert "all" in cmd
+
+
+def test_build_rip_commands_subset_is_per_title_with_indices():
+    cmds = _build_rip_commands("makemkvcon", "dev:F:", "/out", [2, 4])
+    assert [ti for ti, _ in cmds] == [2, 4]
+    assert all(str(ti) in cmd for ti, cmd in cmds)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_extractor_skip.py -v`
+Expected: FAIL with `ImportError: cannot import name '_build_rip_commands'`.
+
+- [ ] **Step 3: Extract a command builder and use tuples**
+
+Add this module-level function to `backend/app/core/extractor.py` (near `_files_to_ignore`):
+
+```python
+def _build_rip_commands(
+    makemkv_path: str,
+    drive_spec: str,
+    output_dir: str,
+    title_indices: list[int] | None,
+) -> list[tuple[int | None, list[str]]]:
+    """Build ``(title_index, argv)`` rip commands.
+
+    ``title_index`` is None for the single full-disc "all" pass (which rips
+    every title in one MakeMKV invocation and cannot drop an individual title);
+    otherwise each command carries the specific title index so the rip loop can
+    consult the live skip-set before starting it.
+    """
+    base = [makemkv_path, "-r", "--progress=-same", "mkv", drive_spec]
+    if not title_indices:
+        return [(None, [*base, "all", output_dir])]
+    return [(idx, [*base, str(idx), output_dir]) for idx in title_indices]
+```
+
+Replace the command-building block in `_rip_titles_unlocked` (the `if not title_indices: ... elif len == 1: ... else: ...` block) with:
+
+```python
+        commands = _build_rip_commands(
+            str(self.makemkv_path),
+            drive_spec,
+            str(output_dir),
+            title_indices,
+        )
+        if not title_indices:
+            logger.info("Ripping ALL titles")
+        else:
+            logger.info(f"Ripping {len(title_indices)} specific title(s): {title_indices}")
+```
+
+In `run_rip_with_streaming`, change the loop header from `for cmd in commands:` to:
+
+```python
+                for title_index, cmd in commands:
+                    if job_id in self._cancelled_jobs:
+                        break
+
+                    current_title_idx += 1
+
+                    # Live skip: a queued title the user skipped before MakeMKV
+                    # reached it is dropped here. (The "all" pass has
+                    # title_index None and cannot be skipped this way; those are
+                    # handled by deleting the finished file downstream.)
+                    if (
+                        title_index is not None
+                        and title_index in self._skipped_indices.get(job_id, set())
+                    ):
+                        logger.info(
+                            f"Skipping title {title_index} (command "
+                            f"{current_title_idx}/{len(commands)}) — user-skipped"
+                        )
+                        continue
+
+                    logger.info(
+                        f"Executing rip command {current_title_idx}/{len(commands)}: "
+                        f"{' '.join(cmd)}"
+                    )
+```
+
+(Remove the now-duplicated `current_title_idx += 1` and the old `logger.info("Executing rip command ...")` that followed the original `for cmd in commands:`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_extractor_skip.py -v`
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Regression-check the extractor suite**
+
+Run: `cd backend && uv run pytest tests/ -k extractor -v`
+Expected: PASS. If any test asserted on the old command-building branches, update it to call `_build_rip_commands`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/core/extractor.py backend/tests/unit/test_extractor_skip.py
+git commit -m "feat(extractor): honor live skip-set in per-title rip loop"
+```
+
+---
+
+## Task 4: `skip_rip_title` / `unskip_rip_title` on JobManager
+
+**Files:**
+- Modify: `backend/app/services/job_manager.py` (add methods near `skip_title` ~1271)
+- Test: `backend/tests/unit/test_skip_rip_title.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/unit/test_skip_rip_title.py
+import pytest
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.services.job_manager import job_manager
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _make_job(state=JobState.RIPPING, title_state=TitleState.PENDING):
+    async with async_session() as s:
+        job = DiscJob(drive_id="Z:", volume_label="TEST", state=state,
+                      content_type=ContentType.TV, staging_path="/tmp/none")
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        title = DiscTitle(job_id=job.id, title_index=3, duration_seconds=1200,
+                          state=title_state, is_selected=True)
+        s.add(title)
+        await s.commit()
+        await s.refresh(title)
+        return job.id, title.id
+
+
+async def test_skip_rip_pending_title_marks_skipped():
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    ok = await job_manager.skip_rip_title(job_id, title_id)
+    assert ok is True
+    async with async_session() as s:
+        t = await s.get(DiscTitle, title_id)
+        assert t.state == TitleState.SKIPPED
+        assert t.is_selected is False
+    assert 3 in job_manager._extractor._skipped_indices.get(job_id, set())
+
+
+async def test_skip_rip_rejects_ripping_title():
+    job_id, title_id = await _make_job(title_state=TitleState.RIPPING)
+    ok = await job_manager.skip_rip_title(job_id, title_id)
+    assert ok is False
+
+
+async def test_unskip_restores_pending():
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    await job_manager.skip_rip_title(job_id, title_id)
+    ok = await job_manager.unskip_rip_title(job_id, title_id)
+    assert ok is True
+    async with async_session() as s:
+        t = await s.get(DiscTitle, title_id)
+        assert t.state == TitleState.PENDING
+        assert t.is_selected is True
+    assert 3 not in job_manager._extractor._skipped_indices.get(job_id, set())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py -v`
+Expected: FAIL with `AttributeError: 'JobManager' object has no attribute 'skip_rip_title'`.
+
+- [ ] **Step 3: Implement the methods**
+
+Add to `JobManager` in `backend/app/services/job_manager.py` (right after `skip_title`):
+
+```python
+    async def skip_rip_title(self, job_id: int, title_id: int) -> bool:
+        """Skip a queued/not-yet-ripped title so MakeMKV does not rip it.
+
+        Acts only on PENDING or QUEUED titles (never one actively RIPPING or
+        already terminal). Marks the title SKIPPED + deselected, registers its
+        index in the extractor's live skip-set (honored by the per-title rip
+        loop), then re-checks job completion. Returns False if the title is not
+        in a skippable state.
+        """
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                return False
+            if title.state not in (TitleState.PENDING, TitleState.QUEUED):
+                return False
+
+            title.state = TitleState.SKIPPED
+            title.is_selected = False
+            title.match_details = json.dumps(
+                {"reason": "Skipped by user", "skipped": True}
+            )
+            session.add(title)
+            await session.commit()
+            title_index = title.title_index
+
+            # Live skip for an in-progress per-title rip loop.
+            self._extractor.skip_title_index(job_id, title_index)
+
+            logger.info(
+                f"Job {sanitize_log_value(job_id)}: title "
+                f"{sanitize_log_value(title_index)} skipped by user -> SKIPPED"
+            )
+            await ws_manager.broadcast_title_update(
+                job_id, title_id, TitleState.SKIPPED.value
+            )
+            await self._finalization.check_job_completion(session, job_id)
+        return True
+
+    async def unskip_rip_title(self, job_id: int, title_id: int) -> bool:
+        """Reverse a skip while the title's file has not been written yet.
+
+        Allowed only while the title is still SKIPPED and no output file exists.
+        Restores PENDING + selected and clears the extractor skip-set entry.
+        """
+        async with async_session() as session:
+            title = await session.get(DiscTitle, title_id)
+            if not title or title.job_id != job_id:
+                return False
+            if title.state != TitleState.SKIPPED:
+                return False
+            if title.output_filename:
+                return False
+
+            title.state = TitleState.PENDING
+            title.is_selected = True
+            title.match_details = None
+            session.add(title)
+            await session.commit()
+            title_index = title.title_index
+
+            self._extractor.unskip_title_index(job_id, title_index)
+
+            logger.info(
+                f"Job {sanitize_log_value(job_id)}: title "
+                f"{sanitize_log_value(title_index)} un-skipped -> PENDING"
+            )
+            await ws_manager.broadcast_title_update(
+                job_id, title_id, TitleState.PENDING.value
+            )
+        return True
+```
+
+(`json` and `sanitize_log_value` are already imported in this module.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py -v`
+Expected: PASS (all tests). If a test errors with "no such table", run the `init_db()` one-liner from Conventions first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/job_manager.py backend/tests/unit/test_skip_rip_title.py
+git commit -m "feat(jobs): add skip_rip_title / unskip_rip_title"
+```
+
+---
+
+## Task 5: `_on_title_ripped` deletes a SKIPPED file (mid-`all`-pass path)
+
+During a full-disc `all` pass, MakeMKV writes a skipped title anyway. When its file completes, delete it and do not dispatch matching.
+
+**Files:**
+- Modify: `backend/app/services/job_manager.py` (`_on_title_ripped` ~2903-2910)
+- Test: `backend/tests/unit/test_skip_rip_title.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to backend/tests/unit/test_skip_rip_title.py
+from pathlib import Path
+
+from app.models.disc_job import DiscTitle as _DT  # alias to avoid shadowing
+
+
+async def test_on_title_ripped_deletes_skipped_file(tmp_path):
+    job_id, title_id = await _make_job(title_state=TitleState.PENDING)
+    # Mark it skipped first.
+    await job_manager.skip_rip_title(job_id, title_id)
+
+    fake = tmp_path / "TEST_t03.mkv"
+    fake.write_bytes(b"x" * 1024)
+
+    async with async_session() as s:
+        title = await s.get(_DT, title_id)
+        sorted_titles = [title]
+
+    await job_manager._on_title_ripped(job_id, 1, fake, sorted_titles)
+
+    assert not fake.exists()
+    async with async_session() as s:
+        t = await s.get(_DT, title_id)
+        assert t.state == TitleState.SKIPPED
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py::test_on_title_ripped_deletes_skipped_file -v`
+Expected: FAIL (file still exists — no delete branch yet).
+
+- [ ] **Step 3: Add the SKIPPED short-circuit**
+
+In `_on_title_ripped`, immediately after the `if not title: return` guard (~line 2908), insert:
+
+```python
+            if title.state == TitleState.SKIPPED:
+                # Mid-"all"-pass skip: MakeMKV wrote this title before we could
+                # drop it. Best-effort — delete the file and do not match it.
+                try:
+                    path.unlink(missing_ok=True)
+                    logger.info(
+                        f"Job {job_id}: title {title.title_index} skipped by user — "
+                        f"deleted ripped file {path.name}"
+                    )
+                except OSError as e:
+                    logger.warning(
+                        f"Job {job_id}: could not delete skipped file {path.name}: {e}"
+                    )
+                await self._finalization.check_job_completion(session, job_id)
+                return
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/test_skip_rip_title.py::test_on_title_ripped_deletes_skipped_file -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/job_manager.py backend/tests/unit/test_skip_rip_title.py
+git commit -m "feat(jobs): delete skipped title's file on completion in all-pass"
+```
+
+---
+
+## Task 6: `_run_ripping` treats SKIPPED like deselected
+
+Prevent the safety-net at `_run_ripping` from re-marking a SKIPPED title as extra/COMPLETED, and ensure it is excluded from the rip selection.
+
+**Files:**
+- Modify: `backend/app/services/job_manager.py:2114-2154`
+- Test: covered by the integration test in Task 8 (no separate unit test — this is a filter tweak verified end-to-end).
+
+- [ ] **Step 1: Update the selection + safety-net filters**
+
+In `_run_ripping`, the `has_selection` loop already skips non-selected titles (a SKIPPED title has `is_selected=False`, so it is excluded from `titles_to_rip` automatically). Update only the deselected-safety-net block so it does not touch SKIPPED titles. Change:
+
+```python
+                deselected_ids = [
+                    dt.id
+                    for dt in disc_titles
+                    if not dt.is_selected and dt.state == TitleState.PENDING
+                ]
+```
+
+to:
+
+```python
+                # SKIPPED titles are already terminal — leave them alone. Only a
+                # deselected-but-still-PENDING title needs the safety-net nudge.
+                deselected_ids = [
+                    dt.id
+                    for dt in disc_titles
+                    if not dt.is_selected
+                    and dt.state == TitleState.PENDING
+                    and dt.state != TitleState.SKIPPED
+                ]
+```
+
+(The `state == PENDING` guard already excludes SKIPPED; the explicit clause documents intent and is defensive against future reordering.)
+
+- [ ] **Step 2: Run the job_manager unit + pipeline suites**
+
+Run: `cd backend && uv run pytest tests/unit/ tests/pipeline/ -k "rip or ripping or select" -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/services/job_manager.py
+git commit -m "refactor(jobs): treat SKIPPED titles as terminal in _run_ripping"
+```
+
+---
+
+## Task 7: Completion logic treats SKIPPED as neutral
+
+`SKIPPED` is auto-excluded from `active_states`, but the "unresolved" query and the outcome booleans need updating so a partially- or fully-skipped disc completes correctly.
+
+**Files:**
+- Modify: `backend/app/services/finalization_coordinator.py` (completion decision ~713-808; unresolved query ~1477-1484)
+- Test: `backend/tests/unit/test_completion_skipped.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/unit/test_completion_skipped.py
+import pytest
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.services.job_manager import job_manager
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _job_with_titles(states):
+    async with async_session() as s:
+        job = DiscJob(drive_id="Z:", volume_label="T", state=JobState.MATCHING,
+                      content_type=ContentType.MOVIE, staging_path="/tmp/x")
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        for i, st in enumerate(states):
+            s.add(DiscTitle(job_id=job.id, title_index=i, duration_seconds=100,
+                            state=st, is_selected=(st != TitleState.SKIPPED),
+                            matched_episode=("S01E01" if st == TitleState.MATCHED else None)))
+        await s.commit()
+        return job.id
+
+
+async def _final_state(job_id):
+    async with async_session() as s:
+        return (await s.get(DiscJob, job_id)).state
+
+
+async def test_all_skipped_completes():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.SKIPPED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.COMPLETED
+
+
+async def test_skipped_plus_completed_completes():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.COMPLETED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.COMPLETED
+
+
+async def test_skipped_plus_failed_is_failed():
+    job_id = await _job_with_titles([TitleState.SKIPPED, TitleState.FAILED])
+    async with async_session() as s:
+        await job_manager._finalization.check_job_completion(s, job_id)
+    assert await _final_state(job_id) == JobState.FAILED
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/unit/test_completion_skipped.py -v`
+Expected: FAIL — `test_skipped_plus_failed_is_failed` and/or `test_all_skipped` land in the wrong state (all_failed computed over the full list, or the subtitle/escalation path misfires).
+
+- [ ] **Step 3: Compute outcome over non-skipped titles + short-circuit all-skipped**
+
+In `check_job_completion`, after the `active_titles` empty-check (~line 711, before `has_matched = ...`), insert the all-skipped short-circuit and a non-skipped working set:
+
+```python
+        # All titles are terminal
+        logger.info(f"All titles for job {job_id} effectively processed. Finalizing...")
+
+        # SKIPPED titles are user-excluded and neutral to the outcome. If nothing
+        # else remains, the disc is done with nothing to organize.
+        matchable = [t for t in titles if t.state != TitleState.SKIPPED]
+        if not matchable:
+            logger.info(
+                f"Job {job_id}: all titles skipped by user — completing with nothing organized"
+            )
+            job.progress_percent = 100.0
+            await self._state_machine.transition_to_completed(job, session)
+            return
+```
+
+Then change the outcome booleans to use `matchable` instead of `titles`:
+
+```python
+        has_matched = any(t.state == TitleState.MATCHED for t in matchable)
+        has_review = any(t.state == TitleState.REVIEW for t in matchable)
+        has_completed = any(t.state == TitleState.COMPLETED for t in matchable)
+        all_failed = all(t.state == TitleState.FAILED for t in matchable)
+```
+
+Also pass `matchable` (not `titles`) to the wrong-show, no-reference-subtitle, and escalation helpers so a skipped track never triggers deep re-match or a subtitle-review misfire:
+
+```python
+        wrong_show = _detect_wrong_show(job, matchable)
+        ...
+        if _no_reference_subtitles(job, matchable):
+        ...
+        if await self._maybe_escalate_conflicts(session, job, matchable):
+        ...
+        if await self._maybe_escalate_reviews(
+            session, job, matchable, wrong_show_suspected=bool(wrong_show)
+        ):
+```
+
+Leave the `has_review` count message using `titles` or `matchable` consistently — use `matchable`:
+
+```python
+                f"{sum(1 for t in matchable if t.state == TitleState.REVIEW)} title(s) need manual episode assignment",
+```
+
+- [ ] **Step 4: Exclude SKIPPED from the unresolved query**
+
+At `finalization_coordinator.py:1481`, change:
+
+```python
+                DiscTitle.state.notin_([TitleState.COMPLETED, TitleState.FAILED]),
+```
+
+to:
+
+```python
+                DiscTitle.state.notin_(
+                    [TitleState.COMPLETED, TitleState.FAILED, TitleState.SKIPPED]
+                ),
+```
+
+Search the file for any other `not_in([TitleState.COMPLETED, TitleState.FAILED])` / `notin_([TitleState.COMPLETED, TitleState.FAILED])` used to mean "still needs work" (grep below) and add `TitleState.SKIPPED` to each. The organize queries that also require `matched_episode.isnot(None)` do not need it (a SKIPPED title has no `matched_episode`), but adding it is harmless and consistent.
+
+Run: `cd backend && grep -n "COMPLETED, TitleState.FAILED" backend/app/services/finalization_coordinator.py`
+For each hit that is a "not terminal" filter, add `TitleState.SKIPPED`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/test_completion_skipped.py -v`
+Expected: PASS (all three).
+
+- [ ] **Step 6: Regression-check completion**
+
+Run: `cd backend && uv run pytest tests/ -k "completion or finaliz" -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/finalization_coordinator.py backend/tests/unit/test_completion_skipped.py
+git commit -m "feat(finalization): treat SKIPPED titles as neutral to completion"
+```
+
+---
+
+## Task 8: API endpoints + integration test
+
+**Files:**
+- Modify: `backend/app/api/routes.py` (near the existing `/skip` + `/rerip` ~975-1016)
+- Test: `backend/tests/integration/test_track_skipping.py` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# backend/tests/integration/test_track_skipping.py
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session, init_db
+from app.main import app
+from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db():
+    await init_db()
+    async with async_session() as s:
+        await s.execute(text("DELETE FROM disc_titles"))
+        await s.execute(text("DELETE FROM disc_jobs"))
+        await s.commit()
+
+
+async def _seed():
+    async with async_session() as s:
+        job = DiscJob(drive_id="Z:", volume_label="T", state=JobState.RIPPING,
+                      content_type=ContentType.TV, staging_path="/tmp/x")
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        t = DiscTitle(job_id=job.id, title_index=4, duration_seconds=300,
+                      state=TitleState.PENDING, is_selected=True)
+        s.add(t)
+        await s.commit()
+        await s.refresh(t)
+        return job.id, t.id
+
+
+async def test_skip_and_unskip_endpoints(client):
+    job_id, title_id = await _seed()
+
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/skip-rip")
+    assert r.status_code == 200
+    assert r.json()["status"] == "skipped"
+    async with async_session() as s:
+        assert (await s.get(DiscTitle, title_id)).state == TitleState.SKIPPED
+
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/unskip-rip")
+    assert r.status_code == 200
+    async with async_session() as s:
+        assert (await s.get(DiscTitle, title_id)).state == TitleState.PENDING
+
+
+async def test_skip_rejects_terminal_job(client):
+    job_id, title_id = await _seed()
+    async with async_session() as s:
+        job = await s.get(DiscJob, job_id)
+        job.state = JobState.COMPLETED
+        await s.commit()
+    r = await client.post(f"/api/jobs/{job_id}/titles/{title_id}/skip-rip")
+    assert r.status_code == 400
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/integration/test_track_skipping.py -v`
+Expected: FAIL with 404 (routes not defined).
+
+- [ ] **Step 3: Add the endpoints**
+
+In `backend/app/api/routes.py`, after the existing `rerip_title` route (~line 1016):
+
+```python
+@router.post("/jobs/{job_id}/titles/{title_id}/skip-rip")
+async def skip_rip_title(
+    title_id: int,
+    job: DiscJob = Depends(get_job_or_404),
+) -> dict:
+    """Skip a queued/not-yet-ripped title so MakeMKV does not rip it."""
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    from app.services.job_manager import job_manager
+
+    ok = await job_manager.skip_rip_title(job.id, title_id)
+    if not ok:
+        raise HTTPException(
+            status_code=400,
+            detail="Title not found, not part of this job, or not skippable "
+            "(only queued/not-yet-ripped titles can be skipped)",
+        )
+    return {"status": "skipped", "job_id": job.id, "title_id": title_id}
+
+
+@router.post("/jobs/{job_id}/titles/{title_id}/unskip-rip")
+async def unskip_rip_title(
+    title_id: int,
+    job: DiscJob = Depends(get_job_or_404),
+) -> dict:
+    """Reverse a skip while the title's file has not been written yet."""
+    if job.state in (JobState.COMPLETED, JobState.FAILED):
+        raise HTTPException(status_code=400, detail="Job has already finished")
+
+    from app.services.job_manager import job_manager
+
+    ok = await job_manager.unskip_rip_title(job.id, title_id)
+    if not ok:
+        raise HTTPException(
+            status_code=400,
+            detail="Title not found or no longer un-skippable (already ripped)",
+        )
+    return {"status": "unskipped", "job_id": job.id, "title_id": title_id}
+```
+
+(`JobState`, `HTTPException`, `Depends`, `get_job_or_404`, `DiscJob` are already imported in this module.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/integration/test_track_skipping.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/routes.py backend/tests/integration/test_track_skipping.py
+git commit -m "feat(api): add skip-rip / unskip-rip title endpoints"
+```
+
+---
+
+## Task 9: Backend lint + full suite gate
+
+- [ ] **Step 1: Lint + format**
+
+Run: `cd backend && uv run ruff check . && uv run ruff format --check .`
+Expected: no errors. Run `uv run ruff format .` if formatting differs, then re-check.
+
+- [ ] **Step 2: Run the full backend suite**
+
+Run: `cd backend && uv run pytest -q`
+Expected: PASS. Investigate and fix any regression before proceeding (do not skip).
+
+- [ ] **Step 3: Commit any lint/format fixups**
+
+```bash
+git add -A
+git commit -m "chore: lint + format for track skipping" || echo "nothing to commit"
+```
+
+---
+
+## Task 10: Frontend `skipped` state plumbing
+
+**Files:**
+- Modify: `frontend/src/types/index.ts:15`
+- Modify: `frontend/src/types/adapters.ts:29-38`
+- Modify: `frontend/src/app/components/DiscCard.tsx:18`
+- Modify: `frontend/src/api/client.ts` (near `reripTitle` ~191)
+
+- [ ] **Step 1: Add `'skipped'` to the backend title-state union**
+
+`frontend/src/types/index.ts:15`:
+
+```typescript
+export type TitleState = 'pending' | 'ripping' | 'queued' | 'matching' | 'matched' | 'review' | 'completed' | 'failed' | 'skipped';
+```
+
+- [ ] **Step 2: Add `'skipped'` to `TrackState`**
+
+`frontend/src/app/components/DiscCard.tsx:18`:
+
+```typescript
+export type TrackState = "pending" | "ripping" | "queued" | "matching" | "matched" | "review" | "failed" | "completed" | "skipped";
+```
+
+- [ ] **Step 3: Map it in the adapter**
+
+`frontend/src/types/adapters.ts`, inside the `stateMap`:
+
+```typescript
+  const stateMap: Record<BackendTitleState, TrackState> = {
+    'pending': 'pending',
+    'ripping': 'ripping',
+    'queued': 'queued',
+    'matching': 'matching',
+    'matched': 'matched',
+    'review': 'review',
+    'completed': 'completed',
+    'failed': 'failed',
+    'skipped': 'skipped'
+  };
+```
+
+- [ ] **Step 4: Add API client helpers**
+
+`frontend/src/api/client.ts`, after `reripTitle`:
+
+```typescript
+/** Skip a queued/not-yet-ripped title so MakeMKV does not rip it. */
+export async function skipRipTitle(jobId: number, titleId: number): Promise<void> {
+  return apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/skip-rip`, { method: 'POST' });
+}
+
+/** Reverse a skip while the title has not been ripped yet. */
+export async function unskipRipTitle(jobId: number, titleId: number): Promise<void> {
+  return apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/unskip-rip`, { method: 'POST' });
+}
+```
+
+- [ ] **Step 5: Verify the TypeScript build compiles**
+
+Run: `cd frontend && npm run build`
+Expected: PASS. If `TrackGrid.tsx`'s `STATE` record now errors as non-exhaustive (missing `skipped`), that is expected and fixed in Task 11 — you may proceed to Task 11 before re-running.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/types/index.ts frontend/src/types/adapters.ts frontend/src/app/components/DiscCard.tsx frontend/src/api/client.ts
+git commit -m "feat(ui): add skipped track state + skip API client helpers"
+```
+
+---
+
+## Task 11: TrackGrid skip / un-skip controls (frontend-design skill)
+
+**REQUIRED SUB-SKILL:** Use `frontend-design:frontend-design` to design the skip (✕) and un-skip controls and the `SKIPPED` badge so they match the Synapse v2 brand system (sharp panels, mono type, cyan/magenta accents, corner ticks). The code below is a correct, wired baseline — apply the frontend-design skill's visual treatment on top of it (do not leave it visually generic).
+
+**Files:**
+- Modify: `frontend/src/app/components/TrackGrid.tsx` (STATE map ~34-45; props ~10-17; card render ~145-247)
+- Modify: `frontend/src/app/components/DiscCard.tsx` (props + the 4 `<TrackGrid ... />` usages at 682, 772, 815, 825)
+
+- [ ] **Step 1: Add the `skipped` STATE entry**
+
+In `TrackGrid.tsx` `STATE`:
+
+```typescript
+  skipped:   { label: "SKIPPED",  color: sv.inkDim,  border: `${sv.inkDim}44`,     bg: `${sv.bg2}55`, Icon: null       },
+```
+
+- [ ] **Step 2: Add skip/un-skip props**
+
+Extend `TrackGridProps`:
+
+```typescript
+interface TrackGridProps {
+  tracks: Track[];
+  conflictStatus?: string;
+  /** Skip a queued/not-yet-ripped track (PENDING/QUEUED). Omit to hide the control. */
+  onSkipTrack?: (titleId: number) => void;
+  /** Reverse a skip while still reversible (SKIPPED, not yet ripped). */
+  onUnskipTrack?: (titleId: number) => void;
+}
+```
+
+And the component signature:
+
+```typescript
+export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus, onSkipTrack, onUnskipTrack }: TrackGridProps) {
+```
+
+- [ ] **Step 3: Render the controls**
+
+Inside the card's top-right control cluster (the `<div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>` that holds the spinner `Icon`), add before/after the `Icon`:
+
+```tsx
+                  {onSkipTrack && (track.state === "pending" || track.state === "queued") && (
+                    <button
+                      type="button"
+                      data-testid={`skip-track-${track.id}`}
+                      aria-label={`Skip track ${track.title}`}
+                      title="Skip this track (don't rip it)"
+                      onClick={(e) => { e.stopPropagation(); onSkipTrack(track.id); }}
+                      style={{
+                        fontFamily: sv.mono, fontSize: 10, letterSpacing: "0.12em",
+                        color: sv.inkDim, background: "transparent",
+                        border: `1px solid ${sv.line}`, padding: "2px 6px", cursor: "pointer",
+                      }}
+                    >
+                      SKIP ✕
+                    </button>
+                  )}
+                  {onUnskipTrack && track.state === "skipped" && (
+                    <button
+                      type="button"
+                      data-testid={`unskip-track-${track.id}`}
+                      aria-label={`Un-skip track ${track.title}`}
+                      title="Un-skip (rip this track after all)"
+                      onClick={(e) => { e.stopPropagation(); onUnskipTrack(track.id); }}
+                      style={{
+                        fontFamily: sv.mono, fontSize: 10, letterSpacing: "0.12em",
+                        color: sv.cyan, background: "transparent",
+                        border: `1px solid ${sv.cyan}44`, padding: "2px 6px", cursor: "pointer",
+                      }}
+                    >
+                      UN-SKIP
+                    </button>
+                  )}
+```
+
+Add a `skipped` body block near the `pending` one (~line 268) so the card reads clearly:
+
+```tsx
+              {track.state === "skipped" && (
+                <div style={{ marginTop: 4 }}>
+                  <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkDim, letterSpacing: "0.18em" }}>
+                    SKIPPED — WILL NOT RIP
+                  </span>
+                </div>
+              )}
+```
+
+- [ ] **Step 4: Thread the handlers through DiscCard**
+
+In `DiscCard.tsx`, add to the props interface (near `onCancel?` ~111):
+
+```typescript
+  onSkipTrack?: (titleId: number) => void;
+  onUnskipTrack?: (titleId: number) => void;
+```
+
+Destructure them in the component signature (~216) and pass to all four `<TrackGrid ... />` usages, e.g.:
+
+```tsx
+<TrackGrid tracks={disc.tracks} conflictStatus={disc.conflictStatus} onSkipTrack={onSkipTrack} onUnskipTrack={onUnskipTrack} />
+```
+
+(Add the two props to each of the four `<TrackGrid>` sites at lines 682, 772, 815, 825.)
+
+- [ ] **Step 5: Verify the build compiles**
+
+Run: `cd frontend && npm run build`
+Expected: PASS (STATE record now exhaustive; props typed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/app/components/TrackGrid.tsx frontend/src/app/components/DiscCard.tsx
+git commit -m "feat(ui): skip / un-skip controls + SKIPPED badge in TrackGrid"
+```
+
+---
+
+## Task 12: Wire handlers at the App level
+
+**Files:**
+- Modify: `frontend/src/app/App.tsx` (where `<DiscCard>` is rendered and `onCancel` is passed)
+
+- [ ] **Step 1: Locate the DiscCard render + cancel wiring**
+
+Run: `cd frontend && grep -rn "onCancel=" src/app/App.tsx`
+Identify the `<DiscCard ... onCancel={...} />` site and how a job id is in scope there (the same pattern `onCancel` uses to know its job).
+
+- [ ] **Step 2: Add skip handlers next to the existing cancel handler**
+
+Import the client helpers at the top of `App.tsx`:
+
+```typescript
+import { skipRipTitle, unskipRipTitle } from "../api/client";
+```
+
+At the `<DiscCard>` render, using the same `job.id` (or equivalent) already used for `onCancel`, add:
+
+```tsx
+  onSkipTrack={(titleId) => { void skipRipTitle(job.id, titleId); }}
+  onUnskipTrack={(titleId) => { void unskipRipTitle(job.id, titleId); }}
+```
+
+The WebSocket `title_update` broadcast from the backend drives the UI state change, so no local optimistic update is required (this matches how `reripTitle` / `onCancel` already rely on server push). If `App.tsx` uses a memoized job id via a hook, follow that same pattern.
+
+- [ ] **Step 3: Verify build + lint**
+
+Run: `cd frontend && npm run build && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/App.tsx
+git commit -m "feat(ui): wire skip / un-skip track handlers to the API"
+```
+
+---
+
+## Task 13: E2E test (skip / un-skip flow)
+
+**Files:**
+- Create: `frontend/e2e/track-skipping.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Model it on an existing spec (`cd frontend && ls e2e/`, then read the disc-flow spec for the simulation + selector helpers used in this repo). Concretely:
+
+```typescript
+// frontend/e2e/track-skipping.spec.ts
+import { test, expect } from "@playwright/test";
+
+// Requires backend running with DEBUG=true (simulation endpoints).
+test("skip a queued track then un-skip it", async ({ page, request }) => {
+  // Insert a TV disc that ripples slowly so tracks sit in PENDING/QUEUED.
+  await request.post("http://localhost:8000/api/simulate/insert-disc", {
+    data: { volume_label: "SKIP_TEST_S1D1", content_type: "tv", simulate_ripping: true },
+  });
+
+  await page.goto("/");
+  const skipBtn = page.getByTestId(/^skip-track-\d+$/).first();
+  await skipBtn.waitFor({ state: "visible", timeout: 15000 });
+  await skipBtn.click();
+
+  // A SKIPPED badge appears and an un-skip control replaces the skip control.
+  await expect(page.getByText("SKIPPED — WILL NOT RIP").first()).toBeVisible();
+  const unskipBtn = page.getByTestId(/^unskip-track-\d+$/).first();
+  await expect(unskipBtn).toBeVisible();
+
+  await unskipBtn.click();
+  await expect(page.getByTestId(/^skip-track-\d+$/).first()).toBeVisible();
+
+  // Cleanup
+  await request.delete("http://localhost:8000/api/simulate/reset-all-jobs");
+});
+```
+
+Adjust selectors/timeouts to match the repo's existing E2E conventions (reduced-motion + `animations: 'disabled'` for stability if the spec captures screenshots; not required here).
+
+- [ ] **Step 2: Run the E2E test**
+
+Start the backend with `DEBUG=true` and the frontend dev server per CLAUDE.md, then:
+Run: `cd frontend && npx playwright test e2e/track-skipping.spec.ts`
+Expected: PASS. If the skip button never appears, confirm the simulated rip keeps at least one track in PENDING/QUEUED long enough (increase title count or rip duration in the sim payload).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/e2e/track-skipping.spec.ts
+git commit -m "test(e2e): skip / un-skip track flow"
+```
+
+---
+
+## Task 14: Changelog
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]` section)
+
+- [ ] **Step 1: Add an entry under `[Unreleased] > ### Added`**
+
+```markdown
+### Added
+- Manual track skipping: skip a queued or not-yet-ripped track (e.g. a bogus play-all title) from the dashboard so MakeMKV does not waste time ripping it. Skipped tracks show a distinct SKIPPED badge, are excluded from the library, and can be un-skipped until ripping reaches them. (#NNN)
+```
+
+Replace `#NNN` with the PR number once the PR is open.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): manual track skipping"
+```
+
+---
+
+## Self-Review Notes (author checklist, already applied)
+
+- **Spec coverage:** model (Task 1), extractor best-effort per-title skip (Tasks 2-3), service methods (Task 4), mid-`all`-pass delete (Task 5), `_run_ripping` (Task 6), completion neutrality incl. all-skipped + unresolved-query fix (Task 7), API (Task 8), frontend state + controls + wiring (Tasks 10-12), tests (Tasks 4/5/7/8/13), changelog (Task 14). No migration (verified: no CHECK constraint on `disc_titles.state`).
+- **Naming consistency:** backend `skip_rip_title` / `unskip_rip_title`, extractor `skip_title_index` / `unskip_title_index` / `_skipped_indices`, endpoints `skip-rip` / `unskip-rip`, frontend `skipRipTitle` / `unskipRipTitle` / `onSkipTrack` / `onUnskipTrack`, state literal `skipped` / `SKIPPED` — used identically across every task.
+- **Verification items from the spec:** no-CHECK-constraint confirmed during planning; other active/terminal state enumerations handled in Task 7 Step 4 (grep-and-fix) and Task 6.

--- a/docs/superpowers/specs/2026-07-03-track-skipping-design.md
+++ b/docs/superpowers/specs/2026-07-03-track-skipping-design.md
@@ -1,0 +1,163 @@
+# Manual Track Skipping (Queued / Not-Yet-Ripped Tracks)
+
+**Date:** 2026-07-03
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Play-all track detection is not always perfect. A disc's "play all" concatenation
+title (or another unwanted track) can slip into the selected-to-rip set, wasting rip
+time on a large duplicate. Users want to manually skip a track while it is queued, or
+during an active rip before MakeMKV reaches it.
+
+## Scope (decided)
+
+- **In scope:** skipping tracks that are `PENDING` or `QUEUED` (not yet ripped),
+  both before the rip starts (pre-rip review window) and during an active rip.
+- **Out of scope:** aborting the track MakeMKV is actively writing right now
+  (would require killing/restarting the makemkvcon process and lose the in-flight
+  file). Explicitly excluded.
+- **Skip guarantee:** best-effort.
+  - Per-title (subset) rips: guaranteed to skip, because the extractor checks a
+    live skip-set before each title's command.
+  - Full-disc `all` pass already underway: MakeMKV writes the bytes regardless;
+    the track is excluded from matching/library and its file is deleted.
+- **Skipped outcome:** a distinct terminal `SKIPPED` disposition. Excluded from
+  matching/library, does not block job completion, is NOT counted as a failure,
+  and is reversible (un-skip) until MakeMKV reaches/writes it.
+
+## Key technical constraint
+
+MakeMKV rips serially. When every title is selected, Engram issues one
+`mkv ... all` command (single disc open, much faster). When a subset is selected,
+it loops one makemkvcon command per title. There is no way to surgically drop a
+single title mid-stream inside an `all` pass without killing the whole process.
+This is why "skip during ripping" is best-effort for the `all`-pass case and
+guaranteed only for the per-title loop.
+
+A useful consequence: a *pre-rip* skip shrinks the selection below "all," which
+routes the rip to the per-title loop automatically. So pre-rip skips are always
+honored with zero extractor involvement; only a skip issued *mid-`all`-pass* needs
+the delete fallback.
+
+## Design
+
+### 1. Data model
+
+Add `SKIPPED = "skipped"` to `TitleState` (`backend/app/models/disc_job.py:31`).
+
+- No new column: the existing `is_selected` (bool, default `True`) pairs with the
+  new state. A skipped track has `is_selected=False` and `state=SKIPPED`.
+- No Alembic migration: `TitleState` is stored as a string in the existing `state`
+  column. Confirm there is no CHECK constraint on the column before relying on this.
+- Record the reason in `match_details`:
+  `{"reason": "Skipped by user", "skipped": true}` for history/diagnostics.
+
+`SKIPPED` is terminal. It must be:
+- Excluded from the `active_states` completion gate
+  (`backend/app/services/finalization_coordinator.py:689`).
+- Excluded from the `all_failed` computation (a partially-skipped disc still
+  completes normally).
+
+### 2. Backend service
+
+New methods on `JobManager`, distinct from the existing `skip_title` (which forces
+*stuck active* tracks to REVIEW/FAILED, a different intent that must be preserved):
+
+**`skip_rip_title(job_id, title_id)`**
+- Guard: acts only on titles in `PENDING` or `QUEUED`. Rejects `RIPPING`,
+  matched, or terminal titles.
+- Effect: `is_selected=False`, `state=SKIPPED`, write `match_details` reason,
+  register the `title_index` in a live skip-set on the extractor
+  (`{job_id: {title_index}}`), broadcast a `title_update`, then re-check job
+  completion.
+
+**`unskip_rip_title(job_id, title_id)`**
+- Guard: allowed while `state==SKIPPED` and the title's output file has not been
+  written.
+- Effect: `state=PENDING`, `is_selected=True`, clear the skip reason, remove the
+  `title_index` from the skip-set, broadcast a `title_update`.
+
+### 3. Extractor
+
+Honor the live skip-set (`MakeMKVExtractor`, `backend/app/core/extractor.py`):
+
+- Add a per-job skip-set: `_skipped_indices: dict[int, set[int]]` plus
+  `skip_title_index(job_id, idx)` / `unskip_title_index(job_id, idx)` methods.
+- Per-title loop (`_rip_titles_unlocked`, around `extractor.py:775`): the loop
+  already checks `job_id in self._cancelled_jobs` before each command. Add a
+  symmetric check: before running a title's command, if its `title_index` is in
+  the skip-set, skip that command (`continue`). Refactor the `commands` list to
+  carry `(title_index, cmd)` tuples so the loop can map command to title. This
+  guarantees the skip saves rip time.
+- Full-disc `all` pass: no extractor change. The single command rips everything.
+  The delete happens downstream (see below).
+
+### 4. Rip orchestration and completion
+
+- `_run_ripping` selection and safety-net logic
+  (`backend/app/services/job_manager.py:2114`) already handles deselected titles.
+  Update it to treat `SKIPPED` like deselected (skip it in the selected set)
+  rather than re-marking it extra/COMPLETED.
+- `_on_title_ripped` (`backend/app/services/job_manager.py:2899`): when a
+  completed file belongs to a title whose current DB state is `SKIPPED` (the
+  mid-`all`-pass case), delete the output file and do not dispatch matching; leave
+  the title `SKIPPED`.
+- Completion (`check_job_completion`): with `SKIPPED` excluded from `active_states`
+  and `all_failed`, a partially-skipped disc completes normally.
+- Edge case: every title skipped. The job should complete as `COMPLETED` with
+  nothing organized. Add an explicit guard/log so this does not read as a silent
+  failure.
+
+### 5. API
+
+`backend/app/api/routes.py`:
+
+- `POST /jobs/{job_id}/titles/{title_id}/skip-rip`
+- `POST /jobs/{job_id}/titles/{title_id}/unskip-rip`
+
+Both return 400 if the job is terminal or the title is not in a skippable
+(`PENDING`/`QUEUED`) / un-skippable (`SKIPPED`, unwritten) state. Kept separate
+from the existing `/skip` endpoint to preserve its stuck-track semantics.
+
+### 6. Frontend (implemented via the frontend-design skill)
+
+`frontend/src/app/components/TrackGrid.tsx` and supporting types/adapters:
+
+- A **skip control** (small ✕ / "skip" affordance) on each `PENDING`/`QUEUED`
+  track card, revealed on hover, wired to `skip-rip`.
+- A new **`skipped`** entry in the `STATE` map and the `TrackState` type, plus
+  `frontend/src/types/adapters.ts`, rendered as a muted "SKIPPED" badge with an
+  **un-skip** affordance while the track is still reversible.
+- API client helpers `skipRipTitle` / `unskipRipTitle` in
+  `frontend/src/api/client.ts`.
+- The same control serves the pre-rip review-selection window (job parked in
+  `REVIEW_NEEDED`), since those are the same `PENDING` tracks.
+
+### 7. Testing
+
+- **Backend unit:** extractor skip-set honored in the per-title loop;
+  `skip_rip_title` / `unskip_rip_title` state transitions and guards
+  (reject `RIPPING`/terminal; un-skip only while unwritten).
+- **Backend integration:** simulate insert, skip a queued title mid-rip, assert it
+  ends `SKIPPED`, its file is absent, the job reaches `COMPLETED`, and other titles
+  match. Un-skip round-trip. All-skipped edge case.
+- **Frontend E2E:** skip and un-skip button flow via simulation endpoints.
+
+## Touch-point summary
+
+| Layer | File | Change |
+|-------|------|--------|
+| Model | `backend/app/models/disc_job.py` | Add `TitleState.SKIPPED` |
+| Extractor | `backend/app/core/extractor.py` | Live skip-set + per-title-loop check; `(idx, cmd)` tuples |
+| Service | `backend/app/services/job_manager.py` | `skip_rip_title` / `unskip_rip_title`; `_run_ripping` + `_on_title_ripped` handle `SKIPPED` |
+| Completion | `backend/app/services/finalization_coordinator.py` | Exclude `SKIPPED` from `active_states` and `all_failed`; all-skipped guard |
+| API | `backend/app/api/routes.py` | `skip-rip` / `unskip-rip` endpoints |
+| Frontend | `TrackGrid.tsx`, `types`, `adapters.ts`, `client.ts` | Skip/un-skip controls + `skipped` state |
+
+## Open items to confirm during implementation
+
+- Verify no CHECK constraint on `disc_titles.state` (so no migration is needed).
+- Confirm any other enumerations of active/terminal title states outside
+  `finalization_coordinator` (for example `reconcile_stuck_titles`, force-progress
+  paths) also treat `SKIPPED` as terminal.

--- a/frontend/e2e/track-skipping.spec.ts
+++ b/frontend/e2e/track-skipping.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { simulateInsertDisc, resetAllJobs } from './fixtures/api-helpers';
+import { TV_DISC_ARRESTED_DEVELOPMENT } from './fixtures/disc-scenarios';
+import { SELECTORS } from './fixtures/selectors';
+
+test.beforeEach(async ({ page }) => {
+    await resetAllJobs().catch(() => {});
+    await page.goto('/');
+    await expect(page.locator(SELECTORS.connectionStatus.connected)).toBeVisible({ timeout: 10000 });
+});
+
+test.afterEach(async () => {
+    // Leave the E2E backend clean so a leftover ripping job cannot bleed into the
+    // next spec (the shared single-worker backend keeps jobs across tests).
+    await resetAllJobs().catch(() => {});
+});
+
+test.describe('Track skipping — skip / un-skip a not-yet-ripped track', () => {
+    test('a PENDING track can be skipped and un-skipped from the dashboard card', async ({ page }) => {
+        // Insert an 8-track TV disc at the SLOWEST rip speed. The simulated rip
+        // loop rips titles strictly in sequence (title[i] -> RIPPING, later
+        // titles stay PENDING until the loop reaches them). At multiplier 1 each
+        // track takes ~2s, so the later-indexed tracks sit PENDING for many
+        // seconds — a wide, stable window to click SKIP before the loop arrives.
+        // The SKIP control only renders for tracks in pending/queued state
+        // (TrackGrid gates it on that), so we act on the LAST pending track,
+        // which the rip loop reaches last.
+        await simulateInsertDisc({
+            ...TV_DISC_ARRESTED_DEVELOPMENT,
+            rip_speed_multiplier: 1,
+        });
+
+        // Wait until the track grid is on screen and at least one SKIP control
+        // has rendered (i.e. we've reached the RIPPING state with pending tracks).
+        await expect(page.locator(SELECTORS.trackGrid).first()).toBeVisible({ timeout: 15000 });
+
+        const skipButtons = page.getByTestId(/^skip-track-\d+$/);
+        await expect(skipButtons.first()).toBeVisible({ timeout: 15000 });
+
+        // Target the LAST skippable track — the rip loop reaches it last, so it
+        // stays PENDING the longest and won't be flipped to RIPPING under us.
+        const skipButton = skipButtons.last();
+
+        // Resolve the concrete track id from the testid so we can assert against
+        // this exact card (and find its matching UN-SKIP control) deterministically.
+        const skipTestId = await skipButton.getAttribute('data-testid');
+        expect(skipTestId).toMatch(/^skip-track-\d+$/);
+        const trackId = skipTestId!.replace('skip-track-', '');
+
+        // Click SKIP. The UI updates from the WebSocket title_update push that the
+        // POST /skip-rip triggers. NOTE: after the skip the SKIP button is removed
+        // and replaced by an UN-SKIP button, so the card can only be re-located via
+        // the UN-SKIP control's id (a ":has(skip-track-N)" locator would go stale).
+        await skipButton.click();
+
+        // SKIPPED state: the SKIP control is replaced by an UN-SKIP control for the
+        // same track, and the skipped-body text appears inside that track's card.
+        const unskipButton = page.getByTestId(`unskip-track-${trackId}`);
+        await expect(unskipButton).toBeVisible({ timeout: 10000 });
+        await expect(page.getByTestId(`skip-track-${trackId}`)).toHaveCount(0);
+
+        const skippedCard = page
+            .locator(`${SELECTORS.trackItem}:has([data-testid="unskip-track-${trackId}"])`)
+            .first();
+        await expect(skippedCard.getByText('SKIPPED, WILL NOT RIP')).toBeVisible({ timeout: 10000 });
+
+        // Un-skip: the SKIP control must return, the UN-SKIP control and the SKIPPED
+        // text must clear.
+        await unskipButton.click();
+
+        await expect(page.getByTestId(`skip-track-${trackId}`)).toBeVisible({ timeout: 10000 });
+        await expect(page.getByTestId(`unskip-track-${trackId}`)).toHaveCount(0);
+        await expect(page.getByText('SKIPPED, WILL NOT RIP')).toHaveCount(0);
+    });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -192,6 +192,16 @@ export async function reripTitle(jobId: number, titleId: number): Promise<void> 
   return apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/rerip`, { method: 'POST' });
 }
 
+/** Skip a queued/not-yet-ripped title so MakeMKV does not rip it. */
+export async function skipRipTitle(jobId: number, titleId: number): Promise<void> {
+  return apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/skip-rip`, { method: 'POST' });
+}
+
+/** Reverse a skip while the title has not been ripped yet. */
+export async function unskipRipTitle(jobId: number, titleId: number): Promise<void> {
+  return apiFetchVoid(`/api/jobs/${jobId}/titles/${titleId}/unskip-rip`, { method: 'POST' });
+}
+
 // ---------------------------------------------------------------------------
 // Manual import
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -25,6 +25,7 @@ import { ROUTES, reviewPath } from "../config/routes";
 import { buildNavItems } from "./navigation";
 import { PROMPT_CTA_LABELS, classifyPromptJob, pruneDismissedIds, selectPromptJobs, shouldAutoOpenPrompt } from "./promptSelection";
 import type { Job } from "../types";
+import { skipRipTitle, unskipRipTitle } from "../api/client";
 import { toast } from "sonner";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { ParkedDiscBanner } from "./components/ParkedDiscBanner";
@@ -733,6 +734,8 @@ function MainDashboard() {
                   key={disc.id}
                   disc={disc}
                   onCancel={disc.state !== 'completed' && disc.state !== 'error' ? () => cancelJob(disc.id) : undefined}
+                  onSkipTrack={(titleId) => { void skipRipTitle(Number(disc.id), titleId); }}
+                  onUnskipTrack={(titleId) => { void unskipRipTitle(Number(disc.id), titleId); }}
                   onAdvance={disc.state !== 'completed' && disc.state !== 'error' ? () => advanceJob(disc.id) : undefined}
                   onReview={disc.needsReview && !disc.identityReview && (disc.tracks?.length ?? 0) > 0 ? () => navigate(reviewPath(disc.id)) : undefined}
                   onReIdentify={disc.needsReview && disc.title ? () => {

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -109,6 +109,8 @@ export interface DiscData {
 interface DiscCardProps {
   disc: DiscData;
   onCancel?: () => void;
+  onSkipTrack?: (titleId: number) => void;
+  onUnskipTrack?: (titleId: number) => void;
   onReview?: () => void;
   onReIdentify?: () => void;
   onAdvance?: () => void;
@@ -213,7 +215,7 @@ function CoverOverlay({ children }: { children: React.ReactNode }) {
 }
 
 const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
-  ({ disc, onCancel, onReview, onReIdentify, onAdvance, onReportBug, onOpenSettings, onIdentify, identifyLabel }, ref) => {
+  ({ disc, onCancel, onSkipTrack, onUnskipTrack, onReview, onReIdentify, onAdvance, onReportBug, onOpenSettings, onIdentify, identifyLabel }, ref) => {
     const [isHovered, setIsHovered] = React.useState(false);
     const posterUrl = usePosterImage(disc.id, disc.title);
     const isActive = !['completed', 'error', 'idle'].includes(disc.state);
@@ -679,7 +681,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.yellow}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkipTrack={onSkipTrack} onUnskipTrack={onUnskipTrack} />
                 </div>
               )}
 
@@ -769,7 +771,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.inkDim}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} conflictStatus={disc.conflictStatus} />
+                  <TrackGrid tracks={disc.tracks} conflictStatus={disc.conflictStatus} onSkipTrack={onSkipTrack} onUnskipTrack={onUnskipTrack} />
                 </div>
               )}
 
@@ -812,7 +814,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                       color={sv.purple}
                     />
                   </div>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkipTrack={onSkipTrack} onUnskipTrack={onUnskipTrack} />
                 </div>
               )}
 
@@ -822,7 +824,7 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   <PulseCaption color={sv.amber}>
                     › PROCESSING…
                   </PulseCaption>
-                  <TrackGrid tracks={disc.tracks} />
+                  <TrackGrid tracks={disc.tracks} onSkipTrack={onSkipTrack} onUnskipTrack={onUnskipTrack} />
                 </div>
               )}
 

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -15,7 +15,7 @@ import { formatEta } from "../../utils/formatting";
 
 export type MediaType = "movie" | "tv" | "unknown";
 export type DiscState = "idle" | "scanning" | "review_needed" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
-export type TrackState = "pending" | "ripping" | "queued" | "matching" | "matched" | "review" | "failed" | "completed";
+export type TrackState = "pending" | "ripping" | "queued" | "matching" | "matched" | "review" | "failed" | "completed" | "skipped";
 
 export interface MatchCandidate {
   episode: string;

--- a/frontend/src/app/components/TrackGrid.tsx
+++ b/frontend/src/app/components/TrackGrid.tsx
@@ -14,6 +14,10 @@ interface TrackGridProps {
    *  currently-matching tracks get a "DEEP RE-MATCH" chip so the user sees that
    *  the spinning matching state is an auto-resolution pass, not initial work. */
   conflictStatus?: string;
+  /** Skip a queued/not-yet-ripped track (PENDING/QUEUED). Omit to hide the control. */
+  onSkipTrack?: (titleId: number) => void;
+  /** Reverse a skip while still reversible (SKIPPED, not yet ripped). */
+  onUnskipTrack?: (titleId: number) => void;
 }
 
 /** Parse "… pass N of M" out of a conflict_status note, if present. */
@@ -42,6 +46,9 @@ const STATE: Record<TrackState, StateConfig> = {
   review:    { label: "NEEDS REVIEW", color: sv.yellow, border: `${sv.yellow}66`,  bg: `${sv.yellow}10`, Icon: IcoError  },
   failed:    { label: "FAILED",   color: sv.red,     border: `${sv.red}66`,        bg: `${sv.red}10`, Icon: IcoError    },
   completed: { label: "DONE",     color: sv.green,   border: `${sv.green}55`,      bg: `${sv.green}10`, Icon: IcoComplete },
+  // SKIPPED: user opted this track out of the rip. Muted, no icon, no accent —
+  // it should recede from the active grid rather than compete for attention.
+  skipped:   { label: "SKIPPED",  color: sv.inkDim,  border: `${sv.inkDim}44`,     bg: `${sv.bg2}55`, Icon: null       },
 };
 
 type SourceDesc = {
@@ -112,7 +119,7 @@ function SourceChip({ source }: { source: string }) {
   );
 }
 
-export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus }: TrackGridProps) {
+export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus, onSkipTrack, onUnskipTrack }: TrackGridProps) {
   const passInfo = parsePassInfo(conflictStatus);
   return (
     <div data-testid="sv-track-grid" style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 10 }}>
@@ -231,6 +238,64 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus 
                 </div>
 
                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
+                  {onSkipTrack && (track.state === "pending" || track.state === "queued") && (
+                    <button
+                      type="button"
+                      data-testid={`skip-track-${track.id}`}
+                      aria-label={`Skip track ${track.title}`}
+                      title="Skip this track (don't rip it)"
+                      onClick={(e) => { e.stopPropagation(); onSkipTrack(Number(track.id)); }}
+                      onMouseEnter={(e) => {
+                        // Arm destructive-but-reversible: magenta is the palette's
+                        // rip/destructive accent, so hover previews the consequence.
+                        e.currentTarget.style.color = sv.magenta;
+                        e.currentTarget.style.borderColor = `${sv.magenta}88`;
+                        e.currentTarget.style.background = `${sv.magenta}12`;
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.color = sv.inkDim;
+                        e.currentTarget.style.borderColor = sv.line;
+                        e.currentTarget.style.background = "transparent";
+                      }}
+                      style={{
+                        fontFamily: sv.mono, fontSize: 10, fontWeight: 700, letterSpacing: "0.12em",
+                        color: sv.inkDim, background: "transparent",
+                        border: `1px solid ${sv.line}`, borderRadius: 0, padding: "2px 6px",
+                        cursor: "pointer", lineHeight: 1, transition: "color 0.15s, border-color 0.15s, background 0.15s",
+                      }}
+                    >
+                      SKIP ✕
+                    </button>
+                  )}
+                  {onUnskipTrack && track.state === "skipped" && (
+                    <button
+                      type="button"
+                      data-testid={`unskip-track-${track.id}`}
+                      aria-label={`Un-skip track ${track.title}`}
+                      title="Un-skip (rip this track after all)"
+                      onClick={(e) => { e.stopPropagation(); onUnskipTrack(Number(track.id)); }}
+                      onMouseEnter={(e) => {
+                        // Cyan is the affirmative/queued accent — brightening on
+                        // hover reads as "put it back in line".
+                        e.currentTarget.style.color = sv.cyanHi;
+                        e.currentTarget.style.borderColor = `${sv.cyan}aa`;
+                        e.currentTarget.style.background = `${sv.cyan}12`;
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.color = sv.cyan;
+                        e.currentTarget.style.borderColor = `${sv.cyan}44`;
+                        e.currentTarget.style.background = "transparent";
+                      }}
+                      style={{
+                        fontFamily: sv.mono, fontSize: 10, fontWeight: 700, letterSpacing: "0.12em",
+                        color: sv.cyan, background: "transparent",
+                        border: `1px solid ${sv.cyan}44`, borderRadius: 0, padding: "2px 6px",
+                        cursor: "pointer", lineHeight: 1, transition: "color 0.15s, border-color 0.15s, background 0.15s",
+                      }}
+                    >
+                      UN-SKIP
+                    </button>
+                  )}
                   {Icon && (
                     <motion.div
                       animate={
@@ -269,6 +334,28 @@ export const TrackGrid = React.memo(function TrackGrid({ tracks, conflictStatus 
                 <div style={{ marginTop: 4 }}>
                   <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkDim, letterSpacing: "0.18em" }}>
                     QUEUED
+                  </span>
+                </div>
+              )}
+
+              {/* Skipped: opted out of the rip — muted, struck-through mark so the
+                  card visually recedes from active tracks. */}
+              {track.state === "skipped" && (
+                <div style={{ marginTop: 4, display: "flex", alignItems: "center", gap: 6 }}>
+                  <span aria-hidden style={{ fontFamily: sv.mono, fontSize: 10, color: `${sv.inkDim}99` }}>
+                    ✕
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: sv.mono,
+                      fontSize: 10,
+                      color: sv.inkDim,
+                      letterSpacing: "0.18em",
+                      textDecoration: "line-through",
+                      textDecorationColor: `${sv.inkDim}66`,
+                    }}
+                  >
+                    SKIPPED, WILL NOT RIP
                   </span>
                 </div>
               )}

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -34,7 +34,8 @@ export function mapTitleStateToTrackState(
     'matched': 'matched',
     'review': 'review',
     'completed': 'completed',
-    'failed': 'failed'
+    'failed': 'failed',
+    'skipped': 'skipped'
   };
 
   return stateMap[titleState] || 'pending';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,7 +12,7 @@ export type JobState =
 
 export type ContentType = 'tv' | 'movie' | 'unknown';
 
-export type TitleState = 'pending' | 'ripping' | 'queued' | 'matching' | 'matched' | 'review' | 'completed' | 'failed';
+export type TitleState = 'pending' | 'ripping' | 'queued' | 'matching' | 'matched' | 'review' | 'completed' | 'failed' | 'skipped';
 
 export type SubtitleStatus = 'downloading' | 'completed' | 'partial' | 'failed' | null;
 


### PR DESCRIPTION
## Summary

Adds the ability to manually skip a queued or not-yet-ripped track from the dashboard, so MakeMKV does not waste time ripping an unwanted title (the motivating case: a bogus "play all" concatenation that slips past auto-detection). Skipped tracks are excluded from the library, do not count as failures, and can be un-skipped until ripping reaches them.

Design spec: `docs/superpowers/specs/2026-07-03-track-skipping-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-03-track-skipping.md`

## What changed

**Backend**
- New terminal `TitleState.SKIPPED` (no migration: `state` is a plain string column).
- `JobManager.skip_rip_title` / `unskip_rip_title` set the state and register/clear the title index in a live skip-set on the extractor. Guards: skip only acts on `PENDING`/`QUEUED`; un-skip only while `SKIPPED` and not yet written.
- Extractor honors the skip-set in its per-title rip loop (`continue` before starting a skipped title's command), so a subset rip genuinely avoids the work. A full-disc `all` pass cannot drop a title mid-stream, so the file is written then deleted in `_on_title_ripped` (best-effort, as designed).
- Completion logic treats `SKIPPED` as neutral: excluded from the active-title gate and the outcome booleans, added to the "still needs work" queries, with an all-skipped short-circuit to `COMPLETED`. Net effect: some-matched+some-skipped completes, all-skipped completes (nothing organized), skipped+failed fails.
- REST: `POST /api/jobs/{job_id}/titles/{title_id}/skip-rip` and `.../unskip-rip`.

**Frontend**
- `skipped` track state plumbed through types/adapters (compiler-enforced state maps).
- SKIP / UN-SKIP controls and a SKIPPED badge in `TrackGrid` (built with the frontend-design skill on the Synapse v2 tokens: magenta rip-accent for SKIP, cyan for UN-SKIP, line-through recede for the skipped card), wired through `DiscCard` to `App`. UI updates via the existing WebSocket `title_update` push.

## Design decisions (from brainstorming)
- Scope is queued / not-yet-ripped tracks only; aborting the in-flight track was explicitly out of scope (it would mean killing makemkvcon and losing the partial file).
- Skip is best-effort: guaranteed for per-title rips, delete-after-write for an in-progress full-disc pass.
- Skipped is a distinct, reversible disposition rather than a silent "extra" or a failure.

## Reviewer notes
- The subtle backend seam is completion: `SKIPPED` is auto-excluded from the `active_states` gate but had to be added to the `state.notin_([COMPLETED, FAILED])` "unresolved" queries (three of them) or a skipped track would strand a job at organize. Verified no other state-enumeration path can resurrect a skipped title (all others gate on positive membership + `is_selected`).
- Frontend id mapping verified: `disc.id` -> `DiscJob.id`, `track.id` -> `DiscTitle.id` (not `title_index`), stringified in the adapter and `Number()`-converted at the call sites.
- Includes a test-isolation fix: the completion tests drive jobs terminal, whose Discord terminal hook fire-and-forgets a detached task that opened an in-memory-DB session and intermittently locked the shared unit StaticPool. Scoped stubs + hermetic (two-title) skip tests resolve it; `conftest` also clears the extractor skip-set between tests, mirroring the existing `_inflight_match_dispatch` reset.

## Test plan
- [x] Backend unit + integration + pipeline: 2781 passed (two consecutive full runs, previously ~50% flaky before the isolation fix). New: `test_extractor_skip`, `test_skip_rip_title`, `test_completion_skipped`, `test_track_skipping` (integration).
- [x] Frontend `npm run build` + `npm run lint` clean.
- [x] E2E `track-skipping.spec.ts`: skip -> SKIPPED badge -> un-skip -> restored, verified with `--repeat-each=3` (3/3).
- [x] Manual: insert a multi-title disc, skip a queued track mid-rip, confirm it ends SKIPPED and is not organized; un-skip before the loop reaches it and confirm it rips.

Note: the `tests/real_data` tier is not run here (it spawns makemkvcon against a physical drive); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)