### PR TITLE
fix(docker): default to privileged: true for reliable drive control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker deployments now run `privileged: true` by default.** Plain `devices:` passthrough wasn't always enough for full optical drive control (eject/tray), and some hosts got stuck unable to stop or restart the container without it. (#459, thanks @MadsTheEngineer!)
+
 ## [0.25.0] - 2026-07-12
 
 _Highlights: manual bulk import of downloaded .srt files for episodes with no automated subtitle match, plus a Background Animation toggle for low-power devices._

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,11 @@ services:
     restart: unless-stopped
     # Plain `devices:` passthrough isn't always enough for full drive control
     # (eject/tray) and some hosts have gotten stuck unable to stop/restart the
-    # container without it (#459).
+    # container without it (#459). NOTE: this disables seccomp/AppArmor
+    # confinement and gives the container access to ALL host devices, not just
+    # the optical drive — a real trade-off if you're running other containers
+    # on the same host. Remove this line if a narrower `cap_add`/`devices`
+    # combination works for your setup.
     privileged: true
 
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     #   dockerfile: Dockerfile
     container_name: engram
     restart: unless-stopped
+    # Plain `devices:` passthrough isn't always enough for full drive control
+    # (eject/tray) and some hosts have gotten stuck unable to stop/restart the
+    # container without it (#459).
+    privileged: true
 
     ports:
       - "8000:8000"

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -84,8 +84,10 @@ Pass each drive through with `devices:`. Find yours with `ls -l /dev/sr*`:
 ```
 
 The entrypoint detects the group that owns the device on the host and adds the
-runtime user to it, so ripping works without `--privileged`. If your host has
-unusual device permissions, you can fall back to `privileged: true`.
+runtime user to it, but the shipped compose file also sets `privileged: true`:
+plain `devices:` passthrough isn't always enough for full drive control
+(eject/tray), and some hosts have gotten stuck unable to stop/restart the
+container without it ([#459](https://github.com/Jsakkos/engram/issues/459)).
 
 ## MakeMKV licensing
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,6 +89,14 @@ plain `devices:` passthrough isn't always enough for full drive control
 (eject/tray), and some hosts have gotten stuck unable to stop/restart the
 container without it ([#459](https://github.com/Jsakkos/engram/issues/459)).
 
+**Know what that costs:** `privileged: true` disables the container's
+seccomp/AppArmor confinement and gives it access to *all* host devices, not
+just the optical drive — a meaningful widening of the isolation boundary if
+you're running other containers on the same host. If you'd rather not accept
+that, try removing the line and using a narrower `cap_add`/`device_cgroup_rules`
+grant instead; it just isn't what's verified against the drive-control issue
+above.
+
 ## MakeMKV licensing
 
 - The **free beta key** rotates roughly monthly. When ripping starts failing with


### PR DESCRIPTION
## Summary

- Adds `privileged: true` to the `engram` service in `docker-compose.yml`.
- Updates `docs/deployment/docker.md` (Optical drive passthrough section), which previously described `privileged: true` as an optional fallback — that contradicted the new default, so it's rewritten to match.
- Adds a `CHANGELOG.md` entry crediting the reporter.

## Why

Follow-up to [#459](https://github.com/Jsakkos/engram/issues/459). Plain `devices:` passthrough (host group discovery + adding the runtime user to it) isn't always sufficient for MakeMKV's tray/eject control, and on at least one host the container also got stuck in a state where `docker compose down`/restart failed with `permission denied`. Adding `--privileged` resolved both symptoms in the issue thread, and the reporter (@MadsTheEngineer) requested it be added to the shipped template.

Trade-off worth flagging for review: `privileged: true` disables the container's seccomp/AppArmor confinement and grants access to all host devices, not just the optical drive — a real widening of the container's security boundary versus the previous group-based approach. Given this is a single-service, non-multi-tenant home deployment and the issue reporter confirmed it fixed real breakage, defaulting to it seemed like the right call, but flagging in case there's a narrower fix preferred instead.

## Test plan

- [x] `docker-compose.yml` parses as valid YAML.
- [ ] Manual: `docker compose up -d` on a Linux host with an optical drive, confirm eject/tray control and `docker compose down`/restart work without permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)