### PR TITLE
feat(config): check configured paths and support network shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Review every disc before it is organized.** A new setting under *Naming &
+  extras* holds every disc in the Review Queue for confirmation, however
+  confident the match was. The matcher still runs and pre-fills its best guess —
+  you just get the last word before anything moves into the library. Useful for
+  shows the matcher handles badly.
+- **One track can now be assigned several episodes.** Segment-format shows
+  (three ~7 minute cartoon segments in one 22 minute DVD track) list each segment
+  as its own TMDB episode, so a single track really is `S01E01-E03`. The review
+  picker can now say so, and the file is named with the range form Plex and
+  Jellyfin both read.
+- **The manual episode picker is searchable.** Type part of an episode name or
+  its number instead of scrolling a dropdown — which matters for the 40-100
+  episode seasons that segment-numbered shows produce. Episode names come from
+  the TMDB data Engram already caches.
+- **Settings now checks your library and staging folders.** Each path field shows
+  whether the folder exists, whether Engram can actually write to it (a real
+  write test, not a guess at permissions), and how much space is free — so a typo
+  or a permissions problem is visible immediately instead of surfacing as a failed
+  organize after a completed rip.
+- **Network shares are supported as library paths.** A Windows UNC path
+  (`\\server\share\TV`) works wherever a local path does, including the pasted
+  `//server/share` spelling, which is normalized to one canonical form. A share
+  that is offline while you are editing settings is flagged as a warning rather
+  than rejected, and a Windows-style share path entered on Linux or macOS now
+  explains that it needs mounting instead of failing obscurely.
+
+### Fixed
+
+- **Discs whose every track was filed as "extras" are held for review instead of
+  quietly completing.** When TMDB's runtimes don't describe the disc, the
+  duration pre-filter could reject every track on it, so a whole box set could
+  file every one of its episodes into `Extras/` and report success. Such
+  a disc now stops for confirmation, because "nothing on this disc is an episode"
+  is far more often a failed match than a genuine bonus disc.
+- **Episode-length tracks are no longer mistaken for extras on segment-format
+  shows.** When no track on a disc matches a single TMDB runtime but tracks match
+  whole multiples of one, Engram now recognises the disc as segment-numbered and
+  accepts the combined tracks as episodes. If nothing fits under either rule, the
+  runtime filter is disabled for that disc and the audio matcher — which compares
+  content, not clocks — decides.
+
 ## [0.32.0] - 2026-08-19
 
 _Highlights: review jobs stay visible even after they age off the dashboard._

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1863,6 +1863,23 @@ async def update_config(config: ConfigUpdate) -> dict:
             if error:
                 raise HTTPException(status_code=400, detail=f"{field}: {error}")
 
+    # Tidy every path the user gave us before it is validated or stored: strip the
+    # quotes Windows' "Copy as path" adds, expand ~, settle separators, and put a
+    # UNC path into one canonical spelling so "//server/share" and
+    # "\\server\share" are the same setting rather than two that behave alike.
+    from app.core.paths import normalize_user_path
+
+    for _field in (
+        "library_movies_path",
+        "library_tv_path",
+        "staging_path",
+        "import_watch_path",
+        "subtitles_cache_path",
+        "discdb_export_path",
+    ):
+        if update_data.get(_field):
+            update_data[_field] = normalize_user_path(update_data[_field])
+
     # Validate library paths are actually writable before persisting (#563).
     # A path Engram cannot write to used to be accepted silently and only
     # surfaced as an opaque organize failure after a full rip: the exact

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -625,7 +625,10 @@ class PathCheckResponse(BaseModel):
 
 
 @router.post("/validate/path", response_model=PathCheckResponse)
-async def validate_path(request: ValidationRequest) -> PathCheckResponse:
+async def validate_path(
+    request: ValidationRequest,
+    _: None = Depends(require_localhost_or_lan),
+) -> PathCheckResponse:
     """Check that a library/staging folder exists and Engram can write to it.
 
     Settings paths are the ones most likely to be quietly wrong — a typo, an
@@ -633,6 +636,10 @@ async def validate_path(request: ValidationRequest) -> PathCheckResponse:
     surfaces as an organize error hours later, after a full rip. The write test is
     a real touch/unlink, because on network shares and container mounts the
     permission bits regularly disagree with what the server can actually do.
+
+    Gated like the other side-effecting validators in this module: the caller
+    chooses the path, and the answer reports existence, writability and free
+    space after really touching and unlinking a probe file there.
     """
     from app.core.paths import describe_path
 

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -607,6 +607,51 @@ async def validate_fpcalc(request: ValidationRequest) -> ValidationResponse:
     return ValidationResponse(valid=True, version=result.version, path=result.path)
 
 
