### PR TITLE
chore: release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-31
+
+_Highlights: run identification and episode matching entirely on your own machine with Ollama or LM Studio._
+
 ### Added
 
 - **Local AI providers: run identification and episode matching on your own
@@ -19,7 +23,7 @@ All notable changes to Engram will be documented in this file.
   extras* holds every disc in the Review Queue for confirmation, however
   confident the match was. The matcher still runs and pre-fills its best guess —
   you just get the last word before anything moves into the library. Useful for
-  shows the matcher handles badly.
+  shows the matcher handles badly. (#611, thanks @raiju!)
 - **Discord notification when a disc finishes ripping**, fired as soon as Engram is finished
   with the drive rather than when the job reaches its final state, and whether or not
   auto-eject is on. Discs that need manual review now ping at the point the drive is free
@@ -45,7 +49,7 @@ All notable changes to Engram will be documented in this file.
   `//server/share` spelling, which is normalized to one canonical form. A share
   that is offline while you are editing settings is flagged as a warning rather
   than rejected, and a Windows-style share path entered on Linux or macOS now
-  explains that it needs mounting instead of failing obscurely.
+  explains that it needs mounting instead of failing obscurely. (#612, thanks @raiju!)
 
 ### Fixed
 
@@ -54,7 +58,7 @@ All notable changes to Engram will be documented in this file.
   duration pre-filter could reject every track on it, so a whole box set could
   file every one of its episodes into `Extras/` and report success. Such
   a disc now stops for confirmation, because "nothing on this disc is an episode"
-  is far more often a failed match than a genuine bonus disc.
+  is far more often a failed match than a genuine bonus disc. (#611, thanks @raiju!)
 - **Episode-length tracks are no longer mistaken for extras on segment-format
   shows.** When no track on a disc matches a single TMDB runtime but tracks match
   whole multiples of one, Engram now recognises the disc as segment-numbered and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ _Highlights: run identification and episode matching entirely on your own machin
   whether the folder exists, whether Engram can actually write to it (a real
   write test, not a guess at permissions), and how much space is free — so a typo
   or a permissions problem is visible immediately instead of surfacing as a failed
-  organize after a completed rip.
+  organize after a completed rip. (#612, thanks @raiju!)
 - **Network shares are supported as library paths.** A Windows UNC path
   (`\\server\share\TV`) works wherever a local path does, including the pasted
   `//server/share` spelling, which is normalized to one canonical form. A share

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,4 +2,5 @@
 
 Engram is built primarily by its maintainer, but these community contributors have shipped improvements — thank you!
 
+- [@raiju](https://github.com/raiju)
 - [@katelovescode](https://github.com/katelovescode) — first contribution: v0.15.0

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.33.0"
+version = "0.34.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.33.0"
+version = "0.34.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.33.0",
+            "version": "0.34.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.33.0",
+    "version": "0.34.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
_Highlights: run identification and episode matching entirely on your own machine with Ollama or LM Studio._

### Added

- **Local AI providers: run identification and episode matching on your own
  machine.** Ollama and LM Studio can now be selected as the AI provider instead
  of a paid hosted API, so transcripts and disc labels never leave your network.
  No API key is required; pick the model from a dropdown of what your server
  actually has installed, and Engram checks it is really there before reporting
  a successful connection. Leave the address blank to use the conventional port
  (`11434` for Ollama, `1234` for LM Studio). See
  [Local AI](https://jsakkos.github.io/engram/getting-started/configuration/#local-ai-ollama-and-lm-studio)
  for setup. (#606)
- **Review every disc before it is organized.** A new setting under *Naming &
  extras* holds every disc in the Review Queue for confirmation, however
  confident the match was. The matcher still runs and pre-fills its best guess —
  you just get the last word before anything moves into the library. Useful for
  shows the matcher handles badly. (#611, thanks @raiju!)
- **Discord notification when a disc finishes ripping**, fired as soon as Engram is finished
  with the drive rather than when the job reaches its final state, and whether or not
  auto-eject is on. Discs that need manual review now ping at the point the drive is free
  instead of staying silent until the review is done. A Status field says whether the rip
  completed, stopped early, or was a re-rip. Off by default; enable it under Notifications
  in Settings.
- **One track can now be assigned several episodes.** Segment-format shows
  (three ~7 minute cartoon segments in one 22 minute DVD track) list each segment
  as its own TMDB episode, so a single track really is `S01E01-E03`. The review
  picker can now say so, and the file is named with the range form Plex and
  Jellyfin both read.
- **The manual episode picker is searchable.** Type part of an episode name or
  its number instead of scrolling a dropdown — which matters for the 40-100
  episode seasons that segment-numbered shows produce. Episode names come from
  the TMDB data Engram already caches.
- **Settings now checks your library and staging folders.** Each path field shows
  whether the folder exists, whether Engram can actually write to it (a real
  write test, not a guess at permissions), and how much space is free — so a typo
  or a permissions problem is visible immediately instead of surfacing as a failed
  organize after a completed rip.
- **Network shares are supported as library paths.** A Windows UNC path
  (`\\server\share\TV`) works wherever a local path does, including the pasted
  `//server/share` spelling, which is normalized to one canonical form. A share
  that is offline while you are editing settings is flagged as a warning rather
  than rejected, and a Windows-style share path entered on Linux or macOS now
  explains that it needs mounting instead of failing obscurely. (#612, thanks @raiju!)

### Fixed

- **Discs whose every track was filed as "extras" are held for review instead of
  quietly completing.** When TMDB's runtimes don't describe the disc, the
  duration pre-filter could reject every track on it, so a whole box set could
  file every one of its episodes into `Extras/` and report success. Such
  a disc now stops for confirmation, because "nothing on this disc is an episode"
  is far more often a failed match than a genuine bonus disc. (#611, thanks @raiju!)
- **Episode-length tracks are no longer mistaken for extras on segment-format
  shows.** When no track on a disc matches a single TMDB runtime but tracks match
  whole multiples of one, Engram now recognises the disc as segment-numbered and
  accepts the combined tracks as episodes. If nothing fits under either rule, the
  runtime filter is disabled for that disc and the audio matcher — which compares
  content, not clocks — decides.
- **Cartoon discs that pack two episodes into one track are no longer filed as
  Extras.** Shows like The Weekenders and Courage the Cowardly Dog put two
  eleven-minute segments into a single half-hour track, while TMDB lists each
  segment as its own episode. Engram compared the track against one episode's
  runtime, found no match, and quietly sorted the whole thing into Extras
  without ever listening to it, so an entire disc could come back with nothing
  organized. Engram now recognises a combined track from where the dialogue
  matches fall across the file, and sends it to manual review naming the
  episodes it found rather than discarding it. Combined tracks still need you to
  assign them by hand, because writing a single file out under two episode
  numbers is a separate change. (#622)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
