### PR TITLE
fix(import): make the folder browser scroll and add a path field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Import folder browser now scrolls.** Browsing a directory with more subfolders than fit on screen previously grew the modal past the edges of the window, stranding you in the middle of the list with no way to scroll, no visible way to go up a level, and no way to reach the start button. The folder list is now a scrolling pane inside a window-sized modal, so the header, the up-a-level row, and the start button stay put. You can also type or paste an exact folder path instead of clicking through hundreds of folders, and going up a level scrolls the folder you came from back into view.
+
 ## [0.24.0] - 2026-07-04
 
 _Highlights: manual track skipping for queued/not-yet-ripped tracks, plus field-validated Jetson GPU setup fixes._

--- a/docs/superpowers/plans/2026-07-09-import-browser-scroll.md
+++ b/docs/superpowers/plans/2026-07-09-import-browser-scroll.md
@@ -1,0 +1,651 @@
+# Import Folder Browser Scroll + Path Entry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Import modal's folder browser scroll inside a viewport-bounded panel, and let the user type an exact path instead of clicking through hundreds of folders.
+
+**Architecture:** The folder list already has `overflow: auto`, but no ancestor caps a height, so the panel grows to its content and `items-center` centers the overflow off-screen. We cap the dialog at `82vh`, turn `SvPanel` into a flex column, and thread `minHeight: 0` down every flex ancestor so the list becomes the shrinking, scrolling box. Separately we add a path `<form>` under the header whose submit reuses the existing `navigate` + `choose` pair that a directory click already fires.
+
+**Tech Stack:** React 18, TypeScript, inline styles + Synapse tokens (`sv`), Vitest + React Testing Library (`npm run test:unit`), Playwright (`npm run test:e2e`).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-import-browser-scroll-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `frontend/src/components/ImportModal.tsx` | The whole modal: browser pane, preview pane, destination, footer | Modify |
+| `frontend/src/components/ImportModal.test.tsx` | Unit tests for path entry, error routing, large lists, scroll restore | Modify |
+| `frontend/e2e/import-flow.spec.ts` | Browser-level proof the panel is bounded and the list scrolls | Modify |
+
+`ImportModal.tsx` is ~450 lines with two small local components (`Row`, `Notice`). It stays one file: the additions are ~40 lines and splitting it would not serve this change.
+
+No backend change. No API change.
+
+---
+
+## Task 1: Bound the panel height so the list scrolls
+
+The layout defect. jsdom reports every height as zero, so this task is proven by Playwright, not Vitest.
+
+**Files:**
+- Modify: `frontend/src/components/ImportModal.tsx:121-231`, `:289`, `:327`
+- Test: `frontend/e2e/import-flow.spec.ts`
+
+- [ ] **Step 1: Write the failing E2E test**
+
+Add this helper below the existing `seedShowTree()` in `frontend/e2e/import-flow.spec.ts`:
+
+```ts
+/** A directory with enough children to overflow any viewport, plus one real show. */
+function seedManyDirs(count = 400): string {
+    const root = mkdtempSync(join(tmpdir(), 'engram-import-big-'));
+    for (let i = 0; i < count; i++) {
+        mkdirSync(join(root, `Show ${String(i).padStart(3, '0')}`), { recursive: true });
+    }
+    const season = join(root, 'Zulu Show', 'Season 1');
+    mkdirSync(season, { recursive: true });
+    writeFileSync(join(season, 't00.mkv'), Buffer.alloc(1024));
+    return root;
+}
+```
+
+Add this test inside the existing `test.describe('Manual media import', ...)` block:
+
+```ts
+test('folder browser stays within the viewport and scrolls', async ({ page, request }) => {
+    const root = seedManyDirs();
+    await request.put('/api/config', { data: { import_watch_path: root } });
+
+    await page.goto('/');
+    await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+    await page.getByTestId('sv-import-btn').click();
+    await expect(page.getByText('IMPORT MEDIA')).toBeVisible();
+
+    const list = page.getByTestId('import-nav-list');
+    await expect(list.getByText('Show 000', { exact: true })).toBeVisible({ timeout: 15000 });
+
+    // The panel must not exceed the viewport.
+    const viewport = page.viewportSize()!;
+    const panel = await page.getByTestId('import-panel').boundingBox();
+    expect(panel!.height).toBeLessThanOrEqual(viewport.height);
+
+    // Header, the up-a-level row, and the footer button all stay reachable.
+    await expect(page.getByText('..', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('import-start-btn')).toBeInViewport();
+
+    // The list itself is the scroll container.
+    const scrolls = await list.evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+    expect(scrolls).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend
+npx playwright test e2e/import-flow.spec.ts -g "stays within the viewport"
+```
+
+Expected: FAIL. Either `getByTestId('import-panel')` resolves 0 elements (the testid does not exist yet), or, once you add the testid, `expect(panel.height).toBeLessThanOrEqual(viewport.height)` fails with a height in the thousands.
+
+- [ ] **Step 3: Cap the dialog wrapper and make the panel a flex column**
+
+In `ImportModal.tsx`, replace the dialog wrapper and `SvPanel` opening tags (currently lines 121-129):
+
+```tsx
+      <motion.div
+        className="relative w-full"
+        style={{ maxWidth: 820, maxHeight: "82vh", minHeight: 340, display: "flex" }}
+        initial={{ opacity: 0, scale: 0.96, y: 16 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.96, y: 16 }}
+        transition={{ type: "spring", stiffness: 400, damping: 30 }}
+      >
+        <SvPanel
+          glow
+          pad={0}
+          testid="import-panel"
+          style={{
+            background: sv.bg1,
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
+```
+
+The `minHeight: 340` floor moves here from the two-pane row, where it would otherwise fight the shrink chain.
+
+- [ ] **Step 4: Thread `minHeight: 0` down the flex chain**
+
+Four edits in the same file. `minHeight: 0` is load-bearing: flex items default to `min-height: auto` and refuse to shrink below their content, which would blow through the `82vh` cap.
+
+Two-pane row (was `style={{ display: "flex", minHeight: 340 }}` at line 169):
+
+```tsx
+          <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
+```
+
+Navigator column (line 171), add `minHeight: 0` to the existing style object:
+
+```tsx
+            <div
+              style={{
+                width: "46%",
+                borderRight: `1px solid ${sv.line}`,
+                display: "flex",
+                flexDirection: "column",
+                minHeight: 0,
+              }}
+            >
+```
+
+Scrolling list container (line 193), add `minHeight: 0` and the testid:
+
+```tsx
+              <div data-testid="import-nav-list" style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
+```
+
+Preview column (line 218) and its scrolling body (line 231):
+
+```tsx
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+```
+
+```tsx
+              <div style={{ flex: 1, overflow: "auto", padding: 14, minHeight: 0 }}>
+```
+
+- [ ] **Step 5: Pin the header, destination block, and footer**
+
+Add `flexShrink: 0` to the existing style objects of the header (line 131), the destination block (line 289), and the footer (line 327). For example the destination block becomes:
+
+```tsx
+              <div style={{ padding: "10px 14px", borderTop: `1px solid ${sv.line}`, flexShrink: 0 }}>
+```
+
+- [ ] **Step 6: Run the E2E test to verify it passes**
+
+```bash
+cd frontend
+npx playwright test e2e/import-flow.spec.ts -g "stays within the viewport"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify the existing import test still passes**
+
+```bash
+cd frontend
+npx playwright test e2e/import-flow.spec.ts
+```
+
+Expected: PASS, both tests. If `browse, preview, and start an import` regressed, the shrink chain is over-constrained: check that the preview pane still renders `SEASON 1`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/ImportModal.tsx frontend/e2e/import-flow.spec.ts
+git commit -m "fix(import): bound folder browser height so the list scrolls"
+```
+
+---
+
+## Task 2: `navigate` reports success
+
+`navigate` currently swallows failures into `error` state and returns `void`. Task 3's path submit must not fire a preview against a path that failed to browse, so it needs a signal. Pure refactor, no behavior change; Task 3's tests cover it.
+
+**Files:**
+- Modify: `frontend/src/components/ImportModal.tsx:36-51`
+
+- [ ] **Step 1: Change the return type**
+
+Replace `navigate` in full:
+
+```tsx
+  const navigate = useCallback(async (path: string): Promise<boolean> => {
+    const seq = ++navSeq.current;
+    setError(null);
+    try {
+      const res = await browseDir(path);
+      if (seq !== navSeq.current) return false; // a newer navigation superseded this one
+      setCwd(res.cwd);
+      setParent(res.parent);
+      setEntries(res.entries);
+      setRoots(res.roots);
+      return true;
+    } catch (e) {
+      if (seq === navSeq.current) {
+        setError(e instanceof Error ? e.message : "Could not read directory");
+      }
+      return false;
+    }
+  }, []);
+```
+
+A superseded navigation returns `false`, so a stale submit never previews. That is correct: the newer navigation owns the pane.
+
+- [ ] **Step 2: Verify nothing broke**
+
+```bash
+cd frontend
+npm run test:unit -- ImportModal
+npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: existing 2 unit tests PASS, no type errors. Existing callers ignore the return value, which TypeScript permits.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ImportModal.tsx
+git commit -m "refactor(import): navigate() returns whether the browse succeeded"
+```
+
+---
+
+## Task 3: Typed path input
+
+Submit runs `navigate` then, only on success, `choose`. Same pair a directory click fires (line 207), so typing is a shortcut for scrolling and clicking.
+
+**Files:**
+- Modify: `frontend/src/components/ImportModal.tsx` (state, submit handler, JSX at `:179-192`)
+- Test: `frontend/src/components/ImportModal.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe("ImportModal", ...)` block in `ImportModal.test.tsx`:
+
+```tsx
+  it("navigates to and previews a typed path", async () => {
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("King of Queens"));
+
+    fireEvent.change(screen.getByTestId("import-path-input"), {
+      target: { value: "/Volumes/TV Shows/Engram" },
+    });
+    fireEvent.submit(screen.getByTestId("import-path-form"));
+
+    await waitFor(() =>
+      expect(client.browseDir).toHaveBeenCalledWith("/Volumes/TV Shows/Engram"),
+    );
+    await waitFor(() =>
+      expect(client.previewImport).toHaveBeenCalledWith("/Volumes/TV Shows/Engram"),
+    );
+  });
+
+  it("shows an error and skips the preview when the typed path is bad", async () => {
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("King of Queens"));
+
+    vi.mocked(client.browseDir).mockRejectedValueOnce(new Error("Not a directory: /nope"));
+    fireEvent.change(screen.getByTestId("import-path-input"), { target: { value: "/nope" } });
+    fireEvent.submit(screen.getByTestId("import-path-form"));
+
+    await waitFor(() => expect(screen.getByText("Not a directory: /nope")).toBeInTheDocument());
+    expect(client.previewImport).not.toHaveBeenCalled();
+  });
+
+  it("keeps the up-a-level row and start button present with a large directory", async () => {
+    vi.mocked(client.browseDir).mockResolvedValue({
+      cwd: "/media",
+      parent: "/",
+      roots: [],
+      entries: Array.from({ length: 400 }, (_, i) => ({
+        name: `Show ${i}`,
+        path: `/media/Show ${i}`,
+        type: "dir" as const,
+        mkv_count: 0,
+      })),
+    });
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+
+    await waitFor(() => expect(screen.getByText("Show 399")).toBeInTheDocument());
+    expect(screen.getByText("..")).toBeInTheDocument();
+    expect(screen.getByTestId("import-start-btn")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd frontend
+npm run test:unit -- ImportModal
+```
+
+Expected: the first two FAIL with `Unable to find an element by: [data-testid="import-path-input"]`. The third PASSES already (the rows render; they were merely off-screen in a real browser, which jsdom cannot model). Keep it as a regression guard.
+
+- [ ] **Step 3: Add the input state and submit handler**
+
+After the `chooseSeq` ref declaration (line 34), add:
+
+```tsx
+  const [pathInput, setPathInput] = useState(defaultPath || "");
+```
+
+After the `choose` callback (line 75), add:
+
+```tsx
+  const submitPath = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const target = pathInput.trim();
+      if (!target) return;
+      // Mirrors the directory-click gesture: browse into it, and preview it.
+      // Only preview if the browse resolved, so one typo yields one error.
+      if (await navigate(target)) await choose(target);
+    },
+    [pathInput, navigate, choose],
+  );
+```
+
+Keep the input in sync with wherever navigation lands, so it doubles as the current-location display. Add below the existing focus effect (line 59):
+
+```tsx
+  useEffect(() => {
+    if (cwd) setPathInput(cwd);
+  }, [cwd]);
+```
+
+- [ ] **Step 4: Replace the `cwd` label with the path form**
+
+Delete the `cwd` label div (lines 179-192) and put this form directly under the header, as a sibling of the two-pane row rather than inside the navigator column, so it spans the full modal width:
+
+```tsx
+          <form
+            onSubmit={submitPath}
+            data-testid="import-path-form"
+            style={{
+              display: "flex",
+              gap: 6,
+              padding: "8px 12px",
+              borderBottom: `1px solid ${sv.line}`,
+              flexShrink: 0,
+            }}
+          >
+            <input
+              data-testid="import-path-input"
+              value={pathInput}
+              onChange={(e) => setPathInput(e.target.value)}
+              spellCheck={false}
+              aria-label="Path"
+              placeholder="Type or paste a folder path"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                fontFamily: sv.mono,
+                fontSize: 11,
+                padding: "5px 8px",
+                background: sv.bg0,
+                border: `1px solid ${sv.lineMid}`,
+                color: sv.ink,
+                outline: "none",
+              }}
+            />
+            <button
+              type="submit"
+              data-testid="import-path-go"
+              style={{
+                fontFamily: sv.mono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.1em",
+                padding: "5px 12px",
+                border: `1px solid ${sv.cyan}`,
+                background: "transparent",
+                color: sv.cyan,
+                cursor: "pointer",
+              }}
+            >
+              GO
+            </button>
+          </form>
+```
+
+Tokens used here are all exported from
+`frontend/src/app/components/synapse/tokens.ts`: `sv.mono`, `sv.bg0`,
+`sv.lineMid`, `sv.ink`, `sv.line`, `sv.cyan`. Note there is no `inkHi` token;
+`sv.ink` (`#e6ecf5`) is the brightest ink.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd frontend
+npm run test:unit -- ImportModal
+npm run lint
+```
+
+Expected: all 5 unit tests PASS, lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ImportModal.tsx frontend/src/components/ImportModal.test.tsx
+git commit -m "feat(import): type or paste an exact path in the folder browser"
+```
+
+---
+
+## Task 4: Restore scroll position when navigating up
+
+Clicking `..` out of `/Volumes/TV Shows/Engram` lands at the top of a 400-row list with no indication of where you were. Scroll the folder you came from into view and highlight it.
+
+**Files:**
+- Modify: `frontend/src/components/ImportModal.tsx` (`navigate`, entries render, `Row`)
+- Test: `frontend/src/components/ImportModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+jsdom does not implement `scrollIntoView`, so stub it. Add to the top of the existing `beforeEach` in `ImportModal.test.tsx`:
+
+```tsx
+  Element.prototype.scrollIntoView = vi.fn();
+```
+
+Then append this test to the `describe` block:
+
+```tsx
+  it("scrolls the folder you came from into view when navigating up", async () => {
+    vi.mocked(client.browseDir)
+      .mockResolvedValueOnce({
+        cwd: "/media/King of Queens",
+        parent: "/media",
+        roots: [],
+        entries: [],
+      })
+      .mockResolvedValueOnce({
+        cwd: "/media",
+        parent: "/",
+        roots: [],
+        entries: [
+          { name: "King of Queens", path: "/media/King of Queens", type: "dir", mkv_count: 0 },
+        ],
+      });
+
+    render(
+      <ImportModal
+        onClose={() => {}}
+        defaultPath="/media/King of Queens"
+        defaultDestinationMode="library"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("..")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText(".."));
+
+    await waitFor(() => expect(screen.getByText("King of Queens")).toBeInTheDocument());
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend
+npm run test:unit -- ImportModal
+```
+
+Expected: FAIL with `expected "spy" to be called with arguments: [ { block: 'center' } ]`, `Number of calls: 0`.
+
+- [ ] **Step 3: Track the directory we left**
+
+Add next to the other refs (after line 34):
+
+```tsx
+  const cwdRef = useRef<string | null>(null);
+```
+
+Add the landmark state next to the other state (after line 25):
+
+```tsx
+  const [landmark, setLandmark] = useState<string | null>(null);
+```
+
+In `navigate`'s success branch (from Task 2), record the previous cwd and set the
+landmark only when it is a child of where we just landed:
+
+```tsx
+      const res = await browseDir(path);
+      if (seq !== navSeq.current) return false; // a newer navigation superseded this one
+      const prev = cwdRef.current;
+      cwdRef.current = res.cwd;
+      setLandmark(prev && res.entries.some((e) => e.path === prev) ? prev : null);
+      setCwd(res.cwd);
+      setParent(res.parent);
+      setEntries(res.entries);
+      setRoots(res.roots);
+      return true;
+```
+
+- [ ] **Step 4: Scroll and highlight the landmark row**
+
+Pass it down in the entries map (line 200), highlighting it the same way a selection is:
+
+```tsx
+                {entries.map((e) => (
+                  <Row
+                    key={e.path}
+                    label={e.name}
+                    count={e.type === "dir" ? e.mkv_count : undefined}
+                    kind={e.type}
+                    active={selected === e.path || landmark === e.path}
+                    scrollTo={landmark === e.path}
+                    onClick={() =>
+                      e.type === "dir"
+                        ? (navigate(e.path), choose(e.path))
+                        : choose(e.path)
+                    }
+                  />
+                ))}
+```
+
+Extend `Row` to take `scrollTo` and act on it. Its signature becomes:
+
+```tsx
+function Row({
+  label,
+  count,
+  kind,
+  active,
+  scrollTo,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  kind: "dir" | "mkv";
+  active?: boolean;
+  scrollTo?: boolean;
+  onClick: () => void;
+}) {
+  const ref = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (scrollTo) ref.current?.scrollIntoView({ block: "center" });
+  }, [scrollTo]);
+
+  return (
+    <button
+      ref={ref}
+      onClick={onClick}
+```
+
+The rest of `Row`'s body is unchanged. `Row` already lives in this file below the
+default export, so `useRef` and `useEffect` are already imported at line 1.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd frontend
+npm run test:unit -- ImportModal
+npm run lint
+npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: all 6 unit tests PASS, lint clean, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ImportModal.tsx frontend/src/components/ImportModal.test.tsx
+git commit -m "feat(import): restore scroll position when navigating up a level"
+```
+
+---
+
+## Task 5: Full verification and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Run the whole frontend suite**
+
+```bash
+cd frontend
+npm run test:unit
+npm run lint
+npm run build
+npx playwright test e2e/import-flow.spec.ts
+```
+
+Expected: all PASS. `npm run build` runs `tsc` then Vite, so it catches type errors the per-file check missed.
+
+- [ ] **Step 2: Drive the real UI**
+
+Start the backend and frontend (from `CLAUDE.md`, and note the parallel-session port rules if another stack is live), then point the import default at a directory with several hundred subfolders and confirm by eye:
+
+- the modal fits the window, header and START IMPORT both visible
+- the folder list scrolls with the wheel
+- `..` sits at the top of the list and goes up a level
+- pasting an absolute path into the field and pressing Enter jumps there and previews it
+- pasting a nonexistent path shows a red notice and no preview
+
+- [ ] **Step 3: Add the changelog entry**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, in `### Fixed` (create the subsection if absent):
+
+```markdown
+- Import folder browser now scrolls instead of overflowing the window when a directory has many subfolders, keeping the up-a-level row and the start button reachable. You can also type or paste an exact folder path.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for import folder browser scroll fix"
+```
+
+- [ ] **Step 5: Stop this session's servers**
+
+Per `CLAUDE.md`, kill the `uvicorn`/`python` and any `makemkvcon` processes this session started, scoped to the ports you launched on, before opening the PR.
+
+---
+
+## Notes for the implementer
+
+- **Do not "fix" the scroll by putting `overflow-y: auto` on the backdrop.** That scrolls the header and the START IMPORT button off with the content, which is worse than the bug.
+- **Do not drop `minHeight: 0`** from any ancestor in Task 1. Removing one silently restores the original bug, and no unit test will catch it because jsdom has no layout engine. Only the Playwright assertion in Task 1 will.
+- **`navSeq`/`chooseSeq`** are monotonic request tokens guarding against a slow earlier browse overwriting a newer one. The typed-path route goes through the same `navigate`/`choose`, so it inherits the guard. Do not bypass them.
+- The backend computes `mkv_count` by running `os.scandir` on **every** direct child (`backend/app/api/routes.py:2583`), so listing a 400-entry directory does 400 extra directory reads. On a network volume that likely makes the modal slow to open. Out of scope here; worth a separate issue.

--- a/docs/superpowers/specs/2026-07-09-import-browser-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-09-import-browser-scroll-design.md
@@ -1,0 +1,150 @@
+# Import folder browser: scroll, path entry, and navigation affordances
+
+**Date:** 2026-07-09
+**Status:** Approved, pending implementation
+**Component:** `frontend/src/components/ImportModal.tsx`
+
+## Problem
+
+A user cannot reach `/Volumes/TV Shows/Engram` through the Import modal's folder
+browser. The parent directory `/Volumes/TV Shows` holds several hundred
+subfolders (their Plex TV library). Reported symptoms:
+
+1. The list does not scroll.
+2. The browser "opens around the Ms", partway down the alphabet.
+3. There is no visible way to go up a level.
+4. There is no way to type or paste an exact path.
+
+Symptoms 1 through 3 are a single CSS defect. Symptom 4 is a missing feature.
+
+## Root cause
+
+The file list at `ImportModal.tsx:193` is `{ flex: 1, overflow: "auto" }`.
+`overflow: auto` only produces a scroll container when the box is smaller than
+its content, so it depends on an ancestor capping the height. No ancestor does:
+
+| Element | Line | Height constraint |
+|---|---|---|
+| List container | 193 | `flex: 1` (resolves against parent) |
+| Navigator column | 171 | none (`width: 46%` only) |
+| Two-pane row | 169 | `minHeight: 340` (a floor, not a ceiling) |
+| `SvPanel` | `SvPanel.tsx:35` | none |
+| Dialog wrapper | 121 | `maxWidth: 820` (width only) |
+
+With ~400 subfolders the panel grows to roughly 15,000px tall. The list box is
+never smaller than its content, so it never scrolls.
+
+The outer container is `fixed inset-0 flex items-center justify-center`
+(line 103). `items-center` vertically centers that oversized panel in the
+viewport, clipping it symmetrically at top and bottom. The visible slice is
+therefore the middle of an alphabetically sorted list, which is why the user
+lands near "M". The `..` row (line 195), the header, the destination toggle, and
+the START IMPORT button all render correctly but sit thousands of pixels outside
+the viewport.
+
+## Design
+
+### 1. Bound the height (fixes symptoms 1 through 3)
+
+Make the panel a bounded flex column so header and footer pin, and the two panes
+scroll independently.
+
+- Dialog wrapper (line 121): add `maxHeight: 82vh`.
+- `SvPanel`: pass `display: flex, flexDirection: column, minHeight: 0` through
+  its existing `style` prop.
+- Two-pane row (line 169): replace `minHeight: 340` with `flex: 1, minHeight: 0`.
+  The 340px floor moves to the dialog wrapper as `minHeight: 340`, where it does
+  not fight the shrink chain. (`minHeight: 340` and `minHeight: 0` cannot coexist
+  on one element, and the row is the element that must shrink.)
+- Navigator column (line 171) and preview column (line 218): add `minHeight: 0`.
+- Header (131), destination block (289), and footer (327): add `flexShrink: 0`.
+
+**`minHeight: 0` is load-bearing.** Flex items default to `min-height: auto`,
+which refuses to shrink a box below its content's intrinsic height. Without it
+on every ancestor between the capped dialog and the scrolling list, the middle
+row stays 15,000px tall and overflows the `maxHeight` cap.
+
+This also repairs the preview pane (line 231), which carries the identical
+unbounded `flex: 1, overflow: auto` and would overflow once a previewed folder
+contains enough shows.
+
+### 2. Path input (fixes symptom 4)
+
+A new row between the header and the two panes:
+
+- Monospace text field, seeded with `cwd` and re-synced to `cwd` on every
+  successful navigation. It therefore doubles as the current-location display
+  and replaces the truncated `cwd` label at line 191.
+- A GO button. Enter in the field is equivalent.
+
+**Submit semantics: navigate and preview.** This is exactly what clicking a
+directory row does today (line 207: `navigate(e.path), choose(e.path)`), so a
+typed path is a pure shortcut for "scroll to that folder and click it". No new
+gesture for the user to learn, and one code path.
+
+Sequencing differs from the click handler in one respect. The click handler
+fires `navigate` and `choose` in parallel against a path known to exist. A typed
+path may not exist, and firing both in parallel yields two errors for one typo.
+So on submit: `await navigate(path)` first, and call `choose(path)` only if it
+succeeded. This requires `navigate` to report success rather than swallowing the
+failure into state; it should return `boolean`.
+
+### 3. Scroll position on upward navigation
+
+Navigating up via `..` currently lands at the top of the parent's list, losing
+the user's place. After a successful `navigate`, if the previous `cwd` appears
+among the new `entries`, scroll that row into view with `block: "center"` and
+render it as active.
+
+### Out of scope
+
+- **Type-to-filter over the current directory.** Overlaps with the path input.
+- **Backend `mkv_count` cost.** `routes.py:2583` runs an `os.scandir` on every
+  direct child to count MKVs, so listing a 400-entry directory performs 400
+  extra directory reads. On a network volume this likely makes the modal slow to
+  open, independent of the layout bug. Worth its own issue; not required to
+  resolve this report.
+
+## Error handling
+
+No new error plumbing. `GET /api/import/browse` already returns
+`400 Not a directory: {path}` (`routes.py:2574`), `navigate` already catches and
+writes to the `error` state (line 48), and `error` already renders through the
+`Notice` component (line 285). A typo surfaces as a red notice in the preview
+pane.
+
+The existing `navSeq` / `chooseSeq` monotonic request tokens (lines 33 and 34)
+must keep guarding the typed-path route, since a slow browse of a large
+directory can still be superseded by a subsequent click.
+
+## Testing
+
+**Unit** (`ImportModal.test.tsx`, existing file, vitest + RTL):
+
+- Typing a valid path and pressing Enter calls `browseDir` then `previewImport`
+  with that path.
+- Typing an invalid path renders the error notice and does **not** call
+  `previewImport`.
+- With a 400-entry `entries` fixture, the `..` row and the START IMPORT button
+  are both present in the document.
+- Navigating up scrolls the previously visited child into view.
+
+jsdom has no layout engine and reports every height as zero, so it cannot verify
+the layout fix. That needs a browser.
+
+**E2E** (`import-flow.spec.ts`, existing file, Playwright):
+
+- With a seeded large directory, assert the panel's `boundingBox().height` does
+  not exceed the viewport height, and that the START IMPORT button is in the
+  viewport.
+- Assert the list pane scrolls: its `scrollHeight` exceeds its `clientHeight`.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `frontend/src/components/ImportModal.tsx` | Flex-column layout, `minHeight: 0` chain, path input row, `navigate` returns boolean, scroll-into-view |
+| `frontend/src/components/ImportModal.test.tsx` | Path input and large-list tests |
+| `frontend/e2e/import-flow.spec.ts` | Bounded-height and scrollability assertions |
+
+No backend change. No API change.

--- a/frontend/e2e/import-flow.spec.ts
+++ b/frontend/e2e/import-flow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -15,8 +15,12 @@ import { join } from 'node:path';
  * so reset-all-jobs is available for test isolation.
  */
 
+/** Seeded trees are torn down in afterAll so runs don't litter the OS temp dir. */
+const seededRoots: string[] = [];
+
 function seedShowTree(): string {
     const root = mkdtempSync(join(tmpdir(), 'engram-import-'));
+    seededRoots.push(root);
     const disc = join(root, 'Demo Show', 'Season 1', 'Disc 1');
     mkdirSync(disc, { recursive: true });
     writeFileSync(join(disc, 't00.mkv'), Buffer.alloc(1024));
@@ -27,6 +31,7 @@ function seedShowTree(): string {
 /** A directory with enough children to overflow any viewport, plus one real show. */
 function seedManyDirs(count = 400): string {
     const root = mkdtempSync(join(tmpdir(), 'engram-import-big-'));
+    seededRoots.push(root);
     for (let i = 0; i < count; i++) {
         mkdirSync(join(root, `Show ${String(i).padStart(3, '0')}`), { recursive: true });
     }
@@ -37,6 +42,22 @@ function seedManyDirs(count = 400): string {
 }
 
 test.describe('Manual media import', () => {
+    // These tests point the app's import_watch_path at a temp tree. That setting
+    // lives in the shared app_config table and outlives the process, so restore
+    // it: otherwise it is left dangling at a directory afterAll just deleted.
+    let originalWatchPath = '';
+
+    test.beforeAll(async ({ request }) => {
+        const cfg = await (await request.get('/api/config')).json();
+        originalWatchPath = cfg.import_watch_path ?? '';
+    });
+
+    test.afterAll(async ({ request }) => {
+        await request.put('/api/config', { data: { import_watch_path: originalWatchPath } });
+        for (const root of seededRoots) rmSync(root, { recursive: true, force: true });
+        seededRoots.length = 0;
+    });
+
     test.beforeEach(async ({ request }) => {
         await request.delete('/api/simulate/reset-all-jobs');
     });

--- a/frontend/e2e/import-flow.spec.ts
+++ b/frontend/e2e/import-flow.spec.ts
@@ -24,6 +24,18 @@ function seedShowTree(): string {
     return root;
 }
 
+/** A directory with enough children to overflow any viewport, plus one real show. */
+function seedManyDirs(count = 400): string {
+    const root = mkdtempSync(join(tmpdir(), 'engram-import-big-'));
+    for (let i = 0; i < count; i++) {
+        mkdirSync(join(root, `Show ${String(i).padStart(3, '0')}`), { recursive: true });
+    }
+    const season = join(root, 'Zulu Show', 'Season 1');
+    mkdirSync(season, { recursive: true });
+    writeFileSync(join(season, 't00.mkv'), Buffer.alloc(1024));
+    return root;
+}
+
 test.describe('Manual media import', () => {
     test.beforeEach(async ({ request }) => {
         await request.delete('/api/simulate/reset-all-jobs');
@@ -72,5 +84,31 @@ test.describe('Manual media import', () => {
                 { timeout: 15000 },
             )
             .toBe(true);
+    });
+
+    test('folder browser stays within the viewport and scrolls', async ({ page, request }) => {
+        const root = seedManyDirs();
+        await request.put('/api/config', { data: { import_watch_path: root } });
+
+        await page.goto('/');
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 10000 });
+        await page.getByTestId('sv-import-btn').click();
+        await expect(page.getByText('IMPORT MEDIA')).toBeVisible();
+
+        const list = page.getByTestId('import-nav-list');
+        await expect(list.getByText('Show 000', { exact: true })).toBeVisible({ timeout: 15000 });
+
+        // The panel must not exceed the viewport.
+        const viewport = page.viewportSize()!;
+        const panel = await page.getByTestId('import-panel').boundingBox();
+        expect(panel!.height).toBeLessThanOrEqual(viewport.height);
+
+        // Header, the up-a-level row, and the footer button all stay reachable.
+        await expect(page.getByText('..', { exact: true })).toBeVisible();
+        await expect(page.getByTestId('import-start-btn')).toBeInViewport();
+
+        // The list itself is the scroll container.
+        const scrolls = await list.evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+        expect(scrolls).toBe(true);
     });
 });

--- a/frontend/src/components/ImportModal.test.tsx
+++ b/frontend/src/components/ImportModal.test.tsx
@@ -94,4 +94,32 @@ describe("ImportModal", () => {
     expect(screen.getByText("..")).toBeInTheDocument();
     expect(screen.getByTestId("import-start-btn")).toBeInTheDocument();
   });
+
+  it("does not overwrite text the user is typing when a slow browse resolves", async () => {
+    let resolveBrowse: (v: client.BrowseResult) => void = () => {};
+    vi.mocked(client.browseDir).mockImplementationOnce(
+      () =>
+        new Promise<client.BrowseResult>((r) => {
+          resolveBrowse = r;
+        }),
+    );
+
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+
+    // The initial browse is still in flight; the user types a path.
+    const input = screen.getByTestId("import-path-input");
+    fireEvent.change(input, { target: { value: "/Volumes/TV Shows/Engram" } });
+
+    // The slow browse now lands on a different directory.
+    resolveBrowse({ cwd: "/media", parent: "/", roots: [], entries: [] });
+
+    await waitFor(() => expect(client.browseDir).toHaveBeenCalled());
+    expect((input as HTMLInputElement).value).toBe("/Volumes/TV Shows/Engram");
+  });
+
+  it("syncs the field to the directory that a folder click navigates into", async () => {
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("King of Queens"));
+    expect((screen.getByTestId("import-path-input") as HTMLInputElement).value).toBe("/media");
+  });
 });

--- a/frontend/src/components/ImportModal.test.tsx
+++ b/frontend/src/components/ImportModal.test.tsx
@@ -118,6 +118,35 @@ describe("ImportModal", () => {
     expect((input as HTMLInputElement).value).toBe("/Volumes/TV Shows/Engram");
   });
 
+  it("resumes tracking the location when the user types but then clicks a folder", async () => {
+    vi.mocked(client.browseDir)
+      .mockResolvedValueOnce({
+        cwd: "/media",
+        parent: "/",
+        roots: [],
+        entries: [
+          { name: "King of Queens", path: "/media/King of Queens", type: "dir", mkv_count: 0 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        cwd: "/media/King of Queens",
+        parent: "/media",
+        roots: [],
+        entries: [],
+      });
+
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    const input = screen.getByTestId("import-path-input") as HTMLInputElement;
+    await waitFor(() => screen.getByText("King of Queens"));
+
+    // User starts typing a path but abandons it and clicks a folder instead.
+    fireEvent.change(input, { target: { value: "/half-typed" } });
+    fireEvent.click(screen.getByText("King of Queens"));
+
+    // The field must follow the click, not stay stuck on the abandoned text.
+    await waitFor(() => expect(input.value).toBe("/media/King of Queens"));
+  });
+
   it("syncs the field to the directory that a folder click navigates into", async () => {
     render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
     await waitFor(() => screen.getByText("King of Queens"));

--- a/frontend/src/components/ImportModal.test.tsx
+++ b/frontend/src/components/ImportModal.test.tsx
@@ -5,6 +5,10 @@ import ImportModal from "./ImportModal";
 import * as client from "../api/client";
 
 beforeEach(() => {
+  // Prior calls must not leak into the next test: vi.spyOn returns the same
+  // mock (with its accumulated call history) once a method is already spied,
+  // since it's the same module-level client object across the whole file.
+  vi.restoreAllMocks();
   vi.spyOn(client, "browseDir").mockResolvedValue({
     cwd: "/media",
     parent: "/",
@@ -41,5 +45,53 @@ describe("ImportModal", () => {
     fireEvent.click(startBtn);
     await waitFor(() => expect(client.startImport).toHaveBeenCalledWith("/media/King of Queens", "library"));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("navigates to and previews a typed path", async () => {
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("King of Queens"));
+
+    fireEvent.change(screen.getByTestId("import-path-input"), {
+      target: { value: "/Volumes/TV Shows/Engram" },
+    });
+    fireEvent.submit(screen.getByTestId("import-path-form"));
+
+    await waitFor(() =>
+      expect(client.browseDir).toHaveBeenCalledWith("/Volumes/TV Shows/Engram"),
+    );
+    await waitFor(() =>
+      expect(client.previewImport).toHaveBeenCalledWith("/Volumes/TV Shows/Engram"),
+    );
+  });
+
+  it("shows an error and skips the preview when the typed path is bad", async () => {
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("King of Queens"));
+
+    vi.mocked(client.browseDir).mockRejectedValueOnce(new Error("Not a directory: /nope"));
+    fireEvent.change(screen.getByTestId("import-path-input"), { target: { value: "/nope" } });
+    fireEvent.submit(screen.getByTestId("import-path-form"));
+
+    await waitFor(() => expect(screen.getByText("Not a directory: /nope")).toBeInTheDocument());
+    expect(client.previewImport).not.toHaveBeenCalled();
+  });
+
+  it("keeps the up-a-level row and start button present with a large directory", async () => {
+    vi.mocked(client.browseDir).mockResolvedValue({
+      cwd: "/media",
+      parent: "/",
+      roots: [],
+      entries: Array.from({ length: 400 }, (_, i) => ({
+        name: `Show ${i}`,
+        path: `/media/Show ${i}`,
+        type: "dir" as const,
+        mkv_count: 0,
+      })),
+    });
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+
+    await waitFor(() => expect(screen.getByText("Show 399")).toBeInTheDocument());
+    expect(screen.getByText("..")).toBeInTheDocument();
+    expect(screen.getByTestId("import-start-btn")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ImportModal.test.tsx
+++ b/frontend/src/components/ImportModal.test.tsx
@@ -5,6 +5,7 @@ import ImportModal from "./ImportModal";
 import * as client from "../api/client";
 
 beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
   // Prior calls must not leak into the next test: vi.spyOn returns the same
   // mock (with its accumulated call history) once a method is already spied,
   // since it's the same module-level client object across the whole file.
@@ -121,5 +122,37 @@ describe("ImportModal", () => {
     render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
     await waitFor(() => screen.getByText("King of Queens"));
     expect((screen.getByTestId("import-path-input") as HTMLInputElement).value).toBe("/media");
+  });
+
+  it("scrolls the folder you came from into view when navigating up", async () => {
+    vi.mocked(client.browseDir)
+      .mockResolvedValueOnce({
+        cwd: "/media/King of Queens",
+        parent: "/media",
+        roots: [],
+        entries: [],
+      })
+      .mockResolvedValueOnce({
+        cwd: "/media",
+        parent: "/",
+        roots: [],
+        entries: [
+          { name: "King of Queens", path: "/media/King of Queens", type: "dir", mkv_count: 0 },
+        ],
+      });
+
+    render(
+      <ImportModal
+        onClose={() => {}}
+        defaultPath="/media/King of Queens"
+        defaultDestinationMode="library"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("..")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText(".."));
+
+    await waitFor(() => expect(screen.getByText("King of Queens")).toBeInTheDocument());
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: "center" });
   });
 });

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -47,6 +47,11 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   const navigate = useCallback(async (path: string): Promise<boolean> => {
     const seq = ++navSeq.current;
     setError(null);
+    // Any navigation (a row click, .., a typed submit) is a fresh location
+    // gesture, so hand the field back to the cwd sync. If the user resumes
+    // typing before the browse resolves, onChange re-dirties it and their text
+    // is preserved.
+    pathDirty.current = false;
     try {
       const res = await browseDir(path);
       if (seq !== navSeq.current) return false; // a newer navigation superseded this one
@@ -101,11 +106,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
       e.preventDefault();
       const target = pathInput.trim();
       if (!target) return;
-      // Hand the field back to the cwd sync. On a failed browse cwd never
-      // changes, so no sync fires and the bad text stays for the user to fix.
-      pathDirty.current = false;
       // Mirrors the directory-click gesture: browse into it, and preview it.
       // Only preview if the browse resolved, so one typo yields one error.
+      // navigate() clears the dirty flag; on a failed browse cwd never changes,
+      // so no sync fires and the bad text stays for the user to fix.
       if (await navigate(target)) await choose(target);
     },
     [pathInput, navigate, choose],

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -120,13 +120,24 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
       />
       <motion.div
         className="relative w-full"
-        style={{ maxWidth: 820 }}
+        style={{ maxWidth: 820, maxHeight: "82vh", minHeight: 340, display: "flex" }}
         initial={{ opacity: 0, scale: 0.96, y: 16 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.96, y: 16 }}
         transition={{ type: "spring", stiffness: 400, damping: 30 }}
       >
-        <SvPanel glow pad={0} style={{ background: sv.bg1 }}>
+        <SvPanel
+          glow
+          pad={0}
+          testid="import-panel"
+          style={{
+            background: sv.bg1,
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
           {/* Header */}
           <div
             style={{
@@ -135,6 +146,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
               gap: 10,
               padding: "14px 18px",
               borderBottom: `1px solid ${sv.line}`,
+              flexShrink: 0,
             }}
           >
             <IcoLibrary size={18} color={sv.cyan} />
@@ -166,7 +178,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
             </button>
           </div>
 
-          <div style={{ display: "flex", minHeight: 340 }}>
+          <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
             {/* Left: navigator */}
             <div
               style={{
@@ -174,6 +186,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
                 borderRight: `1px solid ${sv.line}`,
                 display: "flex",
                 flexDirection: "column",
+                minHeight: 0,
               }}
             >
               <div
@@ -190,7 +203,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
               >
                 {cwd ?? "Select a drive"}
               </div>
-              <div style={{ flex: 1, overflow: "auto" }}>
+              <div data-testid="import-nav-list" style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
                 {parent !== null && (
                   <Row label=".." onClick={() => navigate(parent)} kind="dir" />
                 )}
@@ -215,7 +228,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
             </div>
 
             {/* Right: preview */}
-            <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
               <div
                 style={{
                   padding: "8px 14px",
@@ -228,7 +241,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
               >
                 PREVIEW
               </div>
-              <div style={{ flex: 1, overflow: "auto", padding: 14 }}>
+              <div style={{ flex: 1, overflow: "auto", padding: 14, minHeight: 0 }}>
                 {!preview && (
                   <p style={{ fontFamily: sv.mono, fontSize: 11, color: sv.inkFaint }}>
                     Select a folder or file to preview.
@@ -286,7 +299,9 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
               </div>
 
               {/* Destination */}
-              <div style={{ padding: "10px 14px", borderTop: `1px solid ${sv.line}` }}>
+              <div
+                style={{ padding: "10px 14px", borderTop: `1px solid ${sv.line}`, flexShrink: 0 }}
+              >
                 <div
                   style={{
                     fontFamily: sv.mono,
@@ -331,6 +346,7 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
               gap: 10,
               padding: "12px 16px",
               borderTop: `1px solid ${sv.line}`,
+              flexShrink: 0,
             }}
           >
             <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint }}>

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
 import { motion } from "motion/react";
 import { IcoLibrary, IcoFilter, IcoError } from "../app/components/icons";
 import { SvPanel, sv } from "../app/components/synapse";
@@ -27,12 +28,16 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   const [destMode, setDestMode] = useState<"library" | "in_place">(defaultDestinationMode);
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
+  const [pathInput, setPathInput] = useState(defaultPath || "");
   const dialogRef = useRef<HTMLDivElement>(null);
   // Monotonic request tokens so a slow earlier click can't overwrite the state
   // of a later one (navigate and choose fire together per directory click).
   const navSeq = useRef(0);
   const chooseSeq = useRef(0);
 
+  // Returns false when the browse failed OR was superseded by a newer navigation.
+  // Only the failure case surfaces an error notice; callers must not chain a
+  // preview off a false return either way.
   const navigate = useCallback(async (path: string): Promise<boolean> => {
     const seq = ++navSeq.current;
     setError(null);
@@ -60,6 +65,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
     dialogRef.current?.focus();
   }, []);
 
+  useEffect(() => {
+    if (cwd) setPathInput(cwd);
+  }, [cwd]);
+
   const choose = useCallback(async (path: string) => {
     const seq = ++chooseSeq.current;
     setSelected(path);
@@ -75,6 +84,18 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
       }
     }
   }, []);
+
+  const submitPath = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      const target = pathInput.trim();
+      if (!target) return;
+      // Mirrors the directory-click gesture: browse into it, and preview it.
+      // Only preview if the browse resolved, so one typo yields one error.
+      if (await navigate(target)) await choose(target);
+    },
+    [pathInput, navigate, choose],
+  );
 
   const onStart = useCallback(async () => {
     if (!selected || !preview || preview.total_jobs === 0) return;
@@ -180,6 +201,55 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
             </button>
           </div>
 
+          <form
+            onSubmit={submitPath}
+            data-testid="import-path-form"
+            style={{
+              display: "flex",
+              gap: 6,
+              padding: "8px 12px",
+              borderBottom: `1px solid ${sv.line}`,
+              flexShrink: 0,
+            }}
+          >
+            <input
+              data-testid="import-path-input"
+              value={pathInput}
+              onChange={(e) => setPathInput(e.target.value)}
+              spellCheck={false}
+              aria-label="Path"
+              placeholder="Type or paste a folder path"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                fontFamily: sv.mono,
+                fontSize: 11,
+                padding: "5px 8px",
+                background: sv.bg0,
+                border: `1px solid ${sv.lineMid}`,
+                color: sv.ink,
+                outline: "none",
+              }}
+            />
+            <button
+              type="submit"
+              data-testid="import-path-go"
+              style={{
+                fontFamily: sv.mono,
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.1em",
+                padding: "5px 12px",
+                border: `1px solid ${sv.cyan}`,
+                background: "transparent",
+                color: sv.cyan,
+                cursor: "pointer",
+              }}
+            >
+              GO
+            </button>
+          </form>
+
           <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
             {/* Left: navigator */}
             <div
@@ -191,20 +261,6 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
                 minHeight: 0,
               }}
             >
-              <div
-                style={{
-                  padding: "8px 12px",
-                  fontFamily: sv.mono,
-                  fontSize: 10,
-                  color: sv.inkFaint,
-                  borderBottom: `1px solid ${sv.line}`,
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
-                {cwd ?? "Select a drive"}
-              </div>
               <div data-testid="import-nav-list" style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
                 {parent !== null && (
                   <Row label=".." onClick={() => navigate(parent)} kind="dir" />

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -34,6 +34,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   // of a later one (navigate and choose fire together per directory click).
   const navSeq = useRef(0);
   const chooseSeq = useRef(0);
+  // Set once the user edits the path field, cleared when they submit it. Guards
+  // the cwd sync below; a ref, not state, since it must not trigger a re-render
+  // and must be readable in the same commit that applies a new cwd.
+  const pathDirty = useRef(false);
 
   // Returns false when the browse failed OR was superseded by a newer navigation.
   // Only the failure case surfaces an error notice; callers must not chain a
@@ -65,8 +69,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
     dialogRef.current?.focus();
   }, []);
 
+  // Keep the field showing the current directory, but never overwrite text the
+  // user is actively typing: a slow browse can resolve mid-keystroke.
   useEffect(() => {
-    if (cwd) setPathInput(cwd);
+    if (cwd && !pathDirty.current) setPathInput(cwd);
   }, [cwd]);
 
   const choose = useCallback(async (path: string) => {
@@ -90,6 +96,9 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
       e.preventDefault();
       const target = pathInput.trim();
       if (!target) return;
+      // Hand the field back to the cwd sync. On a failed browse cwd never
+      // changes, so no sync fires and the bad text stays for the user to fix.
+      pathDirty.current = false;
       // Mirrors the directory-click gesture: browse into it, and preview it.
       // Only preview if the browse resolved, so one typo yields one error.
       if (await navigate(target)) await choose(target);
@@ -215,7 +224,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
             <input
               data-testid="import-path-input"
               value={pathInput}
-              onChange={(e) => setPathInput(e.target.value)}
+              onChange={(e) => {
+                pathDirty.current = true;
+                setPathInput(e.target.value);
+              }}
               spellCheck={false}
               aria-label="Path"
               placeholder="Type or paste a folder path"

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -29,7 +29,9 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   const [error, setError] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [pathInput, setPathInput] = useState(defaultPath || "");
+  const [landmark, setLandmark] = useState<string | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const cwdRef = useRef<string | null>(null);
   // Monotonic request tokens so a slow earlier click can't overwrite the state
   // of a later one (navigate and choose fire together per directory click).
   const navSeq = useRef(0);
@@ -48,6 +50,9 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
     try {
       const res = await browseDir(path);
       if (seq !== navSeq.current) return false; // a newer navigation superseded this one
+      const prev = cwdRef.current;
+      cwdRef.current = res.cwd;
+      setLandmark(prev && res.entries.some((e) => e.path === prev) ? prev : null);
       setCwd(res.cwd);
       setParent(res.parent);
       setEntries(res.entries);
@@ -286,7 +291,8 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
                     label={e.name}
                     count={e.type === "dir" ? e.mkv_count : undefined}
                     kind={e.type}
-                    active={selected === e.path}
+                    active={selected === e.path || landmark === e.path}
+                    scrollTo={landmark === e.path}
                     onClick={() =>
                       e.type === "dir"
                         ? (navigate(e.path), choose(e.path))
@@ -473,16 +479,24 @@ function Row({
   count,
   kind,
   active,
+  scrollTo,
   onClick,
 }: {
   label: string;
   count?: number;
   kind: "dir" | "mkv";
   active?: boolean;
+  scrollTo?: boolean;
   onClick: () => void;
 }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (scrollTo) ref.current?.scrollIntoView({ block: "center" });
+  }, [scrollTo]);
+
   return (
     <button
+      ref={ref}
       onClick={onClick}
       style={{
         display: "flex",

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -159,9 +159,11 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
         onClick={onClose}
         data-testid="import-backdrop"
       />
+      {/* min() so the 82vh cap always wins on short viewports: a bare
+          minHeight: 340 would beat max-height below ~415px tall and re-overflow. */}
       <motion.div
         className="relative w-full"
-        style={{ maxWidth: 820, maxHeight: "82vh", minHeight: 340, display: "flex" }}
+        style={{ maxWidth: 820, maxHeight: "82vh", minHeight: "min(340px, 82vh)", display: "flex" }}
         initial={{ opacity: 0, scale: 0.96, y: 16 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.96, y: 16 }}

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -33,20 +33,22 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   const navSeq = useRef(0);
   const chooseSeq = useRef(0);
 
-  const navigate = useCallback(async (path: string) => {
+  const navigate = useCallback(async (path: string): Promise<boolean> => {
     const seq = ++navSeq.current;
     setError(null);
     try {
       const res = await browseDir(path);
-      if (seq !== navSeq.current) return; // a newer navigation superseded this one
+      if (seq !== navSeq.current) return false; // a newer navigation superseded this one
       setCwd(res.cwd);
       setParent(res.parent);
       setEntries(res.entries);
       setRoots(res.roots);
+      return true;
     } catch (e) {
       if (seq === navSeq.current) {
         setError(e instanceof Error ? e.message : "Could not read directory");
       }
+      return false;
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes a reported bug in the manual-import folder browser: when a directory has more subfolders than fit on screen (a user's `/Volumes/TV Shows` has several hundred), the list did not scroll, opened partway down the alphabet, and offered no visible way up.

The root cause was a single CSS defect. The folder list at `ImportModal.tsx` had `overflow: auto` but no ancestor capped a height, so with ~400 entries the modal panel grew to ~15,000px, and the outer `items-center` container centered that oversized panel and clipped it symmetrically. That is why it "opened around the Ms": the visible slice was the middle of an alphabetically sorted list. The `..` row, the header, and the START IMPORT button all rendered correctly but sat far outside the viewport.

## What changed

- **Bounded height (the fix).** The dialog is capped at `82vh`, `SvPanel` is a flex column, and `minHeight: 0` is threaded down the flex chain so the list becomes the shrinking, scrolling pane. Header, destination toggle, and footer stay pinned. This also repairs the preview pane, which carried the same latent defect.
- **Typed path input.** A path field (with GO / Enter) lets you paste an exact folder path instead of clicking through hundreds of folders. Submitting reuses the existing directory-click gesture (browse + preview), so it is a pure shortcut for scrolling and clicking. The field doubles as a current-location display.
- **`navigate()` returns `Promise<boolean>`** so a typed path only previews when the browse succeeded (one typo yields one error, not two).
- **No clobbering while typing.** A dirty-ref guards the location-sync effect so a slow network browse resolving mid-keystroke cannot overwrite what you are typing; clicking a folder or submitting hands the field back to the sync.
- **Scroll-restore.** Going up a level scrolls the folder you came from back into view and highlights it, instead of dumping you at the top of a 400-row list.
- **E2E hygiene.** The import spec now tears down its seeded temp trees and restores the shared `import_watch_path` config in `afterAll`, so runs don't litter the OS temp dir or leave the setting dangling at a deleted directory.

Design and plan: `docs/superpowers/specs/2026-07-09-import-browser-scroll-design.md`, `docs/superpowers/plans/2026-07-09-import-browser-scroll.md`.

## Test plan

- [x] `npm run test:unit` — 310 passed (9 in `ImportModal.test.tsx`, covering typed navigation, bad-path error routing, large-list render completeness, no-clobber-while-typing, click-after-type tracking, and scroll-restore)
- [x] `npm run build` (tsc + vite) — clean
- [x] `npm run lint` — clean
- [x] `npx playwright test e2e/import-flow.spec.ts` — 2 passed, including a new test that seeds 400 subfolders against a real backend and asserts the panel fits the viewport, the list scrolls, `..` is visible, and START IMPORT is in the viewport
- [x] Visually verified in a real browser at 2560x1440 with 400 subfolders (screenshot in PR thread)

Backend untouched; no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)