### PR TITLE
feat: add Background Animation toggle for low-power devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Background Animation toggle.** A new Settings → Preferences → Display checkbox disables the falling-code rip animation, a full-viewport canvas redrawn at 20fps that's a meaningful CPU/GPU cost on low-power devices (reported case: ARM64). Stored per-browser (not synced across devices viewing the same backend), defaults on, and seeds from the OS's reduced-motion setting when no explicit choice has been made. (#502)
+
 ## [0.24.0] - 2026-07-04
 
 _Highlights: manual track skipping for queued/not-yet-ripped tracks, plus field-validated Jetson GPU setup fixes._

--- a/docs/superpowers/plans/2026-07-09-background-effects-toggle.md
+++ b/docs/superpowers/plans/2026-07-09-background-effects-toggle.md
@@ -1,0 +1,444 @@
+# Background Effects Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Settings toggle that disables the resource-hungry falling-code rip animation (`SvRipAnimation`), so low-power devices (the reported case: ARM64) can turn it off independently of the OS's reduced-motion setting.
+
+**Architecture:** A new localStorage-backed React hook (`useBackgroundEffectsEnabled`) is the single source of truth. `App.tsx` reads it to gate whether `SvRipAnimation` ever mounts (one boolean `&&`'d onto the existing `ripActive` expression — no changes inside `SvAtmosphere`/`SvRipAnimation` themselves). A new self-contained settings component (`BackgroundEffectsSetting`, mirroring the existing `GpuAccelerationSetting` pattern) reads/writes the same hook and is dropped into a new "Display" group in `ConfigWizard`'s Preferences step. The preference never touches the backend — it describes the browser rendering the dashboard, not the backend host, so it deliberately bypasses `AppConfig`/`ConfigUpdate`/`ConfigResponse`.
+
+**Tech Stack:** React 18 + TypeScript, Vitest + React Testing Library (`frontend/src/**/__tests__` and colocated `*.test.tsx`), existing `ConfigWizard.tsx` checkbox-group markup/CSS (no new CSS).
+
+**Reference:** Full design rationale in [docs/superpowers/specs/2026-07-09-background-effects-toggle-design.md](../specs/2026-07-09-background-effects-toggle-design.md).
+
+---
+
+### Task 1: `useBackgroundEffectsEnabled` hook
+
+**Files:**
+- Create: `frontend/src/app/hooks/useBackgroundEffectsEnabled.ts`
+- Test: `frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts`:
+
+```ts
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useBackgroundEffectsEnabled } from "../useBackgroundEffectsEnabled";
+
+function stubMatchMedia(reducedMotion: boolean) {
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockImplementation((query: string) => ({
+            matches: reducedMotion,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    );
+}
+
+describe("useBackgroundEffectsEnabled", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        stubMatchMedia(false);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("defaults to enabled when there is no stored preference and the OS has no reduced-motion request", () => {
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("defaults to disabled when the OS requests reduced motion and there is no stored preference", () => {
+        stubMatchMedia(true);
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(false);
+    });
+
+    it("persists an explicit choice to localStorage and a fresh mount reflects it", () => {
+        const { result, unmount } = renderHook(() => useBackgroundEffectsEnabled());
+        act(() => result.current[1](false));
+        expect(result.current[0]).toBe(false);
+        expect(localStorage.getItem("engram:backgroundEffectsEnabled")).toBe("false");
+        unmount();
+
+        const { result: second } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(second.current[0]).toBe(false);
+    });
+
+    it("an explicit stored choice overrides the reduced-motion default", () => {
+        localStorage.setItem("engram:backgroundEffectsEnabled", "true");
+        stubMatchMedia(true); // OS says reduce motion, but the user already chose "on"
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("falls back to enabled when matchMedia is unavailable (matches useMediaQuery's documented fallback)", () => {
+        vi.stubGlobal("matchMedia", undefined);
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("degrades to in-memory state when localStorage throws", () => {
+        const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+            throw new Error("blocked");
+        });
+        const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw new Error("blocked");
+        });
+
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true); // falls back to the reduced-motion-based default
+
+        expect(() => act(() => result.current[1](false))).not.toThrow();
+        expect(result.current[0]).toBe(false); // in-memory state still updates
+
+        getItemSpy.mockRestore();
+        setItemSpy.mockRestore();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts`
+Expected: FAIL — `Cannot find module '../useBackgroundEffectsEnabled'` (the hook doesn't exist yet).
+
+- [ ] **Step 3: Write the hook**
+
+Create `frontend/src/app/hooks/useBackgroundEffectsEnabled.ts`:
+
+```ts
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "engram:backgroundEffectsEnabled";
+
+function readStoredPreference(): boolean | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether ambient background effects (currently: the falling-code rip
+ * animation in SvRipAnimation) should render. Persisted per-browser in
+ * localStorage — this describes the device viewing the dashboard, not the
+ * backend host, so it deliberately does not go through AppConfig.
+ *
+ * With no stored preference yet, seeds from `prefers-reduced-motion` (off if
+ * the OS already asks for reduced motion). Once the user makes an explicit
+ * choice, that choice always wins over the OS setting.
+ */
+export function useBackgroundEffectsEnabled(): [boolean, (enabled: boolean) => void] {
+  const [enabled, setEnabledState] = useState<boolean>(() => {
+    const stored = readStoredPreference();
+    if (stored !== null) return stored;
+    return !prefersReducedMotion();
+  });
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // localStorage unavailable — preference stays in-memory for this session
+    }
+  }, []);
+
+  return [enabled, setEnabled];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/hooks/useBackgroundEffectsEnabled.ts frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts
+git commit -m "feat: add useBackgroundEffectsEnabled hook"
+```
+
+---
+
+### Task 2: Wire the preference into `App.tsx`
+
+**Files:**
+- Modify: `frontend/src/app/App.tsx:1-40` (imports), `frontend/src/app/App.tsx:258-259` (hook call), `frontend/src/app/App.tsx:286` (gate expression)
+- Test: `frontend/src/app/App.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `frontend/src/app/App.test.tsx`, add `localStorage.clear();` as the first line of the existing top-level `beforeEach` (the one that stubs `matchMedia` and `fetch`, currently starting at line 78) so this task's tests don't leak state into others. Then add a new `describe` block anywhere after the existing ones (e.g. at the end of the file):
+
+```tsx
+describe('App — background effects preference', () => {
+    it('renders the rip animation while ripping when the preference is on (default)', async () => {
+        mockJobs([makeJob({ id: 1, state: 'ripping', volume_label: 'INCEPTION_2010', content_type: 'movie' })]);
+        renderApp();
+
+        expect(await screen.findByTestId('sv-rip-animation')).toBeInTheDocument();
+    });
+
+    it('does not render the rip animation while ripping when the preference is off', async () => {
+        localStorage.setItem('engram:backgroundEffectsEnabled', 'false');
+        mockJobs([makeJob({ id: 1, state: 'ripping', volume_label: 'INCEPTION_2010', content_type: 'movie' })]);
+        renderApp();
+
+        await screen.findByTestId('sv-atmosphere');
+        expect(screen.queryByTestId('sv-rip-animation')).not.toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/app/App.test.tsx -t "background effects preference"`
+Expected: FAIL on the second test — the animation renders regardless of the (not-yet-read) preference, so `sv-rip-animation` is still present when the preference is set to `'false'`.
+
+- [ ] **Step 3: Wire the hook into `App.tsx`**
+
+Add the import alongside the other hook imports (`frontend/src/app/App.tsx:9-11`):
+
+```diff
+ import { useMediaQuery } from "./hooks/useMediaQuery";
+ import { useNotifications } from "./hooks/useNotifications";
+ import { useUpdateSuccessToast } from "./hooks/useUpdateSuccessToast";
++import { useBackgroundEffectsEnabled } from "./hooks/useBackgroundEffectsEnabled";
+```
+
+Call the hook right after `railFits` (`frontend/src/app/App.tsx:258-259`):
+
+```diff
+   const railFits = useMediaQuery("(min-width: 1100px)");
+   const showSideRail = filteredDiscs.length > 0 && viewMode === "expanded" && railFits;
++  const [backgroundEffectsEnabled] = useBackgroundEffectsEnabled();
+```
+
+Fold it into the existing `ripActive` expression (`frontend/src/app/App.tsx:286`):
+
+```diff
+-    <SvAtmosphere ripActive={discsData.some((d) => d.state === "ripping")}>
++    <SvAtmosphere ripActive={backgroundEffectsEnabled && discsData.some((d) => d.state === "ripping")}>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/app/App.test.tsx`
+Expected: PASS (full file — confirms this change didn't regress the existing prompt-surfacing / walk-away tests in the same file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/App.tsx frontend/src/app/App.test.tsx
+git commit -m "feat: gate the rip animation on the background-effects preference"
+```
+
+---
+
+### Task 3: Settings UI — `BackgroundEffectsSetting` in the Preferences step
+
+**Files:**
+- Create: `frontend/src/components/BackgroundEffectsSetting.tsx`
+- Modify: `frontend/src/components/ConfigWizard.tsx:8` (import), `frontend/src/components/ConfigWizard.tsx:1716-1718` (new "Display" group)
+- Test: `frontend/src/components/ConfigWizard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+In `frontend/src/components/ConfigWizard.test.tsx`, add `type Mock` to the vitest import (line 3):
+
+```diff
+-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
++import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+```
+
+Add `localStorage.clear();` as the first line of the existing top-level `beforeEach` (starting at line 12) so this task's tests don't leak into others. Then add a new `describe` block at the end of the file:
+
+```tsx
+describe('ConfigWizard — background effects preference', () => {
+    it('shows a Background Animation checkbox in Preferences, on by default, and persists a toggle to localStorage without an API call', async () => {
+        render(<ConfigWizard {...noop} isOnboarding={false} />);
+        const nav = await screen.findByRole('navigation', { name: /settings sections/i });
+        fireEvent.click(within(nav).getByRole('button', { name: 'Preferences' }));
+
+        const toggle = await screen.findByRole('checkbox', { name: /background animation/i });
+        expect(toggle).toBeChecked();
+
+        await waitFor(() => expect((fetch as unknown as Mock).mock.calls.length).toBeGreaterThan(0));
+        const callsBeforeToggle = (fetch as unknown as Mock).mock.calls.length;
+
+        fireEvent.click(toggle);
+
+        expect(toggle).not.toBeChecked();
+        expect(localStorage.getItem('engram:backgroundEffectsEnabled')).toBe('false');
+        expect((fetch as unknown as Mock).mock.calls.length).toBe(callsBeforeToggle);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ConfigWizard.test.tsx -t "background effects preference"`
+Expected: FAIL — no element with role `checkbox` and accessible name matching `/background animation/i` exists yet.
+
+- [ ] **Step 3: Create the settings component**
+
+Create `frontend/src/components/BackgroundEffectsSetting.tsx`:
+
+```tsx
+import { useBackgroundEffectsEnabled } from '../app/hooks/useBackgroundEffectsEnabled';
+
+/**
+ * Self-contained toggle for the ambient falling-code rip animation
+ * (SvRipAnimation). Reads/writes localStorage directly via the hook rather
+ * than routing through ConfigWizard's `config` state — this preference
+ * describes the browser rendering the dashboard, not the backend host, so it
+ * never touches AppConfig or the generic config save.
+ */
+export default function BackgroundEffectsSetting() {
+    const [enabled, setEnabled] = useBackgroundEffectsEnabled();
+
+    return (
+        <div className="form-group checkbox-group">
+            <label className="checkbox-label">
+                <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={(e) => setEnabled(e.target.checked)}
+                />
+                <span className="checkbox-text">
+                    <strong>Background Animation</strong>
+                    <span className="checkbox-hint">
+                        The falling-code effect shown behind the dashboard while a disc is
+                        ripping. Turn this off on low-power devices (e.g. ARM64 single-board
+                        computers) to reduce CPU/GPU usage. Independent of your OS's
+                        reduced-motion setting — takes effect immediately, no restart needed.
+                    </span>
+                </span>
+            </label>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 4: Add it to the Preferences step in `ConfigWizard.tsx`**
+
+Add the import near the other settings-component imports (`frontend/src/components/ConfigWizard.tsx:8`):
+
+```diff
+ import GpuAccelerationSetting from './GpuAccelerationSetting';
++import BackgroundEffectsSetting from './BackgroundEffectsSetting';
+```
+
+Insert a new "Display" group after the "Notifications" group closes and before the "Configuration Summary" block (`frontend/src/components/ConfigWizard.tsx:1716-1718`):
+
+```diff
+                             </div>
+                         </details>
+
++                        {/* ── Display ──────────────────────────────────────────── */}
++                        <details className="wizard-group" open>
++                            <summary>
++                                <span className="wizard-group-chevron">▸</span>Display
++                            </summary>
++                            <div className="wizard-group-body">
++
++                        <BackgroundEffectsSetting />
++
++                            </div>
++                        </details>
++
+                         <div className="config-summary">
+```
+
+(This group defaults `open`, matching the first Preferences group — "Matching & ordering" — rather than the closed default used by the later groups, since this is the exact control a low-power-device user opens Settings to find.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ConfigWizard.test.tsx`
+Expected: PASS (full file — confirms no regression to the other Preferences-step tests, e.g. the GPU deep-link test)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/BackgroundEffectsSetting.tsx frontend/src/components/ConfigWizard.tsx frontend/src/components/ConfigWizard.test.tsx
+git commit -m "feat: add Background Animation toggle to Settings > Preferences > Display"
+```
+
+---
+
+### Task 4: Manual verification in the browser
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Start the backend with simulation enabled**
+
+From `backend/`:
+```powershell
+$env:DEBUG = "true"
+uv run uvicorn app.main:app --port 8000
+```
+
+- [ ] **Step 2: Start the frontend**
+
+From `frontend/`:
+```powershell
+npm run dev
+```
+
+- [ ] **Step 3: Simulate a ripping disc**
+
+```bash
+curl -X POST localhost:8000/api/simulate/insert-disc \
+  -H "Content-Type: application/json" \
+  -d '{"volume_label":"INCEPTION_2010","content_type":"movie","simulate_ripping":true}'
+```
+
+- [ ] **Step 4: Confirm the animation renders by default**
+
+Open `http://localhost:5173` in a browser. Confirm the falling-code background animation is visible behind the dashboard while the simulated disc is ripping.
+
+- [ ] **Step 5: Toggle it off and confirm it stops immediately**
+
+Open Settings (gear icon) → Preferences → Display, and un-check "Background Animation". Confirm the animation disappears immediately, with the settings modal still open (no need to click Save, no page reload).
+
+- [ ] **Step 6: Confirm persistence across a reload**
+
+Reload the page. Confirm the animation stays off (re-check DevTools → Application → Local Storage → `engram:backgroundEffectsEnabled` is `"false"`).
+
+- [ ] **Step 7: Clean up**
+
+```bash
+curl -X DELETE localhost:8000/api/simulate/reset-all-jobs
+```
+
+Stop the backend/frontend dev servers started in Steps 1–2 (see CLAUDE.md "Important Rules" — never leave `uvicorn`/`makemkvcon` processes orphaned).

--- a/docs/superpowers/specs/2026-07-09-background-effects-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-09-background-effects-toggle-design.md
@@ -1,0 +1,137 @@
+# Background Effects Toggle — Design
+
+**Date:** 2026-07-09
+**Status:** Approved for planning
+
+## Problem
+
+`SvRipAnimation` (`frontend/src/app/components/synapse/SvRipAnimation.tsx`) renders a
+full-viewport `<canvas>` "falling code" background whenever a disc is ripping. Per its own
+doc comment, this is a ~8k-cell field redrawn every tick via `requestAnimationFrame` at
+20fps. On weak hardware — an ARM64 device was the reported case — this is a continuous
+CPU/GPU cost with no way to turn it off short of the OS-level `prefers-reduced-motion`
+setting (which the component already respects, but which many users won't touch just for
+one app, and which also silences other, cheaper motion they may want to keep).
+
+This design adds an explicit, app-level toggle scoped to just this animation.
+
+## Non-goals
+
+- **Not** touching `SvAtmosphere`'s static layers (haze gradient, scanline overlay, SVG
+  `feTurbulence` grain filter, vignette). These aren't animated (no RAF loop) and the design
+  handoff calls them always-on with no settings toggle in production. Confirmed with the user
+  as out of scope — the rip animation's continuous redraw is the actual resource cost.
+- **Not** a general "reduce all motion" switch. Framer Motion transitions elsewhere (card
+  hover, page transitions) are cheap, one-shot, and stay on. `prefers-reduced-motion`
+  remains the mechanism for users who want everything quieted.
+- **Not** persisted server-side. See "Storage" below for why.
+- **Not** live-synced across open tabs. A second tab picks up a changed preference on its
+  next reload.
+
+## Storage: browser localStorage, not backend AppConfig
+
+The constraint this preference addresses is the rendering cost on the *browser* showing the
+dashboard, not anything about the backend host. Those can be different machines (e.g. a
+backend running on a NAS, viewed from a weak tablet in one browser and a powerful desktop in
+another). A server-side `AppConfig` field would apply the same setting to every viewer
+regardless of their own hardware, which is the wrong scope. `localStorage`, keyed per
+browser/device, is correct here — and it also sidesteps the three-way sync backend settings
+require (`ConfigUpdate` / `ConfigResponse` / `ConfigWizard` state), since this field never
+touches the backend at all.
+
+## Components
+
+### `useBackgroundEffectsEnabled` hook
+
+New file: `frontend/src/app/hooks/useBackgroundEffectsEnabled.ts`.
+
+```ts
+export function useBackgroundEffectsEnabled(): [boolean, (v: boolean) => void]
+```
+
+- Storage key: `engram:backgroundEffectsEnabled` (`"true"` / `"false"`), following the
+  `engram:` prefix convention already used by `useUpdateSuccessToast`'s
+  `engram:lastSuccessToastVersion`.
+- Read/write wrapped in try/catch, degrading to in-memory-only state if `localStorage` is
+  unavailable (private browsing, storage quota, etc.) — same defensive pattern as
+  `useUpdateSuccessToast`.
+- **Default when no stored value exists:** seeded from
+  `window.matchMedia("(prefers-reduced-motion: reduce)").matches` — `false` (effects off) if
+  the OS already asks for reduced motion, `true` (effects on, i.e. unchanged current
+  behavior) otherwise. This seed is read once at mount; it does not reactively track the
+  media query afterward (unlike `useMediaQuery`), since once a value is stored, the OS
+  setting no longer applies — the explicit user choice always wins from then on.
+- No `storage` event listener — deliberately simple, per the non-goals above.
+
+### Wiring into `App.tsx`
+
+One-line change at the existing call site, [App.tsx:286](../../../frontend/src/app/App.tsx#L286):
+
+```diff
+- <SvAtmosphere ripActive={discsData.some((d) => d.state === "ripping")}>
++ <SvAtmosphere ripActive={backgroundEffectsEnabled && discsData.some((d) => d.state === "ripping")}>
+```
+
+No changes inside `SvAtmosphere.tsx` or `SvRipAnimation.tsx`. When `ripActive` is `false`,
+`SvAtmosphere` never mounts `<SvRipAnimation>` at all (see its existing
+`{ripActive && <SvRipAnimation key="rip" />}` in the `AnimatePresence` block) — so the
+canvas element and its RAF loop simply never exist. This is the same mechanism the
+component already uses to skip rendering when no disc is ripping; we're just adding a
+second condition to the same boolean.
+
+### `BackgroundEffectsSetting` component
+
+New file: `frontend/src/components/BackgroundEffectsSetting.tsx`, self-contained like
+`GpuAccelerationSetting.tsx` — it owns `useBackgroundEffectsEnabled()` directly rather than
+routing through `ConfigWizard`'s `config` state / `handleInputChange`, because this value
+never touches the backend.
+
+Rendered inside a new `<details className="wizard-group">` group titled **"Display"** in the
+Preferences step of `ConfigWizard.tsx` (step 5), alongside the existing "Matching &
+ordering" and "Maintenance & watchdog" groups. Markup follows the existing checkbox-group
+pattern (`form-group checkbox-group` / `checkbox-label` / `checkbox-text` /
+`checkbox-hint`) for visual consistency:
+
+- **Label:** "Background Animation"
+- **Hint:** explains this is the falling-code effect shown while ripping, and that turning
+  it off helps on low-power devices. Mentions it's independent of the OS's reduced-motion
+  setting.
+
+## Data flow
+
+```
+useBackgroundEffectsEnabled()  (localStorage, read once + seeded from prefers-reduced-motion)
+        │
+        ├─→ App.tsx: backgroundEffectsEnabled && ripActive → SvAtmosphere → SvRipAnimation
+        │
+        └─→ BackgroundEffectsSetting (in ConfigWizard Preferences → Display)
+                → setEnabled(checked) → writes localStorage → next App.tsx render picks it up
+```
+
+`App.tsx` and `BackgroundEffectsSetting` both call the hook independently (both are mounted
+under the same React tree while the settings modal is open over the dashboard), so toggling
+the checkbox takes effect immediately without a page reload — React state, not just storage,
+drives the re-render.
+
+## Error handling
+
+- `localStorage` unavailable or throwing: hook degrades to in-memory state (default applies
+  every session, toggle still works for that session, nothing crashes). Matches existing
+  precedent.
+- `window.matchMedia` unavailable (SSR/jsdom): default seed falls back to `true` (effects
+  on), matching `useMediaQuery`'s documented fallback convention for inverted queries.
+
+## Testing
+
+- **Unit (Vitest):** `useBackgroundEffectsEnabled` — default seeding from
+  `prefers-reduced-motion` both ways, persistence round-trip, `localStorage`-unavailable
+  fallback.
+- **Unit (Vitest):** `App.tsx` — with the hook mocked/stubbed off, a ripping job present does
+  *not* render `[data-testid="sv-rip-animation"]`; with it on (default), it does. Existing
+  `App.test.tsx` already stubs `matchMedia` for this component, so this extends existing
+  coverage rather than adding new scaffolding.
+- **Unit (Vitest):** `ConfigWizard` — toggling the new checkbox calls `setEnabled` with the
+  right value; verify it does *not* trigger the generic config save network call.
+- **Manual:** open dashboard, simulate a ripping disc, confirm animation renders; toggle off
+  in Settings → Preferences → Display, confirm it stops immediately without reload; reload
+  the page, confirm the setting persisted.

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -76,6 +76,8 @@ function renderApp() {
 }
 
 beforeEach(() => {
+    localStorage.clear();
+
     // jsdom has no matchMedia; SvRipAnimation (rendered for a ripping job)
     // reads prefers-reduced-motion through it. Shim it as "no preference".
     vi.stubGlobal(
@@ -403,5 +405,23 @@ describe('App — B7 content-change re-arm', () => {
             expect(newDialog).not.toBe(afterClearDialog);
         }
         expect(screen.getByText(/re-identify disc/i)).toBeInTheDocument();
+    });
+});
+
+describe('App — background effects preference', () => {
+    it('renders the rip animation while ripping when the preference is on (default)', async () => {
+        mockJobs([makeJob({ id: 1, state: 'ripping', volume_label: 'INCEPTION_2010', content_type: 'movie' })]);
+        renderApp();
+
+        expect(await screen.findByTestId('sv-rip-animation')).toBeInTheDocument();
+    });
+
+    it('does not render the rip animation while ripping when the preference is off', async () => {
+        localStorage.setItem('engram:backgroundEffectsEnabled', 'false');
+        mockJobs([makeJob({ id: 1, state: 'ripping', volume_label: 'INCEPTION_2010', content_type: 'movie' })]);
+        renderApp();
+
+        await screen.findByTestId('sv-atmosphere');
+        expect(screen.queryByTestId('sv-rip-animation')).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -9,6 +9,7 @@ import { useDiscFilters } from "./hooks/useDiscFilters";
 import { useMediaQuery } from "./hooks/useMediaQuery";
 import { useNotifications } from "./hooks/useNotifications";
 import { useUpdateSuccessToast } from "./hooks/useUpdateSuccessToast";
+import { useBackgroundEffectsEnabled } from "./hooks/useBackgroundEffectsEnabled";
 import ReviewQueue from "../components/ReviewQueue";
 import ConfigWizard from "../components/ConfigWizard";
 import NamePromptModal from "../components/NamePromptModal";
@@ -257,6 +258,7 @@ function MainDashboard() {
   // the 320px rail crushes the card column, so it folds away entirely.
   const railFits = useMediaQuery("(min-width: 1100px)");
   const showSideRail = filteredDiscs.length > 0 && viewMode === "expanded" && railFits;
+  const [backgroundEffectsEnabled] = useBackgroundEffectsEnabled();
 
   const reviewJobs = jobs.filter((j) => j.state === 'review_needed');
   const navItems = buildNavItems({
@@ -283,7 +285,7 @@ function MainDashboard() {
   };
 
   return (
-    <SvAtmosphere ripActive={discsData.some((d) => d.state === "ripping")}>
+    <SvAtmosphere ripActive={backgroundEffectsEnabled && discsData.some((d) => d.state === "ripping")}>
       {/* Full-screen overlay when WS has been down past the grace period.
           Stays on top of all chrome (z-index 100 inside Splash). */}
       {showOfflineSplash && (

--- a/frontend/src/app/components/synapse/SvAtmosphere.tsx
+++ b/frontend/src/app/components/synapse/SvAtmosphere.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties, ReactNode } from "react";
-import { AnimatePresence } from "motion/react";
 import { sv } from "./tokens";
 import { SvRipAnimation } from "./SvRipAnimation";
 
@@ -106,10 +105,15 @@ export function SvAtmosphere({
       </svg>
       <div style={vignette} />
       {/* Ambient falling-code layer — sits above the atmosphere gradients
-          (z-index 0) but below the content (z-index 1). */}
-      <AnimatePresence>
-        {ripActive && <SvRipAnimation key="rip" />}
-      </AnimatePresence>
+          (z-index 0) but below the content (z-index 1). Plain conditional
+          mount, not AnimatePresence: AnimatePresence's exit-then-remove
+          bookkeeping does not reliably fire for this single-child pattern in
+          real browsers (confirmed stuck at opacity:0, DOM node never
+          removed, RAF never resumable — invisible to jsdom tests since they
+          run under MotionConfig reducedMotion="always"). The fade-IN via
+          `initial`/`animate` still works without AnimatePresence; only the
+          fade-out is lost in exchange for reliable mount/unmount. */}
+      {ripActive && <SvRipAnimation />}
       <div style={content}>{children}</div>
     </div>
   );

--- a/frontend/src/app/components/synapse/SvRipAnimation.tsx
+++ b/frontend/src/app/components/synapse/SvRipAnimation.tsx
@@ -109,8 +109,10 @@ function drawField(
 }
 
 /**
- * Ambient falling-code background. Render gated on a ripping job; wrap the
- * call site in `<AnimatePresence>` for the fade-out when ripping ends.
+ * Ambient falling-code background. Conditionally mounted by the call site
+ * (plain `{ripActive && ...}`, not AnimatePresence — see SvAtmosphere.tsx
+ * for why) while ripping is active. Fades in via `initial`/`animate`;
+ * unmounts instantly (no exit transition) when ripping ends.
  */
 export function SvRipAnimation() {
   const reducedMotion = usePrefersReducedMotion();
@@ -173,7 +175,6 @@ export function SvRipAnimation() {
       }}
       initial={{ opacity: 0 }}
       animate={{ opacity: LAYER_OPACITY }}
-      exit={{ opacity: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
     >
       <canvas ref={canvasRef} style={{ display: "block" }} />

--- a/frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts
+++ b/frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useBackgroundEffectsEnabled } from "../useBackgroundEffectsEnabled";
+
+function stubMatchMedia(reducedMotion: boolean) {
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn().mockImplementation((query: string) => ({
+            matches: reducedMotion,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+    );
+}
+
+describe("useBackgroundEffectsEnabled", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        stubMatchMedia(false);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("defaults to enabled when there is no stored preference and the OS has no reduced-motion request", () => {
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("defaults to disabled when the OS requests reduced motion and there is no stored preference", () => {
+        stubMatchMedia(true);
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(false);
+    });
+
+    it("persists an explicit choice to localStorage and a fresh mount reflects it", () => {
+        const { result, unmount } = renderHook(() => useBackgroundEffectsEnabled());
+        act(() => result.current[1](false));
+        expect(result.current[0]).toBe(false);
+        expect(localStorage.getItem("engram:backgroundEffectsEnabled")).toBe("false");
+        unmount();
+
+        const { result: second } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(second.current[0]).toBe(false);
+    });
+
+    it("an explicit stored choice overrides the reduced-motion default", () => {
+        localStorage.setItem("engram:backgroundEffectsEnabled", "true");
+        stubMatchMedia(true); // OS says reduce motion, but the user already chose "on"
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("falls back to enabled when matchMedia is unavailable (matches useMediaQuery's documented fallback)", () => {
+        vi.stubGlobal("matchMedia", undefined);
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true);
+    });
+
+    it("degrades to in-memory state when localStorage throws", () => {
+        const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+            throw new Error("blocked");
+        });
+        const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw new Error("blocked");
+        });
+
+        const { result } = renderHook(() => useBackgroundEffectsEnabled());
+        expect(result.current[0]).toBe(true); // falls back to the reduced-motion-based default
+
+        expect(() => act(() => result.current[1](false))).not.toThrow();
+        expect(result.current[0]).toBe(false); // in-memory state still updates
+
+        getItemSpy.mockRestore();
+        setItemSpy.mockRestore();
+    });
+});

--- a/frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts
+++ b/frontend/src/app/hooks/__tests__/useBackgroundEffectsEnabled.test.ts
@@ -81,4 +81,22 @@ describe("useBackgroundEffectsEnabled", () => {
         getItemSpy.mockRestore();
         setItemSpy.mockRestore();
     });
+
+    it("keeps multiple hook instances in sync within the same tab", () => {
+        // App.tsx and the ConfigWizard settings checkbox each mount their own
+        // instance of this hook. Toggling one must be reflected by the other
+        // immediately, without a page reload (they're separate `useState`
+        // call sites, so this only works if the hook explicitly propagates
+        // changes across instances).
+        const a = renderHook(() => useBackgroundEffectsEnabled());
+        const b = renderHook(() => useBackgroundEffectsEnabled());
+
+        expect(a.result.current[0]).toBe(true);
+        expect(b.result.current[0]).toBe(true);
+
+        act(() => a.result.current[1](false));
+
+        expect(a.result.current[0]).toBe(false);
+        expect(b.result.current[0]).toBe(false);
+    });
 });

--- a/frontend/src/app/hooks/useBackgroundEffectsEnabled.ts
+++ b/frontend/src/app/hooks/useBackgroundEffectsEnabled.ts
@@ -1,6 +1,18 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const STORAGE_KEY = "engram:backgroundEffectsEnabled";
+// Fired on `window` whenever any instance of this hook changes the
+// preference, so other already-mounted instances (e.g. App.tsx's gate and
+// the settings checkbox) re-sync immediately instead of only picking up the
+// change on next mount/reload. Plain `storage` events don't cover this: they
+// only fire in *other* tabs, never in the tab that made the change.
+const CHANGE_EVENT = "engram:background-effects-changed";
+
+// Used only when localStorage itself is unavailable (private browsing, quota,
+// etc.) — the CHANGE_EVENT handler re-derives its value from storage, so
+// without this, an explicit choice would get overwritten back to the
+// reduced-motion-based default the moment the event it triggers fires.
+let memoryFallback: boolean | null = null;
 
 function readStoredPreference(): boolean | null {
   try {
@@ -9,7 +21,7 @@ function readStoredPreference(): boolean | null {
     if (raw === "false") return false;
     return null;
   } catch {
-    return null;
+    return memoryFallback;
   }
 }
 
@@ -25,6 +37,12 @@ function prefersReducedMotion(): boolean {
   }
 }
 
+function computeCurrentValue(): boolean {
+  const stored = readStoredPreference();
+  if (stored !== null) return stored;
+  return !prefersReducedMotion();
+}
+
 /**
  * Whether ambient background effects (currently: the falling-code rip
  * animation in SvRipAnimation) should render. Persisted per-browser in
@@ -34,21 +52,30 @@ function prefersReducedMotion(): boolean {
  * With no stored preference yet, seeds from `prefers-reduced-motion` (off if
  * the OS already asks for reduced motion). Once the user makes an explicit
  * choice, that choice always wins over the OS setting.
+ *
+ * Multiple call sites (App.tsx's gate, the settings checkbox) each mount
+ * their own instance of this hook. A `CHANGE_EVENT` broadcast keeps them in
+ * sync within the tab, so toggling the setting takes effect immediately
+ * rather than only after the next mount/reload.
  */
 export function useBackgroundEffectsEnabled(): [boolean, (enabled: boolean) => void] {
-  const [enabled, setEnabledState] = useState<boolean>(() => {
-    const stored = readStoredPreference();
-    if (stored !== null) return stored;
-    return !prefersReducedMotion();
-  });
+  const [enabled, setEnabledState] = useState<boolean>(computeCurrentValue);
+
+  useEffect(() => {
+    const onChange = () => setEnabledState(computeCurrentValue());
+    window.addEventListener(CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(CHANGE_EVENT, onChange);
+  }, []);
 
   const setEnabled = useCallback((next: boolean) => {
     setEnabledState(next);
     try {
       localStorage.setItem(STORAGE_KEY, String(next));
     } catch {
-      // localStorage unavailable — preference stays in-memory for this session
+      // localStorage unavailable — keep the choice in memory for this session
+      memoryFallback = next;
     }
+    window.dispatchEvent(new Event(CHANGE_EVENT));
   }, []);
 
   return [enabled, setEnabled];

--- a/frontend/src/app/hooks/useBackgroundEffectsEnabled.ts
+++ b/frontend/src/app/hooks/useBackgroundEffectsEnabled.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "engram:backgroundEffectsEnabled";
+
+function readStoredPreference(): boolean | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether ambient background effects (currently: the falling-code rip
+ * animation in SvRipAnimation) should render. Persisted per-browser in
+ * localStorage — this describes the device viewing the dashboard, not the
+ * backend host, so it deliberately does not go through AppConfig.
+ *
+ * With no stored preference yet, seeds from `prefers-reduced-motion` (off if
+ * the OS already asks for reduced motion). Once the user makes an explicit
+ * choice, that choice always wins over the OS setting.
+ */
+export function useBackgroundEffectsEnabled(): [boolean, (enabled: boolean) => void] {
+  const [enabled, setEnabledState] = useState<boolean>(() => {
+    const stored = readStoredPreference();
+    if (stored !== null) return stored;
+    return !prefersReducedMotion();
+  });
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // localStorage unavailable — preference stays in-memory for this session
+    }
+  }, []);
+
+  return [enabled, setEnabled];
+}

--- a/frontend/src/components/BackgroundEffectsSetting.tsx
+++ b/frontend/src/components/BackgroundEffectsSetting.tsx
@@ -1,0 +1,33 @@
+import { useBackgroundEffectsEnabled } from '../app/hooks/useBackgroundEffectsEnabled';
+
+/**
+ * Self-contained toggle for the ambient falling-code rip animation
+ * (SvRipAnimation). Reads/writes localStorage directly via the hook rather
+ * than routing through ConfigWizard's `config` state — this preference
+ * describes the browser rendering the dashboard, not the backend host, so it
+ * never touches AppConfig or the generic config save.
+ */
+export default function BackgroundEffectsSetting() {
+    const [enabled, setEnabled] = useBackgroundEffectsEnabled();
+
+    return (
+        <div className="form-group checkbox-group">
+            <label className="checkbox-label">
+                <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={(e) => setEnabled(e.target.checked)}
+                />
+                <span className="checkbox-text">
+                    <strong>Background Animation</strong>
+                    <span className="checkbox-hint">
+                        The falling-code effect shown behind the dashboard while a disc is
+                        ripping. Turn this off on low-power devices (e.g. ARM64 single-board
+                        computers) to reduce CPU/GPU usage. Independent of your OS's
+                        reduced-motion setting — takes effect immediately, no restart needed.
+                    </span>
+                </span>
+            </label>
+        </div>
+    );
+}

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import ConfigWizard from './ConfigWizard';
 
 /**
@@ -10,6 +10,7 @@ import ConfigWizard from './ConfigWizard';
  * mounts cleanly and the deep-link scroll is observable.
  */
 beforeEach(() => {
+    localStorage.clear();
     Element.prototype.scrollIntoView = vi.fn();
     if (!window.matchMedia) {
         window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -229,5 +230,25 @@ describe('ConfigWizard — background pre-transcription toggles', () => {
         // Both fields sent; sub-toggle carries non-default true value.
         expect(body.enable_background_pretranscription).toBe(true);
         expect(body.pretranscribe_full_file).toBe(true);
+    });
+});
+
+describe('ConfigWizard — background effects preference', () => {
+    it('shows a Background Animation checkbox in Preferences, on by default, and persists a toggle to localStorage without an API call', async () => {
+        render(<ConfigWizard {...noop} isOnboarding={false} />);
+        const nav = await screen.findByRole('navigation', { name: /settings sections/i });
+        fireEvent.click(within(nav).getByRole('button', { name: 'Preferences' }));
+
+        const toggle = await screen.findByRole('checkbox', { name: /background animation/i });
+        expect(toggle).toBeChecked();
+
+        await waitFor(() => expect((fetch as unknown as Mock).mock.calls.length).toBeGreaterThan(0));
+        const callsBeforeToggle = (fetch as unknown as Mock).mock.calls.length;
+
+        fireEvent.click(toggle);
+
+        expect(toggle).not.toBeChecked();
+        expect(localStorage.getItem('engram:backgroundEffectsEnabled')).toBe('false');
+        expect((fetch as unknown as Mock).mock.calls.length).toBe(callsBeforeToggle);
     });
 });

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -6,6 +6,7 @@ import { EngramSelect } from './ui/EngramSelect';
 import { SvActionButton } from '../app/components/synapse/SvActionButton';
 import { BootstrapLibraryFlow } from './BootstrapLibraryFlow';
 import GpuAccelerationSetting from './GpuAccelerationSetting';
+import BackgroundEffectsSetting from './BackgroundEffectsSetting';
 import { requestTmdbValidation } from '../utils/tmdbValidation';
 import { formatToolVersion } from '../utils/formatting';
 import './ConfigWizard.css';
@@ -1711,6 +1712,18 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 Create a webhook in your Discord server's channel settings under Integrations.
                             </span>
                         </div>
+
+                            </div>
+                        </details>
+
+                        {/* ── Display ──────────────────────────────────────────── */}
+                        <details className="wizard-group" open>
+                            <summary>
+                                <span className="wizard-group-chevron">▸</span>Display
+                            </summary>
+                            <div className="wizard-group-body">
+
+                        <BackgroundEffectsSetting />
 
                             </div>
                         </details>


### PR DESCRIPTION
## Summary
- Adds a **Background Animation** toggle in Settings → Preferences → Display that disables the falling-code rip animation (`SvRipAnimation`) — a full-viewport canvas redrawn at 20fps that's a meaningful CPU/GPU cost on low-power devices (reported case: ARM64). Stored in `localStorage`, not backend `AppConfig`, since it describes the browser rendering the dashboard rather than the backend host. Defaults on (backward compatible), seeded from `prefers-reduced-motion` when no explicit choice has been made.
- Two bugs were found and fixed during manual browser verification (not caught by the jsdom test suite, which runs under `MotionConfig reducedMotion="always"`):
  - The hook's `useState` was per-component-instance, so toggling the settings checkbox didn't propagate to `App.tsx`'s already-mounted gate without a full reload. Fixed with a same-tab custom `window` event broadcast so every mounted instance re-syncs immediately.
  - A pre-existing issue in `SvAtmosphere.tsx` (unrelated to this feature, but newly reachable through it): `AnimatePresence`'s exit-then-remove bookkeeping didn't reliably fire in real browsers (confirmed in both `npm run dev` and a production build), leaving the animation layer permanently stuck at `opacity:0`, attached but frozen, unable to resume. Fixed by dropping `AnimatePresence` for this layer in favor of a plain conditional mount — the fade-in still works, only the fade-out transition is lost in exchange for reliable mount/unmount.

## Test plan
- [x] `npx vitest run` — 313/313 tests pass across 35 files
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] Manual verification in both `npm run dev` and a production build (`npm run build && vite preview`): toggle off stops the canvas redraw loop and removes the DOM node; toggle on resumes it; preference persists across reload and syncs live across mounted instances without a reload
- [ ] Reviewer: exercise the toggle in Settings → Preferences → Display with a simulated ripping disc (`POST /api/simulate/insert-disc`, `DEBUG=true`)

Design spec: `docs/superpowers/specs/2026-07-09-background-effects-toggle-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-09-background-effects-toggle.md`