### PR TITLE
fix(subtitle-cache): a non-ASCII show title no longer aborts a harvest

### DIFF
--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -143,6 +143,36 @@ class RunTally:
         return self.cache_hits / denom if denom else 0.0
 
 
+def _ensure_utf8_output(*streams) -> None:
+    """Force the given text streams to UTF-8 so a show title cannot abort a run.
+
+    On Windows both a legacy console and a redirected pipe default to the ANSI
+    codepage (cp1252), which cannot encode titles like "Shogun" (spelled with a
+    macron) or "El Senor de los Cielos". Rich repaints the progress bar through
+    that stream, so ONE such title raised UnicodeEncodeError and killed a real
+    448-show harvest at show 179, discarding the packaging step for the 178
+    shows that had already succeeded. The harvest itself was fine; only the
+    rendering of its progress was fatal.
+
+    ``errors="replace"`` is the half that makes this permanently non-fatal: a
+    character some future stream cannot represent degrades to a placeholder
+    rather than ending a multi-hour run.
+
+    Streams with no ``reconfigure`` (a test double, a plain object) are skipped,
+    and a stream that refuses to be reconfigured (already detached) is left
+    alone. Failing to change an encoding must never be worse than the crash it
+    is preventing.
+    """
+    for stream in streams:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError) as exc:
+            logger.debug(f"Could not force UTF-8 on {stream!r} (non-fatal): {exc}")
+
+
 class QuotaExhausted(Exception):
     """Raised to end a run cleanly when the download budget or quota floor is hit.
 
@@ -608,6 +638,10 @@ def _render_tally(tally: "RunTally") -> str:
 
 
 def main() -> int:
+    # Before anything renders: a single non-ASCII title must not be able to
+    # kill the run through the progress bar. See _ensure_utf8_output.
+    _ensure_utf8_output(sys.stdout, sys.stderr)
+
     parser = argparse.ArgumentParser(description="Build the Engram subtitle-vector cache")
     parser.add_argument(
         "--limit", type=int, default=300, help="Number of shows (top by TMDB vote count)"

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -169,7 +169,14 @@ def _ensure_utf8_output(*streams) -> None:
             continue
         try:
             reconfigure(encoding="utf-8", errors="replace")
-        except (ValueError, OSError) as exc:
+        # Deliberately broad. A detached buffer raises ValueError and a bad
+        # descriptor raises OSError, but an object carrying a `reconfigure`
+        # attribute that is not a callable taking these kwargs raises
+        # TypeError, and anything that escapes here would defeat the whole
+        # point of this function: failing to CHANGE an encoding must never be
+        # worse than the crash it is preventing. This runs once at startup,
+        # so a broad catch costs nothing and cannot mask a later error.
+        except Exception as exc:  # noqa: BLE001
             logger.debug(f"Could not force UTF-8 on {stream!r} (non-fatal): {exc}")
 
 

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -1076,6 +1076,24 @@ class TestEnsureUtf8Output:
 
         bsc._ensure_utf8_output(Detached())
 
+    def test_a_malformed_reconfigure_is_not_fatal(self, bsc):
+        """The docstring promises that failing to change an encoding is never
+        worse than the crash it prevents. An object whose `reconfigure` is not
+        a callable taking these kwargs raises TypeError, so the catch has to be
+        broad enough to honour that promise."""
+
+        class Malformed:
+            reconfigure = "not callable"
+
+        bsc._ensure_utf8_output(Malformed())
+
+    def test_a_reconfigure_raising_anything_is_not_fatal(self, bsc):
+        class Hostile:
+            def reconfigure(self, **kwargs):
+                raise RuntimeError("some future stream implementation")
+
+        bsc._ensure_utf8_output(Hostile())
+
     def test_accepts_several_streams(self, bsc):
         streams = [io.TextIOWrapper(io.BytesIO(), encoding="cp1252") for _ in range(2)]
         bsc._ensure_utf8_output(*streams)

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -1031,3 +1031,52 @@ class TestHarvestShowDegradedSuppressesCoverageRow:
         # A real (non-degraded) below-threshold season keeps its content
         # conclusion and its counter -- only the degraded case is suppressed.
         assert tally.seasons_skipped_below_threshold == 1
+
+
+@pytest.mark.unit
+class TestEnsureUtf8Output:
+    """A non-ASCII show title must never be able to abort a harvest.
+
+    On Windows both a legacy console and a redirected pipe default to the ANSI
+    codepage (cp1252). Rich repaints the progress bar through that stream, so
+    the single title "Shogun" (spelled with a macron) raised UnicodeEncodeError
+    and killed a real 448-show run at show 179, throwing away the packaging
+    step for the 178 shows that had already succeeded.
+    """
+
+    def test_reconfigures_a_cp1252_stream_to_utf8(self, bsc):
+        raw = io.BytesIO()
+        stream = io.TextIOWrapper(raw, encoding="cp1252")
+        assert stream.encoding.lower().replace("-", "") in ("cp1252", "windows1252")
+
+        bsc._ensure_utf8_output(stream)
+
+        assert stream.encoding.lower() == "utf-8"
+        stream.write("Shōgun")
+        stream.flush()
+        assert "Shōgun".encode() in raw.getvalue()
+
+    def test_undecodable_character_is_replaced_not_raised(self, bsc):
+        """errors="replace" is the half that makes this non-fatal: even if some
+        future stream cannot represent a character, a harvest must not die."""
+        raw = io.BytesIO()
+        stream = io.TextIOWrapper(raw, encoding="cp1252")
+        bsc._ensure_utf8_output(stream)
+        assert stream.errors == "replace"
+
+    def test_stream_without_reconfigure_is_skipped(self, bsc):
+        bsc._ensure_utf8_output(object())
+
+    def test_reconfigure_failure_is_not_fatal(self, bsc):
+        class Detached:
+            encoding = "cp1252"
+
+            def reconfigure(self, **kwargs):
+                raise ValueError("underlying buffer has been detached")
+
+        bsc._ensure_utf8_output(Detached())
+
+    def test_accepts_several_streams(self, bsc):
+        streams = [io.TextIOWrapper(io.BytesIO(), encoding="cp1252") for _ in range(2)]
+        bsc._ensure_utf8_output(*streams)
+        assert [s.encoding.lower() for s in streams] == ["utf-8", "utf-8"]


### PR DESCRIPTION
## Summary

A 448-show cache build died at **show 179 of 448** on `Shōgun` (TMDB 126308). Windows opens both a legacy console and a redirected pipe with the ANSI codepage (cp1252), which cannot encode `ō`. Rich repaints the progress bar through that stream, so a single title raised `UnicodeEncodeError` and killed the run:

```
File "rich/_win32_console.py", line 402, in write_text
File "encodings/cp1252.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode character '\u014d'
```

**The harvest itself was fine. Only the rendering of its progress was fatal.** 178 shows had already been harvested successfully; the crash landed before packaging, so the tarball was never written and all of that work went unpublished. The coverage rows and downloaded SRTs survived on disk, so nothing was lost permanently, but the run had to be redone.

`main()` now forces stdout and stderr to UTF-8 with `errors="replace"` before anything renders. An unrepresentable character degrades to a placeholder instead of ending a multi-hour run.

Three other titles in `curated_shows.csv` carry the same hazard (`El Señor de los Cielos`, `Sin senos sí hay paraíso`, `Pasión de Gavilanes`), so this was not a one-off.

## Why `errors="replace"`

Switching to UTF-8 alone would fix the titles we know about. `errors="replace"` is the half that makes it permanently non-fatal: some future stream that cannot represent a character produces a mangled glyph rather than ending the run. For a script that is about to run unattended on a nightly timer, a cosmetic defect is strictly better than a dead build.

Streams that cannot be reconfigured (already detached, or a test double without the method) are skipped rather than raised on. Failing to change an encoding must never be worse than the crash it prevents.

## Verification

Reproduced and fixed against the real failure, not a synthetic one:

```
uv run python scripts/build_subtitle_cache.py --show-list shogun.csv ... > log 2>&1
EXIT=0
Built cache: 1 shows, 10 episodes, 0.1 MB
  from disk:         10 (1 covered seasons shipped without network)
  OS quota left:     1000 downloads today
```

Exit 0, tarball built, and as a bonus this confirms the complete-on-disk fast path from #631: `Shōgun`'s SRTs were harvested moments before the original crash, and `is_done` shipped all 10 episodes without spending a single download.

- [x] 5 new unit tests covering the cp1252 stream, the `replace` handler, a stream with no `reconfigure`, a stream that refuses it, and the multi-stream call
- [x] `tests/unit/test_build_subtitle_cache.py` and the three sibling suites: **83 passed**
- [x] `ruff check` / `ruff format --check` clean
- [x] Live reproduction confirms the fix

## Note

This is not reachable on Linux, so the eventual Ubuntu server would not have hit it. It blocks harvesting from the Windows laptop, which is where the corpus lives today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
