### PR TITLE
feat: customizable Discord notification templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Customizable Discord notification messages.** The Discord embed sent when a disc completes or fails now uses a template you control, instead of a fixed message. Set separate messages for the completed and failed cases in Settings → Notifications, using `{{title}}`, `{{drive}}`, `{{duration}}`, `{{error}}`, and other job details as variables. Leave either field blank to keep the previous default message.
+
 ### Fixed
 
 - **Docker deployments now run `privileged: true` by default.** Plain `devices:` passthrough wasn't always enough for full optical drive control (eject/tray), and some hosts got stuck unable to stop or restart the container without it. (#459, thanks @MadsTheEngineer!)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,6 +348,7 @@ Components use updated settings
 - **API Keys**: `makemkv_key`, `tmdb_api_key` (redacted in responses)
 - **Matching**: `max_concurrent_matches` (default: 3), threshold constants in Analyst
 - **Conflict resolution**: `conflict_resolution_default` ("skip" | "overwrite" | "ask")
+- **Discord notifications**: `discord_template_completed` / `discord_template_failed` — customizable embed description (chevron `{{var}}` mustache syntax, see `app/core/discord_notifier.py::ALLOWED_TEMPLATE_VARS`); empty string = built-in default
 
 ### Configuration Validation
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -374,6 +374,8 @@ class ConfigResponse(BaseModel):
     contribution_pseudonym: str | None = None
     # Notifications
     discord_webhook_url: str = ""
+    discord_template_completed: str = ""
+    discord_template_failed: str = ""
 
 
 class ConfigUpdate(BaseModel):
@@ -459,6 +461,8 @@ class ConfigUpdate(BaseModel):
     fingerprint_disclosure_accepted: bool | None = None
     # Notifications
     discord_webhook_url: str | None = None
+    discord_template_completed: str | None = None
+    discord_template_failed: str | None = None
 
 
 class ReviewRequest(BaseModel):
@@ -1533,6 +1537,8 @@ async def get_config() -> ConfigResponse:
         contribution_pseudonym=config.contribution_pseudonym,
         # Notifications
         discord_webhook_url="***" if config.discord_webhook_url else "",
+        discord_template_completed=config.discord_template_completed,
+        discord_template_failed=config.discord_template_failed,
     )
 
 
@@ -1609,6 +1615,15 @@ async def update_config(config: ConfigUpdate) -> dict:
                 status_code=422,
                 detail="discord_webhook_url must be an http/https URL pointing to a non-internal host",
             )
+
+    # Validate Discord notification templates before persisting
+    from app.core.discord_notifier import validate_discord_template
+
+    for field in ("discord_template_completed", "discord_template_failed"):
+        if update_data.get(field):
+            error = validate_discord_template(update_data[field])
+            if error:
+                raise HTTPException(status_code=422, detail=f"{field}: {error}")
 
     # Validate naming format strings before persisting
     from app.core.organizer import (

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -45,6 +45,12 @@ class TmdbValidationRequest(BaseModel):
     api_key: str
 
 
+class DiscordTemplateValidationRequest(BaseModel):
+    """Request model for Discord notification template validation."""
+
+    template: str
+
+
 class ValidationResponse(BaseModel):
     """Response model for validation endpoints."""
 
@@ -616,3 +622,21 @@ async def validate_tmdb(request: TmdbValidationRequest) -> ValidationResponse:
         )
     except Exception as e:
         return ValidationResponse(valid=False, error=f"Validation failed: {str(e)}")
+
+
+@router.post("/validate/discord-template", response_model=ValidationResponse)
+async def validate_discord_template_endpoint(
+    request: DiscordTemplateValidationRequest,
+) -> ValidationResponse:
+    """Validate a Discord notification template string (chevron/mustache syntax).
+
+    Live per-keystroke check for ConfigWizard; PUT /api/config re-validates via
+    the same underlying function before persisting, so this is UX-only — it
+    can't be bypassed to skip the real enforcement.
+    """
+    from app.core.discord_notifier import validate_discord_template
+
+    error = validate_discord_template(request.template)
+    if error:
+        return ValidationResponse(valid=False, error=error)
+    return ValidationResponse(valid=True)

--- a/backend/app/core/discord_notifier.py
+++ b/backend/app/core/discord_notifier.py
@@ -27,8 +27,8 @@ ALLOWED_TEMPLATE_VARS = frozenset(
     }
 )
 
-DEFAULT_TEMPLATE_COMPLETED = "**{{title}}**"
-DEFAULT_TEMPLATE_FAILED = "**{{title}}**"
+DEFAULT_TEMPLATE_COMPLETED = "**{{{title}}}**"
+DEFAULT_TEMPLATE_FAILED = "**{{{title}}}**"
 
 
 def validate_discord_template(template: str) -> str | None:
@@ -87,7 +87,7 @@ def build_template_context(job: DiscJob | None, job_id: int) -> dict[str, str]:
 
 
 def render_discord_template(template: str, context: dict) -> str:
-    return chevron.render(template, context)
+    return chevron.render(template, context, partials_dict={})
 
 
 async def notify_discord(webhook_url: str, job_id: int, description: str, state: str) -> None:

--- a/backend/app/core/discord_notifier.py
+++ b/backend/app/core/discord_notifier.py
@@ -1,10 +1,96 @@
 """Discord webhook notifications for job completion events."""
 
+import chevron
 import httpx
+from chevron.tokenizer import ChevronError, tokenize
 from loguru import logger
 
+from app.models.disc_job import DiscJob
 
-async def notify_discord(webhook_url: str, job_id: int, label: str, state: str) -> None:
+ALLOWED_TEMPLATE_VARS = frozenset(
+    {
+        "title",
+        "drive",
+        "job_id",
+        "content_type",
+        "season",
+        "tmdb_name",
+        "tmdb_year",
+        "duration",
+        "error",
+        "subtitle_status",
+        "subtitles_downloaded",
+        "subtitles_total",
+        "subtitles_failed",
+        "path",
+        "total_titles",
+    }
+)
+
+DEFAULT_TEMPLATE_COMPLETED = "**{{title}}**"
+DEFAULT_TEMPLATE_FAILED = "**{{title}}**"
+
+
+def validate_discord_template(template: str) -> str | None:
+    """Validate a Discord notification template. Returns an error message, or None if valid."""
+    try:
+        tags = list(tokenize(template))
+    except ChevronError as e:
+        return str(e)
+
+    unknown = sorted(
+        {
+            key.strip()
+            for tag_type, key in tags
+            if tag_type != "literal" and key.strip() not in ALLOWED_TEMPLATE_VARS
+        }
+    )
+    if unknown:
+        return f"Unknown template variable(s): {', '.join(unknown)}"
+    return None
+
+
+def _format_duration(job: DiscJob) -> str:
+    if job.created_at is None or job.completed_at is None:
+        return ""
+    seconds = int((job.completed_at - job.created_at).total_seconds())
+    hours, remainder = divmod(seconds, 3600)
+    minutes = remainder // 60
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def build_template_context(job: DiscJob | None, job_id: int) -> dict[str, str]:
+    """Build the chevron render context from a DiscJob row."""
+    if job is None:
+        return {"title": f"Job #{job_id}"} | dict.fromkeys(ALLOWED_TEMPLATE_VARS - {"title"}, "")
+
+    title = job.detected_title or job.volume_label or f"Job #{job_id}"
+    return {
+        "title": title,
+        "drive": job.volume_label or "",
+        "job_id": str(job.id or job_id),
+        "content_type": job.content_type.value.replace("_", " ").title(),
+        "season": str(job.detected_season) if job.detected_season is not None else "",
+        "tmdb_name": job.tmdb_name or "",
+        "tmdb_year": str(job.tmdb_year) if job.tmdb_year is not None else "",
+        "duration": _format_duration(job),
+        "error": job.error_message or "",
+        "subtitle_status": job.subtitle_status or "",
+        "subtitles_downloaded": str(job.subtitles_downloaded),
+        "subtitles_total": str(job.subtitles_total),
+        "subtitles_failed": str(job.subtitles_failed),
+        "path": job.final_path or "",
+        "total_titles": str(job.total_titles),
+    }
+
+
+def render_discord_template(template: str, context: dict) -> str:
+    return chevron.render(template, context)
+
+
+async def notify_discord(webhook_url: str, job_id: int, description: str, state: str) -> None:
     """POST a Discord embed to webhook_url. No-op if URL is empty."""
     if not webhook_url:
         return
