### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-08-12
+
+_Highlights: the AI model is configurable per-provider, and a Gemini access error now says which models your key can actually use._
+
 ### Added
 
 - **The AI model is configurable now.** Settings → Preferences gains a **Model** field next to the AI provider and key. Leave it blank and nothing changes: Engram uses its own default for that provider. It exists because a key is not guaranteed access to that default. A Gemini key whose Google Cloud project does not carry `gemini-2.5-flash-lite` was told, correctly, that it lacked access to the model, and then given no way whatsoever to point Engram at a model it *could* use. **Test Connection** sends the model as typed, so you can confirm a combination before saving it.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.29.0"
+version = "0.30.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.29.0"
+version = "0.30.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.29.0",
+            "version": "0.30.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.29.0",
+    "version": "0.30.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version to 0.30.0 across `backend/pyproject.toml`, `backend/uv.lock`, `backend/app/__init__.py`, `frontend/package.json`, `frontend/package-lock.json` (both self-version fields).
- Move `CHANGELOG.md`'s `[Unreleased]` content into a curated `## [0.30.0] - 2026-08-12` section with a highlights line.
- Verified `python backend/scripts/extract_changelog.py --version 0.30.0 --check` passes (mirrors the CI `changelog-version-check` gate).
- `CONTRIBUTORS.md` regenerated; no changes (already current).

## What's next
Squash-merge → `tag-release.yml` tags `v0.30.0` from `main` → `release.yml` builds binaries and publishes the release using the extracted CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)