### PR TITLE
fix: allow manual import from LAN when allow_lan_access is enabled (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The manual import feature now works in Docker and other remote setups.** Browsing for files and starting an import over the network returned `403 Forbidden` because those endpoints were locked to the host machine. They now honor the **Allow LAN access** setting: when you've enabled it (headless/Docker installs enable it automatically on first run), import is reachable from another device, while the more sensitive fingerprint and contribution endpoints stay host-only. (#524)
+
 ## [0.26.0] - 2026-07-22
 
 _Highlights: enter your own disc details when Engram can't work them out, plus customizable Discord notification messages._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -114,6 +114,40 @@ def require_localhost(request: Request) -> None:
         )
 
 
+async def require_localhost_or_lan(request: Request) -> None:
+    """FastAPI dependency: allow loopback always, LAN peers only when opted in.
+
+    Like `require_localhost`, but a non-loopback (LAN) client is also permitted
+    when the user has explicitly enabled `allow_lan_access`. Used by the manual
+    *import* endpoints so headless/Docker deployments — where the dashboard is
+    reached from another machine — can browse and import, while the more
+    sensitive fingerprint/contribution endpoints stay strictly host-only via
+    `require_localhost`.
+
+    The filesystem-browse surface this exposes is why the gate is the explicit
+    opt-in rather than always-on: enabling `allow_lan_access` is the user's
+    statement that they trust their network.
+    """
+    if _is_loopback(request.client.host if request.client else None):
+        return
+    try:
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        allow_lan = bool(config.allow_lan_access)
+    except Exception:  # noqa: BLE001 — a config read failure must fail closed
+        allow_lan = False
+    if not allow_lan:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "This endpoint is only reachable from the host machine. To use it "
+                "from another device (e.g. a Docker deployment), enable LAN access "
+                "in Settings."
+            ),
+        )
+
+
 # Request/Response Models
 class JobResponse(BaseModel):
     """Response model for a disc job."""
@@ -2815,13 +2849,14 @@ class ImportStartRequest(BaseModel):
     destination_mode: str = "library"
 
 
-@router.get("/import/browse", dependencies=[Depends(require_localhost)])
+@router.get("/import/browse", dependencies=[Depends(require_localhost_or_lan)])
 async def import_browse(path: str = "") -> dict:
     """Read-only directory listing for the manual-import picker.
 
-    Host-only: guarded by require_localhost so it stays unreachable from LAN
-    peers even when allow_lan_access opens the bind (CORS does not protect
-    non-browser clients). Returns directory names with a shallow direct-child
+    Guarded by require_localhost_or_lan: reachable from the host machine always,
+    and from LAN peers only when the user has enabled allow_lan_access (so
+    headless/Docker deployments accessed from another device can import). Returns
+    directory names with a shallow direct-child
     MKV count, plus selectable .mkv files. Never returns file contents. Empty
     path returns the drive roots (Windows) or / and home (POSIX).
     """
@@ -2871,7 +2906,7 @@ async def import_browse(path: str = "") -> dict:
     return {"cwd": str(p), "parent": parent, "roots": [], "entries": entries}
 
 
-@router.post("/import/preview", dependencies=[Depends(require_localhost)])
+@router.post("/import/preview", dependencies=[Depends(require_localhost_or_lan)])
 async def import_preview(req: ImportPathRequest) -> dict:
     """Scan a path and return the import units, loose files, and totals.
 
@@ -2906,7 +2941,7 @@ async def import_preview(req: ImportPathRequest) -> dict:
     }
 
 
-@router.post("/import/start", dependencies=[Depends(require_localhost)])
+@router.post("/import/start", dependencies=[Depends(require_localhost_or_lan)])
 async def import_start(req: ImportStartRequest) -> dict:
     """Create one import job per (show, season) unit from a chosen path.
 

--- a/backend/tests/integration/test_import_endpoints.py
+++ b/backend/tests/integration/test_import_endpoints.py
@@ -7,20 +7,22 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 
-from app.api.routes import require_localhost
+from app.api.routes import require_localhost_or_lan
 from app.database import async_session, init_db
 from app.main import app
 
 
 @pytest.fixture
 async def client():
