### PR TITLE
fix(ci): don't fail the Docker build when makemkv.com is unreachable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,17 +103,39 @@ jobs:
           fi
           echo "smoke test passed"
 
+      # Guards against makemkv.com changing its download page format and silently
+      # breaking our scraping. It must NOT fail the build when makemkv.com is
+      # simply unreachable (Cloudflare 5xx, DNS, timeout). That is an upstream
+      # outage with nothing for us to fix, and it would block unrelated PRs.
+      # install-makemkv.sh exits 2 for "could not fetch" and 3 for "fetched but
+      # could not parse" so the two cases can be told apart here.
       - name: Verify MakeMKV version detection
         run: |
+          STATUS=0
           VERSION=$(docker run --rm \
             --entrypoint /usr/local/bin/install-makemkv.sh \
             -e MAKEMKV_DETECT_ONLY=1 \
-            engram:ci || true)
-          if [ -z "$VERSION" ]; then
-            echo "::error::MakeMKV version detection returned empty — check if download page format changed"
-            exit 1
-          fi
-          echo "Detected MakeMKV version: $VERSION"
+            engram:ci) || STATUS=$?
+          case "$STATUS" in
+            0)
+              if [ -z "$VERSION" ]; then
+                echo "::error::MakeMKV version detection succeeded but printed nothing; the detect-only contract in docker/install-makemkv.sh is broken"
+                exit 1
+              fi
+              echo "Detected MakeMKV version: $VERSION"
+              ;;
+            2)
+              echo "::warning::Could not reach makemkv.com to verify version detection (upstream outage or network failure). Skipping this check; it is not a problem with this change."
+              ;;
+            3)
+              echo "::error::Fetched the MakeMKV download page but could not find a version in it. The page format has likely changed and the scraping logic in docker/install-makemkv.sh needs updating"
+              exit 1
+              ;;
+            *)
+              echo "::error::MakeMKV version detection exited with unexpected status $STATUS"
+              exit 1
+              ;;
+          esac
 
       - name: Log in to GHCR
         if: env.IS_RELEASE == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -128,7 +128,7 @@ jobs:
               echo "::warning::Could not reach makemkv.com to verify version detection (upstream outage or network failure). Skipping this check; it is not a problem with this change."
               ;;
             3)
-              echo "::error::Fetched the MakeMKV download page but could not find a version in it. The page format has likely changed and the scraping logic in docker/install-makemkv.sh needs updating"
+              echo "::error::Fetched the MakeMKV download page but could not find a version in it. The page format has probably changed and the scraping logic in docker/install-makemkv.sh needs updating; a maintenance page served with a 200 status would look the same, so check makemkv.com before assuming a format change"
               exit 1
               ;;
             *)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **Settings no longer implies you need a TheDiscDB API key to contribute.** The API key field was labelled as required for submitting directly to TheDiscDB, with an empty field meaning local-only export. That was never true: TheDiscDB accepts contributions openly and Engram submits fine without a key. The field is now marked optional. The Data Sharing step also claimed that nothing was enabled by default, which understated fingerprint contributions (on by default, and gated behind the consent dialog shown before the first upload); it now says what is actually on.
-### Fixed
-
 - **A brief makemkv.com outage no longer fails the Docker container's first-run MakeMKV install.** Looking up the latest MakeMKV version now retries transient network and Cloudflare errors before giving up, and when it does give up it says whether the site was unreachable or its download page changed format, instead of reporting the second cause for both. (#554)
 
 ## [0.27.0] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Engram will be documented in this file.
 ### Fixed
 
 - **Settings no longer implies you need a TheDiscDB API key to contribute.** The API key field was labelled as required for submitting directly to TheDiscDB, with an empty field meaning local-only export. That was never true: TheDiscDB accepts contributions openly and Engram submits fine without a key. The field is now marked optional. The Data Sharing step also claimed that nothing was enabled by default, which understated fingerprint contributions (on by default, and gated behind the consent dialog shown before the first upload); it now says what is actually on.
+### Fixed
+
+- **A brief makemkv.com outage no longer fails the Docker container's first-run MakeMKV install.** Looking up the latest MakeMKV version now retries transient network and Cloudflare errors before giving up, and when it does give up it says whether the site was unreachable or its download page changed format, instead of reporting the second cause for both. (#554)
 
 ## [0.27.0] - 2026-07-24
 

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -45,6 +45,11 @@ resolve_latest_version() {
         | head -n1 \
         | sed -E 's/makemkv-sha-([0-9.]+)\.txt/\1/')" || version=""
 
+    # Residual ambiguity, accepted: an outage that returns a maintenance page
+    # with HTTP 200 satisfies curl and lands here rather than in the fetch
+    # branch, so it reports as a parse failure. Sniffing for "looks like a
+    # maintenance page" is not worth the false negatives it would add to the
+    # format-change check, so the messages below name both possibilities.
     if [ -z "${version}" ]; then
         return "${EXIT_PARSE_FAILED}"
     fi
