### PR TITLE
feat(ai): support local AI providers (Ollama, LM Studio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Engram will be documented in this file.
 
 ### Added
 
+- **Local AI providers: run identification and episode matching on your own
+  machine.** Ollama and LM Studio can now be selected as the AI provider instead
+  of a paid hosted API, so transcripts and disc labels never leave your network.
+  No API key is required; pick the model from a dropdown of what your server
+  actually has installed, and Engram checks it is really there before reporting
+  a successful connection. Leave the address blank to use the conventional port
+  (`11434` for Ollama, `1234` for LM Studio). See
+  [Local AI](https://jsakkos.github.io/engram/getting-started/configuration/#local-ai-ollama-and-lm-studio)
+  for setup. (#606)
 - **Review every disc before it is organized.** A new setting under *Naming &
   extras* holds every disc in the Review Queue for confirmation, however
   confident the match was. The matcher still runs and pre-fills its best guess —

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -4596,6 +4596,7 @@ async def _run_llm_match_for_title(*, title: "DiscTitle", job: "DiscJob") -> LLM
     ``matcher_unavailable``, ``show_not_found``, ``transcription_failed``,
     ``llm_error``, ``no_match``) or is ``None`` on success.
     """
+    from app.core.ai_client import ai_is_configured
     from app.services.config_service import get_config
 
     config = await get_config()
@@ -4605,7 +4606,7 @@ async def _run_llm_match_for_title(*, title: "DiscTitle", job: "DiscJob") -> LLM
         return LLMMatchOutcome.failed("not_configured")
     if not getattr(config, "ai_episode_matching_enabled", False):
         return LLMMatchOutcome.failed("ai_disabled")
-    if not config.ai_api_key:
+    if not ai_is_configured(config.ai_provider, config.ai_api_key):
         return LLMMatchOutcome.failed("not_configured")
     if not job.detected_title:
         return LLMMatchOutcome.failed("no_show")
@@ -4648,6 +4649,7 @@ async def _run_llm_match_for_title(*, title: "DiscTitle", job: "DiscJob") -> LLM
             ai_provider=config.ai_provider,
             ai_api_key=config.ai_api_key,
             ai_model=getattr(config, "ai_model", "") or None,
+            ai_local_base_url=getattr(config, "ai_local_base_url", "") or "",
             tmdb_api_key=config.tmdb_api_key,
             raise_on_error=True,
         )

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -316,6 +316,7 @@ class ConfigResponse(BaseModel):
     ai_provider: str
     ai_api_key: str
     ai_model: str
+    ai_local_base_url: str
     ai_episode_matching_enabled: bool
     # Staging watcher
     staging_watch_enabled: bool
@@ -414,6 +415,7 @@ class ConfigUpdate(BaseModel):
     ai_provider: str | None = None
     ai_api_key: str | None = None
     ai_model: str | None = None
+    ai_local_base_url: str | None = None
     ai_episode_matching_enabled: bool | None = None
     # Staging watcher
     staging_watch_enabled: bool | None = None
@@ -1683,6 +1685,8 @@ async def get_config() -> ConfigResponse:
         ai_api_key="***" if config.ai_api_key else "",  # Redacted
         # Not a secret, and the wizard must round-trip it to show what is in use.
         ai_model=config.ai_model or "",
+        # Not a secret; the wizard must round-trip it to show the endpoint in use.
+        ai_local_base_url=config.ai_local_base_url or "",
         ai_episode_matching_enabled=config.ai_episode_matching_enabled,
         # Staging watcher
         staging_watch_enabled=config.staging_watch_enabled,
@@ -1820,6 +1824,23 @@ async def update_config(config: ConfigUpdate) -> dict:
                 detail=(
                     "ai_model must be a plain model id such as 'gemini-2.5-flash-lite' "
                     "or 'anthropic/claude-haiku-4-5-20251001'"
+                ),
+            )
+
+    # Validated on write for the same reason ai_model is: this value is
+    # interpolated into an outbound request URL, so an unchecked value stored
+    # here becomes a request-forgery primitive executed on the next match. A
+    # blank value is the documented way to revert to the provider default and is
+    # deliberately allowed through.
+    if update_data.get("ai_local_base_url"):
+        from app.core.security import is_safe_local_ai_url
+
+        if not is_safe_local_ai_url(update_data["ai_local_base_url"]):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "ai_local_base_url must be a plain http(s) URL with no credentials "
+                    "or query string, such as 'http://localhost:11434/v1'"
                 ),
             )
 

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import httpx
 import requests
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -845,3 +846,77 @@ async def test_discord_webhook(
         return ValidationResponse(valid=False, error=f"Discord rejected the test message: {e}")
 
     return ValidationResponse(valid=True)
+
+
+class LocalModelsResponse(BaseModel):
+    """Model ids available on a local AI server.
+
+    Never signals failure with a status code: an unreachable server is the
+    NORMAL case while a user is still setting things up, and a 5xx would make
+    the wizard render an error banner instead of quietly falling back to a
+    free-text model field.
+    """
+
+    models: list[str] = []
+    error: str | None = None
+
+
+@router.get("/ai/local-models", response_model=LocalModelsResponse)
+async def list_local_models(
+    provider: str,
+    base_url: str = "",
+    _: None = Depends(require_localhost_or_lan),
+) -> LocalModelsResponse:
+    """List the models a local AI server currently offers.
+
+    Both Ollama and LM Studio expose the OpenAI-compatible ``GET /v1/models``,
+    so one implementation serves both. Gated to the host (or an opted-in LAN)
+    for the same reason as validate_ai: it triggers an outbound request the
+    caller can provoke without owning the destination.
+
+    Doubles as a reachability check, which is why the wizard does not need a
+    separate Test button for the local case.
+    """
+    from app.core.ai_client import (
+        LOCAL_PROVIDERS,
+        classify_provider_error,
+        resolve_local_base_url,
+    )
+    from app.core.security import is_safe_local_ai_url
+
+    if provider not in LOCAL_PROVIDERS:
+        return LocalModelsResponse(
+            error=f"'{sanitize_log_value(provider)}' is not a local AI provider"
+        )
+
+    url_base = resolve_local_base_url(provider, base_url)
+    if not is_safe_local_ai_url(url_base):
+        return LocalModelsResponse(
+            error=(
+                "That is not a valid server address. Use a plain http(s) URL such "
+                "as http://localhost:11434/v1."
+            )
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{url_base}/models")
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        _, message = classify_provider_error(provider, e, base_url=url_base)
+        logger.info(
+            "Local model list unavailable for %s: %s",
+            sanitize_log_value(provider),
+            sanitize_log_value(str(e)),
+        )
+        return LocalModelsResponse(error=message)
+    except Exception:  # noqa: BLE001 — this endpoint must never 500
+        logger.warning("Local model list raised unexpectedly", exc_info=True)
+        return LocalModelsResponse(error="Could not read the model list")
+
+    models: list[str] = []
+    for entry in (data or {}).get("data") or []:
+        if isinstance(entry, dict) and entry.get("id"):
+            models.append(str(entry["id"]))
+    return LocalModelsResponse(models=models)

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -63,11 +63,16 @@ class AiValidationRequest(BaseModel):
     sent from the wizard as typed, not as saved, so the button answers "will
     this combination work" rather than "did the last saved one work" — which is
     the whole point when the user is testing a model their key might not have.
+
+    ``base_url`` applies only to the local providers and, like the others, is
+    sent as typed rather than as saved, so the button answers "will this
+    endpoint work" before the user commits to it.
     """
 
     provider: str
     api_key: str | None = None
     model: str | None = None
+    base_url: str | None = None
 
 
 class ValidationResponse(BaseModel):
@@ -672,20 +677,30 @@ async def validate_ai(
     uses, rather than a bespoke auth ping: a ping would exercise a different
     endpoint, without the structured-output convention, and could therefore pass
     while real matching fails. Gated to the host (or an opted-in LAN) because,
-    unlike the other validators, this one spends the user's money.
+    unlike the other validators, this one makes a real outbound request — to a
+    paid hosted API for a remote provider, or to whatever local server the user
+    pointed it at.
     """
-    from app.core.ai_client import DEFAULT_MODELS, complete_json
+    from app.core.ai_client import (
+        DEFAULT_MODELS,
+        KNOWN_PROVIDERS,
+        LOCAL_PROVIDERS,
+        LOCAL_VALIDATE_TIMEOUT_SECONDS,
+        ai_is_configured,
+        complete_json,
+    )
     from app.core.errors import AIProviderError
 
     provider = (request.provider or "").strip()
-    if provider not in DEFAULT_MODELS:
+    if provider not in KNOWN_PROVIDERS:
         return ValidationResponse(
             valid=False, error=f"Unknown AI provider: {provider or '(empty)'}"
         )
 
     api_key = (request.api_key or "").strip()
     model = (request.model or "").strip()
-    if not api_key or not model:
+    base_url = (request.base_url or "").strip()
+    if not api_key or not model or (provider in LOCAL_PROVIDERS and not base_url):
         from app.services.config_service import get_config
 
         # Guarded: this endpoint promises never to 500, and a config read can
@@ -696,10 +711,11 @@ async def validate_ai(
             config = await get_config()
         except Exception:  # noqa: BLE001 — a validator must never 500
             logger.warning("AI validation could not read the stored config", exc_info=True)
-        if config is None and not api_key:
+        if config is None and not api_key and provider not in LOCAL_PROVIDERS:
             # Only fatal when the key itself was what we came for. A failed read
             # with a supplied key just means "no stored model override", which
-            # falls back to the provider default like any blank model.
+            # falls back to the provider default like any blank model. Local
+            # providers never needed a key in the first place.
             return ValidationResponse(
                 valid=False, error="Could not read the saved API key from the database"
             )
@@ -708,9 +724,20 @@ async def validate_ai(
                 api_key = (getattr(config, "ai_api_key", "") or "").strip()
             if not model:
                 model = (getattr(config, "ai_model", "") or "").strip()
-    if not api_key:
+            if not base_url:
+                base_url = (getattr(config, "ai_local_base_url", "") or "").strip()
+
+    if not ai_is_configured(provider, api_key):
         return ValidationResponse(
             valid=False, error="No API key provided and none is saved for this provider"
+        )
+    if provider in LOCAL_PROVIDERS and not model:
+        return ValidationResponse(
+            valid=False,
+            error=(
+                "Select a model first. Local providers have no default, because the "
+                "answer depends on which models you have installed."
+            ),
         )
 
     try:
@@ -722,12 +749,15 @@ async def validate_ai(
             provider=provider,
             api_key=api_key,
             model=model or None,
+            base_url=base_url,
             max_tokens=16,
             raise_on_error=True,
             # A dead key must fail in one request rather than paying the backoff
-            # ladder, and a user waiting on a button should not sit for 30s.
+            # ladder, and a user waiting on a button should not sit for 30s. Local
+            # providers get a much longer budget: LM Studio JIT-loads model
+            # weights on the first request, so a cold model can take a minute-plus.
             retries=0,
-            timeout=10.0,
+            timeout=(LOCAL_VALIDATE_TIMEOUT_SECONDS if provider in LOCAL_PROVIDERS else 10.0),
         )
     except AIProviderError as e:
         logger.warning("AI validation failed for %s: %s", sanitize_log_value(provider), e.code)
@@ -744,7 +774,7 @@ async def validate_ai(
         return ValidationResponse(valid=False, error="Provider returned an empty response")
     # Report the model that actually answered, not the default, so a user testing
     # an override can see which one the key accepted.
-    return ValidationResponse(valid=True, version=model or DEFAULT_MODELS[provider])
+    return ValidationResponse(valid=True, version=model or DEFAULT_MODELS.get(provider, ""))
 
 
 @router.post("/validate/discord-webhook", response_model=ValidationResponse)

--- a/backend/app/api/validation.py
+++ b/backend/app/api/validation.py
@@ -741,6 +741,23 @@ async def validate_ai(
             ),
         )
 
+    if provider in LOCAL_PROVIDERS:
+        # LM Studio answers a request for an unknown model by silently serving
+        # whichever model is currently loaded, with HTTP 200 and no warning, so a
+        # typo would otherwise pass this check and then quietly matter at match
+        # time. Confirming against the server's own list is the only way to catch
+        # it. A server we cannot reach is left to the completion below, whose
+        # error message is better than anything we could say here.
+        available, _list_error = await _fetch_local_model_ids(provider, base_url)
+        if available and model not in available:
+            shown = ", ".join(available[:10])
+            if len(available) > 10:
+                shown += ", ..."
+            return ValidationResponse(
+                valid=False,
+                error=f"'{model}' is not installed on this server. Available: {shown}",
+            )
+
     try:
         result = await complete_json(
             # "JSON" must appear in the prompt: OpenAI rejects a json_object
@@ -773,8 +790,11 @@ async def validate_ai(
 
     if not result:
         return ValidationResponse(valid=False, error="Provider returned an empty response")
-    # Report the model that actually answered, not the default, so a user testing
-    # an override can see which one the key accepted.
+    # Report the model that was requested (or the provider default), not the one
+    # that actually answered — complete_json doesn't surface that. For remote
+    # providers those can differ if the provider silently substitutes a model;
+    # for local providers the pre-flight check above is what keeps them in
+    # agreement, by rejecting a request whose model the server doesn't offer.
     return ValidationResponse(valid=True, version=model or DEFAULT_MODELS.get(provider, ""))
 
 
@@ -861,41 +881,23 @@ class LocalModelsResponse(BaseModel):
     error: str | None = None
 
 
-@router.get("/ai/local-models", response_model=LocalModelsResponse)
-async def list_local_models(
-    provider: str,
-    base_url: str = "",
-    _: None = Depends(require_localhost_or_lan),
-) -> LocalModelsResponse:
-    """List the models a local AI server currently offers.
+async def _fetch_local_model_ids(provider: str, base_url: str) -> tuple[list[str], str | None]:
+    """Model ids a local server offers, plus a human error if it could not be read.
 
-    Both Ollama and LM Studio expose the OpenAI-compatible ``GET /v1/models``,
-    so one implementation serves both. Gated to the host (or an opted-in LAN)
-    for the same reason as validate_ai: it triggers an outbound request the
-    caller can provoke without owning the destination.
-
-    Doubles as a reachability check, which is why the wizard does not need a
-    separate Test button for the local case.
+    Shared by ``GET /ai/local-models`` and ``validate_ai``'s pre-flight check, so
+    the two cannot disagree about what the server offers. Never raises: a bad
+    URL, an unreachable server, or a malformed response all come back as an
+    empty list with a message, never an exception — both callers treat an empty
+    list as "could not confirm", not as "the server has zero models".
     """
-    from app.core.ai_client import (
-        LOCAL_PROVIDERS,
-        classify_provider_error,
-        resolve_local_base_url,
-    )
+    from app.core.ai_client import classify_provider_error, resolve_local_base_url
     from app.core.security import is_safe_local_ai_url
-
-    if provider not in LOCAL_PROVIDERS:
-        return LocalModelsResponse(
-            error=f"'{sanitize_log_value(provider)}' is not a local AI provider"
-        )
 
     url_base = resolve_local_base_url(provider, base_url)
     if not is_safe_local_ai_url(url_base):
-        return LocalModelsResponse(
-            error=(
-                "That is not a valid server address. Use a plain http(s) URL such "
-                "as http://localhost:11434/v1."
-            )
+        return [], (
+            "That is not a valid server address. Use a plain http(s) URL such "
+            "as http://localhost:11434/v1."
         )
 
     try:
@@ -910,13 +912,41 @@ async def list_local_models(
             sanitize_log_value(provider),
             sanitize_log_value(str(e)),
         )
-        return LocalModelsResponse(error=message)
-    except Exception:  # noqa: BLE001 — this endpoint must never 500
+        return [], message
+    except Exception:  # noqa: BLE001 — callers must never see this raise
         logger.warning("Local model list raised unexpectedly", exc_info=True)
-        return LocalModelsResponse(error="Could not read the model list")
+        return [], "Could not read the model list"
 
     models: list[str] = []
     for entry in (data or {}).get("data") or []:
         if isinstance(entry, dict) and entry.get("id"):
             models.append(str(entry["id"]))
-    return LocalModelsResponse(models=models)
+    return models, None
+
+
+@router.get("/ai/local-models", response_model=LocalModelsResponse)
+async def list_local_models(
+    provider: str,
+    base_url: str = "",
+    _: None = Depends(require_localhost_or_lan),
+) -> LocalModelsResponse:
+    """List the models a local AI server currently offers.
+
+    Both Ollama and LM Studio expose the OpenAI-compatible ``GET /v1/models``,
+    so one implementation serves both, shared with ``validate_ai``'s pre-flight
+    check via ``_fetch_local_model_ids``. Gated to the host (or an opted-in LAN)
+    for the same reason as validate_ai: it triggers an outbound request the
+    caller can provoke without owning the destination.
+
+    Doubles as a reachability check, which is why the wizard does not need a
+    separate Test button for the local case.
+    """
+    from app.core.ai_client import LOCAL_PROVIDERS
+
+    if provider not in LOCAL_PROVIDERS:
+        return LocalModelsResponse(
+            error=f"'{sanitize_log_value(provider)}' is not a local AI provider"
+        )
+
+    models, error = await _fetch_local_model_ids(provider, base_url)
+    return LocalModelsResponse(models=models, error=error)

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -31,6 +31,50 @@ DEFAULT_MODELS = {
     "gemini": "gemini-2.5-flash-lite",
 }
 
+# Ollama and LM Studio both expose the OpenAI-compatible /v1/chat/completions
+# contract, so they reuse _call_openai_compatible with only the base URL
+# differing. They are grouped here because several invariants elsewhere
+# (credential presence, timeout, error wording) key off "is this local?" and
+# must not each hardcode the slug list.
+LOCAL_PROVIDERS = frozenset({"ollama", "lmstudio"})
+
+LOCAL_DEFAULT_BASE_URLS = {
+    "ollama": "http://localhost:11434/v1",
+    "lmstudio": "http://localhost:1234/v1",
+}
+
+# DEFAULT_MODELS deliberately has no entry for the local slugs: there is no
+# correct default, because the answer depends on which weights the user pulled.
+# That means DEFAULT_MODELS can no longer double as the set of providers that
+# exist, which is what this is for.
+KNOWN_PROVIDERS = frozenset(DEFAULT_MODELS) | LOCAL_PROVIDERS
+
+
+def resolve_local_base_url(provider: str, configured: str) -> str:
+    """Base URL for a local provider: the configured value, else the default.
+
+    Returns "" for a remote provider so a caller can use a truthy check as
+    "is there a local endpoint here?" without a second membership test.
+    A trailing slash is stripped so callers can append "/chat/completions"
+    unconditionally without producing a double slash.
+    """
+    if provider not in LOCAL_PROVIDERS:
+        return ""
+    url = (configured or "").strip() or LOCAL_DEFAULT_BASE_URLS[provider]
+    return url.rstrip("/")
+
+
+def ai_is_configured(provider: str, api_key: str) -> bool:
+    """True if this provider has what it needs to make a call.
+
+    Local providers authenticate to nothing, so requiring a key would silently
+    disable them at every call site that guards on one. Four such gates exist
+    (this module, curator, matching_coordinator, identification_coordinator);
+    they all call this rather than testing the key directly.
+    """
+    return provider in LOCAL_PROVIDERS or bool(api_key)
+
+
 _TIMEOUT_SECONDS = 30.0
 
 MAX_RETRIES = 3
@@ -77,6 +121,8 @@ _PROVIDER_LABELS = {
     "openai": "OpenAI",
     "openrouter": "OpenRouter",
     "gemini": "Gemini",
+    "ollama": "Ollama",
+    "lmstudio": "LM Studio",
 }
 
 # Human sentences per cause. Rendered verbatim in the UI, so they must be

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -112,10 +112,11 @@ def _is_safe_model_name(model: str) -> bool:
     return bool(_MODEL_NAME_RE.match(model))
 
 
-# Display names for the four provider slugs. The slugs themselves are lowercase
+# Display names for all six provider slugs. The slugs themselves are lowercase
 # identifiers, and these sentences are read by users, so "OpenAI accepted the
 # key" beats "openai accepted the key". Mirrors AI_PROVIDER_LABELS in the
-# frontend's ConfigWizard, which labels the same four providers.
+# frontend's ConfigWizard, though that map still only covers the four remote
+# providers until a later task adds the two local ones there.
 _PROVIDER_LABELS = {
     "anthropic": "Anthropic",
     "openai": "OpenAI",

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -1,9 +1,10 @@
 """Shared AI client for structured-JSON completions across providers.
 
-Wraps anthropic, openai, openrouter, and gemini behind a single
-`complete_json` entry point. Each provider adapter handles its own
-authentication and structured-JSON convention (prompt-only for anthropic,
-response_format for openai/openrouter, responseSchema for gemini).
+Wraps anthropic, openai, openrouter, gemini, and the local servers (ollama,
+lmstudio) behind a single `complete_json` entry point. Each provider adapter
+handles its own authentication and structured-JSON convention (prompt-only for
+anthropic, response_format for openai/openrouter and the local servers, which
+speak the same OpenAI-compatible contract, responseSchema for gemini).
 """
 
 import asyncio
@@ -15,7 +16,7 @@ import re
 import httpx
 
 from app.core.errors import AIProviderError, ProviderErrorCode
-from app.core.security import sanitize_log_value
+from app.core.security import is_safe_local_ai_url, sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,15 @@ def ai_is_configured(provider: str, api_key: str) -> bool:
 
 
 _TIMEOUT_SECONDS = 30.0
+
+# Local inference is not comparable to a hosted API. LM Studio JIT-loads model
+# weights on the FIRST request, so a cold 7B model can spend 30-60s before
+# emitting a token, and CPU-only generation runs into the minutes. The remote
+# 30s value would make local support look broken on first use.
+LOCAL_TIMEOUT_SECONDS = 300.0
+# The Test Connection button: still generous enough to survive a cold load, but
+# bounded so a user is not left staring at a spinner for five minutes.
+LOCAL_VALIDATE_TIMEOUT_SECONDS = 120.0
 
 MAX_RETRIES = 3
 _BACKOFF_BASE = 1.0  # seconds
@@ -367,7 +377,8 @@ async def complete_json(
     max_tokens: int = 1024,
     raise_on_error: bool = False,
     retries: int = MAX_RETRIES,
-    timeout: float = _TIMEOUT_SECONDS,
+    base_url: str = "",
+    timeout: float | None = None,
 ) -> dict | None:
     """Send a prompt to an LLM provider and return its JSON response as a dict.
 
@@ -383,27 +394,62 @@ async def complete_json(
     propagates as-is — so callers can distinguish a provider outage or a
     truncated/garbled reply from "the model ran and was not confident" (which
     stays a plain ``None`` from the layer above ``complete_json``, e.g.
-    ``match_episode_via_llm`` returning None for a low-confidence match). The
-    early-return paths (empty ``api_key``, unknown provider) still return None
-    regardless of ``raise_on_error`` — see the trace in the code, they exit
-    before the try/except that implements the policy above.
+    ``match_episode_via_llm`` returning None for a low-confidence match). Two of
+    the pre-flight guards (a missing credential, an unknown provider slug) return
+    None regardless of ``raise_on_error``, because neither says anything a caller
+    could act on; the three that describe a fixable config mistake (an unsafe
+    base URL, a blank model for a local provider, an unsafe model name) honour
+    ``raise_on_error`` and raise with code ``bad_request``. All five exit before
+    the try/except that implements the transport policy above.
 
     ``retries`` and ``timeout`` let a caller (e.g. a "test connection"
     pre-flight check) fail fast instead of paying the full backoff ladder.
+
+    ``base_url`` applies only to the local providers (ollama, lmstudio); blank
+    means the slug's conventional default port. ``timeout`` of None means "pick
+    the right default for this provider", which is much longer for local ones.
     """
-    if not api_key:
-        logger.debug("complete_json called with empty api_key; returning None")
+    if not ai_is_configured(provider, api_key):
+        logger.debug("complete_json called without a usable credential; returning None")
+        return None
+
+    if provider not in KNOWN_PROVIDERS:
+        logger.warning("Unknown AI provider: %s", sanitize_log_value(provider))
+        return None
+
+    is_local = provider in LOCAL_PROVIDERS
+    local_url = resolve_local_base_url(provider, base_url)
+
+    if is_local and not is_safe_local_ai_url(local_url):
+        # Refused before any request is issued, so a malformed value can never
+        # become an outbound fetch.
+        logger.warning("Rejecting unsafe local AI base URL: %s", sanitize_log_value(local_url))
+        if raise_on_error:
+            raise AIProviderError(
+                f"'{local_url}' is not a valid server address. Use a plain http(s) "
+                "URL such as http://localhost:11434/v1.",
+                code="bad_request",
+            )
         return None
 
     model = model or DEFAULT_MODELS.get(provider)
     if not model:
-        logger.warning("Unknown AI provider: %s", sanitize_log_value(provider))
+        # Only reachable for a local provider now, since KNOWN_PROVIDERS was
+        # checked above and every remote slug has a default.
+        logger.warning("No model set for local provider %s", sanitize_log_value(provider))
+        if raise_on_error:
+            raise AIProviderError(
+                _LOCAL_BLANK_MODEL_MESSAGE.format(
+                    provider=_PROVIDER_LABELS.get(provider, provider)
+                ),
+                code="bad_request",
+            )
         return None
 
     if not _is_safe_model_name(model):
-        # Unlike the two early returns above, this one honours raise_on_error: a
-        # bad model name is a config mistake the user can fix, and silently
-        # returning None would send them hunting for a key or network problem.
+        # A bad model name is a config mistake the user can fix, so this honours
+        # raise_on_error rather than sending them hunting for a key or network
+        # problem.
         logger.warning("Rejecting unsafe AI model name: %s", sanitize_log_value(model))
         if raise_on_error:
             raise AIProviderError(
@@ -411,6 +457,9 @@ async def complete_json(
                 code="bad_request",
             )
         return None
+
+    if timeout is None:
+        timeout = LOCAL_TIMEOUT_SECONDS if is_local else _TIMEOUT_SECONDS
 
     if provider == "anthropic":
 
@@ -432,6 +481,21 @@ async def complete_json(
 
         def factory():
             return _call_gemini(prompt, api_key, model, max_tokens, schema, timeout)
+    elif is_local:
+        # Both local servers speak the OpenAI chat-completions contract, so this
+        # is the same adapter the openai/openrouter slugs use. Ollama requires an
+        # Authorization header but ignores its value, and LM Studio ignores the
+        # header entirely, so an empty api_key is correct for both.
+        def factory():
+            return _call_openai_compatible(
+                prompt,
+                api_key or "local",
+                f"{local_url}/chat/completions",
+                model,
+                max_tokens,
+                schema,
+                timeout,
+            )
     else:
         logger.warning("Unsupported AI provider: %s", sanitize_log_value(provider))
         return None
@@ -447,12 +511,14 @@ async def complete_json(
         )
         if raise_on_error:
             raise AIProviderError(
-                _CAUSE_MESSAGES["response_truncated"].format(provider=provider),
+                _CAUSE_MESSAGES["response_truncated"].format(
+                    provider=_PROVIDER_LABELS.get(provider, provider)
+                ),
                 code="response_truncated",
             ) from None
         return None
     except httpx.HTTPError as e:
-        code, message = classify_provider_error(provider, e)
+        code, message = classify_provider_error(provider, e, base_url=local_url, model=model)
         # str(e) embeds the request URL, which is built from `model` (also
         # user-settable config), so it is sanitized alongside provider and body.
         logger.warning(
@@ -492,7 +558,9 @@ async def complete_json(
         # with raise_on_error set need this separated from "the model ran and had
         # no confident answer", which is also a None from the layer above.
         raise AIProviderError(
-            _CAUSE_MESSAGES["malformed_response"].format(provider=provider),
+            _CAUSE_MESSAGES["malformed_response"].format(
+                provider=_PROVIDER_LABELS.get(provider, provider)
+            ),
             code="malformed_response",
         )
     return result

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -154,14 +154,61 @@ _INVALID_MODEL_MESSAGE = (
     "to use Engram's default for {provider}."
 )
 
+# Local servers have no account, no billing and no key, so the remote wording
+# ("the account has no API credits") is actively misleading. These override
+# _CAUSE_MESSAGES for the local slugs only. {provider} is the display label,
+# {url} the resolved base URL, {model} the requested model id, and {hint} a
+# per-product instruction for starting the server.
+_LOCAL_CAUSE_MESSAGES: dict[ProviderErrorCode, str] = {
+    "network": "Could not reach {provider} at {url}. Is the server running? ({hint})",
+    "timeout": (
+        "{provider} at {url} did not respond in time. A model loading for the first "
+        "time can be slow; try again once it is loaded."
+    ),
+    "model_unavailable": "Model '{model}' is not available in {provider}. {pull}",
+    "bad_key": "{provider} rejected the request at {url}.",
+    "no_credits": "{provider} rejected the request at {url}.",
+    "rate_limited": "{provider} at {url} is busy. Wait a moment and try again.",
+    "bad_request": "{provider} at {url} rejected the request.",
+    "unknown": "{provider} at {url} returned an unexpected error.",
+}
 
-def classify_provider_error(provider: str, exc: Exception) -> tuple[ProviderErrorCode, str]:
+_LOCAL_START_HINTS = {
+    "ollama": "run: ollama serve",
+    "lmstudio": "start the server from LM Studio's Developer tab",
+}
+
+_LOCAL_PULL_HINTS = {
+    "ollama": "Pull it first: ollama pull {model}",
+    "lmstudio": "Download it in LM Studio, then load it.",
+}
+
+# Shown when a local provider has no model set. Unlike the remote providers
+# there is no default to fall back to, so this is a hard stop rather than a
+# silent None.
+_LOCAL_BLANK_MODEL_MESSAGE = (
+    "Select a model for {provider}. Local providers have no default, because the "
+    "answer depends on which models you have installed."
+)
+
+
+def classify_provider_error(
+    provider: str,
+    exc: Exception,
+    *,
+    base_url: str = "",
+    model: str = "",
+) -> tuple[ProviderErrorCode, str]:
     """Map a provider failure to a stable ``(code, human_message)`` pair.
 
     The provider's own body is the only thing that separates a permanently
     exhausted quota from transient throttling (both are HTTP 429 on OpenAI), so
     this reads it. The body is never returned to the caller; it is summarised
     into a fixed sentence and left to the logs.
+
+    ``base_url`` and ``model`` are used only for the local providers, whose
+    messages name the endpoint and the model because "connection refused" is
+    useless to a user who has three inference servers on different ports.
     """
     code: ProviderErrorCode
     if isinstance(exc, httpx.TimeoutException):
@@ -172,7 +219,19 @@ def classify_provider_error(provider: str, exc: Exception) -> tuple[ProviderErro
         code = "network"
     else:
         code = "unknown"
-    return code, _CAUSE_MESSAGES[code].format(provider=_PROVIDER_LABELS.get(provider, provider))
+
+    label = _PROVIDER_LABELS.get(provider, provider)
+    if provider in LOCAL_PROVIDERS:
+        template = _LOCAL_CAUSE_MESSAGES.get(code, _LOCAL_CAUSE_MESSAGES["unknown"])
+        pull = _LOCAL_PULL_HINTS.get(provider, "").format(model=model or "the model")
+        return code, template.format(
+            provider=label,
+            url=base_url or LOCAL_DEFAULT_BASE_URLS.get(provider, ""),
+            model=model or "(none set)",
+            hint=_LOCAL_START_HINTS.get(provider, ""),
+            pull=pull,
+        )
+    return code, _CAUSE_MESSAGES[code].format(provider=label)
 
 
 def _classify_status(provider: str, exc: httpx.HTTPStatusError) -> ProviderErrorCode:

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -495,6 +495,7 @@ async def complete_json(
                 max_tokens,
                 schema,
                 timeout,
+                json_schema_mode=(provider == "lmstudio"),
             )
     else:
         logger.warning("Unsupported AI provider: %s", sanitize_log_value(provider))
@@ -705,6 +706,7 @@ async def _call_openai_compatible(
     max_tokens: int,
     schema: dict | None,
     timeout: float,
+    json_schema_mode: bool = False,
 ) -> dict | None:
     body: dict = {
         "model": model,
@@ -713,7 +715,22 @@ async def _call_openai_compatible(
         "temperature": 0,
     }
     if schema is not None:
-        body["response_format"] = {"type": "json_object"}
+        if json_schema_mode:
+            # LM Studio rejects {"type": "json_object"} outright with
+            # "'response_format.type' must be 'json_schema' or 'text'", so it gets
+            # the richer form. This is strictly better where supported: the server
+            # constrains generation to the schema rather than merely to "some JSON".
+            # openai/openrouter already work on json_object and are left alone to
+            # avoid needless risk to existing users; ollama is not installed on this
+            # machine to verify against, and its documented OpenAI-compatibility
+            # explicitly lists json_object as supported, so it stays on the
+            # documented-safe path too.
+            body["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {"name": "response", "strict": True, "schema": schema},
+            }
+        else:
+            body["response_format"] = {"type": "json_object"}
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         resp = await client.post(

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -600,8 +600,46 @@ def _to_gemini_schema(schema):
     return out
 
 
+def _extract_first_json_object(text: str) -> str | None:
+    """Return the first balanced {...} span in ``text``, or None.
+
+    Small local models frequently wrap their answer in prose ("Let me think...
+    the answer is: {...}"), which no amount of prompting reliably suppresses.
+    Brace counting is string-aware so that a '}' inside a value (an episode
+    title, say) does not truncate the span, and escape-aware so a quote escaped
+    inside a string does not flip the in-string state.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
 def _parse_json_text(text: str | None) -> dict | None:
-    """Parse JSON, tolerating ```json fences and surrounding whitespace.
+    """Parse JSON, tolerating ```json fences, surrounding whitespace, and a
+    reasoning preamble or trailing commentary around the JSON object.
 
     Accepts None so a provider that sends an explicit null text field yields a
     clean "no usable result" rather than an AttributeError.
@@ -615,6 +653,17 @@ def _parse_json_text(text: str | None) -> dict | None:
     try:
         data = json.loads(text)
     except json.JSONDecodeError:
+        # Last resort, and only on a path that has already failed: pull the first
+        # balanced object out of surrounding prose. Reached in practice only for
+        # local models, so it cannot regress the hosted providers.
+        candidate = _extract_first_json_object(text)
+        if candidate is not None and candidate != text:
+            try:
+                data = json.loads(candidate)
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse AI response as JSON: %s", text[:200])
+                return None
+            return data if isinstance(data, dict) else None
         logger.warning("Failed to parse AI response as JSON: %s", text[:200])
         return None
     return data if isinstance(data, dict) else None

--- a/backend/app/core/ai_client.py
+++ b/backend/app/core/ai_client.py
@@ -496,6 +496,7 @@ async def complete_json(
                 schema,
                 timeout,
                 json_schema_mode=(provider == "lmstudio"),
+                warn_on_model_substitution=True,
             )
     else:
         logger.warning("Unsupported AI provider: %s", sanitize_log_value(provider))
@@ -707,6 +708,7 @@ async def _call_openai_compatible(
     schema: dict | None,
     timeout: float,
     json_schema_mode: bool = False,
+    warn_on_model_substitution: bool = False,
 ) -> dict | None:
     body: dict = {
         "model": model,
@@ -743,6 +745,7 @@ async def _call_openai_compatible(
         )
         resp.raise_for_status()
         data = resp.json()
+        _warn_on_model_substitution(model, data, warn=warn_on_model_substitution)
         choices = data.get("choices") or []
         if not choices:
             return None
@@ -750,6 +753,36 @@ async def _call_openai_compatible(
             raise _TruncatedResponse
         text = choices[0].get("message", {}).get("content") or ""
         return _parse_json_text(text)
+
+
+def _warn_on_model_substitution(requested: str, data: dict, *, warn: bool) -> None:
+    """Log when the server answered with a model other than the one asked for.
+
+    LM Studio serves whichever model is currently loaded when asked for one it
+    does not have, returning HTTP 200 with no error. ``validate_ai`` catches a
+    typo up front by checking the server's model list, but that runs only when
+    the user presses Test Connection: swapping the loaded model afterwards would
+    otherwise let real matches run on a different model silently, and nothing in
+    the result would show it.
+
+    The response body names the model that actually answered, so this costs no
+    extra request. It is a log line rather than a failure because the reply is
+    still usable and refusing it would strand a job over a warning.
+
+    Only for local providers. Hosted APIs legitimately answer with a pinned
+    version of the requested id ("gpt-4o-mini" -> "gpt-4o-mini-2024-07-18"),
+    which is why the prefix check below is not enough on its own.
+    """
+    if not warn:
+        return
+    answered = str((data or {}).get("model") or "")
+    if answered and not answered.startswith(requested):
+        logger.warning(
+            "Local AI server answered with model %s, not the requested %s. "
+            "The configured model may no longer be loaded.",
+            sanitize_log_value(answered),
+            sanitize_log_value(requested),
+        )
 
 
 async def _call_gemini(

--- a/backend/app/core/ai_identifier.py
+++ b/backend/app/core/ai_identifier.py
@@ -32,11 +32,15 @@ async def identify_from_label(
     provider: str,
     api_key: str,
     model: str | None = None,
+    base_url: str = "",
 ) -> dict | None:
     """Send volume label to an LLM to identify the disc content.
 
     ``model`` is the user's optional override (AppConfig.ai_model); None means
     the provider default.
+
+    ``base_url`` is the user's local-server endpoint (AppConfig.ai_local_base_url).
+    It applies only to the local providers; blank means the slug's default port.
 
     Returns dict with keys: title, year, type (or None on failure).
     """
@@ -48,6 +52,7 @@ async def identify_from_label(
         api_key=api_key,
         model=model,
         max_tokens=200,
+        base_url=base_url,
     )
     return _validate(raw, volume_label)
 

--- a/backend/app/core/curator.py
+++ b/backend/app/core/curator.py
@@ -605,7 +605,9 @@ class EpisodeCurator:
         config = await get_config()
         if not config or not getattr(config, "ai_episode_matching_enabled", False):
             return None
-        if not config.ai_api_key:
+        from app.core.ai_client import ai_is_configured
+
+        if not ai_is_configured(config.ai_provider, config.ai_api_key):
             return None
 
         # Resolve TMDB show id — prefer the known id; otherwise resolve by name.
@@ -638,6 +640,7 @@ class EpisodeCurator:
                 ai_provider=config.ai_provider,
                 ai_api_key=config.ai_api_key,
                 ai_model=getattr(config, "ai_model", "") or None,
+                ai_local_base_url=getattr(config, "ai_local_base_url", "") or "",
                 tmdb_api_key=config.tmdb_api_key,
             )
         except Exception as e:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -14,7 +14,7 @@ These back the hardening of CodeQL-flagged sinks:
 - ``sanitize_playlist_field`` — strips line breaks/control characters from
   disc-derived text before it is embedded in an ``.m3u`` playlist.
 
-The first three are boolean *predicates* — they return ``True``/``False`` so
+The first four are boolean *predicates* — they return ``True``/``False`` so
 the validation is recognised as a barrier guard by static analysis at the call
 site (``if not guard(x): ...``). ``sanitize_log_value`` and
 ``sanitize_playlist_field`` instead return the cleaned value, the recognised

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -233,6 +233,40 @@ _LOCAL_AI_DENIED_HOSTS: frozenset[str] = frozenset(
 )
 
 
+def _ip_and_embedded_ipv4(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """``addr`` plus any IPv4 address reachable through an IPv6 wrapper.
+
+    An IPv6 literal can name an IPv4 destination in several ways, and the
+    ``is_*`` properties do not all see through the wrapper. Modern CPython does
+    delegate for the IPv4-*mapped* form, so ``::ffff:169.254.169.254`` already
+    reports ``is_link_local``; the deprecated IPv4-*compatible* form
+    ``::169.254.169.254`` does not, and 6to4 and Teredo wrappers do not either.
+    Checking the unwrapped address as well as the literal closes that gap
+    without relying on which forms a given Python version happens to handle.
+
+    No legitimate inference server is addressed this way, so unwrapping costs
+    nothing real.
+    """
+    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [addr]
+    if isinstance(addr, ipaddress.IPv6Address):
+        for attr in ("ipv4_mapped", "sixtofour"):
+            embedded = getattr(addr, attr, None)
+            if embedded is not None:
+                out.append(embedded)
+        teredo = getattr(addr, "teredo", None)
+        if teredo:
+            out.extend(teredo)
+        # "::a.b.c.d" — the whole top 96 bits are zero. Excludes :: and ::1,
+        # whose embedded values (0.0.0.0 / 0.0.0.1) are meaningless, and which
+        # must keep working: ::1 is a normal way to reach a local server.
+        packed = int(addr)
+        if packed >> 32 == 0 and packed > 1:
+            out.append(ipaddress.IPv4Address(packed & 0xFFFFFFFF))
+    return out
+
+
 def is_safe_local_ai_url(url: str) -> bool:
     """Return True if ``url`` is usable as a local AI server's base URL.
 
@@ -300,10 +334,13 @@ def is_safe_local_ai_url(url: str) -> bool:
         return False
 
     try:
-        if ipaddress.ip_address(host).is_link_local:
-            return False
+        addr = ipaddress.ip_address(host)
     except ValueError:
         pass  # Not an IP literal; a hostname is fine.
+    else:
+        for candidate in _ip_and_embedded_ipv4(addr):
+            if candidate.is_link_local or str(candidate) in _LOCAL_AI_DENIED_HOSTS:
+                return False
 
     if ".." in parsed.path.split("/"):
         return False

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -224,6 +224,15 @@ def is_safe_dashboard_url(url: str) -> bool:
     return True
 
 
+# Rejected regardless of the deliberately permissive host policy below. No
+# inference server runs on a cloud metadata endpoint, and the model-list caller
+# reflects part of the response back to the requester, so leaving these
+# reachable would turn a config field into a metadata read.
+_LOCAL_AI_DENIED_HOSTS: frozenset[str] = frozenset(
+    {"169.254.169.254", "metadata.google.internal", "metadata.goog"}
+)
+
+
 def is_safe_local_ai_url(url: str) -> bool:
     """Return True if ``url`` is usable as a local AI server's base URL.
 
@@ -232,22 +241,47 @@ def is_safe_local_ai_url(url: str) -> bool:
     an Ollama or LM Studio server listens on, so this is an intentional
     exemption rather than an oversight.
 
-    Unlike is_safe_dashboard_url (whose value is only rendered as a link), the
-    server DOES issue POST requests to this URL, so this is a blind-SSRF
-    primitive against the host's own loopback interface. It is accepted because
-    the config surface is already fully trusted (it holds API keys, filesystem
-    paths and library roots), because the endpoints that write it are gated by
-    require_localhost_or_lan, and because the response body is parsed as JSON
-    and discarded unless it matches the requested schema, making the primitive
-    blind rather than an exfiltration channel. See
+    Scope of that exemption, stated plainly because the function name understates
+    it: apart from the link-local and metadata hosts denied below, this imposes
+    NO restriction on the host. A public address passes. That is intended, since
+    a user may legitimately run their inference server on another machine, but it
+    means this guard is not what stops a hostile endpoint being configured.
+
+    The server issues real requests to this URL, so it is a request-forgery
+    primitive. It is accepted because the config surface is already fully trusted
+    (it holds API keys, filesystem paths and library roots) and because the
+    endpoints that write it are gated by require_localhost_or_lan. Note that the
+    primitive is blind only on the completion path: the model-list endpoint
+    returns the ids it parses out of the response, so a JSON body shaped like
+    OpenAI's /v1/models is partially reflected to the caller. That is why the
+    metadata hosts are denied outright. See
     docs/superpowers/specs/2026-08-29-local-ai-provider-design.md.
 
-    What is still rejected: non-http(s) schemes (file:, javascript:, ftp:), a
-    missing host, embedded credentials, and any query or fragment. The last two
-    matter because callers append "/chat/completions" to this value, so a query
-    string would silently move the path into the query and a credential would be
-    logged with the request URL.
+    Whitespace and control characters are rejected against the RAW string, before
+    parsing. CPython strips tab, CR and LF out of a URL before urlparse sees it,
+    so without this check "http://localhost\n.evil.com" would be validated as
+    the host "localhost.evil.com" while the caller sent the original bytes, and
+    httpx would raise InvalidURL, which is not an httpx.HTTPError subclass and so
+    escapes the transport handler in ai_client. Keeping the judged string and the
+    sent string identical is what makes this a real barrier. It also keeps CR/LF
+    out of a value that reaches the logs.
+
+    Also rejected: non-http(s) schemes (file:, javascript:, ftp:), a missing
+    host, embedded credentials, query, fragment, path parameters, a port outside
+    the valid range, and any ".." path segment. The traversal check matters
+    because callers append "/chat/completions" or "/models" to this value, so a
+    traversal segment would move the request outside the prefix the user
+    approved.
     """
+    if not isinstance(url, str):
+        return False
+
+    # Against the raw string, before urlparse can normalise it away.
+    if url != url.strip() or any(ch in url for ch in "\t\r\n"):
+        return False
+    if _LOG_CONTROL_CHARS_RE.search(url):
+        return False
+
     try:
         parsed = urlparse(url)
         host = (parsed.hostname or "").lower()
@@ -260,8 +294,26 @@ def is_safe_local_ai_url(url: str) -> bool:
         return False
     if parsed.username or parsed.password:
         return False
-    if parsed.query or parsed.fragment:
+    if parsed.query or parsed.fragment or parsed.params:
         return False
+    if host in _LOCAL_AI_DENIED_HOSTS:
+        return False
+
+    try:
+        if ipaddress.ip_address(host).is_link_local:
+            return False
+    except ValueError:
+        pass  # Not an IP literal; a hostname is fine.
+
+    if ".." in parsed.path.split("/"):
+        return False
+
+    # An out-of-range port parses here but raises inside httpx.
+    try:
+        _ = parsed.port
+    except ValueError:
+        return False
+
     return True
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -7,6 +7,8 @@ These back the hardening of CodeQL-flagged sinks:
   calls to executables that actually look like the expected tool.
 - ``is_within_configured_roots`` — constrains media-endpoint file paths to the
   configured staging and library roots.
+- ``is_safe_local_ai_url`` — a deliberately permissive guard for the
+  user-configured local AI server base URL, which must accept loopback.
 - ``sanitize_log_value`` — strips line breaks/control characters from
   disc/user-controlled values before they are written to logs.
 - ``sanitize_playlist_field`` — strips line breaks/control characters from
@@ -218,6 +220,47 @@ def is_safe_dashboard_url(url: str) -> bool:
         return False
     # Credentials in a URL that gets posted to a chat channel leak them.
     if parsed.username or parsed.password:
+        return False
+    return True
+
+
+def is_safe_local_ai_url(url: str) -> bool:
+    """Return True if ``url`` is usable as a local AI server's base URL.
+
+    Deliberately NOT is_safe_remote_url. That guard rejects loopback, private
+    and link-local hosts to prevent SSRF, and those are precisely the addresses
+    an Ollama or LM Studio server listens on, so this is an intentional
+    exemption rather than an oversight.
+
+    Unlike is_safe_dashboard_url (whose value is only rendered as a link), the
+    server DOES issue POST requests to this URL, so this is a blind-SSRF
+    primitive against the host's own loopback interface. It is accepted because
+    the config surface is already fully trusted (it holds API keys, filesystem
+    paths and library roots), because the endpoints that write it are gated by
+    require_localhost_or_lan, and because the response body is parsed as JSON
+    and discarded unless it matches the requested schema, making the primitive
+    blind rather than an exfiltration channel. See
+    docs/superpowers/specs/2026-08-29-local-ai-provider-design.md.
+
+    What is still rejected: non-http(s) schemes (file:, javascript:, ftp:), a
+    missing host, embedded credentials, and any query or fragment. The last two
+    matter because callers append "/chat/completions" to this value, so a query
+    string would silently move the path into the query and a credential would be
+    logged with the request URL.
+    """
+    try:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+    except ValueError:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if not host:
+        return False
+    if parsed.username or parsed.password:
+        return False
+    if parsed.query or parsed.fragment:
         return False
     return True
 

--- a/backend/app/matcher/llm_episode_matcher.py
+++ b/backend/app/matcher/llm_episode_matcher.py
@@ -87,6 +87,7 @@ async def match_episode_via_llm(
     ai_api_key: str,
     tmdb_api_key: str,
     ai_model: str | None = None,
+    ai_local_base_url: str = "",
     raise_on_error: bool = False,
 ) -> LLMEpisodeMatch | None:
     """Run LLM episode matching. Returns None on no-confident-match or empty response.
@@ -94,6 +95,10 @@ async def match_episode_via_llm(
     ``ai_model`` is the user's optional override (AppConfig.ai_model); None means
     the provider default. It is recorded on the returned match so per-track
     provenance names the model that actually answered.
+
+    ``ai_local_base_url`` is the user's local-server endpoint
+    (AppConfig.ai_local_base_url). It applies only to the local providers; blank
+    means the slug's default port.
 
     When ``raise_on_error`` is True, a provider/transport failure raises
     ``AIProviderError`` (instead of being swallowed to None by ``complete_json``)
@@ -138,6 +143,7 @@ async def match_episode_via_llm(
         api_key=ai_api_key,
         model=ai_model or None,
         max_tokens=512,
+        base_url=ai_local_base_url,
         raise_on_error=raise_on_error,
     )
     if not raw:

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -171,13 +171,20 @@ class AppConfig(SQLModel, table=True):
 
     # AI-powered disc identification
     ai_identification_enabled: bool = False  # Enable AI-powered title resolution
-    ai_provider: str = "anthropic"  # "anthropic" | "openai" | "openrouter" | "gemini"
+    # "anthropic" | "openai" | "openrouter" | "gemini" | "ollama" | "lmstudio"
+    ai_provider: str = "anthropic"
     ai_api_key: str = ""  # API key for the selected provider
     # Optional model override; "" means "use ai_client.DEFAULT_MODELS[provider]".
     # Exists because a key is not guaranteed access to the default model — a
     # Gemini key whose project cannot see gemini-2.5-flash-lite gets a 404, and
     # without this field there is no way to point Engram at a model it can use.
     ai_model: str = ""
+    # Base URL for a local AI server (ollama / lmstudio only). "" means "use the
+    # slug's conventional default port", which is what makes the common case
+    # zero-config. Not a secret: it must stay out of the sensitive_fields set in
+    # config_service, because clearing it back to the default is a legitimate
+    # action and that set exists to prevent blanking.
+    ai_local_base_url: str = ""
     ai_episode_matching_enabled: bool = (
         False  # Enable LLM-based episode identification fallback (uses ai_provider/ai_api_key)
     )

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1806,6 +1806,8 @@ class IdentificationCoordinator:
                 )
                 tmdb_signal = tv_retry
 
+        from app.core.ai_client import ai_is_configured
+
         # AI-powered identification fallback (not for staging). Skipped when the
         # disc network already resolved a confident identity — that result takes
         # precedence and must not be clobbered by a lower-trust AI guess.
@@ -1816,7 +1818,7 @@ class IdentificationCoordinator:
             and not tmdb_signal
             and not (discdb_signal and discdb_signal.confidence >= 0.90)
             and config.ai_identification_enabled
-            and config.ai_api_key
+            and ai_is_configured(config.ai_provider, config.ai_api_key)
         ):
             try:
                 from app.core.ai_identifier import identify_from_label
@@ -1830,6 +1832,7 @@ class IdentificationCoordinator:
                     config.ai_provider,
                     config.ai_api_key,
                     getattr(config, "ai_model", "") or None,
+                    base_url=getattr(config, "ai_local_base_url", "") or "",
                 )
                 if ai_result and ai_result.get("title"):
                     ai_identified_name = ai_result["title"]

--- a/backend/app/services/matching_coordinator.py
+++ b/backend/app/services/matching_coordinator.py
@@ -700,7 +700,8 @@ class MatchingCoordinator:
     ) -> dict | None:
         """AI episode-matching fallback for the no-subtitles case.
 
-        When ``ai_episode_matching_enabled`` is on (with a key) and the season is
+        When ``ai_episode_matching_enabled`` is on (and the provider is usable —
+        a key for the hosted ones, nothing for a local server) and the season is
         known, transcribe the ripped file and match the transcript against the
         TMDB synopsis — no reference subtitles required. Returns enriched
         ``match_details`` carrying an ``llm_suggestion`` for the Review UI, or
@@ -724,7 +725,9 @@ class MatchingCoordinator:
             config = await get_config()
             if not config or not config.ai_episode_matching_enabled:
                 return None
-            if not config.ai_api_key:
+            from app.core.ai_client import ai_is_configured
+
+            if not ai_is_configured(config.ai_provider, config.ai_api_key):
                 return None
 
             logger.info(

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1143,3 +1143,246 @@ class TestLocalErrorMessages:
 
         _, message = classify_provider_error("ollama", _status_error_with_body(402, ""))
         assert "credits" not in message.lower()
+
+
+def _openai_shaped(text: str):
+    """A minimal OpenAI-compatible chat-completions body."""
+    return {"choices": [{"message": {"content": text}, "finish_reason": "stop"}]}
+
+
+class TestLocalDispatch:
+    @pytest.mark.asyncio
+    async def test_ollama_posts_to_the_default_endpoint_without_a_key(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            result = await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="llama3.1:8b",
+            )
+
+        assert result == {"ok": True}
+        call = mock.post.await_args
+        assert call.args[0] == "http://localhost:11434/v1/chat/completions"
+        assert call.kwargs["json"]["model"] == "llama3.1:8b"
+
+    @pytest.mark.asyncio
+    async def test_lmstudio_uses_its_own_default_port(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="lmstudio",
+                api_key="",
+                model="qwen2.5-7b-instruct",
+            )
+
+        assert mock.post.await_args.args[0] == "http://localhost:1234/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_configured_base_url_overrides_the_default(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="llama3.1:8b",
+                base_url="http://gpubox:11434/v1",
+            )
+
+        assert mock.post.await_args.args[0] == "http://gpubox:11434/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_local_default_timeout_is_generous(self):
+        """A cold LM Studio JIT-loads weights; 30s would look like a broken feature."""
+        from app.core.ai_client import LOCAL_TIMEOUT_SECONDS, complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(prompt="hi", schema=None, provider="ollama", api_key="", model="m")
+
+        assert ctor.call_args.kwargs["timeout"] == LOCAL_TIMEOUT_SECONDS
+        assert LOCAL_TIMEOUT_SECONDS >= 300.0
+
+    @pytest.mark.asyncio
+    async def test_remote_default_timeout_is_unchanged(self):
+        from app.core.ai_client import _TIMEOUT_SECONDS, complete_json
+
+        mock = _mock_httpx({"content": [{"text": '{"ok": true}'}]})
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(prompt="hi", schema=None, provider="anthropic", api_key="sk-ant-x")
+
+        assert ctor.call_args.kwargs["timeout"] == _TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_explicit_timeout_still_wins_for_a_local_provider(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="m",
+                timeout=5.0,
+            )
+
+        assert ctor.call_args.kwargs["timeout"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_blank_model_raises_a_pointed_error(self):
+        from app.core.ai_client import complete_json
+        from app.core.errors import AIProviderError
+
+        with pytest.raises(AIProviderError) as exc:
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model=None,
+                raise_on_error=True,
+            )
+
+        assert "Select a model" in str(exc.value)
+        assert exc.value.code == "bad_request"
+
+    @pytest.mark.asyncio
+    async def test_blank_model_returns_none_when_not_raising(self):
+        from app.core.ai_client import complete_json
+
+        result = await complete_json(
+            prompt="hi", schema=None, provider="ollama", api_key="", model=None
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_unsafe_base_url_is_refused_before_any_request(self):
+        from app.core.ai_client import complete_json
+
+        with patch("app.core.ai_client.httpx.AsyncClient") as ctor:
+            result = await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="m",
+                base_url="file:///etc/passwd",
+            )
+
+        assert result is None
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model_id",
+        ["llama3.1:8b", "qwen2.5:7b-instruct-q4_K_M", "lmstudio-community/Model-GGUF"],
+    )
+    async def test_real_local_model_ids_are_accepted(self, model_id):
+        """A rejection here surfaces as a misleading 'clear the AI model field'."""
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            result = await complete_json(
+                prompt="hi", schema=None, provider="ollama", api_key="", model=model_id
+            )
+
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_remote_provider_with_empty_key_still_returns_none(self):
+        """ai_is_configured must not loosen the credential gate for remote slugs."""
+        from app.core.ai_client import complete_json
+
+        with patch("app.core.ai_client.httpx.AsyncClient") as ctor:
+            result = await complete_json(prompt="hi", schema=None, provider="openai", api_key="")
+
+        assert result is None
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_openai_still_routes_to_its_own_endpoint(self):
+        """The is_local branch must not swallow the named remote slugs."""
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(prompt="hi", schema=None, provider="openai", api_key="sk-x")
+
+        assert mock.post.await_args.args[0] == "https://api.openai.com/v1/chat/completions"
+
+
+class TestProviderLabelInFallbackMessages:
+    """The truncated/malformed paths must name the provider, not its slug."""
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_uses_the_display_label_for_ollama(self):
+        from app.core.ai_client import complete_json
+        from app.core.errors import AIProviderError
+
+        truncated = {"choices": [{"message": {"content": ""}, "finish_reason": "length"}]}
+        mock = _mock_httpx(truncated)
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(AIProviderError) as exc:
+                await complete_json(
+                    prompt="hi",
+                    schema=None,
+                    provider="ollama",
+                    api_key="",
+                    model="m",
+                    raise_on_error=True,
+                )
+
+        assert "Ollama" in str(exc.value)
+        assert "ollama " not in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_truncated_response_uses_the_display_label_for_openai(self):
+        from app.core.ai_client import complete_json
+        from app.core.errors import AIProviderError
+
+        truncated = {"choices": [{"message": {"content": ""}, "finish_reason": "length"}]}
+        mock = _mock_httpx(truncated)
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(AIProviderError) as exc:
+                await complete_json(
+                    prompt="hi",
+                    schema=None,
+                    provider="openai",
+                    api_key="sk-x",
+                    raise_on_error=True,
+                )
+
+        assert "OpenAI cut the response off" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_uses_the_display_label(self):
+        from app.core.ai_client import complete_json
+        from app.core.errors import AIProviderError
+
+        mock = _mock_httpx(_openai_shaped("not json at all"))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with pytest.raises(AIProviderError) as exc:
+                await complete_json(
+                    prompt="hi",
+                    schema=None,
+                    provider="openai",
+                    api_key="sk-x",
+                    raise_on_error=True,
+                )
+
+        assert "OpenAI returned a reply that was not valid JSON" in str(exc.value)

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1037,3 +1037,52 @@ class TestModelOverride:
         assert exc.value.code == "bad_request"
         assert "model name" in str(exc.value).lower()
         mock.post.assert_not_awaited()
+
+
+class TestLocalProviderVocabulary:
+    def test_local_providers_are_ollama_and_lmstudio(self):
+        from app.core.ai_client import LOCAL_PROVIDERS
+
+        assert LOCAL_PROVIDERS == {"ollama", "lmstudio"}
+
+    def test_default_base_urls_match_upstream_conventions(self):
+        from app.core.ai_client import LOCAL_DEFAULT_BASE_URLS
+
+        assert LOCAL_DEFAULT_BASE_URLS["ollama"] == "http://localhost:11434/v1"
+        assert LOCAL_DEFAULT_BASE_URLS["lmstudio"] == "http://localhost:1234/v1"
+
+    def test_blank_configured_url_falls_back_to_default(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("ollama", "") == "http://localhost:11434/v1"
+        assert resolve_local_base_url("lmstudio", "   ") == "http://localhost:1234/v1"
+
+    def test_configured_url_wins_and_trailing_slash_is_stripped(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("ollama", "http://box:8080/v1/") == "http://box:8080/v1"
+
+    def test_resolve_returns_blank_for_a_remote_provider(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("openai", "") == ""
+
+    def test_known_providers_covers_remote_and_local(self):
+        from app.core.ai_client import KNOWN_PROVIDERS
+
+        assert {"anthropic", "openai", "openrouter", "gemini"} <= KNOWN_PROVIDERS
+        assert {"ollama", "lmstudio"} <= KNOWN_PROVIDERS
+
+
+class TestAiIsConfigured:
+    def test_remote_provider_requires_a_key(self):
+        from app.core.ai_client import ai_is_configured
+
+        assert ai_is_configured("openai", "sk-x") is True
+        assert ai_is_configured("openai", "") is False
+
+    def test_local_provider_needs_no_key(self):
+        from app.core.ai_client import ai_is_configured
+
+        assert ai_is_configured("ollama", "") is True
+        assert ai_is_configured("lmstudio", "") is True

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1326,6 +1326,103 @@ class TestLocalDispatch:
         assert mock.post.await_args.args[0] == "https://api.openai.com/v1/chat/completions"
 
 
+class TestLocalStructuredOutputDialect:
+    """LM Studio rejects response_format={"type": "json_object"} outright, so it
+
+    needs the richer json_schema form; ollama and the remote OpenAI-compatible
+    slugs stay on json_object (verified live against LM Studio; see #606).
+    """
+
+    @pytest.mark.asyncio
+    async def test_lmstudio_with_schema_uses_json_schema_dialect(self):
+        from app.core.ai_client import complete_json
+
+        schema = {"type": "object", "properties": {"episode": {"type": "integer"}}}
+        mock = _mock_httpx(_openai_shaped('{"episode": 3}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=schema,
+                provider="lmstudio",
+                api_key="",
+                model="qwen2.5-7b-instruct",
+            )
+
+        response_format = mock.post.await_args.kwargs["json"]["response_format"]
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["schema"] == schema
+
+    @pytest.mark.asyncio
+    async def test_ollama_with_schema_still_uses_json_object(self):
+        from app.core.ai_client import complete_json
+
+        schema = {"type": "object", "properties": {"episode": {"type": "integer"}}}
+        mock = _mock_httpx(_openai_shaped('{"episode": 3}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=schema,
+                provider="ollama",
+                api_key="",
+                model="llama3.1:8b",
+            )
+
+        assert mock.post.await_args.kwargs["json"]["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_openai_with_schema_still_uses_json_object(self):
+        """Regression guard: existing openai/openrouter users must not change dialect."""
+        from app.core.ai_client import complete_json
+
+        schema = {"type": "object", "properties": {"episode": {"type": "integer"}}}
+        mock = _mock_httpx(_openai_shaped('{"episode": 3}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(prompt="hi", schema=schema, provider="openai", api_key="sk-x")
+
+        assert mock.post.await_args.kwargs["json"]["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_lmstudio_without_schema_sends_no_response_format(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="lmstudio",
+                api_key="",
+                model="qwen2.5-7b-instruct",
+            )
+
+        assert "response_format" not in mock.post.await_args.kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_lmstudio_forwards_the_real_episode_matcher_schema_intact(self):
+        """Pins the union-type case (runner_up: ["object", "null"]) that live
+
+        testing against LM Studio exercised with strict=True.
+        """
+        from app.core.ai_client import complete_json
+        from app.matcher.llm_episode_matcher import RESPONSE_SCHEMA
+
+        mock = _mock_httpx(_openai_shaped('{"episode": 3, "confidence": 0.9}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=RESPONSE_SCHEMA,
+                provider="lmstudio",
+                api_key="",
+                model="qwen2.5-7b-instruct",
+            )
+
+        response_format = mock.post.await_args.kwargs["json"]["response_format"]
+        assert response_format == {
+            "type": "json_schema",
+            "json_schema": {"name": "response", "strict": True, "schema": RESPONSE_SCHEMA},
+        }
+
+
 class TestProviderLabelInFallbackMessages:
     """The truncated/malformed paths must name the provider, not its slug."""
 

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1533,3 +1533,81 @@ class TestPreambleTolerantParsing:
         from app.core.ai_client import _parse_json_text
 
         assert _parse_json_text("[1, 2, 3]") is None
+
+
+class TestModelSubstitutionWarning:
+    """LM Studio serves whichever model is loaded when asked for an unknown one.
+
+    validate_ai's pre-flight only runs when the user presses Test Connection, so
+    swapping the loaded model afterwards would let real matches run on a
+    different model with nothing in the result showing it. The response names
+    the model that answered, so this costs no extra request.
+    """
+
+    @pytest.mark.asyncio
+    async def test_warns_when_a_local_server_answers_with_another_model(self, caplog):
+        from app.core.ai_client import complete_json
+
+        body = _openai_shaped('{"ok": true}')
+        body["model"] = "google/gemma-4-e4b"
+        mock = _mock_httpx(body)
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with caplog.at_level("WARNING"):
+                result = await complete_json(
+                    prompt="hi",
+                    schema=None,
+                    provider="lmstudio",
+                    api_key="",
+                    model="ibm/granite-4-h-tiny",
+                )
+
+        # Still usable: a warning, not a failure. Refusing would strand the job.
+        assert result == {"ok": True}
+        assert "google/gemma-4-e4b" in caplog.text
+        assert "ibm/granite-4-h-tiny" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_the_model_matches(self, caplog):
+        from app.core.ai_client import complete_json
+
+        body = _openai_shaped('{"ok": true}')
+        body["model"] = "ibm/granite-4-h-tiny"
+        mock = _mock_httpx(body)
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with caplog.at_level("WARNING"):
+                await complete_json(
+                    prompt="hi",
+                    schema=None,
+                    provider="lmstudio",
+                    api_key="",
+                    model="ibm/granite-4-h-tiny",
+                )
+
+        assert "not the requested" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_hosted_providers_are_not_warned_about_pinned_versions(self, caplog):
+        """OpenAI answers "gpt-4o-mini" with "gpt-4o-mini-2024-07-18"."""
+        from app.core.ai_client import complete_json
+
+        body = _openai_shaped('{"ok": true}')
+        body["model"] = "gpt-4o-mini-2024-07-18"
+        mock = _mock_httpx(body)
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with caplog.at_level("WARNING"):
+                await complete_json(prompt="hi", schema=None, provider="openai", api_key="sk-x")
+
+        assert "not the requested" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_response_without_a_model_field_does_not_warn(self, caplog):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            with caplog.at_level("WARNING"):
+                await complete_json(
+                    prompt="hi", schema=None, provider="ollama", api_key="", model="m"
+                )
+
+        assert "not the requested" not in caplog.text

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1086,3 +1086,60 @@ class TestAiIsConfigured:
 
         assert ai_is_configured("ollama", "") is True
         assert ai_is_configured("lmstudio", "") is True
+
+
+class TestLocalErrorMessages:
+    def test_network_failure_names_the_product_and_url(self):
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        code, message = classify_provider_error(
+            "ollama",
+            httpx.ConnectError("refused"),
+            base_url="http://localhost:11434/v1",
+        )
+        assert code == "network"
+        assert "Ollama" in message
+        assert "http://localhost:11434/v1" in message
+        assert "ollama serve" in message
+
+    def test_lmstudio_network_failure_does_not_mention_ollama(self):
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error(
+            "lmstudio",
+            httpx.ConnectError("refused"),
+            base_url="http://localhost:1234/v1",
+        )
+        assert "LM Studio" in message
+        assert "ollama" not in message.lower()
+
+    def test_404_tells_the_user_to_pull_the_model(self):
+        from app.core.ai_client import classify_provider_error
+
+        code, message = classify_provider_error(
+            "ollama",
+            _status_error_with_body(404, "model not found"),
+            model="llama3.1:8b",
+        )
+        assert code == "model_unavailable"
+        assert "ollama pull llama3.1:8b" in message
+
+    def test_remote_providers_keep_their_wording(self):
+        """Regression guard: the local table must not leak into remote text."""
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error("openai", httpx.ConnectError("refused"))
+        assert message == "Could not reach OpenAI. Check the internet connection."
+
+    def test_no_credits_is_never_reported_for_a_local_provider(self):
+        """A local server has no billing, so the remote wording would be nonsense."""
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error("ollama", _status_error_with_body(402, ""))
+        assert "credits" not in message.lower()

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -1386,3 +1386,53 @@ class TestProviderLabelInFallbackMessages:
                 )
 
         assert "OpenAI returned a reply that was not valid JSON" in str(exc.value)
+
+
+class TestPreambleTolerantParsing:
+    def test_extracts_json_after_a_reasoning_preamble(self):
+        from app.core.ai_client import _parse_json_text
+
+        text = 'Let me think about this. The answer is:\n{"episode": 3, "confidence": 0.8}'
+        assert _parse_json_text(text) == {"episode": 3, "confidence": 0.8}
+
+    def test_ignores_trailing_commentary(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('{"ok": true}\nHope that helps!') == {"ok": True}
+
+    def test_handles_nested_braces(self):
+        from app.core.ai_client import _parse_json_text
+
+        text = 'Result: {"a": {"b": 1}, "c": 2} done'
+        assert _parse_json_text(text) == {"a": {"b": 1}, "c": 2}
+
+    def test_ignores_braces_inside_strings(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('x {"title": "a } b"} y') == {"title": "a } b"}
+
+    def test_plain_json_is_unaffected(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('{"ok": true}') == {"ok": True}
+
+    def test_fenced_json_is_still_handled(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('```json\n{"ok": true}\n```') == {"ok": True}
+
+    def test_genuinely_unparseable_text_still_returns_none(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text("I could not determine the episode.") is None
+
+    def test_unbalanced_braces_return_none(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('here you go {"ok": true') is None
+
+    def test_a_bare_json_array_still_returns_none(self):
+        """complete_json's contract is a dict; an array is not a usable result."""
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text("[1, 2, 3]") is None

--- a/backend/tests/unit/test_ai_configured_gates.py
+++ b/backend/tests/unit/test_ai_configured_gates.py
@@ -14,6 +14,7 @@ that was actually POSTed to.
 
 import importlib
 import inspect
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,17 +23,34 @@ _GATED_MODULES = [
     "app.core.curator",
     "app.services.matching_coordinator",
     "app.services.identification_coordinator",
+    "app.api.routes",
 ]
 
 _LOCAL_BASE_URL = "http://box:11434/v1"
+
+# The two spellings a truthiness gate on the key actually takes in this codebase:
+# a standalone `if not config.ai_api_key` and a conjunct `and config.ai_api_key`
+# inside a larger condition. Matching both matters — an earlier version of this
+# test only looked for the `not` form and so passed against
+# identification_coordinator, which used the `and` form, while the bug was live.
+#
+# Deliberately NOT matched, because all three are legitimate:
+#   ai_api_key=config.ai_api_key                    (pass-through to the matcher)
+#   ai_is_configured(config.ai_provider, config.ai_api_key)   (the helper itself)
+#   ai_api_key="***" if config.ai_api_key else ""   (redaction for GET /api/config)
+# The redaction is a truthiness test too, but `if ... else` is not a gate, so the
+# pattern requires the `not`/`and` keywords rather than banning bare truthiness.
+_KEY_GATE_SPELLING = re.compile(r"\b(?:not|and)\s+config\.ai_api_key\b")
 
 
 @pytest.mark.parametrize("module_path", _GATED_MODULES)
 def test_no_module_gates_on_the_api_key_directly(module_path):
     source = inspect.getsource(importlib.import_module(module_path))
-    assert "not config.ai_api_key" not in source, (
-        f"{module_path} still gates on the API key directly. Local providers have "
-        "no key, so this silently disables them. Use ai_is_configured(...)."
+    offenders = _KEY_GATE_SPELLING.findall(source)
+    assert not offenders, (
+        f"{module_path} still gates on the API key directly ({len(offenders)} site(s)). "
+        "Local providers have no key, so this silently disables them. "
+        "Use ai_is_configured(...)."
     )
 
 
@@ -129,4 +147,58 @@ class TestLocalBaseUrlIsThreadedToTheRequest:
             )
 
         assert result is not None and result.episode == 2
+        assert _posted_url(client) == f"{_LOCAL_BASE_URL}/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_manual_rematch_route_posts_to_the_configured_endpoint(self):
+        """The per-track re-match route (POST .../rematch) must honour it too.
+
+        Driven end to end rather than asserted on source: the route's own gate
+        and its base-URL hand-off are two separate mistakes, and only running it
+        catches both at once.
+        """
+        from types import SimpleNamespace
+
+        from app.api.routes import _run_llm_match_for_title
+        from app.models.app_config import AppConfig
+
+        config = AppConfig(
+            ai_episode_matching_enabled=True,
+            ai_provider="ollama",
+            ai_api_key="",
+            ai_model="llama3.1",
+            ai_local_base_url=_LOCAL_BASE_URL,
+            tmdb_api_key="t",
+        )
+        job = SimpleNamespace(id=1, detected_title="The Expanse", detected_season=1)
+        title = SimpleNamespace(id=7)
+        synopses = [{"episode_number": 2, "name": "Cargo", "overview": "A heist."}]
+        client = _mock_transport(
+            _openai_chat_response('{"episode": 2, "confidence": 0.9, "reasoning": "cargo"}')
+        )
+        matcher = MagicMock()
+        matcher.transcribe_full.return_value = "the freighter cargo hold " * 100
+
+        with (
+            patch(
+                "app.services.config_service.get_config",
+                new=AsyncMock(return_value=config),
+            ),
+            patch("app.core.curator.curator._ensure_initialized", MagicMock()),
+            patch("app.core.curator.curator._matcher", matcher),
+            patch("app.matcher.tmdb_client.fetch_show_id", return_value=12345),
+            patch(
+                "app.services.ripping_helpers.find_staging_file",
+                return_value="/staging/t7.mkv",
+            ),
+            patch(
+                "app.matcher.llm_episode_matcher.fetch_season_episodes",
+                return_value=synopses,
+            ),
+            patch("app.core.ai_client.httpx.AsyncClient", return_value=client),
+        ):
+            outcome = await _run_llm_match_for_title(title=title, job=job)
+
+        # A keyless local provider must not be turned away as "not_configured".
+        assert outcome.reason is None, f"route refused a local provider: {outcome.reason}"
         assert _posted_url(client) == f"{_LOCAL_BASE_URL}/chat/completions"

--- a/backend/tests/unit/test_ai_configured_gates.py
+++ b/backend/tests/unit/test_ai_configured_gates.py
@@ -1,0 +1,132 @@
+"""The 'is AI configured?' invariant.
+
+Four call sites once used `if not config.ai_api_key` as a proxy for 'is AI
+usable?'. Local providers have no key, so any site still testing the key
+directly silently disables local AI while appearing correctly configured. This
+is a source-level guard because the alternative is three separate integration
+tests that each need a full job pipeline.
+
+The second half of the file is behavioural: the gates opening is useless if the
+user's configured endpoint never reaches the outbound request, so those tests
+drive the real ``complete_json`` with a mocked transport and assert on the URL
+that was actually POSTed to.
+"""
+
+import importlib
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_GATED_MODULES = [
+    "app.core.curator",
+    "app.services.matching_coordinator",
+    "app.services.identification_coordinator",
+]
+
+_LOCAL_BASE_URL = "http://box:11434/v1"
+
+
+@pytest.mark.parametrize("module_path", _GATED_MODULES)
+def test_no_module_gates_on_the_api_key_directly(module_path):
+    source = inspect.getsource(importlib.import_module(module_path))
+    assert "not config.ai_api_key" not in source, (
+        f"{module_path} still gates on the API key directly. Local providers have "
+        "no key, so this silently disables them. Use ai_is_configured(...)."
+    )
+
+
+@pytest.mark.parametrize("module_path", _GATED_MODULES)
+def test_each_gated_module_uses_the_shared_helper(module_path):
+    source = inspect.getsource(importlib.import_module(module_path))
+    assert "ai_is_configured" in source, f"{module_path} does not use ai_is_configured"
+
+
+def test_complete_json_returns_none_for_a_keyless_remote_provider():
+    """The relaxation must not accidentally let remote providers through."""
+    import asyncio
+
+    from app.core.ai_client import complete_json
+
+    result = asyncio.run(complete_json(prompt="hi", schema=None, provider="openai", api_key=""))
+    assert result is None
+
+
+def _mock_transport(response_json: dict):
+    """A stand-in for httpx.AsyncClient returning ``response_json`` from POST."""
+    response = MagicMock()
+    response.json.return_value = response_json
+    response.raise_for_status = MagicMock()
+
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=response)
+    return client
+
+
+def _openai_chat_response(content: str) -> dict:
+    return {"choices": [{"message": {"content": content}, "finish_reason": "stop"}]}
+
+
+def _posted_url(client) -> str:
+    """The URL argument of the single POST the client received."""
+    assert client.post.await_count == 1, f"expected one POST, saw {client.post.await_count}"
+    args, kwargs = client.post.call_args
+    return args[0] if args else kwargs["url"]
+
+
+class TestLocalBaseUrlIsThreadedToTheRequest:
+    """A configured endpoint must survive the whole call chain, not just be stored."""
+
+    @pytest.mark.asyncio
+    async def test_identify_from_label_posts_to_the_configured_endpoint(self):
+        from app.core.ai_identifier import identify_from_label
+
+        client = _mock_transport(
+            _openai_chat_response('{"title": "Inception", "year": 2010, "type": "movie"}')
+        )
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=client):
+            result = await identify_from_label(
+                "INCEPTION_2010",
+                "ollama",
+                "",
+                "llama3.1",
+                base_url=_LOCAL_BASE_URL,
+            )
+
+        assert result is not None and result["title"] == "Inception"
+        assert _posted_url(client) == f"{_LOCAL_BASE_URL}/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_match_episode_via_llm_posts_to_the_configured_endpoint(self):
+        from app.matcher.llm_episode_matcher import match_episode_via_llm
+
+        synopses = [
+            {"episode_number": 1, "name": "Pilot", "overview": "Aliens arrive."},
+            {"episode_number": 2, "name": "Cargo", "overview": "A heist on a freighter."},
+        ]
+        client = _mock_transport(
+            _openai_chat_response('{"episode": 2, "confidence": 0.9, "reasoning": "cargo"}')
+        )
+        with (
+            patch(
+                "app.matcher.llm_episode_matcher.fetch_season_episodes",
+                return_value=synopses,
+            ),
+            patch("app.core.ai_client.httpx.AsyncClient", return_value=client),
+        ):
+            result = await match_episode_via_llm(
+                transcript="they boarded the freighter and unloaded the cargo " * 50,
+                show_name="The Expanse",
+                season=1,
+                tmdb_show_id="12345",
+                ai_provider="ollama",
+                ai_api_key="",
+                tmdb_api_key="t",
+                ai_model="llama3.1",
+                ai_local_base_url=_LOCAL_BASE_URL,
+            )
+
+        assert result is not None and result.episode == 2
+        assert _posted_url(client) == f"{_LOCAL_BASE_URL}/chat/completions"

--- a/backend/tests/unit/test_config_ai_model_field.py
+++ b/backend/tests/unit/test_config_ai_model_field.py
@@ -59,3 +59,66 @@ class TestModelNameIsValidatedOnWrite:
         # "" is falsy, so the route's guard skips it entirely.
         assert ConfigUpdate(ai_model="").model_dump()[FIELD] == ""
         assert _is_safe_model_name("") is False
+
+
+BASE_URL_FIELD = "ai_local_base_url"
+
+
+class TestAiLocalBaseUrlField:
+    """Three-way sync for the local AI base URL.
+
+    Same hazard as ai_model above: a field missing from ConfigUpdate or
+    ConfigResponse is dropped by Pydantic with no error anywhere, so the wizard
+    appears to save and the value never arrives.
+    """
+
+    def test_appconfig_defaults_to_blank(self):
+        """Blank means "use the slug's conventional port", not "no endpoint"."""
+        assert getattr(AppConfig(), BASE_URL_FIELD) == ""
+
+    def test_config_update_accepts_and_carries_the_field(self):
+        update = ConfigUpdate(**{BASE_URL_FIELD: "http://box:11434/v1"})
+        assert update.model_dump()[BASE_URL_FIELD] == "http://box:11434/v1"
+        # Unset stays None so PUT doesn't clobber it when omitted.
+        assert ConfigUpdate().model_dump()[BASE_URL_FIELD] is None
+
+    def test_config_response_exposes_the_field(self):
+        assert BASE_URL_FIELD in ConfigResponse.model_fields
+
+
+class TestLocalBaseUrlIsValidatedOnWrite:
+    """The value is interpolated into an outbound request URL, so PUT must
+    reject a malformed one rather than storing it for a later request to
+    execute. update_config raises before it touches the database."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "http://user:pass@localhost:11434/v1",
+            "http://localhost:11434/v1?x=1",
+            "//localhost:11434/v1",
+        ],
+    )
+    async def test_unsafe_base_url_is_rejected(self, bad):
+        with pytest.raises(HTTPException) as exc:
+            await update_config(ConfigUpdate(ai_local_base_url=bad))
+        assert exc.value.status_code == 422
+        assert BASE_URL_FIELD in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_blank_clears_back_to_the_default(self):
+        """Unlike a key, this is not a secret: clearing it is how a user reverts
+        to the default port, so "" must pass the guard and reach persistence.
+        A regression here would add it to config_service's sensitive_fields set,
+        where a blank write is deliberately ignored."""
+        assert ConfigUpdate(ai_local_base_url="").model_dump()[BASE_URL_FIELD] == ""
+
+    @pytest.mark.asyncio
+    async def test_a_loopback_url_is_accepted(self):
+        """The whole point: is_safe_remote_url would reject this."""
+        from app.core.security import is_safe_local_ai_url
+
+        assert is_safe_local_ai_url("http://localhost:11434/v1") is True

--- a/backend/tests/unit/test_local_models_endpoint.py
+++ b/backend/tests/unit/test_local_models_endpoint.py
@@ -1,0 +1,92 @@
+"""Tests for the local AI model-list endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.guards import require_localhost_or_lan
+from app.main import app
+
+
+@pytest.fixture
+async def client():
+    app.dependency_overrides[require_localhost_or_lan] = lambda: None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(require_localhost_or_lan, None)
+
+
+def _mock_get(payload: dict, status: int = 200):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.status_code = status
+    response.raise_for_status = MagicMock()
+    c = AsyncMock()
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=False)
+    c.get = AsyncMock(return_value=response)
+    return c
+
+
+class TestLocalModelsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_model_ids_from_the_server(self, client):
+        payload = {"data": [{"id": "llama3.1:8b"}, {"id": "qwen2.5:7b"}]}
+        with patch("app.api.validation.httpx.AsyncClient", return_value=_mock_get(payload)):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == ["llama3.1:8b", "qwen2.5:7b"]
+        assert resp.json()["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_queries_the_default_port_for_the_slug(self, client):
+        mock = _mock_get({"data": []})
+        with patch("app.api.validation.httpx.AsyncClient", return_value=mock):
+            await client.get("/api/ai/local-models?provider=lmstudio")
+
+        assert mock.get.await_args.args[0] == "http://localhost:1234/v1/models"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_server_returns_200_with_an_error_string(self, client):
+        import httpx
+
+        c = AsyncMock()
+        c.__aenter__ = AsyncMock(return_value=c)
+        c.__aexit__ = AsyncMock(return_value=False)
+        c.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        with patch("app.api.validation.httpx.AsyncClient", return_value=c):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        assert "Ollama" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_remote_provider_is_rejected(self, client):
+        resp = await client.get("/api/ai/local-models?provider=openai")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        assert "local" in resp.json()["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unsafe_base_url_is_refused_without_a_request(self, client):
+        with patch("app.api.validation.httpx.AsyncClient") as ctor:
+            resp = await client.get(
+                "/api/ai/local-models?provider=ollama&base_url=file:///etc/passwd"
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_garbage_body_does_not_500(self, client):
+        with patch("app.api.validation.httpx.AsyncClient", return_value=_mock_get({"nope": 1})):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []

--- a/backend/tests/unit/test_matching_coordinator.py
+++ b/backend/tests/unit/test_matching_coordinator.py
@@ -376,11 +376,23 @@ class TestNoSubtitleAIFallback:
     a bare manual-assignment. Otherwise the existing manual-review path is kept.
     """
 
-    def _patch_ai_config(self, monkeypatch, *, enabled: bool, key: str = "k"):
+    def _patch_ai_config(
+        self, monkeypatch, *, enabled: bool, key: str = "k", provider: str = "anthropic"
+    ):
+        # ai_provider is required, not incidental: the gate is ai_is_configured(
+        # provider, key), because a local provider (ollama / lmstudio) has no key
+        # at all. A stub without it raises AttributeError inside the fallback,
+        # which the coordinator swallows as "AI fallback failed" and the test
+        # then fails for the wrong reason.
         monkeypatch.setattr(
             "app.services.config_service.get_config",
             AsyncMock(
-                return_value=SimpleNamespace(ai_episode_matching_enabled=enabled, ai_api_key=key)
+                return_value=SimpleNamespace(
+                    ai_episode_matching_enabled=enabled,
+                    ai_api_key=key,
+                    ai_provider=provider,
+                    ai_local_base_url="",
+                )
             ),
         )
 
@@ -423,6 +435,42 @@ class TestNoSubtitleAIFallback:
             # Must NOT auto-organize — it's only a suggestion for the user.
             assert t.organized_to is None
         coord._check_job_completion.assert_awaited()
+
+    async def test_local_provider_runs_the_fallback_without_a_key(self, monkeypatch, tmp_path):
+        """A keyless local provider must reach the LLM fallback, not be gated out.
+
+        This path once guarded on `if not config.ai_api_key`, which silently
+        disabled Ollama and LM Studio while the settings page looked correctly
+        filled in. The gate is now ai_is_configured(provider, key), and this is
+        the behavioural proof that an empty key no longer stops it.
+        """
+        self._patch_ai_config(monkeypatch, enabled=True, key="", provider="ollama")
+        suggest = AsyncMock(return_value=None)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_awaited_once()
+
+    async def test_remote_provider_without_a_key_is_still_gated_out(self, monkeypatch, tmp_path):
+        """The relaxation must not let a hosted provider through unconfigured."""
+        self._patch_ai_config(monkeypatch, enabled=True, key="", provider="anthropic")
+        suggest = AsyncMock(return_value=None)
+        monkeypatch.setattr(episode_curator, "suggest_episode_via_llm", suggest)
+
+        coord = _make_coord()
+        async with _unit_session_factory() as session:
+            job, title = await self._seed_failed(session)
+            job_id, title_id = job.id, title.id
+
+        await coord._run_match_single_file(job_id, title_id, tmp_path / "x.mkv")
+
+        suggest.assert_not_awaited()
 
     async def test_disabled_keeps_manual_review_path(self, monkeypatch, tmp_path):
         self._patch_ai_config(monkeypatch, enabled=False)

--- a/backend/tests/unit/test_security_local_ai_url.py
+++ b/backend/tests/unit/test_security_local_ai_url.py
@@ -1,0 +1,57 @@
+"""Tests for the local-AI base-URL guard.
+
+This guard is deliberately weaker than is_safe_remote_url: it must ACCEPT
+loopback and private addresses, because that is where a local inference server
+lives. What it still rejects is what makes it a guard at all.
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:1234/v1",
+        "http://192.168.1.50:11434/v1",
+        "https://ai.lan:1234/v1",
+        "http://[::1]:11434/v1",
+    ],
+)
+def test_accepts_local_and_private_endpoints(url):
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "file:///etc/passwd",
+        "ftp://localhost/v1",
+        "javascript:alert(1)",
+        "http://",
+        "//localhost:11434/v1",
+        "http://user:pass@localhost:11434/v1",
+        "http://localhost:11434/v1?x=1",
+        "http://localhost:11434/v1#frag",
+    ],
+)
+def test_rejects_unsafe_shapes(url):
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is False
+
+
+def test_is_not_an_alias_for_the_remote_guard():
+    """Regression guard: the two must stay distinct.
+
+    If someone ever points is_safe_local_ai_url at is_safe_remote_url, every
+    local provider breaks with a confusing validation error rather than an
+    obvious one, so pin the difference.
+    """
+    from app.core.security import is_safe_local_ai_url, is_safe_remote_url
+
+    assert is_safe_remote_url("http://localhost:11434/v1") is False
+    assert is_safe_local_ai_url("http://localhost:11434/v1") is True

--- a/backend/tests/unit/test_security_local_ai_url.py
+++ b/backend/tests/unit/test_security_local_ai_url.py
@@ -130,3 +130,39 @@ def test_deliberately_allows_a_non_local_host():
     from app.core.security import is_safe_local_ai_url
 
     assert is_safe_local_ai_url("https://gpubox.example.com/v1") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # IPv4-mapped. Modern CPython delegates is_link_local through
+        # ipv4_mapped so this was already rejected, but pin it so a future
+        # refactor cannot quietly reopen it.
+        "http://[::ffff:169.254.169.254]:1234/v1",
+        "http://[::ffff:a9fe:a9fe]:1234/v1",
+        # IPv4-compatible ("::a.b.c.d"). This one DID slip through: it has no
+        # ipv4_mapped and reports is_link_local False.
+        "http://[::169.254.169.254]:1234/v1",
+        "http://[::a9fe:a9fe]:1234/v1",
+        # 6to4 wrapper around the same address.
+        "http://[2002:a9fe:a9fe::1]:1234/v1",
+    ],
+)
+def test_rejects_ipv4_embedded_in_an_ipv6_literal(url):
+    """The metadata/link-local denylist must see through IPv6 wrappers.
+
+    An IPv6 literal can name an IPv4 destination several ways and the ``is_*``
+    properties do not all unwrap it, so checking only the literal left the
+    metadata endpoint reachable by spelling it differently.
+    """
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is False
+
+
+@pytest.mark.parametrize("url", ["http://[::1]:11434/v1", "http://[fd00::1]:11434/v1"])
+def test_ipv6_unwrapping_does_not_break_ordinary_local_addresses(url):
+    """::1 must keep working; its "embedded IPv4" (0.0.0.1) is meaningless."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is True

--- a/backend/tests/unit/test_security_local_ai_url.py
+++ b/backend/tests/unit/test_security_local_ai_url.py
@@ -55,3 +55,78 @@ def test_is_not_an_alias_for_the_remote_guard():
 
     assert is_safe_remote_url("http://localhost:11434/v1") is False
     assert is_safe_local_ai_url("http://localhost:11434/v1") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:11434/v1 ",
+        " http://localhost:11434/v1",
+        "http://localhost:11434/v1\n",
+        "http://localhost\n.evil.com:11434/v1",
+        "http://local\thost:11434/v1",
+        "http://localhost:11434/v1\x00",
+    ],
+)
+def test_rejects_whitespace_and_control_characters(url):
+    """urlparse strips tab/CR/LF before parsing, so without a raw-string check
+    the guard would validate a DIFFERENT string than the caller sends, and httpx
+    would then raise InvalidURL, which is not an httpx.HTTPError and so escapes
+    the transport handler in ai_client."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is False
+
+
+def test_rejects_path_traversal():
+    """Callers append "/chat/completions", so a traversal segment would move the
+    request outside the prefix the user approved."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url("http://localhost:11434/v1/../../admin") is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data",
+        "http://metadata.google.internal/v1",
+        "http://169.254.1.1:11434/v1",
+    ],
+)
+def test_rejects_metadata_and_link_local_hosts(url):
+    """No inference server runs here, and the model-list endpoint reflects part
+    of the response back to the caller."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is False
+
+
+def test_rejects_an_out_of_range_port():
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url("http://localhost:99999/v1") is False
+
+
+def test_rejects_path_parameters():
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url("http://localhost:11434/v1;x=1") is False
+
+
+@pytest.mark.parametrize("value", [None, 123, b"http://localhost:11434/v1", object()])
+def test_fails_closed_on_non_string_input(value):
+    """A guard must never raise; raising skips the caller's `if not guard(...)`."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(value) is False
+
+
+def test_deliberately_allows_a_non_local_host():
+    """Pins the load-bearing surprise: this guard imposes no locality restriction
+    beyond the denied metadata/link-local hosts, because a user may run their
+    inference server on another machine. It is NOT what stops a hostile endpoint
+    being configured; require_localhost_or_lan on the writing endpoints is."""
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url("https://gpubox.example.com/v1") is True

--- a/backend/tests/unit/test_validation_ai.py
+++ b/backend/tests/unit/test_validation_ai.py
@@ -101,3 +101,50 @@ class TestValidateAI:
                 "/api/validate/ai", json={"provider": "openai", "api_key": "sk-x"}
             )
         assert resp.json()["valid"] is False
+
+
+class TestValidateAiLocalProviders:
+    @pytest.mark.asyncio
+    async def test_local_provider_is_accepted_without_a_key(self, client):
+        from unittest.mock import AsyncMock, patch
+
+        with patch("app.core.ai_client.complete_json", new=AsyncMock(return_value={"ok": True})):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "ollama", "model": "llama3.1:8b"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_local_provider_with_no_model_is_rejected_clearly(self, client):
+        resp = await client.post("/api/validate/ai", json={"provider": "ollama"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert "model" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_is_still_rejected(self, client):
+        resp = await client.post("/api/validate/ai", json={"provider": "notreal"})
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is False
+        assert "Unknown AI provider" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_local_validation_uses_the_longer_timeout(self, client):
+        from unittest.mock import AsyncMock, patch
+
+        from app.core.ai_client import LOCAL_VALIDATE_TIMEOUT_SECONDS
+
+        spy = AsyncMock(return_value={"ok": True})
+        with patch("app.core.ai_client.complete_json", new=spy):
+            await client.post(
+                "/api/validate/ai",
+                json={"provider": "lmstudio", "model": "qwen2.5-7b-instruct"},
+            )
+
+        assert spy.await_args.kwargs["timeout"] == LOCAL_VALIDATE_TIMEOUT_SECONDS

--- a/backend/tests/unit/test_validation_ai.py
+++ b/backend/tests/unit/test_validation_ai.py
@@ -141,10 +141,103 @@ class TestValidateAiLocalProviders:
         from app.core.ai_client import LOCAL_VALIDATE_TIMEOUT_SECONDS
 
         spy = AsyncMock(return_value={"ok": True})
-        with patch("app.core.ai_client.complete_json", new=spy):
+        with (
+            patch("app.core.ai_client.complete_json", new=spy),
+            patch(
+                "app.api.validation._fetch_local_model_ids",
+                new=AsyncMock(return_value=(["qwen2.5-7b-instruct"], None)),
+            ),
+        ):
             await client.post(
                 "/api/validate/ai",
                 json={"provider": "lmstudio", "model": "qwen2.5-7b-instruct"},
             )
 
         assert spy.await_args.kwargs["timeout"] == LOCAL_VALIDATE_TIMEOUT_SECONDS
+
+
+class TestValidateAiLocalModelPreflight:
+    """LM Studio answers a request for an unknown model by silently serving
+    whichever model is currently loaded (HTTP 200, no error), so a typo'd model
+    name would otherwise sail through this endpoint. The pre-flight confirms the
+    requested model is actually in the server's own list before spending a
+    completion request on it."""
+
+    @pytest.mark.asyncio
+    async def test_model_not_on_server_is_rejected_before_any_completion(self, client):
+        spy = AsyncMock(return_value={"ok": True})
+        with (
+            patch("app.core.ai_client.complete_json", new=spy),
+            patch(
+                "app.api.validation._fetch_local_model_ids",
+                new=AsyncMock(return_value=(["google/gemma-4-e4b", "qwen2.5-7b"], None)),
+            ),
+        ):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "lmstudio", "model": "nope/not-a-real-model"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert "not installed" in body["error"].lower() or "not-a-real-model" in body["error"]
+        assert "google/gemma-4-e4b" in body["error"]
+        spy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_model_on_server_proceeds_to_completion(self, client):
+        spy = AsyncMock(return_value={"ok": True})
+        with (
+            patch("app.core.ai_client.complete_json", new=spy),
+            patch(
+                "app.api.validation._fetch_local_model_ids",
+                new=AsyncMock(return_value=(["google/gemma-4-e4b", "qwen2.5-7b"], None)),
+            ),
+        ):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "lmstudio", "model": "qwen2.5-7b"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+        spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unreachable_server_does_not_short_circuit(self, client):
+        """An unreadable model list must not block validation with a confusing
+        "not installed" message; fall through and let the completion produce
+        the better "could not reach" error instead."""
+        spy = AsyncMock(return_value={"ok": True})
+        with (
+            patch("app.core.ai_client.complete_json", new=spy),
+            patch(
+                "app.api.validation._fetch_local_model_ids",
+                new=AsyncMock(return_value=([], "Could not reach LM Studio")),
+            ),
+        ):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "lmstudio", "model": "whatever-model"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+        spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_remote_provider_never_triggers_preflight(self, client):
+        fetch_spy = AsyncMock(return_value=(["gpt-4o-mini"], None))
+        with (
+            patch("app.core.ai_client.complete_json", new=AsyncMock(return_value={"ok": True})),
+            patch("app.api.validation._fetch_local_model_ids", new=fetch_spy),
+        ):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "openai", "api_key": "sk-x", "model": "some-other-model"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+        fetch_spy.assert_not_awaited()

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -139,16 +139,87 @@ The `conflict_resolution_default` field accepts one of four values:
 
 | Field | Description | Notes |
 |-------|-------------|-------|
-| `ai_identification_enabled` | Enable AI-assisted disc title resolution | Requires `ai_provider` and `ai_api_key` |
-| `ai_provider` | AI provider to use | `anthropic`, `openai`, `openrouter`, `gemini` |
-| `ai_api_key` | API key for the selected provider | Redacted in API responses |
-| `ai_model` | Model override | Blank uses Engram's default for the provider. Set this when your key has no access to that default |
+| `ai_identification_enabled` | Enable AI-assisted disc title resolution | Requires `ai_provider`, plus `ai_api_key` for a hosted provider |
+| `ai_provider` | AI provider to use | Hosted: `anthropic`, `openai`, `openrouter`, `gemini`. Local: `ollama`, `lmstudio` |
+| `ai_api_key` | API key for the selected provider | Redacted in API responses. Not needed for a local provider |
+| `ai_model` | Model override | Blank uses Engram's default for the provider. Set this when your key has no access to that default. **Required** for a local provider, which has no default |
+| `ai_local_base_url` | Address of a local AI server | Local providers only. Blank uses the provider's conventional port |
+
+See [Local AI](#local-ai-ollama-and-lm-studio) to run this against your own machine instead of a paid API.
 
 ### AI-Powered Episode Matching
 
 `ai_episode_matching_enabled` (default: `false`) — when enabled, low-confidence TV episode matches are sent to your configured AI provider with the season's TMDB synopses for a suggested episode. Always surfaces through the [review queue](../guide/review-queue.md); never auto-organizes. Shares `ai_provider`/`ai_api_key` with [AI-Powered Title Resolution](#ai-powered-title-resolution).
 
 See the [LLM Episode Matcher guide](../guide/llm-episode-matcher.md) for accuracy expectations and provider recommendations (Gemini Flash-Lite is best on this task).
+
+### Local AI (Ollama and LM Studio)
+
+Both AI features above can run against a model on your own machine instead of a
+paid hosted API. Two servers are supported, and they work the same way because
+they expose the same OpenAI-compatible interface.
+
+**No API key is required.** The key field is hidden when a local provider is
+selected.
+
+#### Setup
+
+1. Start your server:
+    - **Ollama:** run `ollama serve`, then pull a model with `ollama pull llama3.1:8b`.
+    - **LM Studio:** open the Developer tab, load a model, and start the server.
+2. In Engram, open **Settings → Data sharing → AI assistance**, enable AI
+   identification, and choose **Ollama (local)** or **LM Studio (local)**.
+3. Leave **Server Address** blank to use the default:
+
+    | Provider | Default address |
+    |----------|-----------------|
+    | Ollama | `http://localhost:11434/v1` |
+    | LM Studio | `http://localhost:1234/v1` |
+
+    Set it only if your server runs on another port, or on another machine on
+    your network.
+4. Pick a model from the **Model** dropdown. The list is read from your server,
+   so it only populates once the server is running. Unlike the hosted providers
+   there is no default model, because the answer depends on what you installed.
+5. Click **Test Connection** to confirm Engram can reach it.
+
+#### Choosing a model
+
+Any instruction-tuned model in roughly the 7B-14B range works well. Both tasks
+ask for a small JSON reply, so reasoning-heavy or very large models cost a lot
+of time for little benefit.
+
+The dropdown lists everything the server offers, including embedding models
+(names containing `embed`). Those cannot answer chat requests; pick an
+instruction-tuned model instead. Neither server's model list distinguishes the
+two, so Engram cannot filter them for you.
+
+#### Performance
+
+Set **Max Concurrent Matches** to 1 in *Preferences → Matching*. A local server
+has one GPU or CPU, so parallel requests queue rather than overlap, and several
+large contexts at once can exhaust VRAM. Engram shows a reminder in Settings
+when a local provider is selected with concurrency above 1; it does not override
+your setting.
+
+The first request after loading a model is slow. LM Studio loads weights on
+demand, which can take 30-60 seconds before any text appears. Engram allows up
+to five minutes for a local response, so this is expected rather than a failure.
+
+#### Troubleshooting
+
+| Message | Cause |
+|---------|-------|
+| `Could not reach Ollama at ...` | The server is not running, or the address is wrong |
+| `'<model>' is not installed on this server` | The model is not pulled (Ollama) or not downloaded (LM Studio). The message lists what is available |
+| `Select a model first` | Local providers have no default; pick one from the dropdown |
+
+!!! note "Why Engram checks the model list before testing"
+    LM Studio answers a request for an unknown model by silently serving
+    whichever model is currently loaded, returning HTTP 200 with no warning. A
+    typo would otherwise pass the connection test and then quietly matter at
+    match time, so Engram verifies the model against the server's own list
+    first.
 
 ### Extras Policy
 

--- a/docs/superpowers/plans/2026-08-29-local-ai-provider.md
+++ b/docs/superpowers/plans/2026-08-29-local-ai-provider.md
@@ -1,0 +1,2756 @@
+# Local AI Provider (Ollama + LM Studio) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Engram's AI identification and episode matching run against a local Ollama or LM Studio server instead of a hosted paid provider.
+
+**Architecture:** Both local servers expose the same OpenAI-compatible `/v1/chat/completions` contract that `_call_openai_compatible()` in `backend/app/core/ai_client.py` already speaks, so this adds two provider slugs (`ollama`, `lmstudio`) that reuse that adapter with a configurable base URL. The bulk of the work is relaxing invariants that silently assume a remote paid API: an API key must no longer be required, loopback URLs must pass a dedicated SSRF guard, and timeouts must widen to survive cold model loads.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLModel, httpx, pytest (`unittest.mock.patch`, no respx). Frontend: React 18, TypeScript, Vitest + React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-local-ai-provider-design.md`
+**Issue:** https://github.com/Jsakkos/engram/issues/606
+
+---
+
+## Orientation for the implementer
+
+Read this before Task 1. It is the context that is not obvious from the file names.
+
+**What `complete_json` is.** `backend/app/core/ai_client.py` is the single outbound LLM
+call site for the whole application. Every AI feature funnels through `complete_json()`,
+which dispatches on a provider slug string, calls a per-provider adapter, and returns a
+parsed `dict` or `None`. `None` means "no usable result"; callers must always tolerate it.
+
+**Why an API key is load-bearing today.** Four places treat "the user has stored an API
+key" as equivalent to "AI is configured". Local servers need no key, so unless all four
+change, the feature will appear to be configured and will silently do nothing. This is the
+single most likely way to ship a broken version of this feature.
+
+**Why the SSRF guard matters.** `app/core/security.py` deliberately rejects loopback and
+private addresses in `is_safe_remote_url()`. Local AI servers live at exactly those
+addresses, so a separate, deliberately weaker guard is required. Do not relax
+`is_safe_remote_url` itself; other call sites depend on it.
+
+**Testing convention.** `backend/tests/unit/test_ai_client.py` mocks transport with
+`unittest.mock.patch("app.core.ai_client.httpx.AsyncClient", return_value=mock)` and a
+hand-rolled `_mock_httpx()` helper at the top of the file. Reuse that helper. Do not add
+`respx` or `pytest-httpx`; they are not dependencies of this project.
+
+**Run backend commands from `backend/`** and use `uv`, never bare `python`/`pytest`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backend/app/core/ai_client.py` | Provider vocabulary, dispatch, timeouts, error text, JSON parsing | Modify |
+| `backend/app/core/security.py` | `is_safe_local_ai_url` guard | Modify |
+| `backend/app/models/app_config.py` | `ai_local_base_url` persisted field | Modify |
+| `backend/app/api/routes.py` | `ConfigResponse` / `ConfigUpdate` / `PUT` validation | Modify |
+| `backend/app/api/validation.py` | `validate_ai` fixes, new `GET /ai/local-models` | Modify |
+| `backend/app/core/curator.py` | Gate uses `ai_is_configured` | Modify |
+| `backend/app/services/matching_coordinator.py` | Gate uses `ai_is_configured` | Modify |
+| `backend/app/services/identification_coordinator.py` | Gate uses `ai_is_configured` | Modify |
+| `backend/tests/unit/test_ai_client.py` | Adapter, dispatch, timeout, error tests | Modify |
+| `backend/tests/unit/test_security_local_ai_url.py` | SSRF guard tests | Create |
+| `backend/tests/unit/test_validation_ai.py` | Local-provider validator tests | Modify |
+| `backend/tests/unit/test_local_models_endpoint.py` | Model-list endpoint tests | Create |
+| `backend/tests/unit/test_ai_configured_gates.py` | The four-gate invariant | Create |
+| `frontend/src/utils/localModels.ts` | Fetch helper for the model dropdown | Create |
+| `frontend/src/utils/localModels.test.ts` | Helper tests | Create |
+| `frontend/src/components/ConfigWizard.tsx` | Slugs, base URL field, model dropdown, hint | Modify |
+| `CHANGELOG.md` | `[Unreleased]` entry | Modify |
+| `docs/` | User-facing setup docs | Modify |
+
+---
+
+## Task 1: Provider vocabulary and the `ai_is_configured` invariant
+
+Pure additions to `ai_client.py`. Nothing calls them yet, which keeps this task safe to
+land on its own.
+
+**Files:**
+- Modify: `backend/app/core/ai_client.py`
+- Test: `backend/tests/unit/test_ai_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_ai_client.py`:
+
+```python
+class TestLocalProviderVocabulary:
+    def test_local_providers_are_ollama_and_lmstudio(self):
+        from app.core.ai_client import LOCAL_PROVIDERS
+
+        assert LOCAL_PROVIDERS == {"ollama", "lmstudio"}
+
+    def test_default_base_urls_match_upstream_conventions(self):
+        from app.core.ai_client import LOCAL_DEFAULT_BASE_URLS
+
+        assert LOCAL_DEFAULT_BASE_URLS["ollama"] == "http://localhost:11434/v1"
+        assert LOCAL_DEFAULT_BASE_URLS["lmstudio"] == "http://localhost:1234/v1"
+
+    def test_blank_configured_url_falls_back_to_default(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("ollama", "") == "http://localhost:11434/v1"
+        assert resolve_local_base_url("lmstudio", "   ") == "http://localhost:1234/v1"
+
+    def test_configured_url_wins_and_trailing_slash_is_stripped(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("ollama", "http://box:8080/v1/") == "http://box:8080/v1"
+
+    def test_resolve_returns_blank_for_a_remote_provider(self):
+        from app.core.ai_client import resolve_local_base_url
+
+        assert resolve_local_base_url("openai", "") == ""
+
+    def test_known_providers_covers_remote_and_local(self):
+        from app.core.ai_client import KNOWN_PROVIDERS
+
+        assert {"anthropic", "openai", "openrouter", "gemini"} <= KNOWN_PROVIDERS
+        assert {"ollama", "lmstudio"} <= KNOWN_PROVIDERS
+
+
+class TestAiIsConfigured:
+    def test_remote_provider_requires_a_key(self):
+        from app.core.ai_client import ai_is_configured
+
+        assert ai_is_configured("openai", "sk-x") is True
+        assert ai_is_configured("openai", "") is False
+
+    def test_local_provider_needs_no_key(self):
+        from app.core.ai_client import ai_is_configured
+
+        assert ai_is_configured("ollama", "") is True
+        assert ai_is_configured("lmstudio", "") is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `backend/`:
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k "LocalProviderVocabulary or AiIsConfigured" -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'LOCAL_PROVIDERS' from 'app.core.ai_client'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/ai_client.py`, immediately after the `DEFAULT_MODELS` dict, insert:
+
+```python
+# Ollama and LM Studio both expose the OpenAI-compatible /v1/chat/completions
+# contract, so they reuse _call_openai_compatible with only the base URL
+# differing. They are grouped here because several invariants elsewhere
+# (credential presence, timeout, error wording) key off "is this local?" and
+# must not each hardcode the slug list.
+LOCAL_PROVIDERS = frozenset({"ollama", "lmstudio"})
+
+LOCAL_DEFAULT_BASE_URLS = {
+    "ollama": "http://localhost:11434/v1",
+    "lmstudio": "http://localhost:1234/v1",
+}
+
+# DEFAULT_MODELS deliberately has no entry for the local slugs: there is no
+# correct default, because the answer depends on which weights the user pulled.
+# That means DEFAULT_MODELS can no longer double as the set of providers that
+# exist, which is what this is for.
+KNOWN_PROVIDERS = frozenset(DEFAULT_MODELS) | LOCAL_PROVIDERS
+
+
+def resolve_local_base_url(provider: str, configured: str) -> str:
+    """Base URL for a local provider: the configured value, else the default.
+
+    Returns "" for a remote provider so a caller can use a truthy check as
+    "is there a local endpoint here?" without a second membership test.
+    A trailing slash is stripped so callers can append "/chat/completions"
+    unconditionally without producing a double slash.
+    """
+    if provider not in LOCAL_PROVIDERS:
+        return ""
+    url = (configured or "").strip() or LOCAL_DEFAULT_BASE_URLS[provider]
+    return url.rstrip("/")
+
+
+def ai_is_configured(provider: str, api_key: str) -> bool:
+    """True if this provider has what it needs to make a call.
+
+    Local providers authenticate to nothing, so requiring a key would silently
+    disable them at every call site that guards on one. Four such gates exist
+    (this module, curator, matching_coordinator, identification_coordinator);
+    they all call this rather than testing the key directly.
+    """
+    return provider in LOCAL_PROVIDERS or bool(api_key)
+```
+
+Also extend `_PROVIDER_LABELS` in the same file so local failures read as product names:
+
+```python
+_PROVIDER_LABELS = {
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "openrouter": "OpenRouter",
+    "gemini": "Gemini",
+    "ollama": "Ollama",
+    "lmstudio": "LM Studio",
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k "LocalProviderVocabulary or AiIsConfigured" -v
+```
+
+Expected: PASS, 8 passed.
+
+- [ ] **Step 5: Run the full ai_client suite for regressions**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -v
+```
+
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check app/core/ai_client.py && uv run ruff format app/core/ai_client.py
+git add backend/app/core/ai_client.py backend/tests/unit/test_ai_client.py
+git commit -m "feat(ai): add local provider vocabulary and ai_is_configured (#606)"
+```
+
+---
+
+## Task 2: `is_safe_local_ai_url` SSRF guard
+
+**Files:**
+- Modify: `backend/app/core/security.py`
+- Test: `backend/tests/unit/test_security_local_ai_url.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_security_local_ai_url.py`:
+
+```python
+"""Tests for the local-AI base-URL guard.
+
+This guard is deliberately weaker than is_safe_remote_url: it must ACCEPT
+loopback and private addresses, because that is where a local inference server
+lives. What it still rejects is what makes it a guard at all.
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:1234/v1",
+        "http://192.168.1.50:11434/v1",
+        "https://ai.lan:1234/v1",
+        "http://[::1]:11434/v1",
+    ],
+)
+def test_accepts_local_and_private_endpoints(url):
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "file:///etc/passwd",
+        "ftp://localhost/v1",
+        "javascript:alert(1)",
+        "http://",
+        "//localhost:11434/v1",
+        "http://user:pass@localhost:11434/v1",
+        "http://localhost:11434/v1?x=1",
+        "http://localhost:11434/v1#frag",
+    ],
+)
+def test_rejects_unsafe_shapes(url):
+    from app.core.security import is_safe_local_ai_url
+
+    assert is_safe_local_ai_url(url) is False
+
+
+def test_is_not_an_alias_for_the_remote_guard():
+    """Regression guard: the two must stay distinct.
+
+    If someone ever points is_safe_local_ai_url at is_safe_remote_url, every
+    local provider breaks with a confusing validation error rather than an
+    obvious one, so pin the difference.
+    """
+    from app.core.security import is_safe_local_ai_url, is_safe_remote_url
+
+    assert is_safe_remote_url("http://localhost:11434/v1") is False
+    assert is_safe_local_ai_url("http://localhost:11434/v1") is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_security_local_ai_url.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'is_safe_local_ai_url'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/security.py`, insert directly after `is_safe_dashboard_url`:
+
+```python
+def is_safe_local_ai_url(url: str) -> bool:
+    """Return True if ``url`` is usable as a local AI server's base URL.
+
+    Deliberately NOT is_safe_remote_url. That guard rejects loopback, private
+    and link-local hosts to prevent SSRF, and those are precisely the addresses
+    an Ollama or LM Studio server listens on, so this is an intentional
+    exemption rather than an oversight.
+
+    Unlike is_safe_dashboard_url (whose value is only rendered as a link), the
+    server DOES issue POST requests to this URL, so this is a blind-SSRF
+    primitive against the host's own loopback interface. It is accepted because
+    the config surface is already fully trusted (it holds API keys, filesystem
+    paths and library roots), because the endpoints that write it are gated by
+    require_localhost_or_lan, and because the response body is parsed as JSON
+    and discarded unless it matches the requested schema, making the primitive
+    blind rather than an exfiltration channel. See
+    docs/superpowers/specs/2026-08-29-local-ai-provider-design.md.
+
+    What is still rejected: non-http(s) schemes (file:, javascript:, ftp:), a
+    missing host, embedded credentials, and any query or fragment. The last two
+    matter because callers append "/chat/completions" to this value, so a query
+    string would silently move the path into the query and a credential would be
+    logged with the request URL.
+    """
+    try:
+        parsed = urlparse(url)
+        host = (parsed.hostname or "").lower()
+    except ValueError:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if not host:
+        return False
+    if parsed.username or parsed.password:
+        return False
+    if parsed.query or parsed.fragment:
+        return False
+    return True
+```
+
+Then add a bullet to the module docstring's list, after the
+`is_within_configured_roots` bullet:
+
+```
+- ``is_safe_local_ai_url`` — a deliberately permissive guard for the
+  user-configured local AI server base URL, which must accept loopback.
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_security_local_ai_url.py -v
+```
+
+Expected: PASS, 15 passed.
+
+- [ ] **Step 5: Verify the existing security suite still passes**
+
+```bash
+uv run pytest tests/unit/ -k security -v
+```
+
+Expected: PASS, no failures.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check app/core/security.py && uv run ruff format app/core/security.py
+git add backend/app/core/security.py backend/tests/unit/test_security_local_ai_url.py
+git commit -m "feat(security): add is_safe_local_ai_url loopback-permitting guard (#606)"
+```
+
+---
+
+## Task 3: Local error messages
+
+Do this before wiring dispatch so that Task 4 can assert on real text.
+
+**Files:**
+- Modify: `backend/app/core/ai_client.py`
+- Test: `backend/tests/unit/test_ai_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_ai_client.py`:
+
+```python
+class TestLocalErrorMessages:
+    def test_network_failure_names_the_product_and_url(self):
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        code, message = classify_provider_error(
+            "ollama",
+            httpx.ConnectError("refused"),
+            base_url="http://localhost:11434/v1",
+        )
+        assert code == "network"
+        assert "Ollama" in message
+        assert "http://localhost:11434/v1" in message
+        assert "ollama serve" in message
+
+    def test_lmstudio_network_failure_does_not_mention_ollama(self):
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error(
+            "lmstudio",
+            httpx.ConnectError("refused"),
+            base_url="http://localhost:1234/v1",
+        )
+        assert "LM Studio" in message
+        assert "ollama" not in message.lower()
+
+    def test_404_tells_the_user_to_pull_the_model(self):
+        from app.core.ai_client import classify_provider_error
+
+        code, message = classify_provider_error(
+            "ollama",
+            _status_error_with_body(404, "model not found"),
+            model="llama3.1:8b",
+        )
+        assert code == "model_unavailable"
+        assert "ollama pull llama3.1:8b" in message
+
+    def test_remote_providers_keep_their_wording(self):
+        """Regression guard: the local table must not leak into remote text."""
+        import httpx
+
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error("openai", httpx.ConnectError("refused"))
+        assert message == "Could not reach OpenAI. Check the internet connection."
+
+    def test_no_credits_is_never_reported_for_a_local_provider(self):
+        """A local server has no billing, so the remote wording would be nonsense."""
+        from app.core.ai_client import classify_provider_error
+
+        _, message = classify_provider_error("ollama", _status_error_with_body(402, ""))
+        assert "credits" not in message.lower()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestLocalErrorMessages -v
+```
+
+Expected: FAIL with `TypeError: classify_provider_error() got an unexpected keyword argument 'base_url'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/ai_client.py`, add after `_CAUSE_MESSAGES`:
+
+```python
+# Local servers have no account, no billing and no key, so the remote wording
+# ("the account has no API credits") is actively misleading. These override
+# _CAUSE_MESSAGES for the local slugs only. {provider} is the display label,
+# {url} the resolved base URL, {model} the requested model id, and {hint} a
+# per-product instruction for starting the server.
+_LOCAL_CAUSE_MESSAGES: dict[ProviderErrorCode, str] = {
+    "network": "Could not reach {provider} at {url}. Is the server running? ({hint})",
+    "timeout": (
+        "{provider} at {url} did not respond in time. A model loading for the first "
+        "time can be slow; try again once it is loaded."
+    ),
+    "model_unavailable": "Model '{model}' is not available in {provider}. {pull}",
+    "bad_key": "{provider} rejected the request at {url}.",
+    "no_credits": "{provider} rejected the request at {url}.",
+    "rate_limited": "{provider} at {url} is busy. Wait a moment and try again.",
+    "bad_request": "{provider} at {url} rejected the request.",
+    "unknown": "{provider} at {url} returned an unexpected error.",
+}
+
+_LOCAL_START_HINTS = {
+    "ollama": "run: ollama serve",
+    "lmstudio": "start the server from LM Studio's Developer tab",
+}
+
+_LOCAL_PULL_HINTS = {
+    "ollama": "Pull it first: ollama pull {model}",
+    "lmstudio": "Download it in LM Studio, then load it.",
+}
+
+# Shown when a local provider has no model set. Unlike the remote providers
+# there is no default to fall back to, so this is a hard stop rather than a
+# silent None.
+_LOCAL_BLANK_MODEL_MESSAGE = (
+    "Select a model for {provider}. Local providers have no default, because the "
+    "answer depends on which models you have installed."
+)
+```
+
+Replace `classify_provider_error` with:
+
+```python
+def classify_provider_error(
+    provider: str,
+    exc: Exception,
+    *,
+    base_url: str = "",
+    model: str = "",
+) -> tuple[ProviderErrorCode, str]:
+    """Map a provider failure to a stable ``(code, human_message)`` pair.
+
+    The provider's own body is the only thing that separates a permanently
+    exhausted quota from transient throttling (both are HTTP 429 on OpenAI), so
+    this reads it. The body is never returned to the caller; it is summarised
+    into a fixed sentence and left to the logs.
+
+    ``base_url`` and ``model`` are used only for the local providers, whose
+    messages name the endpoint and the model because "connection refused" is
+    useless to a user who has three inference servers on different ports.
+    """
+    code: ProviderErrorCode
+    if isinstance(exc, httpx.TimeoutException):
+        code = "timeout"
+    elif isinstance(exc, httpx.HTTPStatusError):
+        code = _classify_status(provider, exc)
+    elif isinstance(exc, httpx.HTTPError):
+        code = "network"
+    else:
+        code = "unknown"
+
+    label = _PROVIDER_LABELS.get(provider, provider)
+    if provider in LOCAL_PROVIDERS:
+        template = _LOCAL_CAUSE_MESSAGES.get(code, _LOCAL_CAUSE_MESSAGES["unknown"])
+        pull = _LOCAL_PULL_HINTS.get(provider, "").format(model=model or "the model")
+        return code, template.format(
+            provider=label,
+            url=base_url or LOCAL_DEFAULT_BASE_URLS.get(provider, ""),
+            model=model or "(none set)",
+            hint=_LOCAL_START_HINTS.get(provider, ""),
+            pull=pull,
+        )
+    return code, _CAUSE_MESSAGES[code].format(provider=label)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestLocalErrorMessages -v
+```
+
+Expected: PASS, 5 passed.
+
+- [ ] **Step 5: Run the full ai_client suite**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -v
+```
+
+Expected: PASS. If an existing test asserts on an exact remote message, that
+message must be unchanged; investigate rather than editing the assertion.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check app/core/ai_client.py && uv run ruff format app/core/ai_client.py
+git add backend/app/core/ai_client.py backend/tests/unit/test_ai_client.py
+git commit -m "feat(ai): local-provider error messages naming endpoint and model (#606)"
+```
+
+---
+
+## Task 4: Wire the local slugs into `complete_json`
+
+**Files:**
+- Modify: `backend/app/core/ai_client.py`
+- Test: `backend/tests/unit/test_ai_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_ai_client.py`:
+
+```python
+def _openai_shaped(text: str):
+    """A minimal OpenAI-compatible chat-completions body."""
+    return {"choices": [{"message": {"content": text}, "finish_reason": "stop"}]}
+
+
+class TestLocalDispatch:
+    @pytest.mark.asyncio
+    async def test_ollama_posts_to_the_default_endpoint_without_a_key(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            result = await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="llama3.1:8b",
+            )
+
+        assert result == {"ok": True}
+        call = mock.post.await_args
+        assert call.args[0] == "http://localhost:11434/v1/chat/completions"
+        assert call.kwargs["json"]["model"] == "llama3.1:8b"
+
+    @pytest.mark.asyncio
+    async def test_lmstudio_uses_its_own_default_port(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="lmstudio",
+                api_key="",
+                model="qwen2.5-7b-instruct",
+            )
+
+        assert mock.post.await_args.args[0] == "http://localhost:1234/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_configured_base_url_overrides_the_default(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="llama3.1:8b",
+                base_url="http://gpubox:11434/v1",
+            )
+
+        assert mock.post.await_args.args[0] == "http://gpubox:11434/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_local_default_timeout_is_generous(self):
+        """A cold LM Studio JIT-loads weights; 30s would look like a broken feature."""
+        from app.core.ai_client import LOCAL_TIMEOUT_SECONDS, complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(
+                prompt="hi", schema=None, provider="ollama", api_key="", model="m"
+            )
+
+        assert ctor.call_args.kwargs["timeout"] == LOCAL_TIMEOUT_SECONDS
+        assert LOCAL_TIMEOUT_SECONDS >= 300.0
+
+    @pytest.mark.asyncio
+    async def test_remote_default_timeout_is_unchanged(self):
+        from app.core.ai_client import _TIMEOUT_SECONDS, complete_json
+
+        mock = _mock_httpx({"content": [{"text": '{"ok": true}'}]})
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(
+                prompt="hi", schema=None, provider="anthropic", api_key="sk-ant-x"
+            )
+
+        assert ctor.call_args.kwargs["timeout"] == _TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_explicit_timeout_still_wins_for_a_local_provider(self):
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock) as ctor:
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="m",
+                timeout=5.0,
+            )
+
+        assert ctor.call_args.kwargs["timeout"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_blank_model_raises_a_pointed_error(self):
+        from app.core.ai_client import complete_json
+        from app.core.errors import AIProviderError
+
+        with pytest.raises(AIProviderError) as exc:
+            await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model=None,
+                raise_on_error=True,
+            )
+
+        assert "Select a model" in str(exc.value)
+        assert exc.value.code == "bad_request"
+
+    @pytest.mark.asyncio
+    async def test_blank_model_returns_none_when_not_raising(self):
+        from app.core.ai_client import complete_json
+
+        result = await complete_json(
+            prompt="hi", schema=None, provider="ollama", api_key="", model=None
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_unsafe_base_url_is_refused_before_any_request(self):
+        from app.core.ai_client import complete_json
+
+        with patch("app.core.ai_client.httpx.AsyncClient") as ctor:
+            result = await complete_json(
+                prompt="hi",
+                schema=None,
+                provider="ollama",
+                api_key="",
+                model="m",
+                base_url="file:///etc/passwd",
+            )
+
+        assert result is None
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model_id",
+        ["llama3.1:8b", "qwen2.5:7b-instruct-q4_K_M", "lmstudio-community/Model-GGUF"],
+    )
+    async def test_real_local_model_ids_are_accepted(self, model_id):
+        """A rejection here surfaces as a misleading 'clear the AI model field'."""
+        from app.core.ai_client import complete_json
+
+        mock = _mock_httpx(_openai_shaped('{"ok": true}'))
+        with patch("app.core.ai_client.httpx.AsyncClient", return_value=mock):
+            result = await complete_json(
+                prompt="hi", schema=None, provider="ollama", api_key="", model=model_id
+            )
+
+        assert result == {"ok": True}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestLocalDispatch -v
+```
+
+Expected: FAIL. The first failures are `TypeError: complete_json() got an unexpected keyword argument 'base_url'`.
+
+- [ ] **Step 3: Add the timeout constants**
+
+In `backend/app/core/ai_client.py`, below `_TIMEOUT_SECONDS = 30.0`:
+
+```python
+# Local inference is not comparable to a hosted API. LM Studio JIT-loads model
+# weights on the FIRST request, so a cold 7B model can spend 30-60s before
+# emitting a token, and CPU-only generation runs into the minutes. The remote
+# 30s value would make local support look broken on first use.
+LOCAL_TIMEOUT_SECONDS = 300.0
+# The Test Connection button: still generous enough to survive a cold load, but
+# bounded so a user is not left staring at a spinner for five minutes.
+LOCAL_VALIDATE_TIMEOUT_SECONDS = 120.0
+```
+
+- [ ] **Step 4: Change the `complete_json` signature and guards**
+
+Change the signature so `timeout` resolves per provider. Replace:
+
+```python
+    timeout: float = _TIMEOUT_SECONDS,
+) -> dict | None:
+```
+
+with:
+
+```python
+    base_url: str = "",
+    timeout: float | None = None,
+) -> dict | None:
+```
+
+Add to the docstring, just above the closing `"""`:
+
+```
+    ``base_url`` applies only to the local providers (ollama, lmstudio); blank
+    means the slug's conventional default port. ``timeout`` of None means "pick
+    the right default for this provider", which is much longer for local ones.
+```
+
+Replace the guard block that currently begins `if not api_key:` and ends just
+before the `if provider == "anthropic":` dispatch with:
+
+```python
+    if not ai_is_configured(provider, api_key):
+        logger.debug("complete_json called without a usable credential; returning None")
+        return None
+
+    if provider not in KNOWN_PROVIDERS:
+        logger.warning("Unknown AI provider: %s", sanitize_log_value(provider))
+        return None
+
+    is_local = provider in LOCAL_PROVIDERS
+    local_url = resolve_local_base_url(provider, base_url)
+
+    if is_local and not is_safe_local_ai_url(local_url):
+        # Refused before any request is issued, so a malformed value can never
+        # become an outbound fetch.
+        logger.warning("Rejecting unsafe local AI base URL: %s", sanitize_log_value(local_url))
+        if raise_on_error:
+            raise AIProviderError(
+                f"'{local_url}' is not a valid server address. Use a plain http(s) "
+                "URL such as http://localhost:11434/v1.",
+                code="bad_request",
+            )
+        return None
+
+    model = model or DEFAULT_MODELS.get(provider)
+    if not model:
+        # Only reachable for a local provider now, since KNOWN_PROVIDERS was
+        # checked above and every remote slug has a default.
+        logger.warning("No model set for local provider %s", sanitize_log_value(provider))
+        if raise_on_error:
+            raise AIProviderError(
+                _LOCAL_BLANK_MODEL_MESSAGE.format(
+                    provider=_PROVIDER_LABELS.get(provider, provider)
+                ),
+                code="bad_request",
+            )
+        return None
+
+    if not _is_safe_model_name(model):
+        logger.warning("Rejecting unsafe AI model name: %s", sanitize_log_value(model))
+        if raise_on_error:
+            raise AIProviderError(
+                _INVALID_MODEL_MESSAGE.format(provider=_PROVIDER_LABELS.get(provider, provider)),
+                code="bad_request",
+            )
+        return None
+
+    if timeout is None:
+        timeout = LOCAL_TIMEOUT_SECONDS if is_local else _TIMEOUT_SECONDS
+```
+
+Add the import at the top of the file, alongside the existing `security` import:
+
+```python
+from app.core.security import is_safe_local_ai_url, sanitize_log_value
+```
+
+- [ ] **Step 5: Add the dispatch branch**
+
+In the `if provider == "anthropic": ... elif ...` chain, insert before the final
+`else:`:
+
+```python
+    elif is_local:
+        # Both local servers speak the OpenAI chat-completions contract, so this
+        # is the same adapter the openai/openrouter slugs use. Ollama requires an
+        # Authorization header but ignores its value, and LM Studio ignores the
+        # header entirely, so an empty api_key is correct for both.
+        def factory():
+            return _call_openai_compatible(
+                prompt,
+                api_key or "local",
+                f"{local_url}/chat/completions",
+                model,
+                max_tokens,
+                schema,
+                timeout,
+            )
+```
+
+- [ ] **Step 6: Pass the local context into error classification**
+
+In the `except httpx.HTTPError as e:` block, replace
+
+```python
+        code, message = classify_provider_error(provider, e)
+```
+
+with
+
+```python
+        code, message = classify_provider_error(provider, e, base_url=local_url, model=model)
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestLocalDispatch -v
+```
+
+Expected: PASS, 11 passed.
+
+- [ ] **Step 8: Run the whole unit tier for regressions**
+
+```bash
+uv run pytest tests/unit/ -q
+```
+
+Expected: PASS. Pay attention to `test_ai_identifier.py`, `test_llm_episode_matcher.py`
+and `test_config_ai_model_field.py`, which all exercise `complete_json`.
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+uv run ruff check app/core/ai_client.py && uv run ruff format app/core/ai_client.py
+git add backend/app/core/ai_client.py backend/tests/unit/test_ai_client.py
+git commit -m "feat(ai): route ollama and lmstudio through the OpenAI-compatible adapter (#606)"
+```
+
+---
+
+## Task 5: Preamble-tolerant JSON parsing
+
+Small local models routinely emit reasoning text before the JSON object. This only
+runs where parsing already failed, so it cannot regress the remote providers.
+
+**Files:**
+- Modify: `backend/app/core/ai_client.py`
+- Test: `backend/tests/unit/test_ai_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_ai_client.py`:
+
+```python
+class TestPreambleTolerantParsing:
+    def test_extracts_json_after_a_reasoning_preamble(self):
+        from app.core.ai_client import _parse_json_text
+
+        text = 'Let me think about this. The answer is:\n{"episode": 3, "confidence": 0.8}'
+        assert _parse_json_text(text) == {"episode": 3, "confidence": 0.8}
+
+    def test_ignores_trailing_commentary(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('{"ok": true}\nHope that helps!') == {"ok": True}
+
+    def test_handles_nested_braces(self):
+        from app.core.ai_client import _parse_json_text
+
+        text = 'Result: {"a": {"b": 1}, "c": 2} done'
+        assert _parse_json_text(text) == {"a": {"b": 1}, "c": 2}
+
+    def test_ignores_braces_inside_strings(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('x {"title": "a } b"} y') == {"title": "a } b"}
+
+    def test_plain_json_is_unaffected(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('{"ok": true}') == {"ok": True}
+
+    def test_fenced_json_is_still_handled(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('```json\n{"ok": true}\n```') == {"ok": True}
+
+    def test_genuinely_unparseable_text_still_returns_none(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text("I could not determine the episode.") is None
+
+    def test_unbalanced_braces_return_none(self):
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text('here you go {"ok": true') is None
+
+    def test_a_bare_json_array_still_returns_none(self):
+        """complete_json's contract is a dict; an array is not a usable result."""
+        from app.core.ai_client import _parse_json_text
+
+        assert _parse_json_text("[1, 2, 3]") is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestPreambleTolerantParsing -v
+```
+
+Expected: FAIL on `test_extracts_json_after_a_reasoning_preamble`,
+`test_ignores_trailing_commentary`, `test_handles_nested_braces` and
+`test_ignores_braces_inside_strings`. The other five should already pass.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/ai_client.py`, add above `_parse_json_text`:
+
+```python
+def _extract_first_json_object(text: str) -> str | None:
+    """Return the first balanced {...} span in ``text``, or None.
+
+    Small local models frequently wrap their answer in prose ("Let me think...
+    the answer is: {...}"), which no amount of prompting reliably suppresses.
+    Brace counting is string-aware so that a '}' inside a value (an episode
+    title, say) does not truncate the span, and escape-aware so a quote escaped
+    inside a string does not flip the in-string state.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+```
+
+Then replace the `except json.JSONDecodeError:` block inside `_parse_json_text` with:
+
+```python
+    except json.JSONDecodeError:
+        # Last resort, and only on a path that has already failed: pull the first
+        # balanced object out of surrounding prose. Reached in practice only for
+        # local models, so it cannot regress the hosted providers.
+        candidate = _extract_first_json_object(text)
+        if candidate is not None and candidate != text:
+            try:
+                data = json.loads(candidate)
+            except json.JSONDecodeError:
+                logger.warning("Failed to parse AI response as JSON: %s", text[:200])
+                return None
+            return data if isinstance(data, dict) else None
+        logger.warning("Failed to parse AI response as JSON: %s", text[:200])
+        return None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -k TestPreambleTolerantParsing -v
+```
+
+Expected: PASS, 9 passed.
+
+- [ ] **Step 5: Run the full ai_client suite**
+
+```bash
+uv run pytest tests/unit/test_ai_client.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check app/core/ai_client.py && uv run ruff format app/core/ai_client.py
+git add backend/app/core/ai_client.py backend/tests/unit/test_ai_client.py
+git commit -m "fix(ai): tolerate reasoning preamble around JSON replies (#606)"
+```
+
+---
+
+## Task 6: The `ai_local_base_url` config field
+
+This project has a documented hazard: a new `AppConfig` field that is not also added to
+`ConfigUpdate` and `ConfigResponse` is silently dropped by Pydantic, with no error.
+The round-trip test in Step 1 is the regression guard for exactly that.
+
+**Files:**
+- Modify: `backend/app/models/app_config.py`
+- Modify: `backend/app/api/routes.py`
+- Test: `backend/tests/unit/test_config_ai_model_field.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_config_ai_model_field.py`:
+
+This file is deliberately model-level with no database, and validates writes by calling
+`update_config` directly (it raises before touching persistence). Match that style
+rather than introducing an HTTP client fixture.
+
+```python
+BASE_URL_FIELD = "ai_local_base_url"
+
+
+class TestAiLocalBaseUrlField:
+    """Three-way sync for the local AI base URL.
+
+    Same hazard as ai_model above: a field missing from ConfigUpdate or
+    ConfigResponse is dropped by Pydantic with no error anywhere, so the wizard
+    appears to save and the value never arrives.
+    """
+
+    def test_appconfig_defaults_to_blank(self):
+        """Blank means "use the slug's conventional port", not "no endpoint"."""
+        assert getattr(AppConfig(), BASE_URL_FIELD) == ""
+
+    def test_config_update_accepts_and_carries_the_field(self):
+        update = ConfigUpdate(**{BASE_URL_FIELD: "http://box:11434/v1"})
+        assert update.model_dump()[BASE_URL_FIELD] == "http://box:11434/v1"
+        # Unset stays None so PUT doesn't clobber it when omitted.
+        assert ConfigUpdate().model_dump()[BASE_URL_FIELD] is None
+
+    def test_config_response_exposes_the_field(self):
+        assert BASE_URL_FIELD in ConfigResponse.model_fields
+
+
+class TestLocalBaseUrlIsValidatedOnWrite:
+    """The value is interpolated into an outbound request URL, so PUT must
+    reject a malformed one rather than storing it for a later request to
+    execute. update_config raises before it touches the database."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "http://user:pass@localhost:11434/v1",
+            "http://localhost:11434/v1?x=1",
+            "//localhost:11434/v1",
+        ],
+    )
+    async def test_unsafe_base_url_is_rejected(self, bad):
+        with pytest.raises(HTTPException) as exc:
+            await update_config(ConfigUpdate(ai_local_base_url=bad))
+        assert exc.value.status_code == 422
+        assert BASE_URL_FIELD in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_blank_clears_back_to_the_default(self):
+        """Unlike a key, this is not a secret: clearing it is how a user reverts
+        to the default port, so "" must pass the guard and reach persistence.
+        A regression here would add it to config_service's sensitive_fields set,
+        where a blank write is deliberately ignored."""
+        assert ConfigUpdate(ai_local_base_url="").model_dump()[BASE_URL_FIELD] == ""
+
+    @pytest.mark.asyncio
+    async def test_a_loopback_url_is_accepted(self):
+        """The whole point: is_safe_remote_url would reject this."""
+        from app.core.security import is_safe_local_ai_url
+
+        assert is_safe_local_ai_url("http://localhost:11434/v1") is True
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+uv run pytest tests/unit/test_config_ai_model_field.py -k "LocalBaseUrl" -v
+```
+
+Expected: FAIL. `test_appconfig_defaults_to_blank` fails with
+`AttributeError: 'AppConfig' object has no attribute 'ai_local_base_url'`, and the
+`ConfigUpdate(...)` cases fail because Pydantic ignores the unknown keyword and
+`model_dump()` raises `KeyError: 'ai_local_base_url'`. That KeyError is precisely the
+silent-drop failure mode this class exists to catch.
+
+- [ ] **Step 3: Add the persisted field**
+
+In `backend/app/models/app_config.py`, directly after the `ai_model` field:
+
+```python
+    # Base URL for a local AI server (ollama / lmstudio only). "" means "use the
+    # slug's conventional default port", which is what makes the common case
+    # zero-config. Not a secret: it must stay out of the sensitive_fields set in
+    # config_service, because clearing it back to the default is a legitimate
+    # action and that set exists to prevent blanking.
+    ai_local_base_url: str = ""
+```
+
+Also update the `ai_provider` comment on the line above to list the new slugs:
+
+```python
+    # "anthropic" | "openai" | "openrouter" | "gemini" | "ollama" | "lmstudio"
+    ai_provider: str = "anthropic"
+```
+
+- [ ] **Step 4: Add the field to both API models**
+
+In `backend/app/api/routes.py`, in `ConfigResponse` after `ai_model: str`:
+
+```python
+    ai_local_base_url: str
+```
+
+In `ConfigUpdate` after `ai_model: str | None = None`:
+
+```python
+    ai_local_base_url: str | None = None
+```
+
+In the `ConfigResponse(...)` construction in the GET handler, after the `ai_model=` line:
+
+```python
+        # Not a secret; the wizard must round-trip it to show the endpoint in use.
+        ai_local_base_url=config.ai_local_base_url or "",
+```
+
+- [ ] **Step 5: Validate the URL on write**
+
+In `backend/app/api/routes.py`, immediately after the existing `ai_model` validation
+block in the `PUT /api/config` handler:
+
+```python
+    # Validated on write for the same reason ai_model is: this value is
+    # interpolated into an outbound request URL, so an unchecked value stored
+    # here becomes a request-forgery primitive executed on the next match. A
+    # blank value is the documented way to revert to the provider default and is
+    # deliberately allowed through.
+    if update_data.get("ai_local_base_url"):
+        from app.core.security import is_safe_local_ai_url
+
+        if not is_safe_local_ai_url(update_data["ai_local_base_url"]):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "ai_local_base_url must be a plain http(s) URL with no credentials "
+                    "or query string, such as 'http://localhost:11434/v1'"
+                ),
+            )
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_config_ai_model_field.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Verify the schema reconciler picks up the new column**
+
+The project adds columns through `database.py` reconcilers, not only Alembic, because
+frozen builds skip Alembic entirely. Confirm a fresh boot adds the column:
+
+```bash
+uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"
+uv run python -c "
+import sqlite3
+cols = [r[1] for r in sqlite3.connect('engram.db').execute('PRAGMA table_info(app_config)')]
+assert 'ai_local_base_url' in cols, cols
+print('column present')
+"
+```
+
+Expected: `column present`.
+
+- [ ] **Step 8: Run the config API tests**
+
+```bash
+uv run pytest tests/unit/test_api_routes.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+uv run ruff check app/ && uv run ruff format app/models/app_config.py app/api/routes.py
+git add backend/app/models/app_config.py backend/app/api/routes.py backend/tests/unit/test_config_ai_model_field.py
+git commit -m "feat(config): add ai_local_base_url with write-time URL validation (#606)"
+```
+
+---
+
+## Task 7: Replace the three API-key gates
+
+The highest-risk task in the plan. Miss one of these and the feature ships looking
+configured while doing nothing.
+
+**Files:**
+- Modify: `backend/app/core/curator.py:608`
+- Modify: `backend/app/services/matching_coordinator.py:727`
+- Modify: `backend/app/services/identification_coordinator.py:1819`
+- Test: `backend/tests/unit/test_ai_configured_gates.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_ai_configured_gates.py`:
+
+```python
+"""The 'is AI configured?' invariant.
+
+Four call sites once used `if not config.ai_api_key` as a proxy for 'is AI
+usable?'. Local providers have no key, so any site still testing the key
+directly silently disables local AI while appearing correctly configured. This
+is a source-level guard because the alternative is three separate integration
+tests that each need a full job pipeline.
+"""
+
+import inspect
+
+import pytest
+
+_GATED_MODULES = [
+    "app.core.curator",
+    "app.services.matching_coordinator",
+    "app.services.identification_coordinator",
+]
+
+
+@pytest.mark.parametrize("module_path", _GATED_MODULES)
+def test_no_module_gates_on_the_api_key_directly(module_path):
+    import importlib
+
+    source = inspect.getsource(importlib.import_module(module_path))
+    assert "not config.ai_api_key" not in source, (
+        f"{module_path} still gates on the API key directly. Local providers have "
+        "no key, so this silently disables them. Use ai_is_configured(...)."
+    )
+
+
+@pytest.mark.parametrize("module_path", _GATED_MODULES)
+def test_each_gated_module_uses_the_shared_helper(module_path):
+    import importlib
+
+    source = inspect.getsource(importlib.import_module(module_path))
+    assert "ai_is_configured" in source, f"{module_path} does not use ai_is_configured"
+
+
+def test_complete_json_returns_none_for_a_keyless_remote_provider():
+    """The relaxation must not accidentally let remote providers through."""
+    import asyncio
+
+    from app.core.ai_client import complete_json
+
+    result = asyncio.run(
+        complete_json(prompt="hi", schema=None, provider="openai", api_key="")
+    )
+    assert result is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+uv run pytest tests/unit/test_ai_configured_gates.py -v
+```
+
+Expected: FAIL, 6 failures (three modules times two assertions).
+
+- [ ] **Step 3: Update `curator.py`**
+
+In `backend/app/core/curator.py` around line 608, replace:
+
+```python
+        if not config.ai_api_key:
+            return None
+```
+
+with:
+
+```python
+        from app.core.ai_client import ai_is_configured
+
+        if not ai_is_configured(config.ai_provider, config.ai_api_key):
+            return None
+```
+
+Then, in the `match_episode_via_llm(...)` call in the same method, add the base URL
+after the `ai_model=` argument:
+
+```python
+                ai_local_base_url=getattr(config, "ai_local_base_url", "") or "",
+```
+
+- [ ] **Step 4: Update `matching_coordinator.py`**
+
+In `backend/app/services/matching_coordinator.py` around line 727, replace:
+
+```python
+            if not config.ai_api_key:
+                return None
+```
+
+with:
+
+```python
+            from app.core.ai_client import ai_is_configured
+
+            if not ai_is_configured(config.ai_provider, config.ai_api_key):
+                return None
+```
+
+- [ ] **Step 5: Update `identification_coordinator.py`**
+
+In `backend/app/services/identification_coordinator.py` around line 1819, replace the
+condition line:
+
+```python
+            and config.ai_api_key
+```
+
+with:
+
+```python
+            and ai_is_configured(config.ai_provider, config.ai_api_key)
+```
+
+Add the import at the top of that same `if` block's enclosing function, next to the
+existing local imports:
+
+```python
+        from app.core.ai_client import ai_is_configured
+```
+
+Then extend the `identify_from_label(...)` call with the base URL as a fourth
+positional-compatible keyword:
+
+```python
+                ai_result = await identify_from_label(
+                    job.volume_label,
+                    config.ai_provider,
+                    config.ai_api_key,
+                    getattr(config, "ai_model", "") or None,
+                    base_url=getattr(config, "ai_local_base_url", "") or "",
+                )
+```
+
+- [ ] **Step 6: Thread `base_url` through the two intermediate callers**
+
+In `backend/app/core/ai_identifier.py`, add a `base_url: str = ""` keyword to
+`identify_from_label`'s signature and pass it straight through to `complete_json`:
+
+```python
+        base_url=base_url,
+```
+
+In `backend/app/matcher/llm_episode_matcher.py`, add `ai_local_base_url: str = ""` to
+`match_episode_via_llm`'s signature and pass it to `complete_json` as:
+
+```python
+        base_url=ai_local_base_url,
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_ai_configured_gates.py -v
+```
+
+Expected: PASS, 7 passed.
+
+- [ ] **Step 8: Run the AI-adjacent suites for regressions**
+
+```bash
+uv run pytest tests/unit/test_ai_identifier.py tests/unit/test_llm_episode_matcher.py tests/unit/test_ai_client.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+uv run ruff check app/ && uv run ruff format app/core/curator.py app/core/ai_identifier.py app/services/matching_coordinator.py app/services/identification_coordinator.py app/matcher/llm_episode_matcher.py
+git add backend/app backend/tests/unit/test_ai_configured_gates.py
+git commit -m "fix(ai): gate on ai_is_configured so keyless local providers run (#606)"
+```
+
+---
+
+## Task 8: Fix `validate_ai` for local providers
+
+`DEFAULT_MODELS` is currently doing double duty as the known-provider allowlist. Left
+alone, the Test Connection button rejects the local slugs and then raises `KeyError`.
+
+**Files:**
+- Modify: `backend/app/api/validation.py`
+- Test: `backend/tests/unit/test_validation_ai.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_validation_ai.py`:
+
+```python
+class TestValidateAiLocalProviders:
+    @pytest.mark.asyncio
+    async def test_local_provider_is_accepted_without_a_key(self, client):
+        from unittest.mock import AsyncMock, patch
+
+        with patch(
+            "app.core.ai_client.complete_json", new=AsyncMock(return_value={"ok": True})
+        ):
+            resp = await client.post(
+                "/api/validate/ai",
+                json={"provider": "ollama", "model": "llama3.1:8b"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_local_provider_with_no_model_is_rejected_clearly(self, client):
+        resp = await client.post("/api/validate/ai", json={"provider": "ollama"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert "model" in body["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_is_still_rejected(self, client):
+        resp = await client.post("/api/validate/ai", json={"provider": "notreal"})
+
+        assert resp.status_code == 200
+        assert resp.json()["valid"] is False
+        assert "Unknown AI provider" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_local_validation_uses_the_longer_timeout(self, client):
+        from unittest.mock import AsyncMock, patch
+
+        from app.core.ai_client import LOCAL_VALIDATE_TIMEOUT_SECONDS
+
+        spy = AsyncMock(return_value={"ok": True})
+        with patch("app.core.ai_client.complete_json", new=spy):
+            await client.post(
+                "/api/validate/ai",
+                json={"provider": "lmstudio", "model": "qwen2.5-7b-instruct"},
+            )
+
+        assert spy.await_args.kwargs["timeout"] == LOCAL_VALIDATE_TIMEOUT_SECONDS
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_validation_ai.py -k TestValidateAiLocalProviders -v
+```
+
+Expected: FAIL. The first is `assert 'Unknown AI provider: ollama' ...` because
+`ollama` is not in `DEFAULT_MODELS`.
+
+- [ ] **Step 3: Rewrite the guards in `validate_ai`**
+
+In `backend/app/api/validation.py`, change the import line inside `validate_ai`:
+
+```python
+    from app.core.ai_client import (
+        DEFAULT_MODELS,
+        KNOWN_PROVIDERS,
+        LOCAL_PROVIDERS,
+        LOCAL_VALIDATE_TIMEOUT_SECONDS,
+        ai_is_configured,
+        complete_json,
+    )
+```
+
+Replace the provider membership check:
+
+```python
+    if provider not in KNOWN_PROVIDERS:
+        return ValidationResponse(
+            valid=False, error=f"Unknown AI provider: {provider or '(empty)'}"
+        )
+```
+
+Replace the `if not api_key:` fatal check near the end of the config-loading block with
+one that respects local providers, and add the blank-model check:
+
+```python
+    base_url = (request.base_url or "").strip()
+    if config is not None and not base_url:
+        base_url = (getattr(config, "ai_local_base_url", "") or "").strip()
+
+    if not ai_is_configured(provider, api_key):
+        return ValidationResponse(
+            valid=False, error="No API key provided and none is saved for this provider"
+        )
+    if provider in LOCAL_PROVIDERS and not model:
+        return ValidationResponse(
+            valid=False,
+            error=(
+                "Select a model first. Local providers have no default, because the "
+                "answer depends on which models you have installed."
+            ),
+        )
+```
+
+Update the `complete_json(...)` call to pass the base URL and the right timeout:
+
+```python
+            base_url=base_url,
+            retries=0,
+            timeout=(
+                LOCAL_VALIDATE_TIMEOUT_SECONDS if provider in LOCAL_PROVIDERS else 10.0
+            ),
+```
+
+Fix the success line so it cannot `KeyError` on a local slug:
+
+```python
+    return ValidationResponse(valid=True, version=model or DEFAULT_MODELS.get(provider, ""))
+```
+
+- [ ] **Step 4: Add `base_url` to the request model**
+
+In `backend/app/api/validation.py`, in `AiValidationRequest`:
+
+```python
+    base_url: str | None = None
+```
+
+And extend its docstring with:
+
+```
+    ``base_url`` applies only to the local providers and, like the others, is
+    sent as typed rather than as saved, so the button answers "will this
+    endpoint work" before the user commits to it.
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_validation_ai.py -v
+```
+
+Expected: PASS, including the pre-existing remote-provider tests.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check app/api/validation.py && uv run ruff format app/api/validation.py
+git add backend/app/api/validation.py backend/tests/unit/test_validation_ai.py
+git commit -m "fix(ai): make the connection test work for local providers (#606)"
+```
+
+---
+
+## Task 9: `GET /api/ai/local-models` endpoint
+
+Lives in `validation.py` rather than `routes.py` because it shares that module's two
+conventions: gated by `require_localhost_or_lan`, and never returns 5xx. The router is
+mounted at `/api`, so the decorator path is `/ai/local-models`.
+
+**Files:**
+- Modify: `backend/app/api/validation.py`
+- Test: `backend/tests/unit/test_local_models_endpoint.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_local_models_endpoint.py`:
+
+```python
+"""Tests for the local AI model-list endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+async def client():
+    from app.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def _mock_get(payload: dict, status: int = 200):
+    response = MagicMock()
+    response.json.return_value = payload
+    response.status_code = status
+    response.raise_for_status = MagicMock()
+    c = AsyncMock()
+    c.__aenter__ = AsyncMock(return_value=c)
+    c.__aexit__ = AsyncMock(return_value=False)
+    c.get = AsyncMock(return_value=response)
+    return c
+
+
+class TestLocalModelsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_model_ids_from_the_server(self, client):
+        payload = {"data": [{"id": "llama3.1:8b"}, {"id": "qwen2.5:7b"}]}
+        with patch("app.api.validation.httpx.AsyncClient", return_value=_mock_get(payload)):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == ["llama3.1:8b", "qwen2.5:7b"]
+        assert resp.json()["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_queries_the_default_port_for_the_slug(self, client):
+        mock = _mock_get({"data": []})
+        with patch("app.api.validation.httpx.AsyncClient", return_value=mock):
+            await client.get("/api/ai/local-models?provider=lmstudio")
+
+        assert mock.get.await_args.args[0] == "http://localhost:1234/v1/models"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_server_returns_200_with_an_error_string(self, client):
+        import httpx
+
+        c = AsyncMock()
+        c.__aenter__ = AsyncMock(return_value=c)
+        c.__aexit__ = AsyncMock(return_value=False)
+        c.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        with patch("app.api.validation.httpx.AsyncClient", return_value=c):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        assert "Ollama" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_remote_provider_is_rejected(self, client):
+        resp = await client.get("/api/ai/local-models?provider=openai")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        assert "local" in resp.json()["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unsafe_base_url_is_refused_without_a_request(self, client):
+        with patch("app.api.validation.httpx.AsyncClient") as ctor:
+            resp = await client.get(
+                "/api/ai/local-models?provider=ollama&base_url=file:///etc/passwd"
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+        ctor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_garbage_body_does_not_500(self, client):
+        with patch(
+            "app.api.validation.httpx.AsyncClient", return_value=_mock_get({"nope": 1})
+        ):
+            resp = await client.get("/api/ai/local-models?provider=ollama")
+
+        assert resp.status_code == 200
+        assert resp.json()["models"] == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/unit/test_local_models_endpoint.py -v
+```
+
+Expected: FAIL with 404s, since the route does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/api/validation.py`, add `import httpx` to the imports at the top, then
+append this endpoint:
+
+```python
+class LocalModelsResponse(BaseModel):
+    """Model ids available on a local AI server.
+
+    Never signals failure with a status code: an unreachable server is the
+    NORMAL case while a user is still setting things up, and a 5xx would make
+    the wizard render an error banner instead of quietly falling back to a
+    free-text model field.
+    """
+
+    models: list[str] = []
+    error: str | None = None
+
+
+@router.get("/ai/local-models", response_model=LocalModelsResponse)
+async def list_local_models(
+    provider: str,
+    base_url: str = "",
+    _: None = Depends(require_localhost_or_lan),
+) -> LocalModelsResponse:
+    """List the models a local AI server currently offers.
+
+    Both Ollama and LM Studio expose the OpenAI-compatible ``GET /v1/models``,
+    so one implementation serves both. Gated to the host (or an opted-in LAN)
+    for the same reason as validate_ai: it triggers an outbound request the
+    caller can provoke without owning the destination.
+
+    Doubles as a reachability check, which is why the wizard does not need a
+    separate Test button for the local case.
+    """
+    from app.core.ai_client import (
+        LOCAL_PROVIDERS,
+        classify_provider_error,
+        resolve_local_base_url,
+    )
+    from app.core.security import is_safe_local_ai_url
+
+    if provider not in LOCAL_PROVIDERS:
+        return LocalModelsResponse(
+            error=f"'{sanitize_log_value(provider)}' is not a local AI provider"
+        )
+
+    url_base = resolve_local_base_url(provider, base_url)
+    if not is_safe_local_ai_url(url_base):
+        return LocalModelsResponse(
+            error=(
+                "That is not a valid server address. Use a plain http(s) URL such "
+                "as http://localhost:11434/v1."
+            )
+        )
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(f"{url_base}/models")
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        _, message = classify_provider_error(provider, e, base_url=url_base)
+        logger.info(
+            "Local model list unavailable for %s: %s",
+            sanitize_log_value(provider),
+            sanitize_log_value(str(e)),
+        )
+        return LocalModelsResponse(error=message)
+    except Exception:  # noqa: BLE001 — this endpoint must never 500
+        logger.warning("Local model list raised unexpectedly", exc_info=True)
+        return LocalModelsResponse(error="Could not read the model list")
+
+    models: list[str] = []
+    for entry in (data or {}).get("data") or []:
+        if isinstance(entry, dict) and entry.get("id"):
+            models.append(str(entry["id"]))
+    return LocalModelsResponse(models=models)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/unit/test_local_models_endpoint.py -v
+```
+
+Expected: PASS, 6 passed.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check app/api/validation.py && uv run ruff format app/api/validation.py
+git add backend/app/api/validation.py backend/tests/unit/test_local_models_endpoint.py
+git commit -m "feat(ai): add GET /api/ai/local-models for the model picker (#606)"
+```
+
+---
+
+## Task 10: Frontend model-list helper
+
+**Files:**
+- Create: `frontend/src/utils/localModels.ts`
+- Create: `frontend/src/utils/localModels.test.ts`
+
+Run all frontend commands from `frontend/`. If `node_modules` is absent in this
+worktree, run `npm install` first and then `git checkout package-lock.json` before
+committing, because the install rewrites the lockfile.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/utils/localModels.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchLocalModels, LOCAL_PROVIDERS, localProviderDefaultUrl } from './localModels';
+
+describe('localProviderDefaultUrl', () => {
+    it('knows both default ports', () => {
+        expect(localProviderDefaultUrl('ollama')).toBe('http://localhost:11434/v1');
+        expect(localProviderDefaultUrl('lmstudio')).toBe('http://localhost:1234/v1');
+    });
+
+    it('returns an empty string for a remote provider', () => {
+        expect(localProviderDefaultUrl('openai')).toBe('');
+    });
+});
+
+describe('LOCAL_PROVIDERS', () => {
+    it('matches the backend slugs', () => {
+        expect(LOCAL_PROVIDERS).toEqual(['ollama', 'lmstudio']);
+    });
+});
+
+describe('fetchLocalModels', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the model list on success', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: ['llama3.1:8b'], error: null }),
+        }));
+
+        expect(await fetchLocalModels('ollama', '')).toEqual({
+            models: ['llama3.1:8b'],
+            error: null,
+        });
+    });
+
+    it('passes the base URL through as a query parameter', async () => {
+        const spy = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: [], error: null }),
+        });
+        vi.stubGlobal('fetch', spy);
+
+        await fetchLocalModels('ollama', 'http://box:11434/v1');
+
+        expect(spy.mock.calls[0][0]).toContain('base_url=http%3A%2F%2Fbox%3A11434%2Fv1');
+    });
+
+    it('surfaces the backend error string rather than throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: [], error: 'Could not reach Ollama' }),
+        }));
+
+        expect(await fetchLocalModels('ollama', '')).toEqual({
+            models: [],
+            error: 'Could not reach Ollama',
+        });
+    });
+
+    it('reports a network failure without throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+        const result = await fetchLocalModels('ollama', '');
+        expect(result.models).toEqual([]);
+        expect(result.error).toContain('backend');
+    });
+
+    it('reports a non-ok response without throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({}),
+        }));
+
+        const result = await fetchLocalModels('ollama', '');
+        expect(result.models).toEqual([]);
+        expect(result.error).toContain('403');
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npm run test:unit -- src/utils/localModels.test.ts
+```
+
+Expected: FAIL, cannot resolve `./localModels`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `frontend/src/utils/localModels.ts`:
+
+```typescript
+/**
+ * Model discovery for local AI providers (Ollama, LM Studio).
+ *
+ * Both servers expose the OpenAI-compatible GET /v1/models, which the backend
+ * proxies at /api/ai/local-models. That endpoint never returns 5xx: an
+ * unreachable server is the normal state while a user is still setting up, so
+ * failure arrives as a populated `error` alongside an empty list and the caller
+ * degrades to a free-text model field rather than showing a banner.
+ */
+
+export const LOCAL_PROVIDERS = ['ollama', 'lmstudio'] as const;
+
+export type LocalProvider = (typeof LOCAL_PROVIDERS)[number];
+
+/** Mirrors LOCAL_DEFAULT_BASE_URLS in backend/app/core/ai_client.py. The backend
+ *  is authoritative; these are placeholders and pre-fills only. */
+const DEFAULT_URLS: Record<string, string> = {
+    ollama: 'http://localhost:11434/v1',
+    lmstudio: 'http://localhost:1234/v1',
+};
+
+export function isLocalProvider(provider: string): boolean {
+    return (LOCAL_PROVIDERS as readonly string[]).includes(provider);
+}
+
+export function localProviderDefaultUrl(provider: string): string {
+    return DEFAULT_URLS[provider] ?? '';
+}
+
+export interface LocalModelsResult {
+    models: string[];
+    error: string | null;
+}
+
+export async function fetchLocalModels(
+    provider: string,
+    baseUrl: string,
+): Promise<LocalModelsResult> {
+    const params = new URLSearchParams({ provider });
+    const trimmed = baseUrl.trim();
+    if (trimmed) params.set('base_url', trimmed);
+
+    let response: Response;
+    try {
+        response = await fetch(`/api/ai/local-models?${params.toString()}`);
+    } catch (err) {
+        console.error('Local model list request failed (network):', err);
+        return {
+            models: [],
+            error: "Couldn't reach the backend to list models.",
+        };
+    }
+
+    if (!response.ok) {
+        console.error(`Local model list returned HTTP ${response.status}`);
+        return {
+            models: [],
+            error: `Couldn't list models (HTTP ${response.status}).`,
+        };
+    }
+
+    try {
+        const body = await response.json();
+        return {
+            models: Array.isArray(body.models) ? body.models : [],
+            error: body.error ?? null,
+        };
+    } catch (err) {
+        console.error('Local model list returned an unparseable response:', err);
+        return { models: [], error: "Couldn't read the model list." };
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npm run test:unit -- src/utils/localModels.test.ts
+```
+
+Expected: PASS, 8 passed.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npm run lint
+git add frontend/src/utils/localModels.ts frontend/src/utils/localModels.test.ts
+git commit -m "feat(ui): add local AI model discovery helper (#606)"
+```
+
+---
+
+## Task 11: ConfigWizard integration
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx`
+- Modify: `frontend/src/utils/aiValidation.ts`
+
+- [ ] **Step 1: Extend the validation helper to carry the base URL**
+
+In `frontend/src/utils/aiValidation.ts`, change the signature and payload:
+
+```typescript
+export async function requestAiValidation(
+  provider: string,
+  apiKey: string,
+  model?: string,
+  baseUrl?: string,
+): Promise<AiValidationResult> {
+```
+
+and, after the existing `if (trimmedModel) payload.model = trimmedModel;`:
+
+```typescript
+  const trimmedBaseUrl = (baseUrl ?? '').trim();
+  if (trimmedBaseUrl) payload.base_url = trimmedBaseUrl;
+```
+
+- [ ] **Step 2: Add the new slugs to the label maps**
+
+In `frontend/src/components/ConfigWizard.tsx`, extend the three maps near line 74:
+
+```typescript
+const AI_PROVIDER_LABELS: Record<string, string> = {
+    anthropic: 'Anthropic',
+    openai: 'OpenAI',
+    openrouter: 'OpenRouter',
+    gemini: 'Google Gemini',
+    ollama: 'Ollama',
+    lmstudio: 'LM Studio',
+};
+
+const AI_KEY_PLACEHOLDERS: Record<string, string> = {
+    anthropic: 'sk-ant-...',
+    openai: 'sk-...',
+    openrouter: 'sk-or-...',
+    gemini: 'AIzaSy...',
+};
+
+// Shown as the model-field placeholder so the user can see what they are
+// overriding. Mirrors DEFAULT_MODELS in backend/app/core/ai_client.py — the
+// backend is authoritative, this is a label only. The local providers are
+// deliberately absent: they have no default, and the model field is a required
+// dropdown for them rather than an optional override.
+const AI_DEFAULT_MODELS: Record<string, string> = {
+    anthropic: 'claude-haiku-4-5-20251001',
+    openai: 'gpt-4o-mini',
+    openrouter: 'anthropic/claude-haiku-4-5-20251001',
+    gemini: 'gemini-2.5-flash-lite',
+};
+```
+
+Add the import near the other util imports at the top of the file:
+
+```typescript
+import { fetchLocalModels, isLocalProvider, localProviderDefaultUrl } from '../utils/localModels';
+```
+
+- [ ] **Step 3: Add the config field to state, load and save**
+
+Add to the `ConfigData` interface next to `aiModel: string;`:
+
+```typescript
+    aiLocalBaseUrl: string;
+```
+
+Add to the initial-state object next to the other AI defaults:
+
+```typescript
+        aiLocalBaseUrl: '',
+```
+
+Add to the load mapping next to `aiModel: data.ai_model || '',`:
+
+```typescript
+                    aiLocalBaseUrl: data.ai_local_base_url || '',
+```
+
+Add to the save payload next to `ai_model: config.aiModel.trim(),`:
+
+```typescript
+                    ai_local_base_url: config.aiLocalBaseUrl.trim(),
+```
+
+- [ ] **Step 4: Add model-list state and a fetch effect**
+
+Add alongside the other `useState` declarations in the component:
+
+```typescript
+    const [localModels, setLocalModels] = useState<{models: string[]; error: string | null}>({
+        models: [],
+        error: null,
+    });
+```
+
+Add this effect after the existing effects:
+
+```typescript
+    // Populate the model dropdown whenever a local provider or its endpoint
+    // changes. The fetch doubles as a reachability check, which is why the local
+    // path does not need a separate Test button to tell the user their server is
+    // down. A failure leaves `models` empty, and the field below falls back to
+    // free text so a user with an unreachable server can still type an id.
+    useEffect(() => {
+        if (!config.aiIdentificationEnabled || !isLocalProvider(config.aiProvider)) {
+            setLocalModels({models: [], error: null});
+            return;
+        }
+        let cancelled = false;
+        void (async () => {
+            const result = await fetchLocalModels(config.aiProvider, config.aiLocalBaseUrl);
+            if (!cancelled) setLocalModels(result);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [config.aiIdentificationEnabled, config.aiProvider, config.aiLocalBaseUrl]);
+```
+
+- [ ] **Step 5: Reset the base URL when the provider changes**
+
+The base URL field is shared by both local slugs, so a user who customised an Ollama
+port must not silently inherit it for LM Studio. Replace the `onValueChange` handler of
+the `aiProvider` select with:
+
+```typescript
+                                        onValueChange={(v) => {
+                                            handleInputChange('aiProvider', v);
+                                            // The base URL is shared by both local
+                                            // slugs, so carrying a customised Ollama
+                                            // port over to LM Studio would silently
+                                            // point at the wrong server. Reset to the
+                                            // new slug's default (blank for remote).
+                                            handleInputChange('aiLocalBaseUrl', '');
+                                            handleInputChange('aiModel', '');
+                                            setAiValidation({status: 'idle'});
+                                        }}
+```
+
+- [ ] **Step 6: Add the two new options to the select**
+
+```typescript
+                                        options={[
+                                            { value: 'anthropic', label: 'Anthropic (Claude)' },
+                                            { value: 'openai', label: 'OpenAI' },
+                                            { value: 'openrouter', label: 'OpenRouter' },
+                                            { value: 'gemini', label: 'Google Gemini' },
+                                            { value: 'ollama', label: 'Ollama (local)' },
+                                            { value: 'lmstudio', label: 'LM Studio (local)' },
+                                        ]}
+```
+
+- [ ] **Step 7: Hide the key field and add the base URL field**
+
+Wrap the existing API-key `<div className="form-group">` (the one containing
+`aiApiKey`) in a conditional so it renders only for remote providers:
+
+```typescript
+                                {!isLocalProvider(config.aiProvider) && (
+                                <div className="form-group">
+                                    ... existing API key form-group contents, unchanged ...
+                                </div>
+                                )}
+```
+
+Immediately after it, add the base URL field:
+
+```typescript
+                                {isLocalProvider(config.aiProvider) && (
+                                <div className="form-group">
+                                    <label htmlFor="aiLocalBaseUrl">Server Address</label>
+                                    <input
+                                        id="aiLocalBaseUrl"
+                                        type="text"
+                                        placeholder={localProviderDefaultUrl(config.aiProvider)}
+                                        value={config.aiLocalBaseUrl}
+                                        onChange={(e) => {
+                                            handleInputChange('aiLocalBaseUrl', e.target.value);
+                                            setAiValidation({status: 'idle'});
+                                        }}
+                                    />
+                                    <span className="form-hint">
+                                        Leave blank to use {providerLabel}'s default address
+                                        ({localProviderDefaultUrl(config.aiProvider)}). No API
+                                        key is needed for a local server.
+                                    </span>
+                                    {localModels.error && (
+                                        <span style={{color: '#f59e0b', fontSize: '0.85rem'}}>
+                                            ⚠ {localModels.error}
+                                        </span>
+                                    )}
+                                </div>
+                                )}
+```
+
+- [ ] **Step 8: Turn the model field into a dropdown for local providers**
+
+Replace the existing model `form-group` with:
+
+```typescript
+                                <div className="form-group">
+                                    <label htmlFor="aiModel">
+                                        {isLocalProvider(config.aiProvider) ? 'Model' : 'Model (optional)'}
+                                    </label>
+                                    {isLocalProvider(config.aiProvider) && localModels.models.length > 0 ? (
+                                        <EngramSelect
+                                            id="aiModel"
+                                            value={config.aiModel}
+                                            onValueChange={(v) => {
+                                                handleInputChange('aiModel', v);
+                                                setAiValidation({status: 'idle'});
+                                            }}
+                                            options={localModels.models.map((m) => ({value: m, label: m}))}
+                                        />
+                                    ) : (
+                                        <input
+                                            id="aiModel"
+                                            type="text"
+                                            placeholder={
+                                                isLocalProvider(config.aiProvider)
+                                                    ? 'e.g. llama3.1:8b'
+                                                    : (AI_DEFAULT_MODELS[config.aiProvider] || '')
+                                            }
+                                            value={config.aiModel}
+                                            onChange={(e) => {
+                                                handleInputChange('aiModel', e.target.value);
+                                                setAiValidation({status: 'idle'});
+                                            }}
+                                        />
+                                    )}
+                                    <span className="form-hint">
+                                        {isLocalProvider(config.aiProvider)
+                                            ? "Required. Local providers have no default, because it depends on which models you have installed."
+                                            : "Leave blank to use Engram's default. Set this if your key cannot reach the default model."}
+                                    </span>
+                                </div>
+```
+
+- [ ] **Step 9: Add the concurrency hint**
+
+Immediately after the model `form-group`, inside the same
+`config.aiIdentificationEnabled && (...)` block:
+
+```typescript
+                                {/* Advisory only, never an override: a local server is
+                                    one GPU or CPU, so parallel requests queue rather
+                                    than overlap, and several large contexts at once can
+                                    exhaust VRAM. Silently clamping a setting the user
+                                    configured would be worse than telling them. */}
+                                {isLocalProvider(config.aiProvider) && config.maxConcurrentMatches > 1 && (
+                                    <div className="form-group">
+                                        <span className="form-hint" style={{color: '#f59e0b'}}>
+                                            ⚠ Max Concurrent Matches is set to {config.maxConcurrentMatches}.
+                                            A local server processes one request at a time, so parallel
+                                            matches queue rather than run faster, and several at once can
+                                            exhaust VRAM. Consider setting it to 1 in Matching settings.
+                                        </span>
+                                    </div>
+                                )}
+```
+
+- [ ] **Step 10: Pass the base URL to the Test button**
+
+In `handleTestAi`, skip the key-prefix hint for local providers, drop the
+"enter a key first" gate, and forward the base URL:
+
+```typescript
+    const handleTestAi = async () => {
+        const local = isLocalProvider(config.aiProvider);
+        const key = config.aiApiKey.trim();
+        if (!local && !key && !savedKeys.ai) {
+            setAiValidation({status: 'invalid', error: 'Please enter a key first'});
+            return;
+        }
+        if (local && !config.aiModel.trim()) {
+            setAiValidation({status: 'invalid', error: 'Select a model first'});
+            return;
+        }
+        // Prefix hint only, never a gate: provider key formats change, and a
+        // wrong-provider key is the common mistake after switching providers.
+        // Local providers have no key at all, so the hint does not apply.
+        const expectedPrefix = local ? '' : AI_KEY_PLACEHOLDERS[config.aiProvider]?.replace('...', '');
+        if (key && expectedPrefix && !key.startsWith(expectedPrefix)) {
+            setAiValidation({
+                status: 'invalid',
+                error: `That does not look like a ${AI_PROVIDER_LABELS[config.aiProvider] || config.aiProvider} key (expected it to start with "${expectedPrefix}")`,
+            });
+            return;
+        }
+        setAiValidation({status: 'testing'});
+        const result = await requestAiValidation(
+            config.aiProvider,
+            config.aiApiKey,
+            config.aiModel,
+            config.aiLocalBaseUrl,
+        );
+        if (result.status === 'valid') {
+            setAiValidation({status: 'valid', model: result.model});
+        } else {
+            setAiValidation({status: result.status, error: result.error});
+        }
+    };
+```
+
+- [ ] **Step 11: Move the Test button out of the remote-only block**
+
+Step 7 wrapped the API-key `form-group` in `{!isLocalProvider(...) && (...)}`, and the
+Test button currently lives inside it, so local providers would lose the button
+entirely. Cut the whole `<div style={{display: 'flex', alignItems: 'center', gap:
+'0.5rem', marginTop: '0.5rem'}}>...</div>` block (the button plus its three status
+spans) out of the API-key group and paste it into its own `form-group` placed directly
+after the model field, with the `disabled` clause relaxed for local providers:
+
+```typescript
+                                <div className="form-group">
+                                    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem'}}>
+                                        <button
+                                            type="button"
+                                            onClick={handleTestAi}
+                                            disabled={aiValidation.status === 'testing' || (!isLocalProvider(config.aiProvider) && !config.aiApiKey && !savedKeys.ai)}
+                                            className="btn-secondary"
+                                            style={{padding: '0.25rem 0.75rem', fontSize: '0.85rem'}}
+                                        >
+                                            {aiValidation.status === 'testing' ? 'Testing...' : 'Test Connection'}
+                                        </button>
+                                        {aiValidation.status === 'valid' && (
+                                            <span style={{color: '#22c55e', fontSize: '0.85rem'}}>
+                                                ✓ Connected{aiValidation.model ? ` (${aiValidation.model})` : ''}
+                                            </span>
+                                        )}
+                                        {aiValidation.status === 'invalid' && (
+                                            <span style={{color: '#ef4444', fontSize: '0.85rem'}}>✗ {aiValidation.error}</span>
+                                        )}
+                                        {/* Amber, not red: the key wasn't rejected, the check
+                                            itself failed. Same distinction as the TMDB test. */}
+                                        {aiValidation.status === 'error' && (
+                                            <span style={{color: '#f59e0b', fontSize: '0.85rem'}}>⚠ {aiValidation.error}</span>
+                                        )}
+                                    </div>
+                                </div>
+```
+
+Verify by eye that the API-key `form-group` now ends with its `<span className="form-hint">`
+and no longer contains a button.
+
+- [ ] **Step 12: Typecheck, lint and test**
+
+```bash
+npm run build && npm run lint && npm run test:unit
+```
+
+Expected: all pass. `npm run build` runs the TypeScript check, which catches a missed
+`aiLocalBaseUrl` in the `ConfigData` interface.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add frontend/src/components/ConfigWizard.tsx frontend/src/utils/aiValidation.ts
+git commit -m "feat(ui): local AI provider settings with model picker and concurrency hint (#606)"
+```
+
+---
+
+## Task 12: Manual verification against your LM Studio install
+
+The only step in this plan that exercises real inference. Do not skip it: every test
+above mocks transport, so none of them prove the two servers actually behave as
+documented.
+
+- [ ] **Step 1: Start LM Studio's server**
+
+In LM Studio, open the Developer tab, load a small instruct model (a 7B or 8B is
+plenty), and start the server. Confirm from the shell:
+
+```bash
+curl -s http://localhost:1234/v1/models
+```
+
+Expected: a JSON body with a `data` array containing at least one `id`.
+
+- [ ] **Step 2: Start Engram's backend on this worktree's own port**
+
+From `backend/`:
+
+```bash
+DEBUG=true uv run uvicorn app.main:app --port 8100
+```
+
+Never use `--reload`: it spawns a second drive sentinel and creates duplicate disc events.
+
+- [ ] **Step 3: Start the frontend pointed at that backend**
+
+From `frontend/`:
+
+```bash
+VITE_PORT=5273 VITE_BACKEND_PORT=8100 npm run dev
+```
+
+- [ ] **Step 4: Verify the model list**
+
+```bash
+curl -s "http://localhost:8100/api/ai/local-models?provider=lmstudio"
+```
+
+Expected: `{"models":["<your model id>"],"error":null}`.
+
+- [ ] **Step 5: Verify the wizard end to end**
+
+Open http://localhost:5273, open Settings, enable AI identification, choose
+**LM Studio (local)**. Confirm each of:
+
+- The API key field is gone.
+- The Server Address field shows `http://localhost:1234/v1` as its placeholder.
+- The Model field is a dropdown listing your loaded model.
+- Test Connection reports success, naming the model.
+- Stop the LM Studio server and reload: the model field falls back to free text and an
+  amber warning names LM Studio.
+
+- [ ] **Step 6: Verify a real identification**
+
+Restart the LM Studio server, save the config, and run:
+
+```bash
+curl -X POST localhost:8100/api/simulate/insert-disc \
+  -H "Content-Type: application/json" \
+  -d '{"volume_label":"THE_MATRIX_1999","content_type":"movie","simulate_ripping":true}'
+```
+
+Then confirm the log shows the AI path being taken rather than skipped:
+
+```bash
+grep -i "AI identif" ~/.engram/engram.log | tail -5
+```
+
+Expected: a line showing AI identification ran. A silent absence means a gate from
+Task 7 was missed.
+
+- [ ] **Step 7: Stop this session's servers**
+
+Required before opening the PR. Scoped by port so a sibling session survives:
+
+```powershell
+Get-NetTCPConnection -LocalPort 8100,5273 -State Listen -ErrorAction SilentlyContinue |
+  Select-Object -ExpandProperty OwningProcess -Unique |
+  ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+- [ ] **Step 8: Note the Ollama gap in the PR**
+
+You have LM Studio, not Ollama. Both go through the identical code path and adapter, so
+the risk is low, but say plainly in the PR description that the Ollama path is covered
+by unit tests and not by a live run, so a reviewer with Ollama can confirm it.
+
+---
+
+## Task 13: Documentation and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: the AI configuration page under `docs/`
+
+- [ ] **Step 1: Find the AI docs page**
+
+```bash
+grep -rln "ai_provider\|AI Provider\|OpenRouter" docs/ --include=*.md
+```
+
+- [ ] **Step 2: Document local setup**
+
+Append this section to the page found in Step 1, matching that page's existing heading
+level:
+
+```markdown
+## Local AI (Ollama and LM Studio)
+
+Engram can use a model running on your own machine instead of a paid hosted API.
+Two servers are supported, and both work the same way because they expose the
+same OpenAI-compatible interface.
+
+**No API key is required.** Leave the key field alone; it is hidden when a local
+provider is selected.
+
+### Setup
+
+1. Start your server:
+   - **Ollama:** run `ollama serve`, then pull a model with `ollama pull llama3.1:8b`.
+   - **LM Studio:** open the Developer tab, load a model, and start the server.
+2. In Engram, open **Settings > AI**, enable AI identification, and choose
+   **Ollama (local)** or **LM Studio (local)**.
+3. Leave **Server Address** blank to use the default:
+
+   | Provider | Default address |
+   |---|---|
+   | Ollama | `http://localhost:11434/v1` |
+   | LM Studio | `http://localhost:1234/v1` |
+
+   Set it only if your server runs on another port or another machine on your LAN.
+4. Pick a model from the **Model** dropdown. The list is read from your server, so
+   it only populates once the server is running. Unlike the hosted providers there
+   is no default model, because the answer depends on which models you installed.
+5. Click **Test Connection** to confirm Engram can reach it.
+
+### Choosing a model
+
+Any instruction-tuned model in the 7B to 14B range works well for disc
+identification and episode matching. Both tasks ask for a small JSON reply, so
+reasoning-heavy or very large models buy little and cost a lot of time.
+
+### Performance
+
+Set **Max Concurrent Matches** to 1 in Matching settings. A local server has one
+GPU or CPU, so parallel requests queue rather than overlap, and several large
+contexts at once can exhaust VRAM.
+
+The first request after loading a model is slow: LM Studio loads the weights on
+demand, which can take 30 to 60 seconds before any text appears. Engram allows up
+to five minutes for a local response, so this is expected rather than a failure.
+
+### Troubleshooting
+
+| Message | Cause |
+|---|---|
+| Could not reach Ollama at ... | The server is not running, or the address is wrong. |
+| Model '...' is not available | The model is not pulled (Ollama) or not loaded (LM Studio). |
+| Select a model | Local providers have no default; pick one from the dropdown. |
+```
+
+- [ ] **Step 3: Add the changelog entry**
+
+Under `## [Unreleased]` in `CHANGELOG.md`, in an `### Added` subsection:
+
+```markdown
+- Local AI providers: Engram can now use a local Ollama or LM Studio server for disc
+  identification and episode matching instead of a paid hosted API. No API key is
+  required; pick the model from a dropdown of what the server has installed. (#606)
+```
+
+- [ ] **Step 4: Verify the docs build**
+
+From the repository root:
+
+```bash
+uv run --with mkdocs-material --with "mkdocstrings[python]" mkdocs build
+```
+
+Expected: builds. Roughly 18 pre-existing warnings are normal; do not add `--strict`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md docs/
+git commit -m "docs: document local AI provider setup (#606)"
+```
+
+---
+
+## Task 14: Final verification and PR
+
+- [ ] **Step 1: Run the full backend unit tier**
+
+From `backend/`:
+
+```bash
+uv run pytest tests/unit/ -q
+```
+
+Expected: PASS. This tier can exceed five minutes; do not run it inside a subagent with
+a shorter timeout.
+
+- [ ] **Step 2: Run the pipeline tier**
+
+```bash
+uv run pytest tests/pipeline/ -q
+```
+
+Expected: PASS. If tests fail with "no such table", this worktree's `engram.db` is an
+empty stub; run `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first.
+
+- [ ] **Step 3: Run the frontend checks**
+
+From `frontend/`:
+
+```bash
+npm run build && npm run lint && npm run test:unit
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run the security review**
+
+The spec commits to this, because the change deliberately weakens an SSRF guard.
+
+```
+/security-review
+```
+
+Address anything it raises about `is_safe_local_ai_url` or the two endpoints that
+accept a `base_url`.
+
+- [ ] **Step 5: Confirm no lockfile churn**
+
+```bash
+git status --short
+```
+
+If `frontend/package-lock.json` is modified only because of a local `npm install`,
+restore it:
+
+```bash
+git checkout frontend/package-lock.json
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin claude/local-ai-support-plan-561005
+gh pr create --title "feat(ai): support local AI providers (Ollama, LM Studio)" --body "$(cat <<'BODY'
+Closes #606.
+
+Adds `ollama` and `lmstudio` as AI providers. Both expose the same
+OpenAI-compatible `/v1/chat/completions` contract that `_call_openai_compatible`
+already speaks, so no new adapter was needed: the work was relaxing invariants
+that assumed a remote paid API.
+
+## What changed
+
+- Two new provider slugs sharing the existing OpenAI-compatible adapter, with a
+  configurable base URL (`ai_local_base_url`, blank means the conventional port).
+- `ai_is_configured()` replaces four separate `if not config.ai_api_key` gates.
+  Local servers need no key, so every one of those gates would otherwise have
+  silently disabled the feature while it appeared configured.
+- `is_safe_local_ai_url()`: a deliberately loopback-permitting SSRF guard, kept
+  separate from `is_safe_remote_url` so no other call site is weakened.
+- Longer timeouts for local slugs (300s matching, 120s validation), because a
+  cold LM Studio JIT-loads weights before emitting a token.
+- Local-specific error text naming the endpoint and the model, replacing remote
+  wording like "the account has no API credits".
+- `GET /api/ai/local-models` powering a model dropdown in the wizard.
+- Preamble-tolerant JSON extraction, since small local models wrap replies in prose.
+
+## Testing
+
+Unit tests cover both slugs, URL resolution, the timeout selection, the SSRF
+guard, the four-gate invariant, and the model-list endpoint's failure paths.
+Verified end to end against a live LM Studio server. The Ollama path is covered
+by unit tests but was not exercised against a live server; it shares the adapter
+and dispatch with LM Studio, so the risk is low, but a reviewer with Ollama
+installed confirming it would be welcome.
+
+Design: `docs/superpowers/specs/2026-08-29-local-ai-provider-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 7: Trigger the review bot**
+
+The `code-review` workflow only fires on the `opened` event, so post the trigger
+comment explicitly:
+
+```bash
+gh pr comment --body "@claude please review this PR"
+```
+
+---
+
+## Notes for the reviewer
+
+- **The riskiest change is Task 7.** Three gates in three modules had to change
+  together. `tests/unit/test_ai_configured_gates.py` is a source-level guard against a
+  fourth one being added later that reintroduces the bug.
+- **`is_safe_local_ai_url` is an intentional SSRF exemption**, reasoned about in the
+  spec rather than left implicit. It is deliberately not an alias for
+  `is_safe_remote_url`, and a test pins that difference.
+- **`DEFAULT_MODELS` no longer doubles as the provider allowlist.** `KNOWN_PROVIDERS`
+  took that job. Anywhere that still membership-tests `DEFAULT_MODELS` to mean "is this
+  a real provider?" is a bug.

--- a/docs/superpowers/specs/2026-08-29-local-ai-provider-design.md
+++ b/docs/superpowers/specs/2026-08-29-local-ai-provider-design.md
@@ -1,0 +1,240 @@
+# Local AI Provider Support (Ollama + LM Studio)
+
+Date: 2026-08-29
+Issue: [#606](https://github.com/Jsakkos/engram/issues/606)
+Status: Approved, pending implementation plan
+
+## Problem
+
+Engram's AI features (label identification via `ai_identifier.py`, episode matching via
+`llm_episode_matcher.py`) require a hosted provider and an API key. A user asked for a
+local option so that disc identification and episode matching can run without sending
+transcripts to a third party and without per-token cost.
+
+## Key finding: we do not have to choose
+
+Ollama and LM Studio both expose the **same** OpenAI-compatible surface:
+
+| | Base URL | Chat endpoint | Model list |
+|---|---|---|---|
+| Ollama | `http://localhost:11434/v1` | `POST /chat/completions` | `GET /models` |
+| LM Studio | `http://localhost:1234/v1` | `POST /chat/completions` | `GET /models` |
+
+Both accept `messages`, `max_tokens`, `temperature`, and `response_format`, and both
+return the `choices[0].message.content` / `finish_reason` shape. Ollama requires an
+`Authorization` header but ignores its value; LM Studio requires nothing.
+
+Engram already has an adapter for exactly this contract:
+`_call_openai_compatible()` in `backend/app/core/ai_client.py`, currently shared by the
+`openai` and `openrouter` slugs with only the URL differing. Supporting both local
+servers is therefore primarily **"make the base URL configurable"**, not "write a new
+adapter".
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Provider shape | Two slugs: `ollama` and `lmstudio` | Pre-filled default ports mean zero-config for the common case, and error messages can name the product ("is `ollama serve` running?") rather than surfacing a bare connection error. |
+| Model selection | Fetch `GET /v1/models`, render a dropdown | Local model ids are unguessable and installation-specific. The fetch doubles as a reachability check. |
+| Timeouts | Separate longer constants for local slugs | No new config field, no user decision, and cannot slow the remote paths. |
+| Concurrency | Left at the user's `max_concurrent_matches`, plus a UI hint | An automatic override would silently ignore a configured setting. A hint informs without overriding. |
+
+## Design
+
+### 1. Provider vocabulary (`ai_client.py`)
+
+Three additions, so that no other module has to hardcode the notion of "local":
+
+```python
+LOCAL_PROVIDERS = frozenset({"ollama", "lmstudio"})
+
+LOCAL_DEFAULT_BASE_URLS = {
+    "ollama": "http://localhost:11434/v1",
+    "lmstudio": "http://localhost:1234/v1",
+}
+
+def resolve_local_base_url(provider: str, configured: str) -> str:
+    """Configured value if set, else the slug's conventional default."""
+```
+
+`complete_json` gains two dispatch branches that both call the existing
+`_call_openai_compatible()`, passing `f"{resolve_local_base_url(...)}/chat/completions"`
+as the URL and the api_key verbatim (empty string is acceptable; Ollama ignores the
+value and LM Studio ignores the header).
+
+`DEFAULT_MODELS` deliberately gains **no** entry for the local slugs. There is no
+correct default, and a blank `ai_model` on a local provider is a configuration error the
+user must fix rather than something to paper over with a guess.
+
+**Consequence that must not be missed:** `DEFAULT_MODELS` is currently doing double duty
+as the allowlist of known providers. `validate_ai` (`backend/app/api/validation.py`)
+rejects anything not in it (`if provider not in DEFAULT_MODELS`) and later indexes it
+(`version=model or DEFAULT_MODELS[provider]`), so leaving the local slugs out would make
+the Test button reject them and then raise `KeyError`. The membership test must move to a
+new explicit `KNOWN_PROVIDERS = set(DEFAULT_MODELS) | LOCAL_PROVIDERS`, and the `version`
+line must use `model or DEFAULT_MODELS.get(provider, "")`. `complete_json`'s own
+`model = model or DEFAULT_MODELS.get(provider)` path needs the same care: for a local slug
+that expression yields `None`, which currently falls into the "Unknown AI provider" branch
+and returns `None` silently. It must instead raise or return the blank-model message from
+section 6.
+
+### 2. The "is AI configured?" invariant
+
+Four call sites currently use "is there an API key?" as a proxy for "is AI usable?":
+
+- `backend/app/core/ai_client.py` (early return at the top of `complete_json`)
+- `backend/app/core/curator.py:608`
+- `backend/app/services/matching_coordinator.py:727`
+- `backend/app/services/identification_coordinator.py:1819`
+
+Local providers have no key, so all four would silently return `None` and the feature
+would appear to do nothing. Rather than adding `or is_local(...)` in four places, the
+concept gets named once:
+
+```python
+def ai_is_configured(provider: str, api_key: str) -> bool:
+    """True if this provider has what it needs to make a call.
+
+    Local providers authenticate to nothing, so requiring a key would silently
+    disable them at every call site that guards on one.
+    """
+    return provider in LOCAL_PROVIDERS or bool(api_key)
+```
+
+All four sites call it. This is the single change most likely to be missed and the one
+that makes the feature work at all.
+
+### 3. Configuration
+
+One new field, `ai_local_base_url: str = ""`, where blank means "use the slug's
+default". Per the project's three-way-sync rule it must land in **all four** of:
+
+- `AppConfig` (`backend/app/models/app_config.py`)
+- `ConfigUpdate` (`backend/app/api/routes.py:414`)
+- `ConfigResponse` (`backend/app/api/routes.py:316`)
+- `ConfigWizard` (`frontend/src/components/ConfigWizard.tsx`)
+
+Omitting any one causes Pydantic to drop the value silently.
+
+The field is **not** sensitive: it must not join the `sensitive_fields` set in
+`config_service.py:213` (that set protects secrets from being blanked by an empty
+string; a base URL legitimately needs to be clearable back to its default).
+
+**Provider switching:** the field is shared by both slugs. ConfigWizard resets it to the
+newly selected slug's default whenever the provider changes, so a user who customized an
+Ollama port cannot silently inherit it for LM Studio.
+
+### 4. Security: a deliberate SSRF exemption
+
+`is_safe_remote_url()` (`backend/app/core/security.py:165`) rejects loopback, private,
+and link-local hosts by design. Those are precisely the addresses a local AI server lives
+at, so `ai_local_base_url` needs its own guard, modelled on the existing
+`is_safe_dashboard_url` precedent:
+
+```python
+def is_safe_local_ai_url(url: str) -> bool:
+    """http(s) only, host present, no embedded credentials, no query or fragment."""
+```
+
+This is an intentional weakening and is recorded here rather than buried in a commit.
+Unlike `dashboard_base_url` (never fetched, only rendered as a link), the server **does**
+issue POSTs to this URL, which makes it a blind-SSRF primitive against the host's own
+loopback interface. Accepted because:
+
+- The config surface is already fully trusted: it holds API keys, filesystem paths, and
+  library roots. Anyone able to write `ai_local_base_url` can already do worse.
+- `PUT /api/config` and the new model-list endpoint are gated by
+  `require_localhost_or_lan`, matching the existing AI validator.
+- Only http(s) is accepted, embedded credentials are rejected, and the response body is
+  parsed as JSON and discarded unless it matches the requested schema. The primitive is
+  blind, not an exfiltration channel.
+
+The implementation diff should still be run through `/security-review` before merge.
+
+### 5. Timeouts
+
+```python
+LOCAL_TIMEOUT_SECONDS = 300.0           # matching / identification
+LOCAL_VALIDATE_TIMEOUT_SECONDS = 120.0  # the Test button
+```
+
+Selected by slug in `complete_json` and in `validate_ai`. The wide margin is deliberate:
+LM Studio JIT-loads model weights on the *first* request, so a cold 7B model can spend 30
+to 60 seconds before emitting a token, and CPU-only generation runs into the minutes. The
+existing 30s and 10s values would make local support look broken on first use.
+
+### 6. Error messages
+
+`_CAUSE_MESSAGES` is worded for remote paid APIs ("the account has no API credits"),
+which is meaningless locally. Local slugs get an override table:
+
+| Condition | Message |
+|---|---|
+| Connection refused / network | `Could not reach Ollama at {url}. Is the server running? (ollama serve)` LM Studio variant names its Developer tab instead. |
+| HTTP 404 | `Model '{model}' is not available. Pull it first: ollama pull {model}` |
+| Blank `ai_model` | `Select a model. Local providers have no default.` |
+
+`_PROVIDER_LABELS` gains `ollama: "Ollama"` and `lmstudio: "LM Studio"`.
+
+### 7. Model picker endpoint
+
+```
+GET /api/ai/local-models?provider=ollama&base_url=...
+  -> {"models": ["llama3.1:8b", ...], "error": null}
+```
+
+Gated by `require_localhost_or_lan` for the same reason as `validate_ai`: it triggers an
+outbound request the caller can provoke without owning the destination. It never returns
+5xx. An unreachable server yields HTTP 200 with an empty list and a populated `error`
+string, so ConfigWizard can degrade gracefully to a free-text model field.
+
+### 8. Shared-code fix: preamble-tolerant JSON parsing
+
+`_parse_json_text()` already strips ` ```json ` fences. Small local models additionally
+emit reasoning preamble *before* the JSON object. A last-resort fallback that extracts
+the first balanced `{...}` block is added. It only runs where parsing already failed, so
+it cannot regress the remote providers, and without it match quality on local models is
+visibly worse.
+
+### 9. Frontend
+
+- `AI_PROVIDER_LABELS`, `AI_KEY_PLACEHOLDERS`, `AI_DEFAULT_MODELS` gain the two slugs.
+  The key field is **hidden** (not merely optional) for local providers.
+- A base-URL text input appears only for local providers, placeholdered with the slug
+  default.
+- The model field becomes a dropdown populated from `/api/ai/local-models`, falling back
+  to free text when the fetch fails or returns empty.
+- **Concurrency hint.** When a local provider is selected and `max_concurrent_matches`
+  exceeds 1, the AI section shows an inline note: local inference is served by a single
+  GPU or CPU, so parallel requests queue rather than speed up and may exhaust VRAM;
+  consider setting concurrent matches to 1. Advisory only; the setting is not overridden.
+
+## Testing
+
+Follows the existing `unittest.mock.patch("app.core.ai_client.httpx.AsyncClient")` style
+in `backend/tests/unit/test_ai_client.py`. No new test dependency.
+
+- URL resolution for both slugs, default and override.
+- `ai_is_configured` returns True with an empty key for local slugs, False for remote.
+- The local timeout constant actually reaches the `httpx` call.
+- Local error-message overrides for refused-connection and HTTP 404.
+- `is_safe_local_ai_url` accepts loopback and rejects `file://`, embedded credentials,
+  and non-http schemes.
+- Preamble-tolerant JSON parsing, including a case that must still fail.
+- `_is_safe_model_name` accepts real local model ids. The existing regex allows `.`, `_`,
+  `:`, `-`, `@` and slash-separated segments, so `llama3.1:8b`,
+  `qwen2.5:7b-instruct-q4_K_M`, and `lmstudio-community/Model-GGUF` should all pass. This
+  is asserted rather than assumed, because a rejection surfaces to the user as a
+  misleading "clear the AI model field" message.
+- A local slug with a blank `ai_model` reports the section 6 blank-model message rather
+  than silently returning `None`.
+- `GET /api/ai/local-models` unreachable-server path returns 200 with an empty list.
+- A config round-trip asserting `ai_local_base_url` survives `PUT` then `GET` (the
+  three-way-sync regression guard).
+
+## Out of scope
+
+- Automatic discovery of a running local server (port scanning).
+- Bundling or installing Ollama / LM Studio.
+- Local ASR provider selection; this spec covers text completion only.
+- Overriding `max_concurrent_matches` automatically.

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -462,6 +462,61 @@ describe('ConfigWizard: Discord notification settings', () => {
     });
 });
 
+describe('ConfigWizard — local AI provider settings', () => {
+    /** Data Sharing → AI assistance is collapsed by default; expand it and turn
+     *  the feature on so the provider/model fields render. */
+    async function openAiAssistance() {
+        render(<ConfigWizard {...noop} isOnboarding={false} />);
+        const nav = await screen.findByRole('navigation', { name: /settings sections/i });
+        fireEvent.click(within(nav).getByRole('button', { name: 'Data Sharing' }));
+
+        const summary = await screen.findByText('AI assistance');
+        fireEvent.click(summary);
+
+        const enable = await screen.findByRole('checkbox', { name: /AI-Powered Title Resolution/i });
+        fireEvent.click(enable);
+    }
+
+    async function selectProvider(label: string) {
+        const trigger = screen.getByLabelText('AI Provider');
+        fireEvent.click(trigger);
+        fireEvent.click(await screen.findByText(label));
+    }
+
+    it('selecting a local provider hides the API-key field and shows Server Address', async () => {
+        await openAiAssistance();
+
+        expect(screen.getByLabelText(/Anthropic API Key/i)).toBeInTheDocument();
+        expect(screen.queryByLabelText('Server Address')).not.toBeInTheDocument();
+
+        await selectProvider('Ollama (local)');
+
+        expect(document.getElementById('aiApiKey')).toBeNull();
+        expect(await screen.findByLabelText('Server Address')).toBeInTheDocument();
+    });
+
+    it('shows the concurrency hint only for a local provider with Max Concurrent Matches > 1', async () => {
+        mockApi({ max_concurrent_matches: 3 });
+        await openAiAssistance();
+
+        // Remote provider (default): no hint even though concurrency is 3.
+        expect(screen.queryByText(/processes one request at a time/i)).not.toBeInTheDocument();
+
+        await selectProvider('Ollama (local)');
+
+        expect(await screen.findByText(/processes one request at a time/i)).toBeInTheDocument();
+    });
+
+    it('does not show the concurrency hint for a local provider when Max Concurrent Matches is 1', async () => {
+        mockApi({ max_concurrent_matches: 1 });
+        await openAiAssistance();
+
+        await selectProvider('Ollama (local)');
+
+        expect(screen.queryByText(/processes one request at a time/i)).not.toBeInTheDocument();
+    });
+});
+
 describe('ConfigWizard: webhook test targets the saved value', () => {
     it('refuses to test an unsaved webhook edit instead of silently testing the old one', async () => {
         render(<ConfigWizard {...noop} isOnboarding={false} />);

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -9,6 +9,7 @@ import GpuAccelerationSetting from './GpuAccelerationSetting';
 import BackgroundEffectsSetting from './BackgroundEffectsSetting';
 import { requestTmdbValidation } from '../utils/tmdbValidation';
 import { requestAiValidation } from '../utils/aiValidation';
+import { fetchLocalModels, isLocalProvider, localProviderDefaultUrl } from '../utils/localModels';
 import { requestDiscordTemplateValidation } from '../utils/discordTemplateValidation';
 import { requestDiscordWebhookTest } from '../utils/discordWebhookTest';
 import { formatToolVersion } from '../utils/formatting';
@@ -76,6 +77,8 @@ const AI_PROVIDER_LABELS: Record<string, string> = {
     openai: 'OpenAI',
     openrouter: 'OpenRouter',
     gemini: 'Google Gemini',
+    ollama: 'Ollama',
+    lmstudio: 'LM Studio',
 };
 
 const AI_KEY_PLACEHOLDERS: Record<string, string> = {
@@ -87,7 +90,9 @@ const AI_KEY_PLACEHOLDERS: Record<string, string> = {
 
 // Shown as the model-field placeholder so the user can see what they are
 // overriding. Mirrors DEFAULT_MODELS in backend/app/core/ai_client.py — the
-// backend is authoritative, this is a label only.
+// backend is authoritative, this is a label only. The local providers are
+// deliberately absent: they have no default, and the model field is a required
+// dropdown for them rather than an optional override.
 const AI_DEFAULT_MODELS: Record<string, string> = {
     anthropic: 'claude-haiku-4-5-20251001',
     openai: 'gpt-4o-mini',
@@ -168,6 +173,7 @@ interface ConfigData {
     aiProvider: string;
     aiApiKey: string;
     aiModel: string;
+    aiLocalBaseUrl: string;
     discdbContributionsEnabled: boolean;
     discdbContributionTier: number;
     discdbExportPath: string;
@@ -257,6 +263,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         aiProvider: 'anthropic',
         aiApiKey: '',
         aiModel: '',
+        aiLocalBaseUrl: '',
         discdbContributionsEnabled: false,
         discdbContributionTier: 2,
         discdbExportPath: '',
@@ -291,6 +298,10 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
     // lets the user continue without TMDB.
     const [tmdbValidation, setTmdbValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid' | 'error', error?: string}>({status: 'idle'});
     const [aiValidation, setAiValidation] = useState<{status: 'idle' | 'testing' | 'valid' | 'invalid' | 'error', error?: string, model?: string}>({status: 'idle'});
+    const [localModels, setLocalModels] = useState<{models: string[]; error: string | null}>({
+        models: [],
+        error: null,
+    });
     // Inline validation for manually-entered tool paths (MakeMKV/FFmpeg), keyed by
     // the config field. Without this, a hand-typed override was saved blind — no
     // confirmation it actually points at a working binary.
@@ -325,6 +336,26 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
             setNetworkInfo(null);
         }
     }, [config.allowLanAccess, fetchNetworkInfo]);
+
+    // Populate the model dropdown whenever a local provider or its endpoint
+    // changes. The fetch doubles as a reachability check, which is why the local
+    // path does not need a separate Test button to tell the user their server is
+    // down. A failure leaves `models` empty, and the field below falls back to
+    // free text so a user with an unreachable server can still type an id.
+    useEffect(() => {
+        if (!config.aiIdentificationEnabled || !isLocalProvider(config.aiProvider)) {
+            setLocalModels({models: [], error: null});
+            return;
+        }
+        let cancelled = false;
+        void (async () => {
+            const result = await fetchLocalModels(config.aiProvider, config.aiLocalBaseUrl);
+            if (!cancelled) setLocalModels(result);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [config.aiIdentificationEnabled, config.aiProvider, config.aiLocalBaseUrl]);
 
     // Load existing config on mount
     useEffect(() => {
@@ -384,6 +415,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     aiProvider: data.ai_provider || 'anthropic',
                     aiApiKey: data.ai_api_key === '***' ? '' : (data.ai_api_key || ''),
                     aiModel: data.ai_model || '',
+                    aiLocalBaseUrl: data.ai_local_base_url || '',
                     discdbContributionsEnabled: data.discdb_contributions_enabled ?? false,
                     discdbContributionTier: data.discdb_contribution_tier ?? 2,
                     discdbExportPath: data.discdb_export_path || '',
@@ -601,6 +633,7 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     // which drops blanks so a saved key survives — would make the
                     // override impossible to clear once set.
                     ai_model: config.aiModel.trim(),
+                    ai_local_base_url: config.aiLocalBaseUrl.trim(),
                     discdb_contributions_enabled: config.discdbContributionsEnabled,
                     discdb_contribution_tier: config.discdbContributionTier,
                     discdb_export_path: config.discdbExportPath,
@@ -652,14 +685,20 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
     };
 
     const handleTestAi = async () => {
+        const local = isLocalProvider(config.aiProvider);
         const key = config.aiApiKey.trim();
-        if (!key && !savedKeys.ai) {
+        if (!local && !key && !savedKeys.ai) {
             setAiValidation({status: 'invalid', error: 'Please enter a key first'});
+            return;
+        }
+        if (local && !config.aiModel.trim()) {
+            setAiValidation({status: 'invalid', error: 'Select a model first'});
             return;
         }
         // Prefix hint only, never a gate: provider key formats change, and a
         // wrong-provider key is the common mistake after switching providers.
-        const expectedPrefix = AI_KEY_PLACEHOLDERS[config.aiProvider]?.replace('...', '');
+        // Local providers have no key at all, so the hint does not apply.
+        const expectedPrefix = local ? '' : AI_KEY_PLACEHOLDERS[config.aiProvider]?.replace('...', '');
         if (key && expectedPrefix && !key.startsWith(expectedPrefix)) {
             setAiValidation({
                 status: 'invalid',
@@ -670,7 +709,12 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         setAiValidation({status: 'testing'});
         // The model goes as typed, not as saved: the point of testing is to find
         // out whether this key can reach this model before committing to it.
-        const result = await requestAiValidation(config.aiProvider, config.aiApiKey, config.aiModel);
+        const result = await requestAiValidation(
+            config.aiProvider,
+            config.aiApiKey,
+            config.aiModel,
+            config.aiLocalBaseUrl,
+        );
         if (result.status === 'valid') {
             setAiValidation({status: 'valid', model: result.model});
         } else {
@@ -1262,6 +1306,13 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                         value={config.aiProvider}
                                         onValueChange={(v) => {
                                             handleInputChange('aiProvider', v);
+                                            // The base URL is shared by both local
+                                            // slugs, so carrying a customised Ollama
+                                            // port over to LM Studio would silently
+                                            // point at the wrong server. Reset to the
+                                            // new slug's default (blank for remote).
+                                            handleInputChange('aiLocalBaseUrl', '');
+                                            handleInputChange('aiModel', '');
                                             setAiValidation({status: 'idle'});
                                         }}
                                         options={[
@@ -1269,9 +1320,12 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                             { value: 'openai', label: 'OpenAI' },
                                             { value: 'openrouter', label: 'OpenRouter' },
                                             { value: 'gemini', label: 'Google Gemini' },
+                                            { value: 'ollama', label: 'Ollama (local)' },
+                                            { value: 'lmstudio', label: 'LM Studio (local)' },
                                         ]}
                                     />
                                 </div>
+                                {!isLocalProvider(config.aiProvider) && (
                                 <div className="form-group">
                                     <label htmlFor="aiApiKey">
                                         {providerLabel} API Key
@@ -1287,11 +1341,78 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                             setAiValidation({status: 'idle'});
                                         }}
                                     />
-                                    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.5rem'}}>
+                                    <span className="form-hint">
+                                        API key for {providerLabel}. Used only when TMDB lookup fails.
+                                    </span>
+                                </div>
+                                )}
+                                {isLocalProvider(config.aiProvider) && (
+                                <div className="form-group">
+                                    <label htmlFor="aiLocalBaseUrl">Server Address</label>
+                                    <input
+                                        id="aiLocalBaseUrl"
+                                        type="text"
+                                        placeholder={localProviderDefaultUrl(config.aiProvider)}
+                                        value={config.aiLocalBaseUrl}
+                                        onChange={(e) => {
+                                            handleInputChange('aiLocalBaseUrl', e.target.value);
+                                            setAiValidation({status: 'idle'});
+                                        }}
+                                    />
+                                    <span className="form-hint">
+                                        Leave blank to use {providerLabel}'s default address
+                                        ({localProviderDefaultUrl(config.aiProvider)}). No API
+                                        key is needed for a local server.
+                                    </span>
+                                    {localModels.error && (
+                                        <span style={{color: '#f59e0b', fontSize: '0.85rem'}}>
+                                            ⚠ {localModels.error}
+                                        </span>
+                                    )}
+                                </div>
+                                )}
+                                <div className="form-group">
+                                    <label htmlFor="aiModel">
+                                        {isLocalProvider(config.aiProvider) ? 'Model' : 'Model (optional)'}
+                                    </label>
+                                    {isLocalProvider(config.aiProvider) && localModels.models.length > 0 ? (
+                                        <EngramSelect
+                                            id="aiModel"
+                                            value={config.aiModel}
+                                            onValueChange={(v) => {
+                                                handleInputChange('aiModel', v);
+                                                setAiValidation({status: 'idle'});
+                                            }}
+                                            options={localModels.models.map((m) => ({value: m, label: m}))}
+                                        />
+                                    ) : (
+                                        <input
+                                            id="aiModel"
+                                            type="text"
+                                            placeholder={
+                                                isLocalProvider(config.aiProvider)
+                                                    ? 'e.g. llama3.1:8b'
+                                                    : (AI_DEFAULT_MODELS[config.aiProvider] || '')
+                                            }
+                                            value={config.aiModel}
+                                            onChange={(e) => {
+                                                handleInputChange('aiModel', e.target.value);
+                                                setAiValidation({status: 'idle'});
+                                            }}
+                                        />
+                                    )}
+                                    <span className="form-hint">
+                                        {isLocalProvider(config.aiProvider)
+                                            ? "Required. Local providers have no default, because it depends on which models you have installed."
+                                            : "Leave blank to use Engram's default. Set this if your key cannot reach the default model."}
+                                    </span>
+                                </div>
+                                <div className="form-group">
+                                    <div style={{display: 'flex', alignItems: 'center', gap: '0.5rem'}}>
                                         <button
                                             type="button"
                                             onClick={handleTestAi}
-                                            disabled={aiValidation.status === 'testing' || (!config.aiApiKey && !savedKeys.ai)}
+                                            disabled={aiValidation.status === 'testing' || (!isLocalProvider(config.aiProvider) && !config.aiApiKey && !savedKeys.ai)}
                                             className="btn-secondary"
                                             style={{padding: '0.25rem 0.75rem', fontSize: '0.85rem'}}
                                         >
@@ -1311,28 +1432,22 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                                             <span style={{color: '#f59e0b', fontSize: '0.85rem'}}>⚠ {aiValidation.error}</span>
                                         )}
                                     </div>
-                                    <span className="form-hint">
-                                        API key for {providerLabel}. Used only when TMDB lookup fails.
-                                    </span>
                                 </div>
-                                <div className="form-group">
-                                    <label htmlFor="aiModel">Model (optional)</label>
-                                    <input
-                                        id="aiModel"
-                                        type="text"
-                                        placeholder={AI_DEFAULT_MODELS[config.aiProvider] || ''}
-                                        value={config.aiModel}
-                                        onChange={(e) => {
-                                            handleInputChange('aiModel', e.target.value);
-                                            setAiValidation({status: 'idle'});
-                                        }}
-                                    />
-                                    <span className="form-hint">
-                                        Leave blank to use Engram's default. Set this if your key
-                                        cannot reach the default model — a key without access gets
-                                        a "does not have access" error naming the models it can use.
-                                    </span>
-                                </div>
+                                {/* Advisory only, never an override: a local server is
+                                    one GPU or CPU, so parallel requests queue rather
+                                    than overlap, and several large contexts at once can
+                                    exhaust VRAM. Silently clamping a setting the user
+                                    configured would be worse than telling them. */}
+                                {isLocalProvider(config.aiProvider) && config.maxConcurrentMatches > 1 && (
+                                    <div className="form-group">
+                                        <span className="form-hint" style={{color: '#f59e0b'}}>
+                                            ⚠ Max Concurrent Matches is set to {config.maxConcurrentMatches}.
+                                            A local server processes one request at a time, so parallel
+                                            matches queue rather than run faster, and several at once can
+                                            exhaust VRAM. Consider setting it to 1 in Matching settings.
+                                        </span>
+                                    </div>
+                                )}
                                 </div>
                                 <div className="form-group checkbox-group">
                                     <label className="checkbox-label">

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -1276,7 +1276,10 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                         <details className="wizard-group">
                             <summary>
                                 <span className="wizard-group-chevron">▸</span>AI assistance
-                                <span className="wizard-group-sub">optional · API key required</span>
+                                {/* Not "API key required" any more: the local providers
+                                    (Ollama, LM Studio) authenticate to nothing, so a key
+                                    is only needed for the hosted ones. */}
+                                <span className="wizard-group-sub">optional · hosted or local</span>
                             </summary>
                             <div className="wizard-group-body">
 

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -100,6 +100,10 @@ const AI_DEFAULT_MODELS: Record<string, string> = {
     gemini: 'gemini-2.5-flash-lite',
 };
 
+// Long enough to swallow a typed-out host, short enough that pasting one and
+// stopping still feels immediate.
+const LOCAL_MODEL_FETCH_DEBOUNCE_MS = 400;
+
 interface NamingPreset {
     id: string;
     seasonFormat: string;
@@ -342,18 +346,27 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
     // path does not need a separate Test button to tell the user their server is
     // down. A failure leaves `models` empty, and the field below falls back to
     // free text so a user with an unreachable server can still type an id.
+    // Debounced, because aiLocalBaseUrl is a dependency and someone typing a
+    // custom host would otherwise fire one request per keystroke — each of which
+    // the backend turns into its own outbound fetch with a 5s timeout. Clearing
+    // the timer on cleanup means only the last keystroke actually asks; the
+    // `cancelled` flag then guards the state update for a reply that lands after
+    // the inputs changed again.
     useEffect(() => {
         if (!config.aiIdentificationEnabled || !isLocalProvider(config.aiProvider)) {
             setLocalModels({models: [], error: null});
             return;
         }
         let cancelled = false;
-        void (async () => {
-            const result = await fetchLocalModels(config.aiProvider, config.aiLocalBaseUrl);
-            if (!cancelled) setLocalModels(result);
-        })();
+        const timer = setTimeout(() => {
+            void (async () => {
+                const result = await fetchLocalModels(config.aiProvider, config.aiLocalBaseUrl);
+                if (!cancelled) setLocalModels(result);
+            })();
+        }, LOCAL_MODEL_FETCH_DEBOUNCE_MS);
         return () => {
             cancelled = true;
+            clearTimeout(timer);
         };
     }, [config.aiIdentificationEnabled, config.aiProvider, config.aiLocalBaseUrl]);
 

--- a/frontend/src/utils/aiValidation.test.ts
+++ b/frontend/src/utils/aiValidation.test.ts
@@ -106,6 +106,26 @@ describe('requestAiValidation', () => {
         });
     });
 
+    it('sends the base URL when one is entered', async () => {
+        const spy = vi.fn().mockResolvedValue({
+            ok: true, json: async () => ({ valid: true }),
+        });
+        stubFetch(spy);
+        await requestAiValidation('ollama', '', '', '  http://localhost:11434  ');
+        expect(JSON.parse(spy.mock.calls[0][1].body)).toEqual({
+            provider: 'ollama', base_url: 'http://localhost:11434',
+        });
+    });
+
+    it('omits base_url entirely when blank so the backend falls back to the saved value', async () => {
+        const spy = vi.fn().mockResolvedValue({
+            ok: true, json: async () => ({ valid: true }),
+        });
+        stubFetch(spy);
+        await requestAiValidation('ollama', '', '', '   ');
+        expect(JSON.parse(spy.mock.calls[0][1].body)).toEqual({ provider: 'ollama' });
+    });
+
     it('reports an unparseable body as error', async () => {
         stubFetch(vi.fn().mockResolvedValue({
             ok: true, json: async () => { throw new Error('bad json'); },

--- a/frontend/src/utils/aiValidation.ts
+++ b/frontend/src/utils/aiValidation.ts
@@ -36,6 +36,7 @@ export async function requestAiValidation(
   provider: string,
   apiKey: string,
   model?: string,
+  baseUrl?: string,
 ): Promise<AiValidationResult> {
   // Omit the key entirely when blank so the backend falls back to the stored
   // one. Posting "" would be rejected as an empty key, which is what makes the
@@ -46,6 +47,8 @@ export async function requestAiValidation(
   const payload: Record<string, string> = { provider };
   if (trimmed) payload.api_key = trimmed;
   if (trimmedModel) payload.model = trimmedModel;
+  const trimmedBaseUrl = (baseUrl ?? '').trim();
+  if (trimmedBaseUrl) payload.base_url = trimmedBaseUrl;
 
   let response: Response;
   try {

--- a/frontend/src/utils/localModels.test.ts
+++ b/frontend/src/utils/localModels.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchLocalModels, LOCAL_PROVIDERS, localProviderDefaultUrl } from './localModels';
+
+describe('localProviderDefaultUrl', () => {
+    it('knows both default ports', () => {
+        expect(localProviderDefaultUrl('ollama')).toBe('http://localhost:11434/v1');
+        expect(localProviderDefaultUrl('lmstudio')).toBe('http://localhost:1234/v1');
+    });
+
+    it('returns an empty string for a remote provider', () => {
+        expect(localProviderDefaultUrl('openai')).toBe('');
+    });
+});
+
+describe('LOCAL_PROVIDERS', () => {
+    it('matches the backend slugs', () => {
+        expect(LOCAL_PROVIDERS).toEqual(['ollama', 'lmstudio']);
+    });
+});
+
+describe('fetchLocalModels', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the model list on success', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: ['llama3.1:8b'], error: null }),
+        }));
+
+        expect(await fetchLocalModels('ollama', '')).toEqual({
+            models: ['llama3.1:8b'],
+            error: null,
+        });
+    });
+
+    it('passes the base URL through as a query parameter', async () => {
+        const spy = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: [], error: null }),
+        });
+        vi.stubGlobal('fetch', spy);
+
+        await fetchLocalModels('ollama', 'http://box:11434/v1');
+
+        expect(spy.mock.calls[0][0]).toContain('base_url=http%3A%2F%2Fbox%3A11434%2Fv1');
+    });
+
+    it('surfaces the backend error string rather than throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ models: [], error: 'Could not reach Ollama' }),
+        }));
+
+        expect(await fetchLocalModels('ollama', '')).toEqual({
+            models: [],
+            error: 'Could not reach Ollama',
+        });
+    });
+
+    it('reports a network failure without throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+        const result = await fetchLocalModels('ollama', '');
+        expect(result.models).toEqual([]);
+        expect(result.error).toContain('backend');
+    });
+
+    it('reports a non-ok response without throwing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 403,
+            json: async () => ({}),
+        }));
+
+        const result = await fetchLocalModels('ollama', '');
+        expect(result.models).toEqual([]);
+        expect(result.error).toContain('403');
+    });
+});

--- a/frontend/src/utils/localModels.ts
+++ b/frontend/src/utils/localModels.ts
@@ -1,0 +1,72 @@
+/**
+ * Model discovery for local AI providers (Ollama, LM Studio).
+ *
+ * Both servers expose the OpenAI-compatible GET /v1/models, which the backend
+ * proxies at /api/ai/local-models. That endpoint never returns 5xx: an
+ * unreachable server is the normal state while a user is still setting up, so
+ * failure arrives as a populated `error` alongside an empty list and the caller
+ * degrades to a free-text model field rather than showing a banner.
+ */
+
+export const LOCAL_PROVIDERS = ['ollama', 'lmstudio'] as const;
+
+export type LocalProvider = (typeof LOCAL_PROVIDERS)[number];
+
+/** Mirrors LOCAL_DEFAULT_BASE_URLS in backend/app/core/ai_client.py. The backend
+ *  is authoritative; these are placeholders and pre-fills only. */
+const DEFAULT_URLS: Record<string, string> = {
+    ollama: 'http://localhost:11434/v1',
+    lmstudio: 'http://localhost:1234/v1',
+};
+
+export function isLocalProvider(provider: string): boolean {
+    return (LOCAL_PROVIDERS as readonly string[]).includes(provider);
+}
+
+export function localProviderDefaultUrl(provider: string): string {
+    return DEFAULT_URLS[provider] ?? '';
+}
+
+export interface LocalModelsResult {
+    models: string[];
+    error: string | null;
+}
+
+export async function fetchLocalModels(
+    provider: string,
+    baseUrl: string,
+): Promise<LocalModelsResult> {
+    const params = new URLSearchParams({ provider });
+    const trimmed = baseUrl.trim();
+    if (trimmed) params.set('base_url', trimmed);
+
+    let response: Response;
+    try {
+        response = await fetch(`/api/ai/local-models?${params.toString()}`);
+    } catch (err) {
+        console.error('Local model list request failed (network):', err);
+        return {
+            models: [],
+            error: "Couldn't reach the backend to list models.",
+        };
+    }
+
+    if (!response.ok) {
+        console.error(`Local model list returned HTTP ${response.status}`);
+        return {
+            models: [],
+            error: `Couldn't list models (HTTP ${response.status}).`,
+        };
+    }
+
+    try {
+        const body = await response.json();
+        return {
+            models: Array.isArray(body.models) ? body.models : [],
+            error: body.error ?? null,
+        };
+    } catch (err) {
+        console.error('Local model list returned an unparseable response:', err);
+        return { models: [], error: "Couldn't read the model list." };
+    }
+}


### PR DESCRIPTION
Closes #606.

Adds `ollama` and `lmstudio` as AI providers, so disc identification and episode matching can run against a model on your own machine instead of a paid hosted API. Transcripts and disc labels never leave your network.

## Why no new adapter

Both servers expose the same OpenAI-compatible `/v1/chat/completions` contract that `_call_openai_compatible()` already serves for `openai` and `openrouter`, so we did not have to choose between them. The bulk of the work was relaxing invariants that quietly assumed a remote, paid, key-authenticated API.

## What changed

- **Two provider slugs** sharing the existing adapter, with a configurable base URL (`ai_local_base_url`; blank means the conventional port, 11434 for Ollama and 1234 for LM Studio).
- **`ai_is_configured()` replaces five separate `if not config.ai_api_key` gates.** Local servers have no key, so each of those gates would otherwise have returned `None` before any AI call, leaving the feature looking configured and doing nothing. The spec originally enumerated three; a subagent found a fourth in the manual re-match route and a fifth in the connection test.
- **`is_safe_local_ai_url()`**, a deliberately loopback-permitting SSRF guard kept separate from `is_safe_remote_url` so no other call site is weakened.
- **Longer timeouts for local slugs** (300s matching, 120s validation), because a cold LM Studio JIT-loads weights for 30-60s before emitting a token.
- **Local-specific error text** naming the endpoint and model, replacing wording like "the account has no API credits".
- **`GET /api/ai/local-models`** backing a real model dropdown, since local model ids are installation-specific and unguessable.
- **Preamble-tolerant JSON extraction**, because small local models wrap replies in prose.

## Three bugs that only live testing found

Every unit test mocks the transport, so none of these were visible until the code ran against a real LM Studio server:

1. **LM Studio rejects `response_format: {"type": "json_object"}`**, demanding `json_schema` or `text`. That broke *every* structured call, so episode matching did not work at all. Fixed in `963a4028`; `openai`/`openrouter` keep `json_object` unchanged.
2. **LM Studio silently serves the loaded model when asked for an unknown one**, returning HTTP 200. A typo passed the connection test and would then have quietly run matching against the wrong model. Fixed in `b297cf1e` with a pre-flight check against the server's own model list.
3. **The settings section still read "API key required"**, which stopped being true. Fixed in `b13deef8`.

## Security note for the reviewer

`is_safe_local_ai_url` is an intentional, documented SSRF exemption: it must accept loopback, because that is where an inference server lives. An adversarial review during development found and fixed three real defects in it (`urlparse` silently strips `\t\r\n`, so the guard validated a different string than the caller sent; path traversal survived the append; two docstring claims were false). It now also denies cloud-metadata and link-local hosts.

**One Medium finding is left open for your decision.** `PUT /api/config` has no auth dependency (pre-existing), and this PR adds to it the first config-driven, server-fetched URL allowed to name a loopback or private address. The two siblings on that endpoint, `fingerprint_server_url` and `discord_webhook_url`, are both guarded by `is_safe_remote_url`, which rejects those ranges. Default bind is `127.0.0.1`, so this is not reachable out of the box, but a `0.0.0.0` Docker deployment would expose an internal-network fetch primitive to unauthenticated LAN peers.

The obvious fix is `Depends(require_localhost_or_lan)` on `PUT /api/config`. I did not apply it because it would break headless deployments that configure Engram from another machine, which is a product decision rather than a mechanical one.

## Testing

- Backend: 3059 unit passed, 110 pipeline passed.
- Frontend: 471 unit passed, build and lint clean.
- Verified end to end against a live LM Studio server: model list, real completions on two models, blank-model and bogus-model rejection, and the full settings UI (dropdown populated from the server, API key field hidden, concurrency hint, Test Connection reporting the model).

**The Ollama path was not exercised against a live server** (not installed here). It shares the adapter, dispatch and error handling with LM Studio and is covered by unit tests, but it keeps `json_object` per Ollama's documented compatibility rather than the `json_schema` form LM Studio needs. A reviewer with Ollama confirming it would be welcome.

Design: `docs/superpowers/specs/2026-08-29-local-ai-provider-design.md`
Plan: `docs/superpowers/plans/2026-08-29-local-ai-provider.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)