### PR TITLE
fix: prevent /api/config 500 on DBs upgraded to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **The manual import feature now works in Docker and other remote setups.** Browsing for files and starting an import over the network returned `403 Forbidden` because those endpoints were locked to the host machine. They now honor the **Allow LAN access** setting: when you've enabled it (headless/Docker installs enable it automatically on first run), import is reachable from another device, while the more sensitive fingerprint and contribution endpoints stay host-only. (#524)
+- **Upgrading to 0.26.0 no longer breaks the app with a 500 on every settings load.** On databases created before the customizable Discord messages feature, the new `discord_template_completed` / `discord_template_failed` columns were added without a default, leaving existing rows `NULL`. Because those fields are required text, `GET /api/config` then failed validation and returned HTTP 500 — which broke config loading across the whole dashboard (Settings, Contribute, first-run wizard). The schema reconciler now backfills new non-optional text columns with their declared default, and config responses tolerate legacy `NULL` values.
 
 ## [0.26.0] - 2026-07-22
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1677,8 +1677,11 @@ async def get_config() -> ConfigResponse:
         contribution_pseudonym=config.contribution_pseudonym,
         # Notifications
         discord_webhook_url="***" if config.discord_webhook_url else "",
-        discord_template_completed=config.discord_template_completed,
-        discord_template_failed=config.discord_template_failed,
+        # Coalesce None->"" defensively: a DB upgraded by an early 0.26.0 build may
+        # already hold NULL here (see database._add_missing_columns), and
+        # ConfigResponse requires str — a bare None would 500 GET /api/config.
+        discord_template_completed=config.discord_template_completed or "",
+        discord_template_failed=config.discord_template_failed or "",
     )
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -204,6 +204,32 @@ async def _get_actual_columns(conn, table_name: str) -> set[str]:
     return {row[1] for row in rows}  # column name is at index 1
 
 
+def _model_default_literal(col) -> str | None:
+    """Render a column's declared Python default as a SQL literal, or None.
+
+    Used to backfill existing rows when adding a column on upgrade. Only scalar
+    (non-callable) defaults are rendered — callables like ``datetime.utcnow`` and
+    the sentinel ``None`` fall through to the type-based logic in the caller.
+
+    This is what keeps non-Optional ``str = ""`` columns from landing as NULL:
+    their type is SQLModel's ``AutoString`` (a ``TypeDecorator``), which the
+    caller's ``isinstance(col.type, String)`` check does not match.
+    """
+    default = col.default
+    if default is None or not getattr(default, "is_scalar", False):
+        return None
+
+    value = default.arg
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+    return None
+
+
 async def _add_missing_columns() -> None:
     """Add missing columns to existing tables via ALTER TABLE.
 
@@ -231,9 +257,18 @@ async def _add_missing_columns() -> None:
             for col_name in missing:
                 col = table.c[col_name]
                 col_type = col.type.compile(dialect=engine.dialect)
-                # Build DEFAULT clause from server_default or a safe fallback
+                # Build DEFAULT clause. Prefer an explicit server_default, then the
+                # model's declared Python default (so existing rows backfill with the
+                # value the model would insert), then a type-based fallback.
+                model_default = _model_default_literal(col)
                 if col.server_default is not None:
                     default_clause = f" DEFAULT {col.server_default.arg}"
+                elif model_default is not None:
+                    # Honors non-Optional str = "" columns whose type is SQLModel's
+                    # AutoString (a TypeDecorator, NOT a String subclass) — the
+                    # isinstance checks below miss those and would leave existing
+                    # rows NULL, 500ing GET /api/config for upgrading users.
+                    default_clause = f" DEFAULT {model_default}"
                 elif col.nullable:
                     default_clause = " DEFAULT NULL"
                 elif isinstance(col.type, sqlalchemy.types.String):

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -314,6 +314,33 @@ class TestConfigEndpoints:
         config = verify.json()
         assert config["discord_template_completed"] == ""
 
+    async def test_get_config_survives_null_discord_templates(self, client):
+        """GET /api/config must return 200 even when the Discord template columns
+        are NULL in the database.
+
+        Regression for the 0.26.0 upgrade 500: an early 0.26.0 build could add
+        discord_template_completed / discord_template_failed as NULL on upgrade,
+        but ConfigResponse types them as required str, so a bare None raised a
+        pydantic ValidationError -> HTTP 500 that broke all config loading.
+        """
+        from sqlalchemy import text as sa_text
+
+        await _seed_config()
+        # Reproduce the real upgraded-DB shape: the buggy ADD COLUMN emitted a
+        # plain nullable VARCHAR (no NOT NULL, no default), so existing rows hold
+        # NULL. Rebuild the two columns as nullable, then NULL them out.
+        async with _unit_session_factory() as session:
+            for col in ("discord_template_completed", "discord_template_failed"):
+                await session.execute(sa_text(f"ALTER TABLE app_config DROP COLUMN {col}"))
+                await session.execute(sa_text(f"ALTER TABLE app_config ADD COLUMN {col} VARCHAR"))
+            await session.commit()
+
+        response = await client.get("/api/config")
+        assert response.status_code == 200
+        config = response.json()
+        assert config["discord_template_completed"] == ""
+        assert config["discord_template_failed"] == ""
+
     async def test_ai_api_key_persists_and_blank_does_not_clobber(self, client):
         """Reproduces the user's report end-to-end through the real routes:
 

