### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-08-16
+
+_Highlights: eject a disc mid-rip without losing the job, and Discord notifications now identify the disc._
+
 ### Added
 
 - **You can eject a disc mid-rip without losing the job.** A dirty or damaged disc usually announces itself partway through a rip: read speeds collapse and the drive starts grinding. Until now the only mid-rip control was Cancel, which failed the whole job and deleted everything already staged, so rescuing a scratched disc meant throwing away the tracks that had ripped perfectly. Pulling the disc by hand was not a workaround either: a rip in progress survives the disc vanishing and then sits on MakeMKV until the stall timeout expires, twenty minutes later. The disc card now has an **Eject** button while scanning or ripping. Ripping stops within seconds, the drive opens, and the job carries on: tracks that finished ripping match and organize exactly as they always would, and the rest are parked in review marked re-rippable, so you can clean the disc, put it back in, and recover them one at a time. Ejecting during the initial scan cancels the job instead, since nothing has been produced yet. If the tray refuses to open, the rip is still stopped and the disc is safe to remove by hand; Engram says so rather than pretending it worked.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.30.0"
+version = "0.31.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.30.0"
+version = "0.31.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.30.0",
+    "version": "0.31.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.30.0",
+            "version": "0.31.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.30.0",
+    "version": "0.31.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.31.0

Version bump in lockstep across the 6 tracked files (`backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, `frontend/package-lock.json` x2, plus the new `CHANGELOG.md` section).

_Highlights: eject a disc mid-rip without losing the job, and Discord notifications now identify the disc._

### Added
- Eject a disc mid-rip without losing the job (#593)
- Discord notifications identify the disc, per-event toggles, test-message button, poster thumbnails, new template variables (#592)

### Changed
- `{{drive}}` documented as a deprecated alias for `{{volume_label}}`

No new external contributors since v0.30.0, so `CONTRIBUTORS.md` is unchanged.

Verified `extract_changelog.py --version 0.31.0 --check` resolves the new section.

Merging is left to the user per repo convention (squash-merge triggers the tag + release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)