+class PathCheckResponse(BaseModel):
+    """Whether a configured folder will actually work, and why not if it won't."""
+
+    ok: bool
+    # The value as Engram would store it: quotes stripped, ~ expanded, separators
+    # settled. Shown back so the user can see what their input became.
+    normalized: str
+    exists: bool
+    writable: bool
+    is_network: bool
+    # True when the location is fine to save but not reachable right now (an
+    # offline share) — a warning, not a rejection.
+    unreachable: bool = False
+    free_bytes: int | None = None
+    reason: str | None = None
+
+
+@router.post("/validate/path", response_model=PathCheckResponse)
+async def validate_path(request: ValidationRequest) -> PathCheckResponse:
+    """Check that a library/staging folder exists and Engram can write to it.
+
+    Settings paths are the ones most likely to be quietly wrong — a typo, an
+    offline NAS, a Docker volume owned by another uid — and the failure otherwise
+    surfaces as an organize error hours later, after a full rip. The write test is
+    a real touch/unlink, because on network shares and container mounts the
+    permission bits regularly disagree with what the server can actually do.
+    """
+    from app.core.paths import describe_path
+
+    status = await asyncio.to_thread(describe_path, request.path)
+    logger.debug(
+        "Path check: %s -> ok=%s", sanitize_log_value(status.path), sanitize_log_value(status.ok)
+    )
+    return PathCheckResponse(
+        ok=status.ok,
+        normalized=status.path,
+        exists=status.exists,
+        writable=status.writable,
+        is_network=status.is_network,
+        unreachable=status.unreachable,
+        free_bytes=status.free_bytes,
+        reason=status.reason,
+    )
+
+
 @router.post("/validate/tmdb", response_model=ValidationResponse)
 async def validate_tmdb(request: TmdbValidationRequest) -> ValidationResponse:
     """Validate a TMDB API key by making a lightweight configuration request."""

