### PR TITLE
fix(analyst): apply uncorroborated-identity review gate to movies too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Engram will be documented in this file.
 
 ### Fixed
 
+- **An unconfirmed movie identity no longer auto-accepts.** When a disc's title couldn't be confirmed by DiscDB/TMDB from its label, an AI-guessed title was sometimes matched to an unrelated, low-popularity movie — and because that guess "agreed" with the movie heuristic, the mismatch was silently accepted and ripped straight through, misfiling real content as movie extras with no way to correct it afterward (#499). The disc-identity corroboration check that already gated this for TV shows now applies to movies too: an uncorroborated TMDB/AI identity pauses for confirmation via the existing re-identify prompt instead of completing unreviewed.
 - **The Import folder browser now scrolls.** Browsing a directory with more subfolders than fit on screen previously grew the modal past the edges of the window, stranding you in the middle of the list with no way to scroll, no visible way to go up a level, and no way to reach the start button. The folder list is now a scrolling pane inside a window-sized modal, so the header, the up-a-level row, and the start button stay put. You can also type or paste an exact folder path instead of clicking through hundreds of folders, and going up a level scrolls the folder you came from back into view.
 
 ## [0.24.0] - 2026-07-04

--- a/backend/app/core/analyst.py
+++ b/backend/app/core/analyst.py
@@ -580,11 +580,10 @@ class DiscAnalyst:
                 classification_source="tmdb",
                 play_all_title_indices=tmdb_play_all,
             )
-            # Review escalation (Fix 3) is scoped to TV identity (the corroboration
-            # gap this addresses); movie discs keep their prior auto-accept behavior.
+            # Review escalation (Fix 3): an uncorroborated TMDB identity — TV or
+            # movie — escalates to review rather than auto-accepting.
             if (
-                tmdb_signal.content_type == ContentType.TV
-                and tmdb_signal.tmdb_name
+                tmdb_signal.tmdb_name
                 and effective_name
                 and not _names_are_similar(effective_name, tmdb_signal.tmdb_name)
             ):
@@ -730,14 +729,16 @@ class DiscAnalyst:
             return result
 
         # Use TMDB name if similar enough to the heuristic name (same guard as analyze()).
-        # Otherwise the identity is uncorroborated -> escalate to review (Fix 3), scoped
-        # to TV (movie discs keep their prior auto-accept behavior).
+        # Otherwise the identity is uncorroborated -> escalate to review (Fix 3). Applies
+        # to both TV and movie discs: agreement between the heuristic and TMDB on
+        # *content type* is not corroboration of *which* title TMDB picked (e.g. an AI
+        # guess from an opaque label landing on an unrelated low-popularity movie).
         if tmdb_signal.tmdb_name:
             if result.detected_name is None or _names_are_similar(
                 result.detected_name, tmdb_signal.tmdb_name
             ):
                 result.detected_name = tmdb_signal.tmdb_name
