### PR TITLE
fix: scope bug-report recent errors to the requested job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **Docker deployments now run `privileged: true` by default.** Plain `devices:` passthrough wasn't always enough for full optical drive control (eject/tray), and some hosts got stuck unable to stop or restart the container without it. (#459, thanks @MadsTheEngineer!)
+- **Bug reports no longer show another job's errors as if they were yours.** The "Report Bug" diagnostic report ignored which job it was opened for and always pulled the last 20 global error lines — a report opened for a cancelled job with no errors of its own could show an unrelated job's failure from days earlier. Recent errors are now scoped to the job the report is for, and when a job predates per-job log tagging and there's genuinely nothing job-specific to show, the report (both the modal and the copied/GitHub text) now says so instead of silently substituting unrelated errors. (#506, #522)
 
 ## [0.25.0] - 2026-07-12
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3127,12 +3127,12 @@ def _build_markdown_summary(
     if recent_errors:
         parts += ["### Recent Errors"]
         if recent_errors_is_fallback:
-            parts += [
+            fallback_note = (
                 "_Note: this job has no tagged log lines (predates job-tagged "
                 "logging or none were emitted) — showing the most recent global "
-                "error tail below, which is not specific to this job._",
-                "",
-            ]
+                "error tail below, which is not specific to this job._"
+            )
+            parts += [fallback_note, ""]
         parts += ["```"]
         parts += recent_errors[-10:]
         parts += ["```", ""]

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3089,7 +3089,12 @@ async def _collect_environment() -> dict:
     }
 
 