--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -50,9 +50,22 @@ def is_unc_path(value: str) -> bool:
 
     Accepts the forward-slash spelling too (``//server/share``): it is what a
     browser address bar and most shells produce, and Windows itself accepts it.
+
+    The slash spelling is recognised on Windows only. POSIX allows a leading
+    ``//`` on an ordinary absolute path — ``//mnt/media`` names the same
+    directory as ``/mnt/media`` — so reading it as a UNC path on Linux rejected a
+    working path with advice to mount a share that was already mounted. The
+    backslash spelling stays UNC everywhere, since it cannot be a POSIX path.
     """
     stripped = value.strip()
-    return len(stripped) > 2 and stripped[0] in "\\/" and stripped[1] in "\\/"
+    if len(stripped) <= 2:
+        return False
+    first, second = stripped[0], stripped[1]
+    if first == "\\" and second == "\\":
+        return True
+    if first not in "\\/" or second not in "\\/":
+        return False
+    return IS_WINDOWS
 
 
 def normalize_user_path(value: str | None) -> str:

--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -1,0 +1,212 @@
+"""Understanding and checking the paths a user configures.
+
+Engram writes into directories the user names in Settings, and those are the
+settings most likely to be wrong in a way nothing notices: a typo, a share that
+isn't mounted, a Docker volume owned by another uid. Left unchecked the mistake
+surfaces hours later as an organize failure after a completed rip, which is the
+worst possible moment to learn about it.
+
+Network locations get first-class treatment here because they are the normal case
+for a media library. On Windows that means UNC paths (``\\\\server\\share``);
+elsewhere a share is an ordinary mount point and needs nothing special — but a
+Windows-style UNC typed on Linux is a mistake worth naming rather than silently
+treating as a relative directory.
+"""
+
+import contextlib
+import os
+import platform
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+IS_WINDOWS = platform.system() == "Windows"
+
+
+@dataclass
+class PathStatus:
+    """The answer to "will Engram actually be able to use this path?"."""
+
+    path: str
+    exists: bool
+    writable: bool
+    is_network: bool
+    free_bytes: int | None = None
+    # None when the path is usable; otherwise a sentence the user can act on.
+    reason: str | None = None
+    # A path that is fine to save but that Engram cannot see right now — an
+    # unmounted share, typically. Distinct from an outright error: saving it is
+    # reasonable, using it today is not.
+    unreachable: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.exists and self.writable and self.reason is None
+
+
+def is_unc_path(value: str) -> bool:
+    r"""True for a Windows network path (``\\server\share\...``).
+
+    Accepts the forward-slash spelling too (``//server/share``): it is what a
+    browser address bar and most shells produce, and Windows itself accepts it.
+    """
+    stripped = value.strip()
+    return len(stripped) > 2 and stripped[0] in "\\/" and stripped[1] in "\\/"
+
+
+def normalize_user_path(value: str | None) -> str:
+    r"""Clean up a path a human typed or pasted, without changing what it means.
+
+    Handles the mundane damage of copy/paste — surrounding whitespace, the quotes
+    Windows' "Copy as path" adds — then expands ``~``. UNC paths are normalized to
+    backslashes on Windows so ``//server/share`` and ``\\server\share`` are stored
+    identically rather than as two settings that look different and behave the
+    same.
+    """
+    if not value:
+        return ""
+    cleaned = value.strip().strip('"').strip("'").strip()
+    if not cleaned:
+        return ""
+
+    if is_unc_path(cleaned):
+        if IS_WINDOWS:
+            body = cleaned[2:].replace("/", "\\")
+            # Collapse repeats inside the body; the leading pair is the marker.
+            while "\\\\" in body:
+                body = body.replace("\\\\", "\\")
+            return "\\\\" + body.rstrip("\\")
+        # Not Windows: leave it exactly as typed. Rewriting it would disguise a
+        # real mistake (a UNC path cannot be opened directly on Linux/macOS);
+        # describe_path names it instead.
+        return cleaned
+
+    expanded = os.path.expanduser(cleaned)
+    # normpath settles the separator style (a pasted "C:/Users/me" and a typed
+    # "C:\Users\me" are one setting) and resolves any "..", without touching the
+    # filesystem — this must stay usable for a path that does not exist yet.
+    expanded = os.path.normpath(expanded)
+    # Trailing separators are noise except on a drive root ("C:\") — trimming
+    # that would turn an absolute path into a relative one.
+    if len(expanded) > 3:
+        expanded = expanded.rstrip("\\/") or expanded
+    return expanded
+
+
+def describe_path(value: str | None, *, probe_write: bool = True) -> PathStatus:
+    r"""Check a configured directory and explain, in one sentence, what's wrong.
+
+    The write check is a real touch/unlink probe rather than a permissions
+    calculation: on network shares and Docker volumes the mode bits routinely
+    disagree with what the server can actually do, and only writing settles it.
+
+    Never raises — a settings screen asking "is this path ok?" must always get an
+    answer, even for a nonsense value.
+    """
+    raw = normalize_user_path(value)
+    if not raw:
+        return PathStatus(
+            path="",
+            exists=False,
+            writable=False,
+            is_network=False,
+            reason="No path set.",
+        )
+
+    network = is_unc_path(raw)
+    if network and not IS_WINDOWS:
+        return PathStatus(
+            path=raw,
+            exists=False,
+            writable=False,
+            is_network=True,
+            reason=(
+                "Windows network paths (\\\\server\\share) can't be opened directly on this "
+                "platform. Mount the share and use its mount point instead."
+            ),
+        )
+
+    path = Path(raw)
+    if not network and not path.is_absolute():
+        return PathStatus(
+            path=raw,
+            exists=False,
+            writable=False,
+            is_network=False,
+            reason="Use a full path, not a relative one — otherwise it depends on where Engram was started.",
+        )
+
+    try:
+        exists = path.exists()
+    except OSError as e:
+        # A dead share can make even exists() fail rather than return False.
+        return PathStatus(
+            path=raw,
+            exists=False,
+            writable=False,
+            is_network=network,
+            unreachable=True,
+            reason=f"Can't reach this location: {e.strerror or e}",
+        )
+
+    if not exists:
+        if network:
+            return PathStatus(
+                path=raw,
+                exists=False,
+                writable=False,
+                is_network=True,
+                unreachable=True,
+                reason=(
+                    "This share isn't reachable right now. Check the server is on and that "
+                    "Windows has credentials for it (open it once in Explorer to sign in)."
+                ),
+            )
+        return PathStatus(
+            path=raw,
+            exists=False,
+            writable=False,
+            is_network=False,
+            reason="This folder doesn't exist. Engram will create it when it first needs it.",
+        )
+
+    if not path.is_dir():
+        return PathStatus(
+            path=raw,
+            exists=True,
+            writable=False,
+            is_network=network,
+            reason="That's a file, not a folder.",
+        )
+
+    free_bytes: int | None = None
+    with contextlib.suppress(OSError):
+        free_bytes = shutil.disk_usage(str(path)).free
+
+    if not probe_write:
+        return PathStatus(
+            path=raw, exists=True, writable=True, is_network=network, free_bytes=free_bytes
+        )
+
+    # Unique probe name: two checks (or a check racing an organize) must not
+    # unlink each other's probe and report a good path as broken.
+    probe = path / f".engram-write-test-{uuid.uuid4().hex}"
+    try:
+        probe.touch()
+    except OSError as e:
+        return PathStatus(
+            path=raw,
+            exists=True,
+            writable=False,
+            is_network=network,
+            free_bytes=free_bytes,
+            reason=f"Engram can't write here: {e.strerror or e}",
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            probe.unlink()
+
+    return PathStatus(
+        path=raw, exists=True, writable=True, is_network=network, free_bytes=free_bytes
+    )

--- a/backend/tests/unit/test_api_routes.py
+++ b/backend/tests/unit/test_api_routes.py
@@ -273,7 +273,12 @@ class TestConfigEndpoints:
 
         verify = await client.get("/api/config")
         config = verify.json()
-        assert config["staging_path"] == "/new/staging/path"
+        # Paths are stored normalized (separator style settled, ~ expanded, UNC
+        # canonicalized), so the expectation is the normalized form rather than
+        # the literal input — the same value, spelled one way.
+        from app.core.paths import normalize_user_path
+
+        assert config["staging_path"] == normalize_user_path("/new/staging/path")
         assert config["max_concurrent_matches"] == 8
 
     async def test_update_config_with_new_api_keys(self, client):

--- a/backend/tests/unit/test_paths.py
+++ b/backend/tests/unit/test_paths.py
@@ -9,18 +9,51 @@ reporting honestly whether Engram can actually use it.
 from unittest.mock import patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 from app.core import paths as paths_mod
 from app.core.paths import describe_path, is_unc_path, normalize_user_path
+from app.main import app
 
 
 @pytest.mark.unit
 class TestIsUncPath:
-    @pytest.mark.parametrize(
-        "value", [r"\\server\share", "//server/share", r"\\server\share\Media", "//server/share/"]
+    @pytest.mark.parametrize("value", [r"\\server\share", r"\\server\share\Media"])
+    def test_a_backslash_share_reads_as_unc_on_any_platform(self, value):
+        """A backslash pair cannot be a POSIX path, so it means UNC everywhere."""
+        for windows in (True, False):
+            with patch.object(paths_mod, "IS_WINDOWS", windows):
+                assert is_unc_path(value) is True
+
+    @pytest.mark.parametrize("value", ["//server/share", "//server/share/"])
+    def test_a_slash_share_reads_as_unc_only_on_windows(self, value):
+        with patch.object(paths_mod, "IS_WINDOWS", True):
+            assert is_unc_path(value) is True
+        with patch.object(paths_mod, "IS_WINDOWS", False):
+            assert is_unc_path(value) is False
+
+    @pytest.mark.parametrize("value", ["//mnt/media", "//srv/library/TV"])
+    def test_a_double_slash_posix_path_is_not_a_share(self, value):
+        """POSIX allows a leading '//' on an ordinary absolute path.
+
+        ``//mnt/media`` names the same directory as ``/mnt/media``. Reading it as
+        a Windows share on Linux rejected a working path with advice to mount
+        something that was already mounted.
+        """
+        with patch.object(paths_mod, "IS_WINDOWS", False):
+            assert is_unc_path(value) is False
+
+    @pytest.mark.skipif(
+        paths_mod.IS_WINDOWS,
+        reason="normalize_user_path leans on os.path.normpath, which is platform-specific",
     )
-    def test_network_paths(self, value):
-        assert is_unc_path(value) is True
+    def test_a_double_slash_posix_path_is_checked_as_an_ordinary_folder(self, tmp_path):
+        """End to end on POSIX: '//tmp/...' must not be rejected as a share."""
+        target = tmp_path / "library"
+        target.mkdir()
+        status = describe_path(f"/{target}")
+        assert status.is_network is False
+        assert status.ok is True
 
     @pytest.mark.parametrize("value", [r"C:\Media", "/mnt/media", "media", "", "/"])
     def test_local_paths(self, value):
@@ -145,3 +178,31 @@ class TestNetworkShares:
             status = describe_path(r"\\server\share")
         assert status.ok is False
         assert "mount" in status.reason.lower()
+
+
+@pytest.mark.unit
+class TestValidatePathGuard:
+    """``POST /api/validate/path`` is reachable from the host, or an opted-in LAN.
+
+    The endpoint takes a caller-chosen path, really touches and unlinks a probe
+    file there, and reports back existence, writability and free space. That is
+    filesystem reconnaissance plus a write, so it is gated like the other
+    side-effecting validators rather than left open.
+    """
+
+    @staticmethod
+    def _client(host: str) -> AsyncClient:
+        transport = ASGITransport(app=app, client=(host, 12345))
+        return AsyncClient(transport=transport, base_url="http://test")
+
+    async def test_lan_client_rejected_by_default(self, tmp_path):
+        async with self._client("10.0.0.5") as client:
+            resp = await client.post("/api/validate/path", json={"path": str(tmp_path)})
+        assert resp.status_code == 403
+
+    async def test_loopback_client_allowed(self, tmp_path):
+        """Positive control: same request, only the client IP differs."""
+        async with self._client("127.0.0.1") as client:
+            resp = await client.post("/api/validate/path", json={"path": str(tmp_path)})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True

--- a/backend/tests/unit/test_paths.py
+++ b/backend/tests/unit/test_paths.py
@@ -1,0 +1,147 @@
+"""Configured-path normalization and checking, including network shares.
+
+Library and staging paths are the settings most likely to be silently wrong, and
+a wrong one only surfaces as an organize failure after a full rip. These tests
+cover the two halves of preventing that: storing what the user meant, and
+reporting honestly whether Engram can actually use it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core import paths as paths_mod
+from app.core.paths import describe_path, is_unc_path, normalize_user_path
+
+
+@pytest.mark.unit
+class TestIsUncPath:
+    @pytest.mark.parametrize(
+        "value", [r"\\server\share", "//server/share", r"\\server\share\Media", "//server/share/"]
+    )
+    def test_network_paths(self, value):
+        assert is_unc_path(value) is True
+
+    @pytest.mark.parametrize("value", [r"C:\Media", "/mnt/media", "media", "", "/"])
+    def test_local_paths(self, value):
+        assert is_unc_path(value) is False
+
+
+@pytest.mark.unit
+class TestNormalizeUserPath:
+    def test_strips_the_quotes_windows_copy_as_path_adds(self):
+        assert normalize_user_path('"/mnt/media"') == normalize_user_path("/mnt/media")
+
+    def test_strips_surrounding_whitespace(self):
+        assert normalize_user_path("  /mnt/media  ") == normalize_user_path("/mnt/media")
+
+    def test_blank_input_is_blank_output(self):
+        assert normalize_user_path(None) == ""
+        assert normalize_user_path("   ") == ""
+
+    def test_unc_spellings_converge_on_windows(self):
+        # "//server/share" (what a shell or address bar gives) and the typed
+        # backslash form are ONE setting, not two that happen to behave alike.
+        with patch.object(paths_mod, "IS_WINDOWS", True):
+            assert normalize_user_path("//server/share/Media") == r"\\server\share\Media"
+            assert normalize_user_path(r"\\server\share\Media") == r"\\server\share\Media"
+
+    def test_unc_keeps_its_leading_pair(self):
+        with patch.object(paths_mod, "IS_WINDOWS", True):
+            assert normalize_user_path(r"\\server\share").startswith("\\\\")
+
+    def test_unc_trailing_separator_is_trimmed(self):
+        with patch.object(paths_mod, "IS_WINDOWS", True):
+            assert normalize_user_path("//server/share/") == r"\\server\share"
+
+    def test_unc_is_left_alone_off_windows(self):
+        # Rewriting it would disguise a real mistake; describe_path names it.
+        with patch.object(paths_mod, "IS_WINDOWS", False):
+            assert normalize_user_path(r"\\server\share") == r"\\server\share"
+
+    def test_home_is_expanded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        assert "~" not in normalize_user_path("~/Media")
+
+
+@pytest.mark.unit
+class TestDescribePath:
+    def test_a_writable_folder_is_ok(self, tmp_path):
+        status = describe_path(str(tmp_path))
+        assert status.ok is True
+        assert status.exists is True
+        assert status.writable is True
+        assert status.reason is None
+
+    def test_the_write_probe_leaves_nothing_behind(self, tmp_path):
+        describe_path(str(tmp_path))
+        assert list(tmp_path.iterdir()) == []
+
+    def test_a_missing_folder_is_reported_but_not_fatal(self, tmp_path):
+        status = describe_path(str(tmp_path / "not-yet"))
+        assert status.exists is False
+        assert status.ok is False
+        assert "doesn't exist" in status.reason
+
+    def test_a_relative_path_is_rejected(self):
+        # It would resolve against wherever Engram happened to be started.
+        status = describe_path("media/tv")
+        assert status.ok is False
+        assert "full path" in status.reason
+
+    def test_a_file_is_not_a_folder(self, tmp_path):
+        target = tmp_path / "a-file.mkv"
+        target.write_text("x")
+        status = describe_path(str(target))
+        assert status.ok is False
+        assert "not a folder" in status.reason
+
+    def test_an_empty_setting_says_so(self):
+        status = describe_path("")
+        assert status.ok is False
+        assert status.reason == "No path set."
+
+    def test_an_unwritable_folder_is_reported(self, tmp_path):
+        # The permission bits on a share or container mount routinely disagree
+        # with reality, so the check writes rather than reasoning about modes.
+        with patch("pathlib.Path.touch", side_effect=PermissionError(13, "Permission denied")):
+            status = describe_path(str(tmp_path))
+        assert status.ok is False
+        assert status.writable is False
+        assert "can't write" in status.reason
+
+    def test_probe_write_false_skips_the_touch(self, tmp_path):
+        with patch("pathlib.Path.touch", side_effect=AssertionError("must not probe")):
+            status = describe_path(str(tmp_path), probe_write=False)
+        assert status.ok is True
+
+    def test_reports_free_space_for_an_existing_folder(self, tmp_path):
+        assert describe_path(str(tmp_path)).free_bytes > 0
+
+
+@pytest.mark.unit
+class TestNetworkShares:
+    def test_an_offline_share_is_a_warning_not_an_error(self, tmp_path):
+        with patch.object(paths_mod, "IS_WINDOWS", True):
+            status = describe_path(r"\\server\share")
+        assert status.is_network is True
+        # Unreachable, but still worth saving: the share may simply be off right
+        # now, and refusing to save it would be worse than flagging it.
+        assert status.unreachable is True
+        assert "reachable" in status.reason
+
+    def test_a_dead_share_that_errors_on_exists_is_handled(self, tmp_path):
+        with (
+            patch.object(paths_mod, "IS_WINDOWS", True),
+            patch("pathlib.Path.exists", side_effect=OSError(64, "The specified network name...")),
+        ):
+            status = describe_path(r"\\server\share")
+        assert status.unreachable is True
+        assert status.ok is False
+
+    def test_a_windows_share_path_on_another_platform_is_explained(self):
+        with patch.object(paths_mod, "IS_WINDOWS", False):
+            status = describe_path(r"\\server\share")
+        assert status.ok is False
+        assert "mount" in status.reason.lower()

--- a/frontend/src/components/ConfigWizard.css
+++ b/frontend/src/components/ConfigWizard.css
@@ -1107,3 +1107,27 @@
     letter-spacing: 0.08em;
     font-size: 0.78rem;
 }
+
+/* Path check status — the live "will this folder actually work?" line under a
+   library/staging field. Colour carries the verdict at a glance: an offline
+   share is a warning (the path may be right, just not mounted right now), while
+   an unwritable or malformed path is an error. */
+.path-status {
+    display: block;
+}
+
+.path-status-checking {
+    color: var(--color-sv-ink-faint);
+}
+
+.path-status-ok {
+    color: var(--color-sv-cyan);
+}
+
+.path-status-warn {
+    color: var(--color-sv-yellow);
+}
+
+.path-status-error {
+    color: var(--color-sv-red);
+}

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -7,6 +7,7 @@ import { SvActionButton } from '../app/components/synapse/SvActionButton';
 import { BootstrapLibraryFlow } from './BootstrapLibraryFlow';
 import GpuAccelerationSetting from './GpuAccelerationSetting';
 import BackgroundEffectsSetting from './BackgroundEffectsSetting';
+import { PathStatusHint } from './PathStatusHint';
 import { requestTmdbValidation } from '../utils/tmdbValidation';
 import { requestAiValidation } from '../utils/aiValidation';
 import { requestDiscordTemplateValidation } from '../utils/discordTemplateValidation';
@@ -851,6 +852,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 Temporary storage during ripping. Files are moved to library after processing.
                                 Ensure this directory has adequate disk space (10-50GB recommended).
                             </span>
+                            <PathStatusHint path={config.stagingPath} label="staging directory" />
                         </div>
 
                         <div className="form-group">
@@ -860,8 +862,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 type="text"
                                 value={config.libraryMoviesPath}
                                 onChange={(e) => handleInputChange('libraryMoviesPath', e.target.value)}
-                                placeholder="e.g., D:\Media\Movies"
+                                placeholder="e.g., D:\Media\Movies or \server\share\Movies"
                             />
+                            <PathStatusHint path={config.libraryMoviesPath} label="movies library" />
                         </div>
 
                         <div className="form-group">
@@ -871,8 +874,9 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                 type="text"
                                 value={config.libraryTvPath}
                                 onChange={(e) => handleInputChange('libraryTvPath', e.target.value)}
-                                placeholder="e.g., D:\Media\TV Shows"
+                                placeholder="e.g., D:\Media\TV Shows or \server\share\TV"
                             />
+                            <PathStatusHint path={config.libraryTvPath} label="TV library" />
                         </div>
 
                     </div>

--- a/frontend/src/components/PathStatusHint.test.tsx
+++ b/frontend/src/components/PathStatusHint.test.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PathStatusHint, type PathCheck } from './PathStatusHint';
+
+const OK: PathCheck = {
+    ok: true,
+    normalized: 'D:\\Media\\TV',
+    exists: true,
+    writable: true,
+    is_network: false,
+    unreachable: false,
+    free_bytes: 5_660_000_000_000,
+    reason: null,
+};
+
+function mockCheck(body: Partial<PathCheck>) {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ...OK, ...body }) });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('PathStatusHint', () => {
+    it('checks nothing while the field is empty', () => {
+        const fetchMock = mockCheck({});
+        const { container } = render(<PathStatusHint path="  " label="TV library" />);
+        expect(container).toBeEmptyDOMElement();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('confirms a writable path and shows the free space', async () => {
+        mockCheck({});
+        render(<PathStatusHint path="D:\\Media\\TV" label="TV library" />);
+        await waitFor(() => expect(screen.getByText(/Writable/)).toBeInTheDocument());
+        expect(screen.getByText(/5\.7 TB free/)).toBeInTheDocument();
+    });
+
+    it('calls out a network share', async () => {
+        mockCheck({ is_network: true, normalized: '\\\\server\\share\\TV' });
+        render(<PathStatusHint path="\\\\server\\share\\TV" label="TV library" />);
+        await waitFor(() => expect(screen.getByText(/network share/)).toBeInTheDocument());
+    });
+
+    it('shows what a pasted path was stored as', async () => {
+        mockCheck({ normalized: '\\\\server\\share\\TV' });
+        render(<PathStatusHint path="//server/share/TV" label="TV library" />);
+        await waitFor(() => expect(screen.getByText(/saved as/)).toBeInTheDocument());
+    });
+
+    it('treats an offline share as a warning, not an error', async () => {
+        mockCheck({
+            ok: false,
+            exists: false,
+            writable: false,
+            is_network: true,
+            unreachable: true,
+            reason: "This share isn't reachable right now.",
+        });
+        const { container } = render(<PathStatusHint path="\\\\server\\share" label="TV library" />);
+        await waitFor(() => expect(screen.getByText(/isn't reachable/)).toBeInTheDocument());
+        expect(container.querySelector('.path-status-warn')).toBeInTheDocument();
+        expect(container.querySelector('.path-status-error')).not.toBeInTheDocument();
+    });
+
+    it('reports an unwritable path as an error', async () => {
+        mockCheck({
+            ok: false,
+            writable: false,
+            reason: "Engram can't write here: Permission denied",
+        });
+        const { container } = render(<PathStatusHint path="D:\\Media\\TV" label="TV library" />);
+        await waitFor(() => expect(screen.getByText(/can't write here/)).toBeInTheDocument());
+        expect(container.querySelector('.path-status-error')).toBeInTheDocument();
+    });
+
+    it('stays silent when the check itself fails', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+        const { container } = render(<PathStatusHint path="D:\\Media\\TV" label="TV library" />);
+        await waitFor(() => expect(container).toBeEmptyDOMElement());
+    });
+});

--- a/frontend/src/components/PathStatusHint.tsx
+++ b/frontend/src/components/PathStatusHint.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+
+export interface PathCheck {
+    ok: boolean;
+    normalized: string;
+    exists: boolean;
+    writable: boolean;
+    is_network: boolean;
+    unreachable: boolean;
+    free_bytes: number | null;
+    reason: string | null;
+}
+
+function formatFree(bytes: number | null): string {
+    if (!bytes) return '';
+    const tb = bytes / 1e12;
+    return tb >= 1 ? `${tb.toFixed(1)} TB free` : `${Math.round(bytes / 1e9)} GB free`;
+}
+
+/**
+ * Live "does this folder actually work?" status under a path field.
+ *
+ * Library and staging paths are the settings most likely to be silently wrong —
+ * a typo, an offline NAS, a container volume owned by another uid — and without
+ * a check the mistake only shows up as an organize failure after a full rip. The
+ * backend performs a real write test, so a share that merely *looks* writable is
+ * still reported honestly.
+ *
+ * Debounced, and idle until there is something to check, so typing a path
+ * doesn't fire a probe per keystroke.
+ */
+export function PathStatusHint({ path, label }: { path: string; label: string }) {
+    const [check, setCheck] = useState<PathCheck | null>(null);
+    const [checking, setChecking] = useState(false);
+
+    useEffect(() => {
+        const value = path.trim();
+        if (!value) {
+            setCheck(null);
+            return;
+        }
+        let cancelled = false;
+        setChecking(true);
+        const timer = setTimeout(() => {
+            fetch('/api/validate/path', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ path: value }),
+            })
+                .then((r) => (r.ok ? (r.json() as Promise<PathCheck>) : null))
+                .then((data) => {
+                    if (!cancelled) setCheck(data);
+                })
+                .catch(() => {
+                    if (!cancelled) setCheck(null);
+                })
+                .finally(() => {
+                    if (!cancelled) setChecking(false);
+                });
+        }, 500);
+        return () => {
+            cancelled = true;
+            clearTimeout(timer);
+        };
+    }, [path]);
+
+    if (!path.trim()) return null;
+    if (checking && !check) {
+        return <span className="form-hint path-status path-status-checking">Checking {label}…</span>;
+    }
+    if (!check) return null;
+
+    if (check.ok) {
+        const free = formatFree(check.free_bytes);
+        return (
+            <span className="form-hint path-status path-status-ok">
+                ✓ Writable{check.is_network ? ' network share' : ''}
+                {free ? ` · ${free}` : ''}
+                {check.normalized !== path.trim() ? ` · saved as ${check.normalized}` : ''}
+            </span>
+        );
+    }
+
+    // An offline share is a warning, not an error: the path may be perfectly
+    // correct and simply not mounted at the moment you are editing settings.
+    const tone = check.unreachable ? 'path-status-warn' : 'path-status-error';
+    return (
+        <span className={`form-hint path-status ${tone}`}>
+            {check.unreachable ? '⚠' : '✕'} {check.reason}
+        </span>
+    );
+}


### PR DESCRIPTION
Second of the four PRs split out of #609. Fully orthogonal to the others — no pipeline coupling,
no migration.

## What it does

Settings paths are the ones most likely to be quietly wrong: a typo, a share that isn't mounted, a
Docker volume owned by another uid. Left unchecked the mistake surfaces hours later as an organize
failure after a completed rip, which is the worst possible moment to learn about it.

`app/core/paths.py` answers "will Engram actually be able to use this path?" — exists, is a
directory, is writable, how much room is left, and is it a network location. The write check is a
real touch/unlink probe rather than a permissions calculation, because on network shares and
container mounts the mode bits routinely disagree with what the server can actually do. It never
raises: a settings screen asking "is this path ok?" must always get an answer, even for a nonsense
value.

Network locations get first-class treatment because they are the normal case for a media library.
On Windows that means UNC paths (`\\server\share`), normalized so `//server/share` and
`\\server\share` are stored as one setting rather than two that look different and behave the
same. An unreachable share is reported as *unreachable* rather than *invalid* — saving it is
reasonable, using it today is not.

`PathStatusHint` surfaces the result inline under each path field in the Config Wizard.

## Changes since the review on #609

- **`POST /api/validate/path` now requires `require_localhost_or_lan`.** You were right that it is
  the one endpoint in `validation.py` doing real filesystem work at a caller-chosen location — it
  touches and unlinks a probe file and reports existence, writability and free space. It is now
  gated like the other two.
- **Fixed a POSIX bug in `is_unc_path` before running the Linux pass.** It treated any leading
  `//` as a Windows UNC path, but `//mnt/media` is a legal POSIX absolute path, so on Linux a
  perfectly good path was rejected with "mount the share and use its mount point instead". UNC
  detection is now Windows-only, and `//path` on Linux is treated as the ordinary absolute path it
  is.
- Ran the suite on Linux rather than asserting it was fine.

## Tests

`tests/unit/test_paths.py` (normalization, UNC handling on both platforms, the unreachable-share
case, probe cleanup), the new route tests in `tests/unit/test_api_routes.py` including the
localhost/LAN gate, and `PathStatusHint.test.tsx` on the frontend.
