### PR TITLE
chore: release v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
-## [0.28.2] - 2026-07-30
+## [0.28.2] - 2026-07-31
 
 _Highlights: a failed disc no longer claims it is still analyzing._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.2] - 2026-07-30
+
+_Highlights: a failed disc no longer claims it is still analyzing._
+
 ### Fixed
 
 - **A failed disc no longer claims it is still analyzing.** When a job died during identification, typically because the disc was ejected mid-scan or the container could not read the drive, its card showed a pulsing amber "Analyzing" chip on the poster for good, sitting right beside its own red "Error" badge. The chip was driven by the content type alone, and a job that never got past identification never gets one. Cards that have finished, failed, or are waiting on you now show a plain "Unknown" instead, and the pulse is reserved for discs that really are being worked on. (#566)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.28.1"
+__version__ = "0.28.2"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.28.1"
+version = "0.28.2"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.28.1"
+version = "0.28.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.28.1",
+    "version": "0.28.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.28.1",
+            "version": "0.28.2",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.28.1",
+    "version": "0.28.2",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version to **0.28.2** (fix-only patch) across the six version files: `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json` (both self-version fields).
- Cut the `## [0.28.2]` CHANGELOG section from `[Unreleased]`, covering the single change since v0.28.1:
  - fix: stop the media-type badge pulsing "ANALYZING" on settled jobs (#566)

On squash-merge, `tag-release.yml` will tag `v0.28.2` from `main` and dispatch the binary/Docker release builds.

## Test plan
- [x] `uv run python scripts/extract_changelog.py --version 0.28.2 --check` confirms the CHANGELOG section resolves
- [x] All six version fields verified in lockstep (0.28.2)
- [x] `CONTRIBUTORS.md` regenerated — no changes (no new external contributors since last release)
- [x] Pre-commit hooks (ruff, ruff format, toml/yaml checks) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)