@@ -16,7 +102,7 @@ async def notify_discord(webhook_url: str, job_id: int, label: str, state: str) 
         "embeds": [
             {
                 "title": f"{emoji} Disc {state.title()}",
-                "description": f"**{label}**",
+                "description": description,
                 "color": color,
             }
         ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,14 @@
 """Data models for UMA."""
 
 from app.models.app_config import AppConfig
-from app.models.disc_job import ContentType, DiscJob, DiscTitle, JobState, TitleState
+from app.models.disc_job import (
+    TERMINAL_JOB_STATES,
+    ContentType,
+    DiscJob,
+    DiscTitle,
+    JobState,
+    TitleState,
+)
 from app.models.fingerprint import DiscContribution, FingerprintContribution
 from app.models.show_ordering import ShowOrderingPreference
 
@@ -9,6 +16,7 @@ __all__ = [
     "DiscJob",
     "DiscTitle",
     "JobState",
+    "TERMINAL_JOB_STATES",
     "TitleState",
     "ContentType",
     "AppConfig",

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -195,6 +195,10 @@ class AppConfig(SQLModel, table=True):
 
     # Notifications
     discord_webhook_url: str = ""  # Discord webhook URL for job completion alerts
+    # Discord embed description templates (chevron/mustache {{var}} syntax).
+    # "" means use the built-in default (see app.core.discord_notifier).
+    discord_template_completed: str = ""
+    discord_template_failed: str = ""
 
     # Onboarding
     setup_complete: bool = False  # Set True after user completes setup wizard

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -20,6 +20,9 @@ class JobState(StrEnum):
     FAILED = "failed"
 
 
+TERMINAL_JOB_STATES = frozenset({JobState.COMPLETED, JobState.FAILED})
+
+
 class ContentType(StrEnum):
     """Type of content on the disc."""
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -33,7 +33,7 @@ from app.core.organizer import movie_organizer
 from app.core.security import sanitize_log_value
 from app.core.sentinel import DriveMonitor
 from app.database import async_session
-from app.models import DiscJob, JobState
+from app.models import TERMINAL_JOB_STATES, DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.cleanup_service import CleanupService
 from app.services.event_broadcaster import EventBroadcaster
@@ -1006,7 +1006,7 @@ class JobManager:
 
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
-            if job and job.state not in (JobState.COMPLETED, JobState.FAILED):
+            if job and job.state not in TERMINAL_JOB_STATES:
                 await state_machine.transition_to_failed(
                     job, session, error_message="Cancelled by user"
                 )
@@ -1088,7 +1088,7 @@ class JobManager:
             if not config.discord_webhook_url:
                 return
 
-            if state not in (JobState.COMPLETED, JobState.FAILED):
+            if state not in TERMINAL_JOB_STATES:
                 logger.warning(
                     f"Job {job_id}: Discord notification requested for non-terminal state {state}"
                 )

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1088,6 +1088,12 @@ class JobManager:
             if not config.discord_webhook_url:
                 return
 
+            if state not in (JobState.COMPLETED, JobState.FAILED):
+                logger.warning(
+                    f"Job {job_id}: Discord notification requested for non-terminal state {state}"
+                )
+                return
+
             async with async_session() as session:
                 job = await session.get(DiscJob, job_id)
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1075,7 +1075,13 @@ class JobManager:
     async def _send_discord_notification(self, job_id: int, state: JobState) -> None:
         """Send the Discord embed. Runs as a background task; all errors are swallowed."""
         try:
-            from app.core.discord_notifier import notify_discord
+            from app.core.discord_notifier import (
+                DEFAULT_TEMPLATE_COMPLETED,
+                DEFAULT_TEMPLATE_FAILED,
+                build_template_context,
+                notify_discord,
+                render_discord_template,
+            )
             from app.services.config_service import get_config
 
             config = await get_config()
@@ -1084,12 +1090,15 @@ class JobManager:
 
             async with async_session() as session:
                 job = await session.get(DiscJob, job_id)
-            label = (
-                (job.detected_title or job.volume_label or f"Job #{job_id}")
-                if job
-                else f"Job #{job_id}"
-            )
-            await notify_discord(config.discord_webhook_url, job_id, label, state.value)
+
+            if state == JobState.COMPLETED:
+                template = config.discord_template_completed or DEFAULT_TEMPLATE_COMPLETED
+            else:
+                template = config.discord_template_failed or DEFAULT_TEMPLATE_FAILED
+
+            context = build_template_context(job, job_id)
+            description = render_discord_template(template, context)
+            await notify_discord(config.discord_webhook_url, job_id, description, state.value)
         except Exception as e:
             logger.warning(f"Job {job_id}: Discord notification failed: {e}", exc_info=True)
 

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import DiscJob, JobState
+from app.models import TERMINAL_JOB_STATES, DiscJob, JobState
 from app.services.event_broadcaster import EventBroadcaster
 
 logger = logging.getLogger(__name__)
@@ -136,7 +136,7 @@ class JobStateMachine:
 
         # Set completed_at timestamp for terminal states
         prompt_cleared = False
-        if to_state in (JobState.COMPLETED, JobState.FAILED):
+        if to_state in TERMINAL_JOB_STATES:
             job.completed_at = datetime.now(UTC)
             # Walk-away Phase B: a terminal job can't act on an identity answer
             # — retire the non-blocking CTA in the same commit (the model's
@@ -182,7 +182,7 @@ class JobStateMachine:
                 )
 
         # Fire terminal-state callbacks (COMPLETED or FAILED)
-        if to_state in (JobState.COMPLETED, JobState.FAILED):
+        if to_state in TERMINAL_JOB_STATES:
             for cb in self._on_terminal_callbacks:
                 try:
                     await cb(job.id, to_state)

--- a/backend/migrations/versions/33568e53d94d_add_discord_notification_templates.py
+++ b/backend/migrations/versions/33568e53d94d_add_discord_notification_templates.py
@@ -1,0 +1,47 @@
+"""add discord notification templates
+
+Revision ID: 33568e53d94d
+Revises: 6148bcd5c13a
+Create Date: 2026-07-13 20:04:50.800238
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "33568e53d94d"
+down_revision: str | Sequence[str] | None = "6148bcd5c13a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "app_config",
+        sa.Column(
+            "discord_template_completed",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "app_config",
+        sa.Column(
+            "discord_template_failed",
+            sa.String(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("discord_template_failed")
+        batch_op.drop_column("discord_template_completed")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "librosa>=0.11.0",
     "soundfile>=0.12.1",
     "zstandard>=0.25.0",
+    "chevron>=0.14.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -288,6 +288,32 @@ class TestConfigEndpoints:
         assert config["makemkv_key"] == "***"
         assert config["tmdb_api_key"] == "***"
 
+    async def test_update_config_rejects_unknown_discord_template_variable(self, client):
+        await _seed_config()
+        response = await client.put("/api/config", json={"discord_template_completed": "{{bogus}}"})
+        assert response.status_code == 422
+        assert "bogus" in response.json()["detail"]
+
+    async def test_update_config_accepts_valid_discord_template(self, client):
+        await _seed_config()
+        response = await client.put(
+            "/api/config", json={"discord_template_completed": "{{title}} is done"}
+        )
+        assert response.status_code == 200
+
+        verify = await client.get("/api/config")
+        config = verify.json()
+        assert config["discord_template_completed"] == "{{title}} is done"
+
+    async def test_update_config_accepts_blank_discord_template(self, client):
+        await _seed_config(discord_template_completed="{{title}} is done")
+        response = await client.put("/api/config", json={"discord_template_completed": ""})
+        assert response.status_code == 200
+
+        verify = await client.get("/api/config")
+        config = verify.json()
+        assert config["discord_template_completed"] == ""
+
     async def test_ai_api_key_persists_and_blank_does_not_clobber(self, client):
         """Reproduces the user's report end-to-end through the real routes:
 

--- a/backend/tests/unit/test_discord_notifier.py
+++ b/backend/tests/unit/test_discord_notifier.py
@@ -225,6 +225,20 @@ async def test_send_notification_noop_when_no_webhook():
 
 
 @pytest.mark.asyncio
+async def test_send_notification_noop_for_non_terminal_state():
+    """Called with a non-terminal state (defensive guard) → notify_discord never called."""
+    from app.models import JobState
+    from app.services.config_service import update_config
+    from app.services.job_manager import job_manager
+
+    await update_config(discord_webhook_url="https://discord.com/api/webhooks/1/tok")
+
+    with patch("app.core.discord_notifier.notify_discord", new_callable=AsyncMock) as mock_notify:
+        await job_manager._send_discord_notification(99, JobState.RIPPING)
+        mock_notify.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_send_notification_fires_on_completed():
     """COMPLETED with webhook URL → notify_discord called with job label."""
     from app.database import async_session

--- a/backend/tests/unit/test_discord_notifier.py
+++ b/backend/tests/unit/test_discord_notifier.py
@@ -9,7 +9,6 @@ import pytest
 from app.core.discord_notifier import (
     build_template_context,
     notify_discord,
-    render_discord_template,
     validate_discord_template,
 )
 from app.models.disc_job import ContentType, DiscJob
@@ -121,6 +120,9 @@ def test_validate_discord_template_rejects_unknown_variable():
 
 
 def test_validate_discord_template_rejects_malformed_syntax():
+    """Malformed mustache syntax is rejected; the exact wording is chevron's own
+    (we pass its exception through verbatim), so we only assert rejection, not
+    the message text — pinning that would test chevron, not our code."""
     error = validate_discord_template("{{title")
     assert error is not None
 
@@ -144,8 +146,7 @@ def test_build_template_context_default_template_matches_current_output():
         volume_label="BREAKING_BAD_S1D1",
     )
     context = build_template_context(job, job_id=1)