@@ -69,7 +74,9 @@ if [ "${MAKEMKV_DETECT_ONLY:-}" = "1" ]; then
             exit "${EXIT_FETCH_FAILED}"
             ;;
         "${EXIT_PARSE_FAILED}")
-            echo "ERROR: fetched ${DL_BASE}/ but found no version in it; the download page format has changed." >&2
+            echo "ERROR: fetched ${DL_BASE}/ but found no version in it." >&2
+            echo "       The download page format has probably changed; makemkv.com serving an" >&2
+            echo "       error or maintenance page with a 200 status would look the same." >&2
             exit "${EXIT_PARSE_FAILED}"
             ;;
         *)
@@ -87,7 +94,9 @@ if [ "${VERSION}" = "latest" ]; then
             echo "ERROR: could not reach ${DL_BASE}/ to resolve the latest MakeMKV version." >&2
             echo "       makemkv.com may be down; check your network and try again." >&2
         else
-            echo "ERROR: fetched ${DL_BASE}/ but found no version in it; the download page format has changed." >&2
+            echo "ERROR: fetched ${DL_BASE}/ but found no version in it." >&2
+            echo "       The download page format has probably changed; makemkv.com serving an" >&2
+            echo "       error or maintenance page with a 200 status would look the same." >&2
         fi
         echo "       Set MAKEMKV_VERSION to a specific release (e.g. 1.18.1) to skip detection." >&2
         exit 1

--- a/docker/install-makemkv.sh
+++ b/docker/install-makemkv.sh
@@ -16,33 +16,80 @@ VERSION="${MAKEMKV_VERSION:-latest}"
 DL_BASE="https://www.makemkv.com/download"
 MARKER="${INSTALL_DIR}/.installed-version"
 
+# Version-resolution failure modes, kept distinct so callers can tell an
+# upstream outage (nothing we can fix) from a page-format change (our scraping
+# logic is broken and needs updating). CI branches on these; see the
+# "Verify MakeMKV version detection" step in .github/workflows/docker.yml.
+EXIT_FETCH_FAILED=2
+EXIT_PARSE_FAILED=3
+
+# Resolves the latest MakeMKV version, or returns EXIT_FETCH_FAILED /
+# EXIT_PARSE_FAILED. curl's own error goes to stderr (-S), so the log still
+# shows why the fetch failed.
 resolve_latest_version() {
+    local page version
+
+    # Retry transient failures before giving up. --retry-all-errors is needed
+    # because makemkv.com sits behind Cloudflare, whose origin-unreachable
+    # codes (520-527) are not in curl's default retryable set.
+    if ! page="$(curl -fsSL --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors "${DL_BASE}/")"; then
+        return "${EXIT_FETCH_FAILED}"
+    fi
+
     # The download page no longer lists Linux tarballs directly; scrape the
     # hash file link instead (e.g. makemkv-sha-1.18.3.txt) — same version
-    # format, present on every release.
-    curl -fsSL "${DL_BASE}/" \
+    # format, present on every release. A no-match grep exits non-zero, which
+    # is the parse-failure case rather than an error worth propagating.
+    version="$(printf '%s' "${page}" \
         | grep -oE 'makemkv-sha-[0-9]+\.[0-9]+\.[0-9]+\.txt' \
         | head -n1 \
-        | sed -E 's/makemkv-sha-([0-9.]+)\.txt/\1/'
+        | sed -E 's/makemkv-sha-([0-9.]+)\.txt/\1/')" || version=""
+
+    if [ -z "${version}" ]; then
+        return "${EXIT_PARSE_FAILED}"
+    fi
+
+    printf '%s\n' "${version}"
 }
 
 # Detect-only mode: resolve latest version, print it, and exit. Used by CI to
 # verify the download page is still parseable without running the full compile.
+# Exits 2 if makemkv.com could not be reached, 3 if it was reached but no
+# version could be parsed out of the page.
 if [ "${MAKEMKV_DETECT_ONLY:-}" = "1" ]; then
-    DETECTED="$(resolve_latest_version || true)"
-    if [ -z "${DETECTED}" ]; then
-        echo "ERROR: could not resolve latest MakeMKV version — download page format may have changed" >&2
-        exit 1
-    fi
-    echo "${DETECTED}"
-    exit 0
+    DETECT_STATUS=0
+    DETECTED="$(resolve_latest_version)" || DETECT_STATUS=$?
+    case "${DETECT_STATUS}" in
+        0)
+            echo "${DETECTED}"
+            exit 0
+            ;;
+        "${EXIT_FETCH_FAILED}")
+            echo "ERROR: could not reach ${DL_BASE}/ to check the latest MakeMKV version." >&2
+            exit "${EXIT_FETCH_FAILED}"
+            ;;
+        "${EXIT_PARSE_FAILED}")
+            echo "ERROR: fetched ${DL_BASE}/ but found no version in it; the download page format has changed." >&2
+            exit "${EXIT_PARSE_FAILED}"
+            ;;
+        *)
+            echo "ERROR: version detection failed unexpectedly (status ${DETECT_STATUS})." >&2
+            exit 1
+            ;;
+    esac
 fi
 
 if [ "${VERSION}" = "latest" ]; then