--- a/backend/tests/unit/test_database_migration.py
+++ b/backend/tests/unit/test_database_migration.py
@@ -290,6 +290,77 @@ class TestSchemaMigration:
         finally:
             db_mod.engine = original_engine
 
+    async def test_add_missing_string_column_backfills_declared_default(
+        self, migration_engine, migration_factory
+    ):
+        """A non-Optional string column added on upgrade must backfill existing
+        rows with the model's declared default (''), never NULL.
+
+        Regression for the 0.26.0 /api/config 500: SQLModel wraps str columns in
+        AutoString (a TypeDecorator, not a String subclass), so the old
+        type-based default logic fell through to no DEFAULT clause and existing
+        app_config rows got NULL for discord_template_completed /
+        discord_template_failed. ConfigResponse requires str, so GET /api/config
+        raised a pydantic ValidationError -> HTTP 500 for every upgrading user.
+        """
+        import app.database as db_mod
+
+        original_engine = db_mod.engine
+        db_mod.engine = migration_engine
+
+        try:
+            # Pre-0.26.0 app_config: a minimal older schema that predates the
+            # Discord template columns (added in #508). disc tables come from the
+            # model so unrelated reconciliation is a no-op.
+            async with migration_engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        """
+                        CREATE TABLE app_config (
+                            id INTEGER PRIMARY KEY,
+                            makemkv_key VARCHAR DEFAULT ''
+                        )
+                        """
+                    )
+                )
+                await conn.run_sync(
+                    lambda sync_conn: DiscJob.__table__.create(sync_conn, checkfirst=True)
+                )
+                await conn.run_sync(
+                    lambda sync_conn: DiscTitle.__table__.create(sync_conn, checkfirst=True)
+                )
+
+            # Seed a config row through the older schema
+            async with migration_factory() as session:
+                await session.execute(
+                    text("INSERT INTO app_config (makemkv_key) VALUES ('pre-026-key')")
+                )
+                await session.commit()
+
+            # Sanity: the new columns really are missing beforehand
+            async with migration_engine.connect() as conn:
+                actual = await db_mod._get_actual_columns(conn, "app_config")
+                assert "discord_template_completed" not in actual
+                assert "discord_template_failed" not in actual
+
+            await db_mod._add_missing_columns()
+
+            # Existing row must have '' (the declared default), not NULL
+            async with migration_factory() as session:
+                row = (
+                    await session.execute(
+                        text(
+                            "SELECT discord_template_completed, discord_template_failed "
+                            "FROM app_config LIMIT 1"
+                        )
+                    )
+                ).fetchone()
+                assert row is not None
+                assert row[0] == "", f"expected '' got {row[0]!r}"
+                assert row[1] == "", f"expected '' got {row[1]!r}"
+        finally:
+            db_mod.engine = original_engine
+
     async def test_add_missing_columns_is_idempotent(self, migration_engine):
         """Running _add_missing_columns on a correct schema should be a no-op."""
         import app.database as db_mod


### PR DESCRIPTION
## Summary

Fixes a **0.26.0 upgrade regression** that returns HTTP 500 from `GET /api/config` on any database created before the customizable Discord messages feature (#508). Because config loading powers the whole dashboard, the first launch of 0.26.0 against a pre-existing DB broke Settings, the Contribute page, and the first-run wizard.

Reproduced against a real pre-0.26.0 `~/.engram/engram.db`.

## Root cause

The new `discord_template_completed` / `discord_template_failed` columns (`app_config`, model default `str = ""`) landed as **NULL** on upgrade. `ConfigResponse` types them as required `str`, so a `None` raised a pydantic `ValidationError` → 500.

The mechanism was subtler than "column defaults to NULL": these columns are `nullable=False`. The real bug is that SQLModel types `str` fields as **`AutoString`**, a `TypeDecorator` that is **not** a subclass of `sqlalchemy.types.String`. So `_add_missing_columns`' `isinstance(col.type, String)` check missed it and fell through to the no-default branch, and `ALTER TABLE ADD COLUMN` left existing rows NULL. (Frozen/dev-fallback builds skip Alembic, so this reconciler is the path that runs.)

## Fix

- **`database.py`** — new `_model_default_literal(col)` renders a column's declared scalar Python default as a SQL literal; `_add_missing_columns` prefers it over the type-based fallback. This backfills existing rows with the model's declared default for **all** column types, not just these two.
- **`routes.py`** — defensive `or ""` coalesce on the two Discord fields in `get_config`, covering DBs an *early* 0.26.0 build already NULLed (where re-running `_add_missing_columns` won't re-add the existing column).

## Tests

- `test_add_missing_string_column_backfills_declared_default` (migration layer) — asserts the reconciler backfills `''`, not NULL.
- `test_get_config_survives_null_discord_templates` (route layer) — reproduces the real nullable-column shape and asserts `GET /api/config` returns 200.

Both confirmed to fail before the fix. Full unit suite: `2539 passed, 19 skipped`; `ruff check` clean.

## Reviewer notes

- Behavior change: `_add_missing_columns` now backfills declared defaults instead of NULL for **every** added column (e.g. `fingerprint_server_url` now backfills its default URL rather than NULL). This is strictly more correct and matches what an ORM insert would write.
- CHANGELOG `[Unreleased]` entry added — this is a fix for shipped 0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
