### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-04
+
+_Highlights: manual track skipping for queued/not-yet-ripped tracks, plus field-validated Jetson GPU setup fixes._
+
 ### Added
 
-- **Manual track skipping.** Skip a queued or not-yet-ripped track (for example a bogus "play all" title that slipped past auto-detection) straight from the dashboard, so MakeMKV does not waste time ripping it. Skipped tracks show a distinct SKIPPED badge, are excluded from the library, do not count as failures, and can be un-skipped until ripping reaches them. Skipping is best-effort during an in-progress full-disc rip (the file is written then deleted) and guaranteed for per-title rips. (#NNN)
+- **Manual track skipping.** Skip a queued or not-yet-ripped track (for example a bogus "play all" title that slipped past auto-detection) straight from the dashboard, so MakeMKV does not waste time ripping it. Skipped tracks show a distinct SKIPPED badge, are excluded from the library, do not count as failures, and can be un-skipped until ripping reaches them. Skipping is best-effort during an in-progress full-disc rip (the file is written then deleted) and guaranteed for per-title rips. (#486)
 
 ### Fixed
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.23.0"
+version = "0.24.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.23.0"
+version = "0.24.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.23.0",
+    "version": "0.24.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.23.0",
+            "version": "0.24.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.23.0",
+    "version": "0.24.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version to 0.24.0 across `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json`
- Curate `CHANGELOG.md`: manual track skipping (#486) and Jetson GPU setup fixes (#485)
- `CONTRIBUTORS.md` unchanged — no new external contributors since v0.23.0

## Test plan
- [x] `uv run python backend/scripts/extract_changelog.py --version 0.24.0 --check` passes
- [ ] Merge triggers `tag-release.yml` → tags `v0.24.0` → `release.yml` + `docker.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)