-def _build_markdown_summary(env: dict, job_summary: dict | None, recent_errors: list[str]) -> str:
+def _build_markdown_summary(
+    env: dict,
+    job_summary: dict | None,
+    recent_errors: list[str],
+    recent_errors_is_fallback: bool = False,
+) -> str:
     """Render the factual core of a bug report (env + job context + errors).
 
     Used verbatim by the GitHub issue body and as the opening of the
@@ -3120,7 +3125,15 @@ def _build_markdown_summary(env: dict, job_summary: dict | None, recent_errors: 
             parts.append(f"- **Error**: {job_summary['error']}")
         parts.append("")
     if recent_errors:
-        parts += ["### Recent Errors", "```"]
+        parts += ["### Recent Errors"]
+        if job_summary and recent_errors_is_fallback:
+            parts += [
+                "_Note: this job has no tagged log lines (predates job-tagged "
+                "logging or none were emitted) — showing the most recent global "
+                "error tail below, which is not specific to this job._",
+                "",
+            ]
+        parts += ["```"]
         parts += recent_errors[-10:]
         parts += ["```", ""]
     return "\n".join(parts)
@@ -3184,6 +3197,24 @@ def _read_job_tagged_logs(
     if matched:
         return ([_sanitize_line(ln) for ln in matched[-limit:]], False)
     return (_read_recent_error_lines(log_path=log_path), True)
+
+
+def _read_job_error_lines(
+    job_id: int, limit: int = 20, log_path: Path | None = None
+) -> tuple[list[str], bool]:
+    """Return ``(lines, is_fallback)`` — this job's ERROR/CRITICAL log lines.
+
+    Scopes to the job via ``_read_job_tagged_logs`` so a bug report for one
+    job never surfaces another job's errors (#506: job 47's report showed
+    job 39's errors because the old code read the unscoped global tail
+    regardless of ``job_id``). When the job has no tagged lines at all
+    (predates job-tagged logging), the fallback is already the global
+    ERROR/CRITICAL tail — ``is_fallback`` lets callers flag it as such.
+    """
+    lines, is_fallback = _read_job_tagged_logs(job_id, log_path=log_path)
+    if not is_fallback:
+        lines = [ln for ln in lines if "ERROR" in ln or "CRITICAL" in ln]
+    return (lines[-limit:], is_fallback)
 
 
 def _cap_text(text: str, max_chars: int = 200_000) -> str:
@@ -3310,7 +3341,14 @@ async def generate_bug_report(
                 "completed_at": str(job.completed_at) if job.completed_at else None,
             }
 
-    recent_errors = _read_recent_error_lines()
+    # Scope "recent errors" to the requested job so a bug report never leaks
+    # an unrelated job's errors (#506). Only fall back to the unscoped global
+    # tail when the report was opened without job context at all.
+    if job_id is not None:
+        recent_errors, recent_errors_is_fallback = _read_job_error_lines(job_id)
+    else:
+        recent_errors = _read_recent_error_lines()
+        recent_errors_is_fallback = False
 
     report = {
         "app_version": env["app_version"],
@@ -3320,12 +3358,13 @@ async def generate_bug_report(
         "ffmpeg_version": env["ffmpeg_version"],
         "job": job_summary,
         "recent_errors": recent_errors,
+        "recent_errors_is_fallback": recent_errors_is_fallback,
         "config": env["config"],
     }
 
     # --- GitHub issue body (kept small; full detail lives in the bundle) ---
     body_parts = [
-        _build_markdown_summary(env, job_summary, recent_errors),
+        _build_markdown_summary(env, job_summary, recent_errors, recent_errors_is_fallback),
         "### Steps to Reproduce",
         "1. ",
         "",

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3126,7 +3126,7 @@ def _build_markdown_summary(
         parts.append("")
     if recent_errors:
         parts += ["### Recent Errors"]
-        if job_summary and recent_errors_is_fallback:
+        if recent_errors_is_fallback:
             parts += [
                 "_Note: this job has no tagged log lines (predates job-tagged "
                 "logging or none were emitted) — showing the most recent global "

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -171,6 +171,30 @@ class TestBugReport:
         assert data["recent_errors_is_fallback"] is True
         assert "not specific to this job" in data["markdown"].lower()
 
+    async def test_report_marks_fallback_note_even_when_job_id_does_not_resolve(
+        self, client, fake_tools, monkeypatch
+    ):
+        """A stale/deleted job_id has no DB row (job_summary stays None), but
+
+        _read_job_error_lines still runs off job_id alone and can return the
+        fallback tail — the disclaimer must track recent_errors_is_fallback,
+        not job_summary's presence, or the two representations disagree.
+        """
+        monkeypatch.setattr(
+            "app.api.routes._read_job_tagged_logs",
+            lambda jid, limit=2000, log_path=None: (
+                ["t | ERROR | job=39 | a:b:1 - unrelated job's error"],
+                True,
+            ),
+        )
+
+        resp = await client.get("/api/diagnostics/report?job_id=999999")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["job"] is None
+        assert data["recent_errors_is_fallback"] is True
+        assert "not specific to this job" in data["markdown"].lower()
+
 
 class TestBundle:
     async def test_bundle_returns_zip_with_expected_members(self, client, fake_tools, monkeypatch):

--- a/backend/tests/unit/test_diagnostics.py
+++ b/backend/tests/unit/test_diagnostics.py
@@ -115,6 +115,62 @@ class TestBugReport:
         assert data["makemkv_version"] == "MakeMKV not found"
         assert data["ffmpeg_version"] == "FFmpeg not found"
 
+    async def test_report_without_job_id_uses_global_recent_errors(self, client, fake_tools):
+        """No job context → falls back to the plain global ERROR/CRITICAL tail."""
+        resp = await client.get("/api/diagnostics/report")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recent_errors_is_fallback"] is False
+
+    async def test_report_scopes_recent_errors_to_the_requested_job(
+        self, client, fake_tools, monkeypatch
+    ):
+        """Regression for #506: job 47's report must not surface job 39's errors."""
+        job = await _seed_job(volume_label="MOVIE_47")
+
+        def fake_tagged_logs(jid, limit=2000, log_path=None):
+            assert jid == job.id
+            return (
+                [f"t | ERROR | job={job.id} | x:y:1 - this job's own error"],
+                False,
+            )
+
+        monkeypatch.setattr("app.api.routes._read_job_tagged_logs", fake_tagged_logs)
+        # If the endpoint fell back to the unscoped global reader, this
+        # unrelated line would leak into the report instead.
+        monkeypatch.setattr(
+            "app.api.routes._read_recent_error_lines",
+            lambda *a, **k: ["t | ERROR | job=39 | a:b:1 - unrelated job's error"],
+        )
+
+        resp = await client.get(f"/api/diagnostics/report?job_id={job.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recent_errors"] == [f"t | ERROR | job={job.id} | x:y:1 - this job's own error"]
+        assert not any("unrelated" in ln for ln in data["recent_errors"])
+        assert data["recent_errors_is_fallback"] is False
+        assert "unrelated" not in data["markdown"]
+
+    async def test_report_marks_fallback_when_job_has_no_tagged_lines(
+        self, client, fake_tools, monkeypatch
+    ):
+        """No tagged lines → the fallback must be labeled, not silently mixed in."""
+        job = await _seed_job(volume_label="CANCELLED_MOVIE")
+
+        monkeypatch.setattr(
+            "app.api.routes._read_job_tagged_logs",
+            lambda jid, limit=2000, log_path=None: (
+                ["t | ERROR | job=39 | a:b:1 - unrelated job's error"],
+                True,
+            ),
+        )
+
+        resp = await client.get(f"/api/diagnostics/report?job_id={job.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["recent_errors_is_fallback"] is True
+        assert "not specific to this job" in data["markdown"].lower()
+
 
 class TestBundle:
     async def test_bundle_returns_zip_with_expected_members(self, client, fake_tools, monkeypatch):
@@ -223,6 +279,39 @@ class TestJobTaggedLogReader:
         lines, is_fallback = _read_job_tagged_logs(1, log_path=tmp_path / "nope.log")
         assert lines == []
         assert is_fallback is True
+
+
+class TestJobErrorLineReader:
+    """_read_job_error_lines scopes 'recent errors' to one job (issue #506)."""
+
+    def test_filters_to_matching_job_errors_only(self, tmp_path):
+        from app.api.routes import _read_job_error_lines
+
+        log = tmp_path / "engram.log"
+        log.write_text(
+            "t | ERROR | job=47 | a:b:1 - job 47's own error\n"
+            "t | ERROR | job=39 | a:b:1 - unrelated job's error\n"
+            "t | INFO | job=47 | a:b:1 - job 47 info, not an error\n",
+            encoding="utf-8",
+        )
+        lines, is_fallback = _read_job_error_lines(47, log_path=log)
+        assert is_fallback is False
+        assert lines == ["t | ERROR | job=47 | a:b:1 - job 47's own error"]
+
+    def test_falls_back_when_job_has_no_tagged_lines(self, tmp_path):
+        from app.api.routes import _read_job_error_lines
+
+        log = tmp_path / "engram.log"
+        log.write_text(
+            "t | ERROR | job=- | a:b:1 - global error, no job tag\n"
+            "t | ERROR | job=99 | a:b:1 - a different job's error\n",
+            encoding="utf-8",
+        )
+        # Job 47 has no tagged lines at all → fall back to the global tail,
+        # but flag it so callers know these aren't job 47's errors.
+        lines, is_fallback = _read_job_error_lines(47, log_path=log)
+        assert is_fallback is True
+        assert any("global error" in ln for ln in lines)
 
 
 def test_sanitize_obj_redacts_home_and_secrets():

--- a/frontend/src/components/BugReportModal.test.tsx
+++ b/frontend/src/components/BugReportModal.test.tsx
@@ -1,0 +1,46 @@
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import BugReportModal from "./BugReportModal";
+import * as client from "../api/client";
+
+const BASE_REPORT = {
+  app_version: "0.25.0",
+  python_version: "3.13.11",
+  os: "Windows 11",
+  makemkv_version: "MakeMKV v1.17.7",
+  ffmpeg_version: "ffmpeg version 6.1.1",
+  job: null,
+  recent_errors: ["t | ERROR | job=47 | a:b:1 - job 47's own error"],
+  recent_errors_is_fallback: false,
+  config: {},
+  github_url: "https://github.com/Jsakkos/engram/issues/new?title=x&body=y",
+  markdown: "## Bug Report\n",
+  bundle_available: false,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BugReportModal", () => {
+  it("does not show a fallback notice when recent_errors_is_fallback is false", async () => {
+    vi.spyOn(client, "apiFetch").mockResolvedValue(BASE_REPORT);
+    render(<BugReportModal open onClose={() => {}} jobId={47} />);
+
+    await waitFor(() => expect(screen.getByText(/job 47's own error/)).toBeInTheDocument());
+    expect(screen.queryByText(/not specific to this job/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a fallback notice above Recent Errors when the errors aren't job-specific", async () => {
+    vi.spyOn(client, "apiFetch").mockResolvedValue({
+      ...BASE_REPORT,
+      recent_errors: ["t | ERROR | job=39 | a:b:1 - unrelated job's error"],
+      recent_errors_is_fallback: true,
+    });
+    render(<BugReportModal open onClose={() => {}} jobId={47} />);
+
+    await waitFor(() => expect(screen.getByText(/unrelated job's error/)).toBeInTheDocument());
+    expect(screen.getByText(/not specific to this job/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -21,6 +21,8 @@ interface BugReport {
     completed_at: string | null;
   } | null;
   recent_errors: string[];
+  /** True when recent_errors is the unscoped global tail, not this job's own errors. */
+  recent_errors_is_fallback: boolean;
   config: Record<string, string | number | boolean>;
   github_url: string;
   markdown: string;
@@ -351,6 +353,12 @@ export default function BugReportModal({ open, onClose, jobId }: BugReportModalP
                     </Section>
 
                     <Section title="Recent Errors">
+                      {report.recent_errors_is_fallback && report.recent_errors.length > 0 && (
+                        <SvNotice tone="warn">
+                          These are the most recent global errors, not specific to this job — it
+                          has no tagged log lines of its own.
+                        </SvNotice>
+                      )}
                       <pre
                         style={{
                           margin: 0,


### PR DESCRIPTION
## Summary
- `generate_bug_report()` (the `/api/diagnostics/report` endpoint behind the "Report Bug" button) always pulled the last 20 global ERROR/CRITICAL log lines, ignoring `job_id` entirely — so a report for one job could show another, unrelated job's errors.
- Adds `_read_job_error_lines()`, a thin ERROR/CRITICAL filter layered on the existing `_read_job_tagged_logs()` job-scoping helper (already used correctly by the diagnostics bundle endpoint). `generate_bug_report()` now uses it when `job_id` is provided, falling back to the unscoped global tail only when the report is opened without job context.
- When a job predates job-tagged logging (no tagged lines at all), the response now carries `recent_errors_is_fallback: true` and the markdown body/GitHub issue text explicitly notes the shown errors aren't specific to that job, instead of silently presenting an unrelated tail as if it were.

Fixes #506.

## Test plan
- [x] New tests in `backend/tests/unit/test_diagnostics.py`:
  - `TestJobErrorLineReader` — unit tests for `_read_job_error_lines()` (job-scoped filtering, ERROR/CRITICAL-only, fallback flagging)
  - `TestBugReport::test_report_scopes_recent_errors_to_the_requested_job` — regression for #506, asserts an unrelated job's tagged error never leaks into another job's report
  - `TestBugReport::test_report_marks_fallback_when_job_has_no_tagged_lines` — fallback is labeled, not silently shown as job-specific
  - `TestBugReport::test_report_without_job_id_uses_global_recent_errors` — no-job-context behavior preserved
- [x] `uv run pytest tests/unit/test_diagnostics.py tests/unit/test_api_routes.py` — 62 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files — clean
- [x] Full `uv run pytest` — one unrelated pre-existing flaky failure (`test_build_subtitle_cache.py::test_main_produces_loadable_tarball`), confirmed to pass in isolation on both main and this branch; not touched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)