-    rendered = render_discord_template("**{{title}}**", context)
-    assert rendered == "**Breaking Bad**"
+    assert context["title"] == "Breaking Bad"
 
 
 def test_build_template_context_error_populated_on_failed_job():
@@ -156,8 +157,7 @@ def test_build_template_context_error_populated_on_failed_job():
         error_message="disc unreadable",
     )
     context = build_template_context(job, job_id=2)
-    rendered = render_discord_template("{{error}}", context)
-    assert rendered == "disc unreadable"
+    assert context["error"] == "disc unreadable"
 
 
 def test_build_template_context_error_empty_on_completed_job():
@@ -168,8 +168,7 @@ def test_build_template_context_error_empty_on_completed_job():
         volume_label="INCEPTION_2010",
     )
     context = build_template_context(job, job_id=3)
-    rendered = render_discord_template("[{{error}}]", context)
-    assert rendered == "[]"
+    assert context["error"] == ""
 
 
 def test_build_template_context_duration_formatted_when_both_timestamps_set():
@@ -200,8 +199,7 @@ def test_build_template_context_duration_empty_when_not_completed():
 def test_build_template_context_falls_back_when_job_is_none():
     """Job vanished before re-fetch — context still yields a usable title, no crash."""
     context = build_template_context(None, job_id=42)
-    rendered = render_discord_template("{{title}}", context)
-    assert rendered == "Job #42"
+    assert context["title"] == "Job #42"
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/unit/test_discord_notifier.py
+++ b/backend/tests/unit/test_discord_notifier.py
@@ -1,11 +1,17 @@
 """Tests for Discord webhook notifications."""
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.core.discord_notifier import notify_discord
+from app.core.discord_notifier import (
+    build_template_context,
+    notify_discord,
+    render_discord_template,
+    validate_discord_template,
+)
 from app.models.disc_job import ContentType, DiscJob
 
 # --------------------------------------------------------------------------- #
@@ -17,13 +23,13 @@ from app.models.disc_job import ContentType, DiscJob
 async def test_notify_discord_noop_on_empty_url():
     """Empty webhook URL → no HTTP call made."""
     with patch("httpx.AsyncClient") as mock_client_cls:
-        await notify_discord("", job_id=1, label="Show Name", state="completed")
+        await notify_discord("", job_id=1, description="**Show Name**", state="completed")
         mock_client_cls.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_notify_discord_posts_completed_embed():
-    """COMPLETED state → green embed with checkmark title."""
+    """COMPLETED state → green embed with checkmark title, description passed through verbatim."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_client = AsyncMock()
@@ -35,7 +41,7 @@ async def test_notify_discord_posts_completed_embed():
         await notify_discord(
             "https://discord.com/api/webhooks/123/abc",
             job_id=5,
-            label="The Wire",
+            description="**The Wire**",
             state="completed",
         )
 
@@ -45,13 +51,13 @@ async def test_notify_discord_posts_completed_embed():
     embed = kwargs["json"]["embeds"][0]
     assert "✅" in embed["title"]
     assert "Completed" in embed["title"]
-    assert "The Wire" in embed["description"]
+    assert embed["description"] == "**The Wire**"
     assert embed["color"] == 0x00B97A  # green
 
 
 @pytest.mark.asyncio
 async def test_notify_discord_posts_failed_embed():
-    """FAILED state → red embed with X title."""
+    """FAILED state → red embed with X title, description passed through verbatim."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_client = AsyncMock()
@@ -63,13 +69,14 @@ async def test_notify_discord_posts_failed_embed():
         await notify_discord(
             "https://discord.com/api/webhooks/123/abc",
             job_id=5,
-            label="Mystery Disc",
+            description="**Mystery Disc**",
             state="failed",
         )
 
     embed = mock_client.post.call_args[1]["json"]["embeds"][0]
     assert "❌" in embed["title"]
     assert "Failed" in embed["title"]
