### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-07-29
+
+_Highlights: contribute disc metadata to two shared identification networks (TheDiscDB and the Engram acoustic fingerprint network), a What's New summary after you update, and a Test Connection button for your AI provider — plus much clearer error messages when AI episode matching fails._
+
 ### Added
 
 - **Engram is part of two shared identification networks, and you can now see exactly what that means.** A new [Contributing Data](https://jsakkos.github.io/engram/guide/contributing-data/) guide explains both halves. **TheDiscDB** answers "which disc is this?" by content hash, and you can now contribute disc layouts back to it so others can identify the same pressing automatically: opt in under Settings → TheDiscDB Contributions, with no account and no API key needed. The **Engram acoustic fingerprint network** answers "which episode is this track?" from chromaprint audio fingerprints, so episode identification no longer depends on finding reference subtitles for the specific show you are ripping. No audio or video ever leaves your machine, contributions are pseudonymous, and everything you have sent can be deleted. Identification now reads from the fingerprint catalog by default and falls back to the existing TMDB, AI, and heuristic paths on a miss.
-- **A "What's new" summary after you update.** Engram now shows the release notes for the version you are running, once per version, the first time you open the dashboard after updating. It works however you updated: in-app self-update, a fresh download, or a new Docker image. Click the version number in the top bar to read them again at any time.
+- **A "What's new" summary after you update.** Engram now shows the release notes for the version you are running, once per version, the first time you open the dashboard after updating. It works however you updated: in-app self-update, a fresh download, or a new Docker image. Click the version number in the top bar to read them again at any time. (#553)
 - **Test your AI provider connection before you rely on it.** Settings → AI Provider now has a **Test Connection** button that sends one tiny request and tells you exactly what happened: the key was rejected, the account has no API credits, the provider is rate limiting you, or the key has no access to the model Engram uses. Previously the only way to find out was to rip a disc and wait through a one-to-three-minute transcription before the request was even attempted. Leave the key field blank to test the key you already saved, without having to paste it again. (#555)
 
 ### Fixed
@@ -18,6 +22,10 @@ All notable changes to Engram will be documented in this file.
 - **A failing AI provider now names the actual cause instead of showing raw JSON.** Every provider failure collapsed into one opaque message, surfaced in the review inspector as `Request failed (503 Service Unavailable): {"suggestion":null,"reason":"llm_error"}`. The provider's own explanation was discarded before anyone could read it, so an exhausted account quota, a rejected key, ordinary rate limiting, and a network outage were indistinguishable from each other in the app and in the logs. Engram now reads the provider's response and reports the specific cause. A permanently out-of-credit key also stops being retried, which previously cost four requests and several seconds of backoff on every attempt for a failure that could never succeed. (#555)
 - **A truncated or refused AI response no longer masquerades as "no match".** When a provider cut its reply off at the token limit, or refused the request outright, the reply was silently discarded and reported as though the model had run and simply been unsure. A refusal could also crash the request outright with an internal server error. Both now report what actually went wrong. (#555)
 - **Gemini failures no longer blame your API key for unrelated problems.** Google returns the same generic error code for nearly every rejected request, so a bad prompt, an unsupported parameter, or an internal schema problem would all have been reported as "the API key was rejected", sending people to re-check a key that was fine. (#555)
+
+### Changed
+
+- **Dependency updates** — @radix-ui/react-accordion 1.2.12→1.2.20 (#550), @radix-ui/react-dialog 1.1.17→1.1.23 (#549), eslint 10.6.0→10.8.0 (#548), tailwindcss monorepo 4.3.2→4.3.3 (#543), postcss ^8.5.19→^8.5.23 (#544), autoprefixer ^10.5.2→^10.5.4 (#542), @vitejs/plugin-react ^6.0.3→^6.0.4 (#556), loguru >=0.7.0→>=0.7.3 (#545), mkdocs-material >=9.5→>=9.7.7 (#557).
 
 ## [0.27.0] - 2026-07-24
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.27.0"
+version = "0.28.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.27.0"
+version = "0.28.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.27.0",
+    "version": "0.28.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.27.0",
+            "version": "0.28.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.27.0",
+    "version": "0.28.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

Cuts v0.28.0. Curates the `[Unreleased]` CHANGELOG section (fingerprint/TheDiscDB contribution networks, What's New modal, AI provider connection test, AI-matching error messaging fixes, Docker MakeMKV outage fix) into `## [0.28.0] - 2026-07-29`, adds a `### Changed` dependency-update roundup, and bumps the version in the six lockstep files (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json` x2, `CHANGELOG.md`).

On squash-merge, `tag-release.yml` tags `v0.28.0` from `backend/pyproject.toml` and dispatches `release.yml` (binaries + GitHub release, notes extracted from this CHANGELOG section) and `docker.yml` (GHCR image).

## Test plan

- [x] `uv run python scripts/extract_changelog.py --version 0.28.0 --check` → ok
- [x] `uv run python -c "from app import __version__; print(__version__)"` → 0.28.0
- [x] Pre-commit (ruff, ruff format, toml check) passed on commit
- [x] `CONTRIBUTORS.md` regenerated — no roster changes this cycle
- [ ] User merges (do not merge here — see repo convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)