### PR TITLE
chore: release v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-08-18
+
+_Highlights: downloadable builds work again._
+
 ### Fixed
 
 - **Release builds produce a working binary again.** Since v0.29.0 every packaged

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.31.0"
+__version__ = "0.31.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.31.0"
+version = "0.31.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.31.0"
+version = "0.31.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.31.0",
+            "version": "0.31.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.31.0",
+    "version": "0.31.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Patch release carrying the PyInstaller bundling fix from #598, so downloadable
binaries ship again. v0.29.0, v0.30.0 and v0.31.0 all published no usable build.

Fixes-only, so a patch bump per the version convention.

## Version bumped in all six lockstep locations

- `backend/pyproject.toml`
- `backend/app/__init__.py` (outbound User-Agent)
- `backend/uv.lock` (`engram-backend` self-version)
- `frontend/package.json`
- `frontend/package-lock.json` (both self-version fields)
- `CHANGELOG.md` (new dated section, `[Unreleased]` left empty above it)

## Note for the reviewer: package-lock has a version-string collision this cycle

`frontend/package-lock.json` contains **three** occurrences of `"version": "0.31.0"`, not
the usual two. Lines 3 and 9 are the package's own self-version fields; line 12095 is
`node_modules/react-slick`, which is genuinely released at 0.31.0. Only the two
self-version fields were changed, and the react-slick pin is deliberately left at 0.31.0.
A blind find-replace on that string would have invented a react-slick version that does
not exist.

## Verification

- `extract_changelog.py --version 0.31.1 --check` passes, so `changelog-version-check` is satisfied.
- `--version 0.31.0 --check` still passes, confirming the previous section was not orphaned under `[Unreleased]`.
- `git log v0.31.0..main` contained only #598, so no merged-but-unlogged user-facing change is missing from the notes.
- Dated `2026-08-18` (UTC publish day), not the local date.

## After merge

Squash-merge preserves the `chore: release v` prefix, so `tag-release.yml` tags v0.31.1
and dispatches `release.yml` + `docker.yml`. This is the first release since v0.28.2 that
should actually produce working binaries. The release build is worth watching: it is the
real end-to-end proof of #598, since nothing in CI builds a frozen binary today (a
separate task is open to close that gap).
