### PR TITLE
fix(build): bundle scipy's relocated array_api_compat fft module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release builds produce a working binary again.** Since v0.29.0 every packaged
+  release crashed the moment it started, with `No module named
+  'scipy._external.array_api_compat.numpy.fft'`, so no downloadable build shipped for
+  v0.29.0, v0.30.0 or v0.31.0. A scipy update relocated a vendored module that
+  PyInstaller can only find when it is named explicitly, and the bundler's built-in
+  rule still pointed at the old location. Both locations are now declared, so the
+  packaged app starts whichever one scipy uses.
+
 ## [0.31.0] - 2026-08-16
 
 _Highlights: eject a disc mid-rip without losing the job, and Discord notifications now identify the disc._

--- a/backend/engram.spec
+++ b/backend/engram.spec
@@ -4,7 +4,9 @@
 Bundles the FastAPI backend + React frontend into a single distributable directory.
 """
 
+import importlib.util
 import os
+
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 block_cipher = None
@@ -78,7 +80,27 @@ third_party_hidden = [
     "bs4",
 ]
 
-all_hidden = app_hidden + third_party_hidden
+# scipy vendors array_api_compat, whose numpy backend loads its `fft` and `linalg`
+# submodules via `__import__(__package__ + ".fft")`, a module name built from a
+# string, which PyInstaller's static analysis cannot see. PyInstaller's own
+# hook-scipy.py covers this, but hardcodes the old `scipy._lib.array_api_compat`
+# path; scipy 1.17.1 moved the vendored copy to `scipy._external.array_api_compat`,
+# so that hidden import silently degraded to a "not found" WARNING and the frozen
+# app died at startup with:
+#   ModuleNotFoundError: No module named 'scipy._external.array_api_compat.numpy.fft'
+# The build itself stayed green (only the binary broke), which is how three
+# releases (v0.29.0-v0.31.0) shipped nothing. Declare both vendoring locations so
+# this survives the module moving again in either direction.
+scipy_array_api_hidden = []
+for _vendored in ("scipy._external.array_api_compat", "scipy._lib.array_api_compat"):
+    try:
+        _found = importlib.util.find_spec(_vendored) is not None
+    except ModuleNotFoundError:
+        _found = False
+    if _found:
+        scipy_array_api_hidden += [f"{_vendored}.numpy.fft", f"{_vendored}.numpy.linalg"]
+
+all_hidden = app_hidden + third_party_hidden + scipy_array_api_hidden
 
 # Data files that must be included
 datas = []


### PR DESCRIPTION
## Problem

The last three releases (v0.29.0, v0.30.0, v0.31.0) all failed. Every build job on
every platform died at the same step, `Smoke test built executable`:

```
Fatal error: No module named 'scipy._external.array_api_compat.numpy.fft'
```

The build itself succeeded each time. The binary it produced could not start, so no
downloadable artifact has shipped since v0.28.2.

## Root cause

scipy vendors `array_api_compat`. Its numpy backend loads two submodules like this:

```python
__import__(__package__ + ".linalg")
__import__(__package__ + ".fft")
```

A module name assembled from a string is invisible to PyInstaller's static analysis,
so it must be declared as a hidden import. PyInstaller's own `hook-scipy.py` has done
exactly that since scipy 1.14:

```python
if check_requirement("scipy >= 1.14.0"):
    hiddenimports += ['scipy._lib.array_api_compat.numpy.fft']
```

scipy 1.17.1 relocated the vendored copy from `scipy._lib` to `scipy._external`. The
hook's hardcoded path no longer resolves, and PyInstaller downgrades an unresolvable
hidden import to a warning rather than an error:

```
WARNING: Hidden import "scipy._lib.array_api_compat.numpy.fft" not found!
```

That one line sits in a 90,000-line build log. The build stayed green; only the binary
broke. (`linalg` survived because it is also imported statically further down the same
file, which is why only `fft` shows up in the traceback.)

Timeline lines up exactly: renovate bumped scipy 1.17.0 to 1.17.1 in #570 on Aug 1,
one day after v0.28.2, the last release that produced working binaries.

Upstream `pyinstaller-hooks-contrib` ships four hooks for **sklearn's** copy of the
same vendored library, written specifically for this `__import__` pattern. scipy's
relocated copy has no equivalent hook yet.

## Fix

Declare the hidden imports in `engram.spec`, guarded on which vendoring location the
installed scipy actually has, so this survives the module moving again in either
direction. Same shape as the existing `collect_data_files("certifi")` workaround,
which was added for the same class of bug.

## Verification

Built the frozen bundle locally with the release toolchain pinned in `release.yml`
(`pyinstaller==6.20.0`, `pyinstaller-hooks-contrib==2026.5`):

- **Before the fix:** binary reproduces the CI traceback exactly, same module, same frames.
- **After the fix:** build log shows `Analyzing hidden import 'scipy._external.array_api_compat.numpy.fft'`, and the binary passes the release smoke test: serves `/api/jobs` in 5s, one process (no fork bomb), `detect-tools` reports fpcalc found.

## Follow-up worth considering (not in this PR)

Nothing in CI builds a frozen binary. `backend-smoke` boots the app **from source**,
where the dynamic import resolves fine at runtime, so a dependency bump that breaks
only the packaged build merges green and is not discovered until release day. That is
how this shipped three times. A PyInstaller build plus the existing smoke test on one
platform in `ci.yml` (or gated to lockfile PRs) would have caught it on #570.

Also note v0.31.0's tag points at a commit without this fix, so re-running the release
workflow on that tag will fail again. Landing this needs a follow-up patch release.