-    # The import endpoints are guarded by require_localhost; ASGITransport has no
-    # real client host, so override the dependency (the documented test pattern).
-    app.dependency_overrides[require_localhost] = lambda: None
+    # The import endpoints are guarded by require_localhost_or_lan; override it so
+    # these tests exercise the handlers regardless of peer/LAN config (the
+    # documented test pattern). The guard's own branches are covered directly in
+    # TestRequireLocalhostOrLan below.
+    app.dependency_overrides[require_localhost_or_lan] = lambda: None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
-    app.dependency_overrides.pop(require_localhost, None)
+    app.dependency_overrides.pop(require_localhost_or_lan, None)
 
 
 def _mkv(p: Path) -> None:

--- a/backend/tests/integration/test_import_endpoints.py
+++ b/backend/tests/integration/test_import_endpoints.py
@@ -142,3 +142,69 @@ async def test_start_no_mkvs_400(client, tmp_path: Path):
     (tmp_path / "empty").mkdir()
     res = await client.post("/api/import/start", json={"path": str(tmp_path / "empty")})
     assert res.status_code == 400
+
+
+class TestRequireLocalhostOrLan:
+    """The import guard: loopback always, LAN peers only when opted in (#524)."""
+
+    def _request(self, host: str | None):
+        from unittest.mock import MagicMock
+
+        req = MagicMock()
+        if host is None:
+            req.client = None
+        else:
+            req.client.host = host
+        return req
+
+    async def test_loopback_allowed_without_lan(self):
+        # Loopback never touches config: allowed even with LAN access off.
+        from unittest.mock import AsyncMock, patch
+
+        from app.api.routes import require_localhost_or_lan
+
+        with patch("app.services.config_service.get_config", new_callable=AsyncMock) as gc:
+            await require_localhost_or_lan(self._request("127.0.0.1"))  # no raise
+            gc.assert_not_called()
+
+    async def test_lan_rejected_when_disabled(self):
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi import HTTPException
+
+        from app.api.routes import require_localhost_or_lan
+
+        cfg = type("C", (), {"allow_lan_access": False})()
+        with patch(
+            "app.services.config_service.get_config", new_callable=AsyncMock, return_value=cfg
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await require_localhost_or_lan(self._request("192.168.1.50"))
+            assert exc.value.status_code == 403
+
+    async def test_lan_allowed_when_enabled(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.api.routes import require_localhost_or_lan
+
+        cfg = type("C", (), {"allow_lan_access": True})()
+        with patch(
+            "app.services.config_service.get_config", new_callable=AsyncMock, return_value=cfg
+        ):
+            await require_localhost_or_lan(self._request("192.168.1.50"))  # no raise
+
+    async def test_config_read_failure_fails_closed(self):
+        from unittest.mock import AsyncMock, patch
+
+        from fastapi import HTTPException
+
+        from app.api.routes import require_localhost_or_lan
+
+        with patch(
+            "app.services.config_service.get_config",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db down"),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await require_localhost_or_lan(self._request("192.168.1.50"))
+            assert exc.value.status_code == 403


### PR DESCRIPTION
Fixes #524.

## Problem

Manual import failed in Docker/remote deployments with `403 Forbidden: {"detail":"This endpoint is only reachable from the host machine"}`. The import endpoints (`/import/browse`, `/import/preview`, `/import/start`) were guarded by `require_localhost`, which rejects **any** non-loopback client unconditionally. When the dashboard is accessed from another machine (the whole point of a headless/Docker install), the request never originates from `127.0.0.1`, so import was architecturally unreachable — even though headless first-run already seeds `allow_lan_access=True`.

## Fix

Added `require_localhost_or_lan`: loopback is always allowed, and LAN peers are permitted **only when the user has enabled `allow_lan_access`**. The three import endpoints now use this guard; the more sensitive fingerprint/contribution endpoints keep the strict `require_localhost`. Config-read failures fail closed (deny).

The 403 message now points users to the LAN access setting. The frontend surfaces the response body verbatim, so the improved guidance reaches the UI with no frontend change.

## Tests

- New `TestRequireLocalhostOrLan`: loopback-always-allowed (never reads config), LAN-rejected-when-off, LAN-allowed-when-on, fail-closed-on-config-error.
- `tests/integration/test_import_endpoints.py`: 12 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)