+    assert embed["description"] == "**Mystery Disc**"
     assert embed["color"] == 0xE53935  # red
 
 
@@ -88,9 +95,113 @@ async def test_notify_discord_swallows_http_errors():
         await notify_discord(
             "https://discord.com/api/webhooks/123/abc",
             job_id=3,
-            label="Some Disc",
+            description="**Some Disc**",
             state="completed",
         )
+
+
+# --------------------------------------------------------------------------- #
+# validate_discord_template
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_discord_template_accepts_valid_template():
+    assert validate_discord_template("{{title}} - {{duration}}") is None
+
+
+def test_validate_discord_template_accepts_empty_string():
+    """Empty template is valid — falls back to the built-in default at render time."""
+    assert validate_discord_template("") is None
+
+
+def test_validate_discord_template_rejects_unknown_variable():
+    error = validate_discord_template("{{bogus}}")
+    assert error is not None
+    assert "bogus" in error
+
+
+def test_validate_discord_template_rejects_malformed_syntax():
+    error = validate_discord_template("{{title")
+    assert error is not None
+
+
+def test_validate_discord_template_rejects_unknown_variable_in_section_tag():
+    error = validate_discord_template("{{#bogus}}x{{/bogus}}")
+    assert error is not None
+    assert "bogus" in error
+
+
+# --------------------------------------------------------------------------- #
+# build_template_context / render_discord_template
+# --------------------------------------------------------------------------- #
+
+
+def test_build_template_context_default_template_matches_current_output():
+    job = DiscJob(
+        drive_id="E:",
+        content_type=ContentType.TV,
+        detected_title="Breaking Bad",
+        volume_label="BREAKING_BAD_S1D1",
+    )
+    context = build_template_context(job, job_id=1)
+    rendered = render_discord_template("**{{title}}**", context)
+    assert rendered == "**Breaking Bad**"
+
+
+def test_build_template_context_error_populated_on_failed_job():
+    job = DiscJob(
+        drive_id="E:",
+        content_type=ContentType.MOVIE,
+        volume_label="BAD_DISC",
+        error_message="disc unreadable",
+    )
+    context = build_template_context(job, job_id=2)
+    rendered = render_discord_template("{{error}}", context)
+    assert rendered == "disc unreadable"
+
+
+def test_build_template_context_error_empty_on_completed_job():
+    job = DiscJob(
+        drive_id="E:",
+        content_type=ContentType.MOVIE,
+        detected_title="Inception",
+        volume_label="INCEPTION_2010",
+    )
+    context = build_template_context(job, job_id=3)
+    rendered = render_discord_template("[{{error}}]", context)
+    assert rendered == "[]"
+
+
+def test_build_template_context_duration_formatted_when_both_timestamps_set():
+    job = DiscJob(
+        drive_id="E:",
+        content_type=ContentType.MOVIE,
+        detected_title="Inception",
+        volume_label="INCEPTION_2010",
+        created_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 1, 1, 11, 12, tzinfo=UTC),
+    )
+    context = build_template_context(job, job_id=4)
+    assert context["duration"] == "1h 12m"
+
+
+def test_build_template_context_duration_empty_when_not_completed():
+    job = DiscJob(
+        drive_id="E:",
+        content_type=ContentType.MOVIE,
+        detected_title="Inception",
+        volume_label="INCEPTION_2010",
+        completed_at=None,
+    )
+    context = build_template_context(job, job_id=5)
+    assert context["duration"] == ""
+
+
+def test_build_template_context_falls_back_when_job_is_none():
+    """Job vanished before re-fetch — context still yields a usable title, no crash."""
+    context = build_template_context(None, job_id=42)
+    rendered = render_discord_template("{{title}}", context)
+    assert rendered == "Job #42"
 
 
 # --------------------------------------------------------------------------- #
@@ -139,12 +250,12 @@ async def test_send_notification_fires_on_completed():
         await job_manager._send_discord_notification(job_id, JobState.COMPLETED)
 
     mock_notify.assert_called_once()