-            elif not result.needs_review and result.content_type == ContentType.TV:
+            elif not result.needs_review:
                 result.needs_review = True
                 result.review_reason = _uncorroborated_review_reason(
                     result.detected_name, tmdb_signal

--- a/backend/tests/unit/test_analyst.py
+++ b/backend/tests/unit/test_analyst.py
@@ -297,7 +297,10 @@ class TestTmdbSignalIntegration:
         assert result.tmdb_id is None
 
     def test_tmdb_resolves_unknown_to_movie(self):
-        """Heuristic gives UNKNOWN, TMDB says movie -> movie."""
+        """Heuristic gives UNKNOWN, TMDB says movie -> movie, but an uncorroborated
+        name (label 'MYSTERY_DISC' matches neither 'Inception' nor its disc title)
+        escalates to review (issue #499: movie identities get the same
+        corroboration check as TV, not a free pass)."""
         analyst = DiscAnalyst(config=_default_config())
         titles = _make_titles([5, 15, 75, 10, 30])  # Ambiguous durations
         signal = TmdbSignal(
@@ -310,7 +313,8 @@ class TestTmdbSignalIntegration:
 
         assert result.content_type == ContentType.MOVIE
         assert result.classification_source == "tmdb"
-        assert result.needs_review is False
+        assert result.needs_review is True
+        assert result.identity_unconfirmed is True
 
     def test_tmdb_resolves_unknown_to_tv(self):
         """Heuristic gives UNKNOWN, TMDB says TV -> TV."""
@@ -760,3 +764,28 @@ class TestUncorroboratedIdentityFlag:
         from app.core.analyst import DiscAnalysisResult
 
         assert DiscAnalysisResult(content_type=ContentType.TV).identity_unconfirmed is False
+
+    def test_uncorroborated_movie_identity_sets_flag(self):
+        """Regression for issue #499 (job 103): a disc with only 2 episode-length
+        titles plus one Play-All-length title falls through to the movie
+        heuristic (TV cluster detection needs 3+). An AI/TMDB movie guess that
+        matches neither the volume label nor the disc title must not auto-accept
+        just because the heuristic and TMDB happen to agree on 'movie' — that
+        agreement is not corroboration of *which* movie."""
+        analyst = DiscAnalyst(config=_default_config())
+        titles = _make_titles([43, 43, 84])
+        tmdb = TmdbSignal(
+            content_type=ContentType.MOVIE,
+            confidence=0.70,
+            tmdb_id=340102,
+            tmdb_name="The New Mutants",
+        )
+        result = analyst.analyze(
+            titles,
+            volume_label="DH20NNT5",
+            tmdb_signal=tmdb,
+            disc_title="DH20NNT5#9FF3",
+        )
+        assert result.content_type == ContentType.MOVIE
+        assert result.needs_review is True
+        assert result.identity_unconfirmed is True


### PR DESCRIPTION
## Summary

Fixes #499. Root-caused via the diagnostics bundle attached to the issue (job 103):

- The disc has only **2** real episode-length titles (43min, 43min) plus a Play-All-length title (84min). TV cluster detection in `_detect_tv_show` requires **3+** similarly-sized titles, so this disc can never be recognized as TV by duration alone, and the label (`DH20NNT5`) has no season pattern to trigger the label-fallback path either.
- With no TV signal, `_detect_movie` wins by default (the 84min title alone clears the 80-min movie floor).
- DiscDB/TMDB lookup on the opaque label failed, so identification fell back to AI, which guessed an unrelated, low-popularity movie ("The New Mutants").
- The analyst *does* have a check for exactly this — "TMDB name corroborated by neither the volume-label name nor the disc title" — but the review-escalation that's supposed to follow (`identity_unconfirmed`) was explicitly scoped to `content_type == TV` only ("movie discs keep their prior auto-accept behavior").
- Because the heuristic and the wrong TMDB guess both said "movie," that agreement boosted confidence and cleared the auto-rip gate (`needs_review` stayed `False`). The job ripped and auto-organized, filing the two real episodes as `Extras/Extra 1.mkv` / `Extra 2.mkv` with no way back — `re-identify` only works on `RIPPING`/`REVIEW_NEEDED` jobs, and this one went straight to `COMPLETED`.

## What changed

Removed the TV-only restriction on the uncorroborated-identity review gate in `backend/app/core/analyst.py` (two call sites: the heuristic+TMDB agreement path, and the TMDB-only path). An uncorroborated movie identity now gets the same treatment TV already has — it rips first (walk-away preserved) but parks with a confirm/correct prompt via the existing `re-identify` endpoint and `ReIdentifyModal` (which already supports switching movie↔tv), instead of silently completing.

This is the narrowly-scoped fix (discussed as "Fix A" in the issue thread) — it does not change the underlying 2-episode TV-cluster detection gap or add a reclassify path for already-`COMPLETED` jobs; those were explicitly left out of scope.

## Test plan

- [x] New test `test_uncorroborated_movie_identity_sets_flag` reproduces job 103's exact disc shape (43/43/84 min, label `DH20NNT5`, TMDB movie match "The New Mutants") — written first, watched it fail (`needs_review` stayed `False`), then the fix made it pass.
- [x] Updated one pre-existing test (`test_tmdb_resolves_unknown_to_movie`) whose assertion encoded the same bug on a different code path (uncorroborated "MYSTERY_DISC" → "Inception") — now asserts the corrected behavior.
- [x] `uv run pytest tests/unit` — 2436 passed, 19 skipped
- [x] `uv run pytest tests/pipeline` — 99 passed
- [x] `uv run pytest tests/integration tests/real_data` — 253 passed, 8 skipped, 1 failed (pre-existing, unrelated: a real-optical-drive hardware test that fails identically with the change stashed out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)