-    VERSION="$(resolve_latest_version || true)"
-    if [ -z "${VERSION}" ]; then
-        echo "ERROR: could not resolve the latest MakeMKV version from ${DL_BASE}/" >&2
-        echo "       Set MAKEMKV_VERSION to a specific release (e.g. 1.18.1)." >&2
+    RESOLVE_STATUS=0
+    VERSION="$(resolve_latest_version)" || RESOLVE_STATUS=$?
+    if [ "${RESOLVE_STATUS}" -ne 0 ]; then
+        if [ "${RESOLVE_STATUS}" -eq "${EXIT_FETCH_FAILED}" ]; then
+            echo "ERROR: could not reach ${DL_BASE}/ to resolve the latest MakeMKV version." >&2
+            echo "       makemkv.com may be down; check your network and try again." >&2
+        else
+            echo "ERROR: fetched ${DL_BASE}/ but found no version in it; the download page format has changed." >&2
+        fi
+        echo "       Set MAKEMKV_VERSION to a specific release (e.g. 1.18.1) to skip detection." >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## Problem

The **Verify MakeMKV version detection** step in `docker.yml` hard-fails the image build whenever makemkv.com is unreachable.

Seen on 2026-07-28 on #553: the step failed twice with `curl: (22) The requested URL returned error: 525` (Cloudflare could not reach makemkv.com's origin, for at least 15 minutes). That PR touched no Docker, CI, or MakeMKV code, so an unrelated change was blocked by a third-party outage.

The check's purpose is sound: it catches makemkv.com changing its download page format and silently breaking our scraping. The problem is that it could not distinguish two very different causes, and asserted the wrong one:

1. **Page fetched but not parseable.** Format changed, our logic is broken. Should fail the build.
2. **Page could not be fetched at all** (525, 5xx, DNS, timeout). Upstream outage, nothing on our side to fix. Should not fail the build.

Both produced the same empty string and the same misleading error: *"check if download page format changed"*.

## Root cause

The information was destroyed inside `resolve_latest_version()`, not at the workflow layer. It ran the fetch and the scrape as a single pipeline:

```bash
curl -fsSL "${DL_BASE}/" | grep -oE '...' | head -n1 | sed -E '...'
```

Both causes collapse into empty output before the workflow ever sees them. The caller then wrote `$(resolve_latest_version || true)`, discarding the exit status to keep `set -e` from killing the script, so the status was unusable as a signal too.

## Fix

**`docker/install-makemkv.sh`** splits fetch from parse and returns distinct codes: `2` = could not fetch, `3` = fetched but could not parse. Detect-only mode exits with those codes and prints an accurate message for each. `curl` also now retries transient failures with `--retry-all-errors`, which is needed because Cloudflare's origin-unreachable codes (520 to 527) are not in curl's default retryable set.

**`.github/workflows/docker.yml`** reads that status (it previously threw it away with `|| true`) and branches:

| Status | Behavior |
|---|---|
| 0 with a version | Pass, logs the detected version |
| 0 with no output | Fail: detect-only contract broken |
| 2 (could not fetch) | **`::warning::`, step passes** |
| 3 (could not parse) | Fail: page format changed, scraping needs updating |
| anything else | Fail: unexpected status (e.g. docker itself failed) |

The error text no longer states the format-changed diagnosis as fact, and the outage warning says explicitly that it is not a problem with the change under test.

The retries and clearer messages also improve the real container install path, which resolves `latest` the same way, so a Docker user hitting a blip now gets a retry and an accurate reason instead of a wrong one.

## Verification

Both layers were exercised locally against a stubbed `curl` and a stubbed `docker`, since neither is otherwise testable without an outage:

Detect-only path (`MAKEMKV_DETECT_ONLY=1`):

```
PASS  fetch ok + parseable page -> version, exit 0 (status=0 stdout='1.18.3')
PASS  fetch fails (525) -> exit 2, no stdout
PASS  fetch ok + unparseable page -> exit 3, no stdout
PASS  DNS failure -> exit 2, no stdout
```

Workflow step, run under `bash -e` the way Actions invokes it:

```
PASS  detect ok -> step exit=0
PASS  fetch failed (2) -> step exit=0    ::warning::Could not reach makemkv.com ...
PASS  parse failed (3) -> step exit=1    ::error::Fetched the MakeMKV download page ...
PASS  docker itself broke -> step exit=1 ::error::... unexpected status 125
PASS  empty but exit 0 -> step exit=1    ::error::... printed nothing
```

The nightly `makemkv-install.yml` also runs on pushes touching `docker/install-makemkv.sh`, so this branch exercises the real network path end to end.

## Notes

- Does not touch #553 or its branch.
- `makemkv-install.yml`'s `latest` leg still fails outright on an outage. Left as is deliberately: it is a nightly full-compile check, not a PR gate, and its install genuinely cannot proceed without a resolved version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)