-    _, label, state = (
+    _, description, state = (
         mock_notify.call_args[0][1],
         mock_notify.call_args[0][2],
         mock_notify.call_args[0][3],
     )
-    assert label == "Breaking Bad"
+    assert description == "**Breaking Bad**"
     assert state == "completed"
 
 
@@ -202,8 +313,76 @@ async def test_send_notification_falls_back_to_volume_label():
     with patch("app.core.discord_notifier.notify_discord", new_callable=AsyncMock) as mock_notify:
         await job_manager._send_discord_notification(job_id, JobState.COMPLETED)
 
-    label = mock_notify.call_args[0][2]
-    assert label == "UNKNOWN_DISC"
+    description = mock_notify.call_args[0][2]
+    assert description == "**UNKNOWN_DISC**"
+
+
+@pytest.mark.asyncio
+async def test_send_notification_uses_configured_completed_template():
+    """A custom discord_template_completed renders instead of the default."""
+    from app.database import async_session
+    from app.models import JobState
+    from app.services.config_service import update_config
+    from app.services.job_manager import job_manager
+
+    await update_config(
+        discord_webhook_url="https://discord.com/api/webhooks/1/tok",
+        discord_template_completed="Done: {{title}} ({{drive}})",
+    )
+
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="E:",
+            content_type=ContentType.TV,
+            detected_title="Breaking Bad",
+            volume_label="BREAKING_BAD_S1D1",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    with patch("app.core.discord_notifier.notify_discord", new_callable=AsyncMock) as mock_notify:
+        await job_manager._send_discord_notification(job_id, JobState.COMPLETED)
+
+    description = mock_notify.call_args[0][2]
+    assert description == "Done: Breaking Bad (BREAKING_BAD_S1D1)"
+
+    await update_config(discord_template_completed="")
+
+
+@pytest.mark.asyncio
+async def test_send_notification_uses_configured_failed_template():
+    """A custom discord_template_failed renders and includes the error."""
+    from app.database import async_session
+    from app.models import JobState
+    from app.services.config_service import update_config
+    from app.services.job_manager import job_manager
+
+    await update_config(
+        discord_webhook_url="https://discord.com/api/webhooks/1/tok",
+        discord_template_failed="Failed: {{title}} — {{error}}",
+    )
+
+    async with async_session() as session:
+        job = DiscJob(
+            drive_id="E:",
+            content_type=ContentType.MOVIE,
+            volume_label="BAD_DISC",
+            error_message="disc unreadable",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        job_id = job.id
+
+    with patch("app.core.discord_notifier.notify_discord", new_callable=AsyncMock) as mock_notify:
+        await job_manager._send_discord_notification(job_id, JobState.FAILED)
+
+    description = mock_notify.call_args[0][2]
+    assert description == "Failed: BAD_DISC — disc unreadable"
+
+    await update_config(discord_template_failed="")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_discord_notifier.py
+++ b/backend/tests/unit/test_discord_notifier.py
@@ -7,8 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.core.discord_notifier import (
+    DEFAULT_TEMPLATE_COMPLETED,
     build_template_context,
     notify_discord,
+    render_discord_template,
     validate_discord_template,
 )
 from app.models.disc_job import ContentType, DiscJob
@@ -133,6 +135,13 @@ def test_validate_discord_template_rejects_unknown_variable_in_section_tag():
     assert "bogus" in error
 
 
+def test_validate_discord_template_accepts_comment_tag():
+    """Mustache comments ({{! ... }}) are inert and shouldn't be flagged as unknown
+    variables. Chevron's tokenizer already filters comment tags out internally —
+    this pins that behavior against a future chevron version regressing it."""
+    assert validate_discord_template("{{title}} {{! a comment }}") is None
+
+
 # --------------------------------------------------------------------------- #
 # build_template_context / render_discord_template
 # --------------------------------------------------------------------------- #
@@ -200,6 +209,22 @@ def test_build_template_context_falls_back_when_job_is_none():
     """Job vanished before re-fetch — context still yields a usable title, no crash."""
     context = build_template_context(None, job_id=42)
     assert context["title"] == "Job #42"
+
+
+def test_render_discord_template_default_does_not_html_escape_title():
+    """The built-in default must reproduce the old raw-f-string output byte-for-byte,
+    including titles with mustache-escaped characters — regression test for the
+    DEFAULT_TEMPLATE_* switch to unescaped {{{title}}} syntax."""
+    rendered = render_discord_template(DEFAULT_TEMPLATE_COMPLETED, {"title": "Law & Order"})
+    assert rendered == "**Law & Order**"
+
+
+def test_render_discord_template_does_not_resolve_partial_tags_from_filesystem():
+    """{{>title}} tokenizes as a partial (not a variable) and passes validation since
+    'title' is an allowed variable name too. Without partials_dict={}, chevron would
+    try to load ./title.mustache from the backend's CWD at render time."""
+    rendered = render_discord_template("{{>title}}", {"title": "Inception"})
+    assert rendered == ""
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/unit/test_validation.py
+++ b/backend/tests/unit/test_validation.py
@@ -1210,3 +1210,58 @@ class TestTmdbValidationRemainingBranches:
         result = _run(validate_tmdb(TmdbValidationRequest(api_key="k")))
         assert result.valid is False
         assert "Validation failed" in result.error
+
+
+class TestValidateDiscordTemplateEndpoint:
+    """POST /validate/discord-template — live per-keystroke validation for ConfigWizard."""
+
+    def test_valid_template(self):
+        from app.api.validation import (
+            DiscordTemplateValidationRequest,
+            validate_discord_template_endpoint,
+        )
+
+        result = _run(
+            validate_discord_template_endpoint(
+                DiscordTemplateValidationRequest(template="{{title}} - {{duration}}")
+            )
+        )
+        assert result.valid is True
+        assert result.error is None
+
+    def test_empty_template_is_valid(self):
+        from app.api.validation import (
+            DiscordTemplateValidationRequest,
+            validate_discord_template_endpoint,
+        )
+
+        result = _run(
+            validate_discord_template_endpoint(DiscordTemplateValidationRequest(template=""))
+        )
+        assert result.valid is True
+
+    def test_unknown_variable(self):
+        from app.api.validation import (
+            DiscordTemplateValidationRequest,
+            validate_discord_template_endpoint,
+        )
+
+        result = _run(
+            validate_discord_template_endpoint(
+                DiscordTemplateValidationRequest(template="{{bogus}}")
+            )
+        )
+        assert result.valid is False
+        assert "bogus" in result.error
+
+    def test_malformed_syntax(self):
+        from app.api.validation import (
+            DiscordTemplateValidationRequest,
+            validate_discord_template_endpoint,
+        )
+
+        result = _run(
+            validate_discord_template_endpoint(DiscordTemplateValidationRequest(template="{{title"))
+        )
+        assert result.valid is False
+        assert result.error is not None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -330,6 +330,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chevron"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/1f/ca74b65b19798895d63a6e92874162f44233467c9e7c1ed8afd19016ebe9/chevron-0.14.0.tar.gz", hash = "sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf", size = 11440, upload-time = "2021-01-02T22:47:59.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/93/342cc62a70ab727e093ed98e02a725d85b746345f05d2b5e5034649f4ec8/chevron-0.14.0-py3-none-any.whl", hash = "sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443", size = 11595, upload-time = "2021-01-02T22:47:57.847Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +512,7 @@ dependencies = [
     { name = "alembic" },
     { name = "beautifulsoup4" },
     { name = "chardet" },
+    { name = "chevron" },
     { name = "ctranslate2" },
     { name = "fastapi" },
     { name = "faster-whisper" },
@@ -556,6 +566,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.5" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "chardet", specifier = ">=5.2.0" },
+    { name = "chevron", specifier = ">=0.14.0" },
     { name = "ctranslate2", specifier = ">=4.0.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "faster-whisper", specifier = ">=1.2.1" },

--- a/frontend/src/components/ConfigWizard.css
+++ b/frontend/src/components/ConfigWizard.css
@@ -317,7 +317,9 @@
 
 .form-group input[type="text"],
 .form-group input[type="password"],
-.form-group input[type="number"] {
+.form-group input[type="number"],
+.form-group input[type="url"],
+.form-group textarea {
     width: 100%;
     padding: 0.65rem 0.75rem;
     background: rgba(94, 234, 212, 0.04);
@@ -328,14 +330,20 @@
     transition: background 120ms ease-out, border-color 120ms ease-out, box-shadow 120ms ease-out;
 }
 
-.form-group input:focus {
+.form-group textarea {
+    resize: vertical;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
     outline: none;
     border-color: var(--color-sv-cyan);
     box-shadow: 0 0 12px rgba(94, 234, 212, 0.25);
     background: rgba(94, 234, 212, 0.08);
 }
 
-.form-group input::placeholder {
+.form-group input::placeholder,
+.form-group textarea::placeholder {
     color: var(--color-sv-ink-ghost);
 }
 

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { toast } from 'sonner';
 import ConfigWizard from './ConfigWizard';
 
 /**
@@ -250,5 +251,76 @@ describe('ConfigWizard — background effects preference', () => {
         expect(toggle).not.toBeChecked();
         expect(localStorage.getItem('engram:backgroundEffectsEnabled')).toBe('false');
         expect((fetch as unknown as Mock).mock.calls.length).toBe(callsBeforeToggle);
+    });
+});
+
+describe('ConfigWizard — Discord notification templates', () => {
+    it('reads the saved templates from GET and sends edits on PUT', async () => {
+        mockApi({
+            discord_template_completed: '{{title}} is done',
+            discord_template_failed: '{{title}} failed: {{error}}',
+        });
+        const onComplete = vi.fn();
+        render(<ConfigWizard {...noop} onComplete={onComplete} isOnboarding={false} initialSection="preferences" />);
+
+        const completedField = await screen.findByLabelText(/completed message/i);
+        expect(completedField).toHaveValue('{{title}} is done');
+        const failedField = screen.getByLabelText(/failed message/i);
+        expect(failedField).toHaveValue('{{title}} failed: {{error}}');
+
+        fireEvent.change(completedField, { target: { value: '{{title}} - {{duration}}' } });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+        await waitFor(() => expect(onComplete).toHaveBeenCalled());
+        const putCall = (fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls.find(
+            (c) => c[1]?.method === 'PUT',
+        );
+        const body = JSON.parse(putCall?.[1]?.body as string);
+        expect(body.discord_template_completed).toBe('{{title}} - {{duration}}');
+        expect(body.discord_template_failed).toBe('{{title}} failed: {{error}}');
+    });
+
+    it('surfaces a 422 validation error from the server as a toast', async () => {
+        mockApi();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+                const url = typeof input === 'string' ? input : input.toString();
+                if (init?.method === 'PUT') {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 422,
+                        json: async () => ({ detail: 'discord_template_completed: Unknown template variable(s): bogus' }),
+                        text: async () => JSON.stringify({ detail: 'discord_template_completed: Unknown template variable(s): bogus' }),
+                    });
+                }
+                const config = { setup_complete: true, staging_path: '/staging', library_movies_path: '/movies', library_tv_path: '/tv' };
+                if (url.includes('/api/asr-status')) return Promise.resolve({ ok: true, status: 200, json: async () => ASR_STATUS, text: async () => '' });
+                if (url.includes('/api/detect-tools'))
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            makemkv: { found: false, path: null, version: null, error: null },
+                            ffmpeg: { found: false, path: null, version: null, error: null },
+                            platform: 'win32',
+                        }),
+                        text: async () => '',
+                    });
+                if (url.includes('/api/network/info'))
+                    return Promise.resolve({ ok: true, status: 200, json: async () => ({ lan_access_enabled: false, active_lan_bound: false, lan_ip: null, port: 8000, lan_url: null }), text: async () => '' });
+                return Promise.resolve({ ok: true, status: 200, json: async () => config, text: async () => JSON.stringify(config) });
+            }),
+        );
+
+        const toastErrorSpy = vi.spyOn(toast, 'error');
+        render(<ConfigWizard {...noop} isOnboarding={false} initialSection="preferences" />);
+        const completedField = await screen.findByLabelText(/completed message/i);
+        fireEvent.change(completedField, { target: { value: '{{bogus}}' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() =>
+            expect(toastErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown template variable')),
+        );
     });
 });

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -78,6 +78,7 @@ function mockApi(configOverrides: Record<string, unknown> = {}) {
                     };
                 if (url.includes('/api/network/info'))
                     return { lan_access_enabled: false, active_lan_bound: false, lan_ip: null, port: 8000, lan_url: null };
+                if (url.includes('/api/validate/discord-template')) return { valid: true };
                 return config;
             };
             return Promise.resolve({ ok: true, status: 200, json, text: async () => JSON.stringify(config) });
@@ -322,5 +323,86 @@ describe('ConfigWizard — Discord notification templates', () => {
         await waitFor(() =>
             expect(toastErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown template variable')),
         );
+    });
+
+    it('shows a live validation error and disables Save Changes while a template is invalid', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+                const url = typeof input === 'string' ? input : input.toString();
+                const config = { setup_complete: true, staging_path: '/staging', library_movies_path: '/movies', library_tv_path: '/tv' };
+                const json = async () => {
+                    if (url.includes('/api/asr-status')) return ASR_STATUS;
+                    if (url.includes('/api/detect-tools'))
+                        return {
+                            makemkv: { found: false, path: null, version: null, error: null },
+                            ffmpeg: { found: false, path: null, version: null, error: null },
+                            platform: 'win32',
+                        };
+                    if (url.includes('/api/network/info'))
+                        return { lan_access_enabled: false, active_lan_bound: false, lan_ip: null, port: 8000, lan_url: null };
+                    if (url.includes('/api/validate/discord-template')) {
+                        const { template } = JSON.parse((init?.body as string) || '{}');
+                        return template === '{{bogus}}'
+                            ? { valid: false, error: 'Unknown template variable(s): bogus' }
+                            : { valid: true };
+                    }
+                    return config;
+                };
+                return Promise.resolve({ ok: true, status: 200, json, text: async () => JSON.stringify(config) });
+            }),
+        );
+
+        render(<ConfigWizard {...noop} isOnboarding={false} initialSection="preferences" />);
+        const completedField = await screen.findByLabelText(/completed message/i);
+        const saveButton = screen.getByRole('button', { name: 'Save Changes' });
+        expect(saveButton).toBeEnabled();
+
+        fireEvent.change(completedField, { target: { value: '{{bogus}}' } });
+
+        expect(await screen.findByText(/unknown template variable/i)).toBeInTheDocument();
+        await waitFor(() => expect(saveButton).toBeDisabled());
+    });
+
+    it('clears the validation error and re-enables Save Changes once the template becomes valid', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+                const url = typeof input === 'string' ? input : input.toString();
+                const config = { setup_complete: true, staging_path: '/staging', library_movies_path: '/movies', library_tv_path: '/tv' };
+                const json = async () => {
+                    if (url.includes('/api/asr-status')) return ASR_STATUS;
+                    if (url.includes('/api/detect-tools'))
+                        return {
+                            makemkv: { found: false, path: null, version: null, error: null },
+                            ffmpeg: { found: false, path: null, version: null, error: null },
+                            platform: 'win32',
+                        };
+                    if (url.includes('/api/network/info'))
+                        return { lan_access_enabled: false, active_lan_bound: false, lan_ip: null, port: 8000, lan_url: null };
+                    if (url.includes('/api/validate/discord-template')) {
+                        const { template } = JSON.parse((init?.body as string) || '{}');
+                        return template === '{{bogus}}'
+                            ? { valid: false, error: 'Unknown template variable(s): bogus' }
+                            : { valid: true };
+                    }
+                    return config;
+                };
+                return Promise.resolve({ ok: true, status: 200, json, text: async () => JSON.stringify(config) });
+            }),
+        );
+
+        render(<ConfigWizard {...noop} isOnboarding={false} initialSection="preferences" />);
+        const completedField = await screen.findByLabelText(/completed message/i);
+        const saveButton = screen.getByRole('button', { name: 'Save Changes' });
+
+        fireEvent.change(completedField, { target: { value: '{{bogus}}' } });
+        expect(await screen.findByText(/unknown template variable/i)).toBeInTheDocument();
+        await waitFor(() => expect(saveButton).toBeDisabled());
+
+        fireEvent.change(completedField, { target: { value: '{{title}}' } });
+
+        await waitFor(() => expect(screen.queryByText(/unknown template variable/i)).not.toBeInTheDocument());
+        await waitFor(() => expect(saveButton).toBeEnabled());
     });
 });

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -8,6 +8,7 @@ import { BootstrapLibraryFlow } from './BootstrapLibraryFlow';
 import GpuAccelerationSetting from './GpuAccelerationSetting';
 import BackgroundEffectsSetting from './BackgroundEffectsSetting';
 import { requestTmdbValidation } from '../utils/tmdbValidation';
+import { requestDiscordTemplateValidation } from '../utils/discordTemplateValidation';
 import { formatToolVersion } from '../utils/formatting';
 import './ConfigWizard.css';
 
@@ -232,6 +233,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
     });
     const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
     const [isSaving, setIsSaving] = useState(false);
+    const [discordTemplateErrors, setDiscordTemplateErrors] = useState<{completed: string; failed: string}>({completed: '', failed: ''});
     const [toolDetection, setToolDetection] = useState<DetectToolsResponse | null>(null);
     const [isDetecting, setIsDetecting] = useState(false);
     const [showMakemkvOverride, setShowMakemkvOverride] = useState(false);
@@ -352,6 +354,23 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         };
         loadConfig();
     }, []);
+
+    // Live Discord template validation, debounced. The real enforcement is
+    // server-side (PUT /api/config re-validates before persisting) — this is
+    // UX only, so a network hiccup ('error' status) doesn't block Save.
+    useEffect(() => {
+        const timer = window.setTimeout(async () => {
+            const [completedResult, failedResult] = await Promise.all([
+                requestDiscordTemplateValidation(config.discordTemplateCompleted),
+                requestDiscordTemplateValidation(config.discordTemplateFailed),
+            ]);
+            setDiscordTemplateErrors({
+                completed: completedResult.status === 'invalid' ? completedResult.error : '',
+                failed: failedResult.status === 'invalid' ? failedResult.error : '',
+            });
+        }, 400);
+        return () => window.clearTimeout(timer);
+    }, [config.discordTemplateCompleted, config.discordTemplateFailed]);
 
     // Detect tools when entering step 2
     useEffect(() => {
@@ -1730,6 +1749,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 placeholder="**{{title}}**"
                                 rows={2}
                             />
+                            {discordTemplateErrors.completed && (
+                                <span style={{color: '#ef4444', fontSize: '0.85rem'}}>✗ {discordTemplateErrors.completed}</span>
+                            )}
                             <span className="form-hint">
                                 Available variables: {'{{'}title{'}}'}, {'{{'}drive{'}}'}, {'{{'}content_type{'}}'}, {'{{'}season{'}}'},{' '}
                                 {'{{'}tmdb_name{'}}'}, {'{{'}tmdb_year{'}}'}, {'{{'}duration{'}}'}, {'{{'}subtitle_status{'}}'},{' '}
@@ -1746,6 +1768,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 placeholder="**{{title}}**"
                                 rows={2}
                             />
+                            {discordTemplateErrors.failed && (
+                                <span style={{color: '#ef4444', fontSize: '0.85rem'}}>✗ {discordTemplateErrors.failed}</span>
+                            )}
                             <span className="form-hint">
                                 Same variables as above, plus {'{{'}error{'}}'} for the failure reason. Leave blank to use the default.
                             </span>
@@ -1872,7 +1897,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                         <button
                             className="btn-primary"
                             onClick={handleNext}
-                            disabled={isSaving}
+                            disabled={isSaving || !!discordTemplateErrors.completed || !!discordTemplateErrors.failed}
                         >
                             {step === totalSteps ? (isSaving ? 'Saving...' : 'Complete Setup') : 'Next →'}
                         </button>
@@ -1880,7 +1905,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                         <button
                             className="btn-primary"
                             onClick={handleSave}
-                            disabled={isSaving}
+                            disabled={isSaving || !!discordTemplateErrors.completed || !!discordTemplateErrors.failed}
                         >
                             {isSaving ? 'Saving...' : 'Save Changes'}
                         </button>

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -360,9 +360,16 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
     // UX only, so a network hiccup ('error' status) doesn't block Save.
     useEffect(() => {
         const timer = window.setTimeout(async () => {
+            // Empty template is always valid (falls back to the built-in default) —
+            // skip the round-trip, which also avoids validating on mount before the
+            // user has touched either field.
             const [completedResult, failedResult] = await Promise.all([
-                requestDiscordTemplateValidation(config.discordTemplateCompleted),
-                requestDiscordTemplateValidation(config.discordTemplateFailed),
+                config.discordTemplateCompleted
+                    ? requestDiscordTemplateValidation(config.discordTemplateCompleted)
+                    : Promise.resolve({ status: 'valid' as const }),
+                config.discordTemplateFailed
+                    ? requestDiscordTemplateValidation(config.discordTemplateFailed)
+                    : Promise.resolve({ status: 'valid' as const }),
             ]);
             setDiscordTemplateErrors({
                 completed: completedResult.status === 'invalid' ? completedResult.error : '',
@@ -1755,7 +1762,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                             <span className="form-hint">
                                 Available variables: {'{{'}title{'}}'}, {'{{'}drive{'}}'}, {'{{'}content_type{'}}'}, {'{{'}season{'}}'},{' '}
                                 {'{{'}tmdb_name{'}}'}, {'{{'}tmdb_year{'}}'}, {'{{'}duration{'}}'}, {'{{'}subtitle_status{'}}'},{' '}
-                                {'{{'}path{'}}'}, {'{{'}total_titles{'}}'}. Leave blank to use the default.
+                                {'{{'}path{'}}'}, {'{{'}total_titles{'}}'}. Leave blank to use the default. Use triple braces
+                                ({'{{{'}var{'}}}'}) instead of double to avoid HTML-escaping characters like {'&'}, {'<'}, {'>'}.
                             </span>
                         </div>
 
@@ -1773,6 +1781,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                             )}
                             <span className="form-hint">
                                 Same variables as above, plus {'{{'}error{'}}'} for the failure reason. Leave blank to use the default.
+                                Use triple braces ({'{{{'}var{'}}}'}) to avoid HTML-escaping.
                             </span>
                         </div>
 

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -147,6 +147,8 @@ interface ConfigData {
     opensubtitlesPassword: string;
     allowLanAccess: boolean;
     discordWebhookUrl: string;
+    discordTemplateCompleted: string;
+    discordTemplateFailed: string;
 }
 
 interface NetworkInfo {
@@ -225,6 +227,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         opensubtitlesPassword: '',
         allowLanAccess: false,
         discordWebhookUrl: '',
+        discordTemplateCompleted: '',
+        discordTemplateFailed: '',
     });
     const [networkInfo, setNetworkInfo] = useState<NetworkInfo | null>(null);
     const [isSaving, setIsSaving] = useState(false);
@@ -337,6 +341,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     opensubtitlesPassword: data.opensubtitles_password === '***' ? '' : (data.opensubtitles_password || ''),
                     allowLanAccess: data.allow_lan_access ?? false,
                     discordWebhookUrl: data.discord_webhook_url === '***' ? '' : (data.discord_webhook_url || ''),
+                    discordTemplateCompleted: data.discord_template_completed || '',
+                    discordTemplateFailed: data.discord_template_failed || '',
                 });
             } catch (error) {
                 console.error('Failed to load config:', error);
@@ -493,6 +499,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     ...optional('opensubtitles_password', config.opensubtitlesPassword),
                     allow_lan_access: config.allowLanAccess,
                     ...optional('discord_webhook_url', config.discordWebhookUrl),
+                    discord_template_completed: config.discordTemplateCompleted,
+                    discord_template_failed: config.discordTemplateFailed,
                     setup_complete: true,
                 }),
             });
@@ -1710,6 +1718,36 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                             <span className="form-hint">
                                 When a disc finishes (completed or failed), Engram posts a message to this channel.
                                 Create a webhook in your Discord server's channel settings under Integrations.
+                            </span>
+                        </div>
+
+                        <div className="form-group">
+                            <label htmlFor="discordTemplateCompleted">Completed Message</label>
+                            <textarea
+                                id="discordTemplateCompleted"
+                                value={config.discordTemplateCompleted}
+                                onChange={(e) => handleInputChange('discordTemplateCompleted', e.target.value)}
+                                placeholder="**{{title}}**"
+                                rows={2}
+                            />
+                            <span className="form-hint">
+                                Available variables: {'{{'}title{'}}'}, {'{{'}drive{'}}'}, {'{{'}content_type{'}}'}, {'{{'}season{'}}'},{' '}
+                                {'{{'}tmdb_name{'}}'}, {'{{'}tmdb_year{'}}'}, {'{{'}duration{'}}'}, {'{{'}subtitle_status{'}}'},{' '}
+                                {'{{'}path{'}}'}, {'{{'}total_titles{'}}'}. Leave blank to use the default.
+                            </span>
+                        </div>
+
+                        <div className="form-group">
+                            <label htmlFor="discordTemplateFailed">Failed Message</label>
+                            <textarea
+                                id="discordTemplateFailed"
+                                value={config.discordTemplateFailed}
+                                onChange={(e) => handleInputChange('discordTemplateFailed', e.target.value)}
+                                placeholder="**{{title}}**"
+                                rows={2}
+                            />
+                            <span className="form-hint">
+                                Same variables as above, plus {'{{'}error{'}}'} for the failure reason. Leave blank to use the default.
                             </span>
                         </div>
 

--- a/frontend/src/utils/discordTemplateValidation.test.ts
+++ b/frontend/src/utils/discordTemplateValidation.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Discord notification template validation — live per-keystroke check against
+ * POST /api/validate/discord-template. Same three-outcome shape as
+ * requestTmdbValidation: 'valid' | 'invalid' (rejected, user must fix) |
+ * 'error' (the check itself failed, template was never actually checked).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { requestDiscordTemplateValidation } from './discordTemplateValidation';
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  consoleError.mockRestore();
+});
+
+function stubFetch(impl: () => Promise<unknown>) {
+  vi.stubGlobal('fetch', vi.fn(impl));
+}
+
+describe('requestDiscordTemplateValidation', () => {
+  it('returns valid when the endpoint accepts the template', async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ valid: true }) }));
+
+    expect(await requestDiscordTemplateValidation('{{title}}')).toEqual({ status: 'valid' });
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid with the backend message when the template is rejected', async () => {
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ valid: false, error: 'Unknown template variable(s): bogus' }),
+    }));
+
+    expect(await requestDiscordTemplateValidation('{{bogus}}')).toEqual({
+      status: 'invalid',
+      error: 'Unknown template variable(s): bogus',
+    });
+  });
+
+  it('treats a non-OK HTTP response as a failed CHECK, not an invalid template, and logs it', async () => {
+    stubFetch(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+      json: async () => ({}),
+    }));
+
+    const result = await requestDiscordTemplateValidation('{{title}}');
+    expect(result.status).toBe('error');
+    expect(result.status === 'error' && result.error).toMatch(/couldn't check|could not check/i);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('treats a network failure as a failed CHECK and logs the underlying error', async () => {
+    const boom = new TypeError('Failed to fetch');
+    stubFetch(async () => {
+      throw boom;
+    });
+
+    const result = await requestDiscordTemplateValidation('{{title}}');
+    expect(result.status).toBe('error');
+    expect(result.status === 'error' && result.error).toMatch(/reach/i);
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), boom);
+  });
+});

--- a/frontend/src/utils/discordTemplateValidation.ts
+++ b/frontend/src/utils/discordTemplateValidation.ts
@@ -1,0 +1,50 @@
+/**
+ * Discord notification template validation against POST /api/validate/discord-template.
+ *
+ * Same three-outcome shape as requestTmdbValidation — 'valid' | 'invalid' (the
+ * server rejected the template) | 'error' (the check itself couldn't run, the
+ * template was never actually validated).
+ */
+export type DiscordTemplateValidationResult =
+  | { status: 'valid' }
+  | { status: 'invalid'; error: string }
+  | { status: 'error'; error: string };
+
+export async function requestDiscordTemplateValidation(
+  template: string,
+): Promise<DiscordTemplateValidationResult> {
+  let response: Response;
+  try {
+    response = await fetch('/api/validate/discord-template', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ template }),
+    });
+  } catch (err) {
+    console.error('Discord template validation request failed (network):', err);
+    return {
+      status: 'error',
+      error: "Couldn't reach the validation endpoint — is the backend running?",
+    };
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    console.error(`Discord template validation endpoint returned HTTP ${response.status}:`, detail);
+    return {
+      status: 'error',
+      error: `Couldn't check the template — validation endpoint returned HTTP ${response.status}`,
+    };
+  }
+
+  try {
+    const result = await response.json();
+    if (result.valid) {
+      return { status: 'valid' };
+    }
+    return { status: 'invalid', error: result.error || 'Invalid template' };
+  } catch (err) {
+    console.error('Discord template validation returned an unparseable response:', err);
+    return { status: 'error', error: "Couldn't check the template — unexpected response" };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #507. Discord embeds sent on job COMPLETED/FAILED now render from a user-editable template instead of a fixed message.

- Two new config fields — `discord_template_completed` / `discord_template_failed` — using **chevron** (`{{var}}` mustache syntax), per your comment on #507.
- Template controls the embed **description text only**; title/color/emoji (✅ green / ❌ red) stay hardcoded.
- Validated at `PUT /api/config` (422 on unknown variable or malformed syntax) so a bad template can never reach a live job — never validated/rejected at render time.
- **Live validation in ConfigWizard**: a new `POST /api/validate/discord-template` endpoint reuses the same server-side validator (no second parser reimplemented in TypeScript). Each template textarea debounces (400ms) a call to it, shows the error inline, and disables Save Changes / Next while either template is currently invalid — catching mistakes before Save instead of after a 422 toast. This is UX only; the real enforcement stays at `PUT /api/config`, so it can't be used to bypass validation.
- Available variables: `title`, `drive`, `job_id`, `content_type`, `season`, `tmdb_name`, `tmdb_year`, `duration` (derived from `completed_at - created_at`), `error`, `subtitle_status`, `subtitles_downloaded`, `subtitles_total`, `subtitles_failed`, `path`, `total_titles`.
- Empty template string = use the built-in default (`**{{title}}**`, matching current behavior byte-for-byte).
- New Alembic migration adds the two `app_config` columns.
- ConfigWizard gets two new textareas in the Notifications section.

## Design notes / open questions for review

- **Status code**: template validation returns 422, while the existing naming-format check in the same endpoint returns 400 — pre-existing inconsistency, not touched here.
- `notify_discord()` now takes a pre-rendered `description: str` rather than doing the templating itself — keeps chevron out of the low-level POST helper's hot path/test surface. Happy to restructure if you'd rather see a `discord_templates.py` split.
- `{{drive}}` kept separate from `{{title}}` despite overlap in the common case (title falls back to drive label) — lets a template reference the raw label even when a TMDB override exists.
- Introduced `TERMINAL_JOB_STATES` (`app/models/disc_job.py`) to replace four separate `(JobState.COMPLETED, JobState.FAILED)` literal tuples scattered across `job_state_machine.py` and `job_manager.py` — one of them was added by this PR (a defensive guard in `_send_discord_notification`), which is what surfaced the existing duplication. Small refactor, no behavior change, but touches code outside the Discord feature itself — flagging in case you'd rather see it split out.

## Test plan

- [x] Backend: `uv run pytest` (full suite green) — new unit tests for `validate_discord_template`, `build_template_context`, `render_discord_template`, updated `notify_discord`/`_send_discord_notification` tests, new `PUT /api/config` validation tests (422/200/blank-ok), new `POST /api/validate/discord-template` endpoint tests.
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] Frontend: `npx vitest run` (full suite green) — new ConfigWizard tests for template load/save roundtrip, 422 toast surfacing, live-validation error display, and Save/Next disabling; new `discordTemplateValidation` util tests.
- [x] `npm run build` (typecheck) / `npm run lint`
- [x] Migration manually verified against a simulated pre-migration DB (add_column path), not just autogenerate diff.
- [x] Manually confirmed via local dev server: live validation errors and re-enabling of Save Changes work end-to-end.
- [x] Manual: set a webhook + custom template via the UI, trigger a simulated COMPLETED/FAILED job, confirm the rendered Discord message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)