### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-08-19
+
+_Highlights: review jobs stay visible even after they age off the dashboard._
+
 ### Changed
 
 - **CI now builds and boots the packaged app before a dependency change can

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.31.1"
+__version__ = "0.32.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.31.1"
+version = "0.32.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.31.1"
+version = "0.32.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.31.1",
+    "version": "0.32.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.31.1",
+            "version": "0.32.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.31.1",
+    "version": "0.32.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Version bump to v0.32.0 and CHANGELOG cut for release.

## Changelog

_Highlights: review jobs stay visible even after they age off the dashboard._

### Changed

- CI now builds and boots the packaged app before a dependency change can merge. (#599)

### Fixed

- Discs parked in review no longer vanish if you leave them for a few days. (#601)
- History can now show jobs that have not finished (Needs review / All jobs filters). (#601)

## Files bumped

- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `backend/uv.lock`
- `frontend/package.json`
- `frontend/package-lock.json`
- `CHANGELOG.md`

No new external contributors since v0.31.1, so `CONTRIBUTORS.md` is unchanged.

Merging this (squash, title kept as `chore: release v0.32.0`) triggers `tag-release.yml` → tags `v0.32.0` → `release.yml` (binaries + GitHub release) and `docker.yml` (GHCR image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
