### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-23
+
+_Highlights: watch a track in your own video player, straight from manual review._
+
 ### Added
 
 - **Watch a track in your own video player, straight from manual review.** When

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.32.0"
+version = "0.33.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.32.0"
+version = "0.33.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.32.0",
+    "version": "0.33.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.32.0",
+            "version": "0.33.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.32.0",
+    "version": "0.33.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Release v0.33.0

Minor release: one user-facing feature since v0.32.0, no fixes-only entries.

### Highlights
Watch a track in your own video player, straight from manual review.

### Version bump
Bumped all 6 version-tracked files to `0.33.0` in lockstep:
- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `backend/uv.lock`
- `frontend/package.json`
- `frontend/package-lock.json` (both self-version fields)
- `CHANGELOG.md` — new `## [0.33.0] - 2026-08-23` section curated from `[Unreleased]`

`CONTRIBUTORS.md` unchanged — both PRs in this release (#610, #616) are from the maintainer.

On squash-merge, `tag-release.yml` tags `v0.33.0` from `main` and dispatches the release + docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)