### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-08-09
+
+_Highlights: movie folder and filename naming is configurable, a skipped track no longer stops the track that's currently ripping, and re-importing an already-imported folder no longer fails permanently._
+
 ### Added
 
 - **Movie naming is configurable now, the same way TV naming already was.** Settings → Preferences → Naming & extras gains a **Movie Folder Format** and a **Movie Filename Format**, with `{title}`, `{year}`, `{tmdb_id}`, and, on the filename, `{edition}`. Two same-titled movies can finally sit side by side by adding the id tag your media server expects, Plex `{title} ({year}) {{tmdb-{tmdb_id}}}` or Jellyfin `{title} ({year}) [tmdbid-{tmdb_id}]`, exactly as TV shows could. Leave the filename format blank and it reuses your folder format, so customizing one carries through to the other instead of the two quietly drifting apart. (#576, thanks @DrAquafreshhh!)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.28.2"
+__version__ = "0.29.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.28.2"
+version = "0.29.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.28.2"
+version = "0.29.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.28.2",
+    "version": "0.29.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.28.2",
+            "version": "0.29.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.28.2",
+    "version": "0.29.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.29.0

Version bump: `0.28.2` -> `0.29.0` (minor, includes a new feature).

Bumps all 6 lockstep version locations:
- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `backend/uv.lock`
- `frontend/package.json`
- `frontend/package-lock.json` (both self-version fields)
- `CHANGELOG.md` — moves `[Unreleased]` entries into a dated `## [0.29.0] - 2026-08-09` section

Verified `[Unreleased]` matched the commit history since `v0.28.2` (no missing user-facing entries), and confirmed the changelog extractor resolves the new section:
```
uv run python scripts/extract_changelog.py --version 0.29.0 --check
ok: CHANGELOG has a section for 0.29.0
```

On squash-merge, `tag-release.yml` will tag `v0.29.0` and dispatch the release + Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)