### PR TITLE
test: colocate useJobManagement test with its hook

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -130,7 +130,7 @@ Run: `cd frontend && npm run test:unit` (~0.5s)
 | File | Tests | What It Covers |
 |------|------:|----------------|
 | `src/types/__tests__/adapters.test.ts` | 24 | Data transformation layer: `JobState` to UI state mapping (8 values), `TitleState` mapping (7 values), full job-to-disc-data transformation (TV/movie/fallback/unknown), duration formatting edge cases, match candidate extraction from JSON |
-| `src/hooks/__tests__/useJobManagement.test.ts` | 8 | WebSocket data merging logic: partial job update merging, title update targeting correct job/title, all-terminal-state detection, `titles_discovered` replacement, `subtitle_event` field updates |
+| `src/app/hooks/__tests__/useJobManagement.test.ts` | 16 | WebSocket data merging logic: partial job update merging, title update targeting correct job/title, all-terminal-state detection, `titles_discovered` replacement, `subtitle_event` field updates |
 
 ### Frontend E2E Tests (`frontend/e2e/`)
 

--- a/frontend/src/app/hooks/__tests__/useJobManagement.test.ts
+++ b/frontend/src/app/hooks/__tests__/useJobManagement.test.ts
@@ -9,7 +9,7 @@ import type {
   SubtitleEvent,
   WebSocketMessage,
   FingerprintDisclosureRequiredMessage,
-} from "../../types";
+} from "../../../types";
 
 // ---------------------------------------------------------------------------
 // Mocks for the hook-level integration tests below.
@@ -25,7 +25,7 @@ vi.mock("sonner", () => ({
 let capturedOnOpen: (() => void) | undefined;
 let capturedListener: ((msg: WebSocketMessage) => void) | undefined;
 
-vi.mock("../useWebSocket", () => ({
+vi.mock("../../../hooks/useWebSocket", () => ({
   useWebSocket: (
     _url: string,
     options?: { onOpen?: () => void },
@@ -45,7 +45,7 @@ vi.mock("../useWebSocket", () => ({
 }));
 
 // Imported after the mocks so the hook picks up the mocked useWebSocket.
-import { useJobManagement } from "../../app/hooks/useJobManagement";
+import { useJobManagement } from "../useJobManagement";
 
 /**
  * Tests for the job management logic extracted from useJobManagement.


### PR DESCRIPTION
## What changed

Moves `frontend/src/hooks/__tests__/useJobManagement.test.ts` to `frontend/src/app/hooks/__tests__/useJobManagement.test.ts`, next to the hook it tests.

- Three relative import paths updated (the only content change).
- Removed the emptied `src/hooks/__tests__/` directory so the fossil doesn't recreate the ambiguity.
- Updated the `TESTING.md` row, which pointed at the old path.

**No test logic changed.** This is a pure relocation.

## Why

The hook lives at `src/app/hooks/useJobManagement.ts`, but its test sat in a separate `src/hooks/__tests__/` tree. Three other hook tests are already colocated under `src/app/hooks/__tests__/`, so this file was the sole outlier across the repo's two parallel `hooks/` directories.

The split had a concrete cost: during work on #571, a search for existing coverage near the hook missed all 16 tests in this file, producing a false conclusion that `clearCompleted` was untested and nearly leading to a redundant test harness.

## Reviewer notes

The import fixes are asymmetric, which is the one thing worth a second look:

| Import | Before | After |
|---|---|---|
| hook under test | `../../app/hooks/useJobManagement` | `../useJobManagement` |
| `vi.mock` of `useWebSocket` | `../useWebSocket` | `../../../hooks/useWebSocket` |
| types | `../../types` | `../../../types` |

The hook import loses two levels (the subject is now adjacent) while the `vi.mock` path *gains* two, because `useWebSocket` genuinely still lives in `src/hooks/` and is now further away. This matters: `vi.mock` resolves relative to the test file and must match the module id the subject imports (`useJobManagement.ts` imports it as `../../hooks/useWebSocket`). A wrong mock path here fails quietly rather than loudly, so I verified the mock is still bound rather than trusting a green run: the tests make 21 references to the mock's captured `onOpen`/message callbacks, which would be `undefined` and throw if the real hook had loaded.

Three premise corrections found while doing this:

- `useDiscFilters` has **no** test at all, so it isn't the colocation precedent; the three other tests already in `src/app/hooks/__tests__/` are.
- The file has **16** tests, not 15. `TESTING.md` claimed 8; corrected to 16 since I measured it.
- No other mislocated tests exist. `src/hooks/__tests__/` held exactly one file, and the two hooks genuinely in `src/hooks/` (`useWebSocket`, `useSeasonRoster`) have no tests to move.

No CHANGELOG entry: internal test layout, no user-facing impact.

## Verification

| Check | Result |
|---|---|
| `npx vitest run src/app/hooks/__tests__/useJobManagement.test.ts` | 16 passed |
| Same file at old location, before the move | 16 passed (count unchanged) |
| `npm run build` | passed |
| `npm run test:unit` (full tier) | 45 files, 402 tests passed |
| `package-lock.json` | untouched (`node_modules` already present, no `npm install`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
