### PR TITLE
fix(subtitle-cache): treat a scraper outage as unmeasurable, not as zero coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to Engram will be documented in this file.
   that exhausted the quota in the first place. Run summaries also credit
   OpenSubtitles correctly instead of reporting its downloads as cache hits.
 
+- **The same protection now covers the subtitle scrapers.** The fix above read
+  only OpenSubtitles' health, so a build where OpenSubtitles was fine but both
+  Addic7ed and TVsubtitles were unreachable still wrote those seasons down as
+  having no subtitles and stopped retrying them for 30 days. A scraper that
+  goes down is now told apart from one that simply has nothing, so a season
+  nobody could reach is left unmeasured and picked up on the next run, and the
+  run summary names the provider that never answered.
+
 ## [0.34.0] - 2026-08-31
 
 _Highlights: run identification and episode matching entirely on your own machine with Ollama or LM Studio._

--- a/backend/app/matcher/provider_scheduler.py
+++ b/backend/app/matcher/provider_scheduler.py
@@ -16,7 +16,11 @@ Public surface:
 - ``EpisodeJob`` — dataclass describing one episode's lifecycle.
 - ``ProviderWorker`` — thread that pulls jobs for one provider.
 - ``Scheduler`` — wires workers together and waits for completion.
-- ``run_jobs(jobs, workers)`` — convenience entry point.
+- ``ProviderHealth`` / ``SchedulerRun`` -- per-provider reachability, so a
+  caller can tell "this provider had nothing" from "this provider never
+  answered".
+- ``run_jobs(jobs, workers)`` — convenience entry point; returns a
+  ``SchedulerRun``, not a bare results dict.
 
 Worker contract (any provider):
 - ``client.get_best_subtitle(show, season, episode) -> entry | None``
@@ -79,6 +83,63 @@ class EpisodeJob:
     result: dict[str, Any] | None = None
 
 
+@dataclass(frozen=True)
+class ProviderHealth:
+    """One provider's reachability across a scheduler run.
+
+    ``responded`` is the load-bearing field: the worker calls
+    ``record_success`` for a hit, a clean miss AND an unusable download,
+    because all three mean the provider answered. Only an exception is a
+    ``transport_failure``. That is the difference between "this provider had
+    nothing" (a real measurement of the content) and "this provider never
+    answered" (a measurement of our infrastructure, which must not be
+    recorded as a fact about the show).
+    """
+
+    name: str
+    responded: bool
+    transport_failures: int
+    breaker_tripped: bool
+    skipped_by_breaker: int
+
+    @property
+    def failed(self) -> bool:
+        """True when this provider is down, not merely unlucky.
+
+        Deliberately keyed to the breaker trip rather than to
+        ``transport_failures > 0``. A lone scraper exception is routine noise;
+        treating it as a failure would mark nearly every season degraded, so
+        the cache builder would stop recording coverage entirely and re-harvest
+        the whole corpus forever. Three consecutive transport failures is the
+        already-tuned "this provider is down" verdict, so reuse it.
+        """
+        return self.breaker_tripped or self.skipped_by_breaker > 0
+
+
+@dataclass(frozen=True)
+class SchedulerRun:
+    """A scheduler run's per-episode results plus per-provider health.
+
+    ``run_jobs`` returns this rather than the bare results dict it used to,
+    because the results dict cannot express the difference above: a dead
+    provider and an unsubtitled episode both come back ``not_found``. The
+    subtitle-cache builder read that ambiguity as genuine zero coverage and
+    skip-listed 664 seasons for 30 days during a June 2026 outage.
+
+    A dataclass rather than a dict subclass carrying an attribute: a stale
+    mock returning a plain ``{}`` must fail loudly here, not silently report
+    "no providers failed" and reintroduce the very defect this closes.
+    """
+
+    results: dict[str, dict[str, Any]]
+    provider_health: dict[str, ProviderHealth]
+
+    @property
+    def failed_providers(self) -> list[str]:
+        """Registered providers that never answered, in registration order."""
+        return [name for name, health in self.provider_health.items() if health.failed]
+
+
 class _CircuitBreaker:
     """Per-provider circuit breaker.
 
@@ -114,6 +175,15 @@ class _CircuitBreaker:
         self._opened_at = 0.0
         self._cooldown = base_cooldown
         self._probe_in_flight = False
+        # Run-scoped health tallies. The breaker already computes the only
+        # distinction that matters to the cache builder -- a miss or an
+        # unusable download calls record_success because the provider
+        # RESPONDED, while only an exception counts as a failure -- so these
+        # just stop that verdict being thrown away. See ProviderHealth.
+        self._total_failures = 0
+        self._ever_opened = False
+        self._ever_responded = False
+        self._skipped_while_open = 0
 
     def allow(self, now: float | None = None) -> bool:
         """True if a job may be sent to this provider right now."""
@@ -122,11 +192,13 @@ class _CircuitBreaker:
             if not self._open:
                 return True
             if now - self._opened_at < self._cooldown:
+                self._skipped_while_open += 1
                 return False
             # Cooldown elapsed → half-open. Let exactly ONE probe through; its
             # outcome (record_success / record_failure) decides what happens
             # next. Concurrent callers see probe_in_flight and stay blocked.
             if self._probe_in_flight:
+                self._skipped_while_open += 1
                 return False
             self._probe_in_flight = True
             logger.info(f"{self.name} circuit half-open: probing recovery")
@@ -137,6 +209,7 @@ class _CircuitBreaker:
         with self._lock:
             if self._open:
                 logger.info(f"{self.name} circuit closed (recovered)")
+            self._ever_responded = True
             self._consecutive_failures = 0
             self._open = False
             self._probe_in_flight = False
@@ -148,6 +221,7 @@ class _CircuitBreaker:
         with self._lock:
             was_probe = self._probe_in_flight
             self._probe_in_flight = False
+            self._total_failures += 1
             if self._open:
                 # A probe failed → stay open and back off further. Stragglers
                 # (jobs dispatched just before the trip) failing while already
@@ -163,12 +237,24 @@ class _CircuitBreaker:
             self._consecutive_failures += 1
             if self._consecutive_failures >= self.failure_threshold:
                 self._open = True
+                self._ever_opened = True
                 self._opened_at = now
                 self._cooldown = self.base_cooldown
                 logger.warning(
                     f"{self.name} circuit opened after {self._consecutive_failures} "
                     f"consecutive failures; skipping it for {self._cooldown:.0f}s"
                 )
+
+    def health(self) -> ProviderHealth:
+        """Snapshot this provider's reachability for the run so far."""
+        with self._lock:
+            return ProviderHealth(
+                name=self.name,
+                responded=self._ever_responded,
+                transport_failures=self._total_failures,
+                breaker_tripped=self._ever_opened,
+                skipped_by_breaker=self._skipped_while_open,
+            )
 
 
 class ProviderWorker(threading.Thread):
@@ -297,6 +383,10 @@ class Scheduler:
         if breaker is not None:
             breaker.record_success()
 
+    def provider_health(self) -> dict[str, ProviderHealth]:
+        """Per-provider reachability for the run so far, keyed by name."""
+        return {name: breaker.health() for name, breaker in self._breakers.items()}
+
     def run(
         self, jobs: list[EpisodeJob], timeout: float | None = None
     ) -> dict[str, dict[str, Any]]:
@@ -385,14 +475,38 @@ def run_jobs(
     jobs: list[EpisodeJob],
     workers: dict[str, SubtitleProviderClient],
     timeout: float | None = None,
-) -> dict[str, dict[str, Any]]:
+) -> SchedulerRun:
     """One-shot helper: create a scheduler, register workers, run, shut
     down. Suitable when the caller (e.g. ``download_subtitles``) handles
-    one season at a time and doesn't need to reuse worker state."""
+    one season at a time and doesn't need to reuse worker state.
+
+    Returns a ``SchedulerRun`` (``.results`` plus ``.provider_health``), not a
+    bare results dict, so the caller can tell a dead provider from an
+    unsubtitled episode.
+
+    Because a fresh ``Scheduler`` is built here per call, breaker state is
+    scoped to this batch. ``download_subtitles`` calls this once per season, so
+    every breaker starts closed at a season boundary and a trip always means
+    "this provider went down during THIS season". If breakers are ever made
+    process-global (a separate follow-up, to stop re-paying a dead provider's
+    timeouts each season), that stops being true and a provider could be
+    breaker-open for a season it never attempted; such a season would then have
+    to count as failed too, for the same reason a mid-season trip does.
+    """
     scheduler = Scheduler()
     for name, client in workers.items():
         scheduler.register(name, client)
     try:
-        return scheduler.run(jobs, timeout=timeout)
+        results = scheduler.run(jobs, timeout=timeout)
+        health = scheduler.provider_health()
     finally:
         scheduler.shutdown()
+
+    for name in [n for n, h in health.items() if h.failed]:
+        detail = health[name]
+        logger.warning(
+            f"Provider {name} never answered this batch: "
+            f"{detail.transport_failures} transport failure(s), "
+            f"{detail.skipped_by_breaker} job(s) skipped with the circuit open"
+        )
+    return SchedulerRun(results=results, provider_health=health)

--- a/backend/app/matcher/provider_scheduler.py
+++ b/backend/app/matcher/provider_scheduler.py
@@ -106,14 +106,29 @@ class ProviderHealth:
     def failed(self) -> bool:
         """True when this provider is down, not merely unlucky.
 
-        Deliberately keyed to the breaker trip rather than to
-        ``transport_failures > 0``. A lone scraper exception is routine noise;
-        treating it as a failure would mark nearly every season degraded, so
-        the cache builder would stop recording coverage entirely and re-harvest
-        the whole corpus forever. Three consecutive transport failures is the
-        already-tuned "this provider is down" verdict, so reuse it.
+        Two ways to reach that verdict, because the breaker alone cannot see a
+        small batch. The breaker needs three CONSECUTIVE transport failures,
+        and a batch can be smaller than three: ``_fetch_episodes`` healing a
+        precomputed gap usually asks for one or two episodes, so a completely
+        dead provider would never trip inside that call and the gap would be
+        recorded as a genuine absence. Hence the second clause: a provider that
+        raised on every attempt and never once answered is down on this batch's
+        own evidence, whatever the threshold says.
+
+        ``not responded`` is what keeps that second clause honest, and it is
+        why the rule is not simply ``transport_failures > 0``. A lone exception
+        partway through a season a provider is otherwise serving is routine
+        noise; flagging on it would mark nearly every season degraded, so the
+        cache builder would stop recording coverage entirely and re-harvest the
+        whole corpus forever. A provider that answered even once is reachable,
+        so later blips do not condemn it.
+
+        A provider the cascade never reached has no failures and no responses,
+        and stays unflagged: absence of evidence is not evidence of an outage.
         """
-        return self.breaker_tripped or self.skipped_by_breaker > 0
+        if self.breaker_tripped or self.skipped_by_breaker > 0:
+            return True
+        return self.transport_failures > 0 and not self.responded
 
 
 @dataclass(frozen=True)

--- a/backend/app/matcher/testing_service.py
+++ b/backend/app/matcher/testing_service.py
@@ -138,12 +138,21 @@ def get_last_quota() -> dict | None:
     return _OS.last_quota
 
 
-def _is_degraded(os_failed: bool, episodes: list[dict]) -> bool:
+def _is_degraded(os_failed: bool, episodes: list[dict], *, providers_failed: bool = False) -> bool:
     """Return True when this season's result is NOT a trustworthy measurement.
 
-    Degraded means the OpenSubtitles path did not serve (exhausted quota, login
-    failure, hard error -- at login time OR mid-run) AND the season is not
-    fully retrieved. Quota exhaustion does not respect season boundaries: it
+    Degraded means some part of the cascade did not serve AND the season is not
+    fully retrieved. Two independent failure signals feed the first half:
+    ``os_failed`` (OpenSubtitles exhausted its quota, failed to log in, or hard
+    errored -- at login time OR mid-run) and ``providers_failed`` (a scraper
+    went down hard enough to trip its circuit breaker; see
+    ``provider_scheduler.ProviderHealth.failed``).
+
+    Both doors lead to the same defect. A dead scraper and an unsubtitled
+    episode both surface as ``not_found``, so without the second signal a
+    season whose scrapers were ALL down records as a genuine 0% and is
+    skip-listed for 30 days -- exactly what a June 2026 OpenSubtitles outage
+    did to 664 seasons through the first door. Quota exhaustion does not respect season boundaries: it
     can land mid-loop with a few episodes already downloaded, so requiring
     "nothing at all" would let a partial season (e.g. 3/13) get recorded as a
     real 23% coverage measurement and skip-listed for 30 days on the strength
@@ -151,17 +160,16 @@ def _is_degraded(os_failed: bool, episodes: list[dict]) -> bool:
     Recording NO coverage for such a season instead just costs a retry on the
     next run -- cheap and self-correcting, versus a month-long blind spot.
 
-    Conservative by design in the other direction: a season the OpenSubtitles
-    path fully retrieved, or one where OpenSubtitles was healthy and simply
-    had nothing, is a real measurement and SHOULD be recorded so genuinely
-    dead seasons stop consuming quota.
-
-    This predicate covers the OpenSubtitles half of the cascade ONLY.
-    ``degraded=False`` does not mean the measurement is trustworthy in
-    general -- the scraper cascade (Addic7ed/TVsubtitles) has no equivalent
-    failure signal, which is a known, separate gap.
+    Conservative by design in the other direction: a fully retrieved season is
+    a real measurement whichever provider went down afterwards, because there
+    is no gap left for the outage to have hidden. So is a season where every
+    provider answered and simply had nothing -- that one SHOULD be recorded, so
+    genuinely dead seasons stop consuming quota. One dead scraper plus one
+    healthy one is judged on the same rule: complete records, incomplete
+    degrades, because a partial season cannot distinguish "genuinely absent"
+    from "was behind the dead provider".
     """
-    if not os_failed:
+    if not (os_failed or providers_failed):
         return False
     if not episodes:
         return True
@@ -342,8 +350,12 @@ def _fetch_episodes(
     cache already covers. Per-episode work fans out across the same
     addic7ed/tvsubtitles scheduler the full season download uses for its residual.
 
-    Returns ``{episode_number: result_dict}`` with the same shape as the full
-    download's per-episode results (``code``/``status``/``path``/``source``).
+    Returns ``({episode_number: result_dict}, failed_providers)``. The results
+    share the full download's per-episode shape
+    (``code``/``status``/``path``/``source``); ``failed_providers`` names any
+    scraper that never answered, because a dead provider and an episode nobody
+    has both surface as ``not_found`` and the caller must not record the first
+    as if it were the second.
     """
     from app.matcher.subtitle_utils import find_existing_subtitle
 
@@ -376,18 +388,20 @@ def _fetch_episodes(
             )
         )
 
+    failed_providers: list[str] = []
     if residual_jobs:
         workers = {"addic7ed": Addic7edClient(), "tvsubtitles": TVSubtitlesClient()}
-        scheduler_results = run_jobs(residual_jobs, workers)
+        scheduler_run = run_jobs(residual_jobs, workers)
+        failed_providers = scheduler_run.failed_providers
         for episode in wanted:
             if episode in results:
                 continue
             episode_code = f"S{season:02d}E{episode:02d}"
-            results[episode] = scheduler_results.get(
+            results[episode] = scheduler_run.results.get(
                 episode_code,
                 {"code": episode_code, "status": "not_found", "path": None, "source": None},
             )
-    return results
+    return results, failed_providers
 
 
 def _heal_precomputed_gaps(
@@ -436,7 +450,9 @@ def _heal_precomputed_gaps(
         f"{len(gap_eps)} of {episode_count} episode(s): {', '.join(gap_codes)}; fetching"
     )
     series_cache_dir = cache_path / "data" / corpus_dir_name(tmdb_id, show_name)
-    fetched = _fetch_episodes(resolved_id, show_name, season, gap_eps, series_cache_dir, config)
+    fetched, failed_providers = _fetch_episodes(
+        resolved_id, show_name, season, gap_eps, series_cache_dir, config
+    )
 
     still_missing = [
         fetched[ep]["code"] for ep in gap_eps if fetched.get(ep, {}).get("status") == "not_found"
@@ -463,6 +479,18 @@ def _heal_precomputed_gaps(
     )
     healed["episodes"] = healed_episodes
     healed["total_episodes"] = len(healed_episodes)
+    # The skip dict this copies is unconditionally `degraded: False`, which is
+    # right for a complete precomputed season and wrong for one whose gaps we
+    # just failed to fill because the scrapers were down. Same rule as the full
+    # download: a provider went dark AND something is still missing means the
+    # season was not measured, so the cache builder must not record it.
+    if failed_providers and still_missing:
+        logger.warning(
+            f"{show_name} S{season:02d}: scraper(s) {', '.join(failed_providers)} never "
+            f"answered while healing {len(still_missing)} gap(s); marking degraded so the "
+            "season is re-measured rather than recorded short"
+        )
+        healed["degraded"] = True
     return healed
 
 
@@ -867,12 +895,24 @@ def download_subtitles(
     # a different episode — total wall-time falls from the sum of
     # per-provider times toward their max.
     scheduler_results: dict[str, dict] = {}
+    # Whether any scraper went down hard during this season, as opposed to
+    # merely having nothing. Both look like `not_found` per episode, so this
+    # flag is the only thing that separates them; see _is_degraded.
+    scrapers_failed = False
     if residual_jobs:
         workers = {
             "addic7ed": Addic7edClient(),
             "tvsubtitles": TVSubtitlesClient(),
         }
-        scheduler_results = run_jobs(residual_jobs, workers)
+        scheduler_run = run_jobs(residual_jobs, workers)
+        scheduler_results = scheduler_run.results
+        failed = scheduler_run.failed_providers
+        scrapers_failed = bool(failed)
+        if failed:
+            logger.warning(
+                f"{canonical_show_name} S{season:02d}: scraper(s) {', '.join(failed)} "
+                "never answered; this season's coverage may not be measurable"
+            )
 
     # Re-assemble episode results in episode order.
     episodes = []
@@ -906,9 +946,14 @@ def download_subtitles(
         # True when this result is not a trustworthy measurement -- see
         # _is_degraded. Combines the sticky process-wide login-failure flag
         # with the season-local mid-run failure flag, since either one means
-        # OpenSubtitles did not serve this season. The cache builder skips
-        # coverage recording for these.
-        "degraded": _is_degraded(_OS.failed or os_failed_this_season, episodes),
+        # OpenSubtitles did not serve this season, plus the scraper cascade's
+        # own reachability verdict. The cache builder skips coverage recording
+        # for these.
+        "degraded": _is_degraded(
+            _OS.failed or os_failed_this_season,
+            episodes,
+            providers_failed=scrapers_failed,
+        ),
     }
 
 

--- a/backend/scripts/build_subtitle_cache.py
+++ b/backend/scripts/build_subtitle_cache.py
@@ -116,7 +116,7 @@ class RunTally:
     # complete-on-disk fast path nor the skip-list bypassed it). Denominator
     # for seasons_degraded's share of the run -- see the final-summary hint.
     seasons_attempted: int = 0
-    # Seasons whose result was degraded (OpenSubtitles unavailable, season
+    # Seasons whose result was degraded (some provider never answered, season
     # incomplete) and therefore NOT recorded to subtitle_coverage. This is a
     # QUALIFIER on seasons_attempted, not a disposition parallel to OK /
     # skipped / failed -- a season can be both "done" and "degraded" (it
@@ -486,8 +486,9 @@ def _harvest_show(
         # it, low-coverage seasons get re-attempted every day, burning quota on
         # shows that simply don't have subtitles.
         #
-        # A degraded season is NOT a measurement: OpenSubtitles was unavailable
-        # and the season is incomplete, so 0% says nothing about availability.
+        # A degraded season is NOT a measurement: some provider never answered
+        # (OpenSubtitles, or a scraper whose circuit breaker tripped) and the
+        # season is incomplete, so 0% says nothing about availability.
         # Recording it would skip-list the season for 30 days on the strength of
         # an outage. That defect cost 664 seasons on 2026-06-12; see the
         # harvester-repair spec.
@@ -505,7 +506,7 @@ def _harvest_show(
             tally.seasons_degraded += 1
             logger.warning(
                 f"  {canonical} S{season:02d}: degraded result "
-                f"(OpenSubtitles unavailable, season incomplete); "
+                f"(a provider never answered and the season is incomplete); "
                 "NOT recording coverage so the season is re-measured next run"
             )
 
@@ -593,15 +594,17 @@ def _render_tally(tally: "RunTally") -> str:
 
     # Half or more of the seasons this run actually attempted came back
     # degraded: far more likely a misconfigured run (bad OpenSubtitles
-    # credentials, or the opensubtitlescom package missing) than a brief
-    # mid-run outage. Surfaced so a silently-empty skip-list gets diagnosed
-    # instead of misread as "these shows have little content".
+    # credentials, or the opensubtitlescom package missing) or a scraper
+    # outage than a brief mid-run blip. Surfaced so a silently-empty
+    # skip-list gets diagnosed instead of misread as "these shows have
+    # little content".
     if tally.seasons_attempted and tally.seasons_degraded / tally.seasons_attempted >= 0.5:
         lines.append(
             "  HINT: half or more of the seasons attempted this run were degraded -- "
-            "check the OpenSubtitles credentials (opensubtitles_api_key/username/password) "
-            "and that the opensubtitlescom package is installed, rather than reading this "
-            "as a content problem"
+            "check the OpenSubtitles credentials (opensubtitles_api_key/username/password), "
+            "that the opensubtitlescom package is installed, and the 'never answered' "
+            "warnings above for a scraper outage, rather than reading this as a content "
+            "problem"
         )
 
     return "\n".join(lines)

--- a/backend/tests/unit/test_build_subtitle_cache.py
+++ b/backend/tests/unit/test_build_subtitle_cache.py
@@ -18,13 +18,14 @@ import tarfile
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 import app.services.config_service as cfg_svc
 from app.matcher import coverage_tracker
 from app.matcher.episode_identification import EpisodeMatcher, TfidfMatcher
+from app.matcher.provider_scheduler import ProviderHealth, SchedulerRun
 from app.matcher.subtitle_utils import corpus_dir_name
 from app.matcher.vectorizer_config import (
     CACHE_FORMAT_VERSION,
@@ -1031,3 +1032,100 @@ class TestHarvestShowDegradedSuppressesCoverageRow:
         # A real (non-degraded) below-threshold season keeps its content
         # conclusion and its counter -- only the degraded case is suppressed.
         assert tally.seasons_skipped_below_threshold == 1
+
+
+@pytest.mark.unit
+class TestScraperOutageWritesNoCoverageRow:
+    """The second door, end to end and unmocked between the layers: the real
+    ``download_subtitles`` runs under ``_harvest_show`` with OpenSubtitles
+    healthy-but-empty and both scrapers down. Before the scheduler surfaced
+    provider health this recorded a 0% row and skip-listed the season for 30
+    days -- the same defect the OpenSubtitles fix repaired, reached through
+    the scrapers."""
+
+    @staticmethod
+    def _args():
+        return type(
+            "Args",
+            (),
+            {
+                "min_episodes_ratio": 0.6,
+                "sleep": 0,
+                "retry_low_coverage": True,
+                "refresh": True,
+                "skip_window_days": 30,
+            },
+        )()
+
+    @staticmethod
+    def _config(tmp_path):
+        cfg = SimpleNamespace(
+            subtitles_cache_path=str(tmp_path),
+            opensubtitles_api_key="key",
+            opensubtitles_username="user",
+            opensubtitles_password="pass",
+            tmdb_api_key="tmdb-key",
+        )
+        return cfg
+
+    @contextmanager
+    def _healthy_os_dead_scrapers(self, tmp_path, scheduler_run):
+        import app.matcher.testing_service as ts
+
+        with (
+            patch.object(ts._OS, "failed", False),
+            patch(
+                "app.services.config_service.get_config_sync", return_value=self._config(tmp_path)
+            ),
+            patch.object(ts, "fetch_show_details", return_value={"name": "Outage Show"}),
+            patch.object(ts, "fetch_season_details", return_value=4),
+            patch.object(ts, "fetch_season_episodes", return_value=[]),
+            patch.object(ts, "_precomputed_skip_result", return_value=None),
+            patch.object(ts, "_get_os_client", return_value=Mock()),
+            patch.object(ts, "os_api_call", return_value=Mock(data=[])),
+            patch.object(ts, "run_jobs", return_value=scheduler_run),
+        ):
+            yield
+
+    def _scheduler_run(self, failed):
+        health = {
+            name: ProviderHealth(
+                name=name,
+                responded=name not in failed,
+                transport_failures=3 if name in failed else 0,
+                breaker_tripped=name in failed,
+                skipped_by_breaker=0,
+            )
+            for name in ("addic7ed", "tvsubtitles")
+        }
+        return SchedulerRun(results={}, provider_health=health)
+
+    def test_all_scrapers_down_writes_no_coverage_row(self, bsc, tmp_path):
+        show = {"name": "Outage Show", "tmdb_id": 9202, "seasons": 1}
+        tally = bsc.RunTally()
+
+        with self._healthy_os_dead_scrapers(
+            tmp_path, self._scheduler_run(("addic7ed", "tvsubtitles"))
+        ):
+            bsc._harvest_show(show, self._args(), tally, tmp_path)
+
+        assert coverage_tracker.get_show_coverage(9202) == [], (
+            "scrapers that never answered must not be recorded as a season with "
+            "no subtitles; that skip-lists it for 30 days on an outage"
+        )
+        assert tally.seasons_degraded == 1
+
+    def test_healthy_scrapers_finding_nothing_still_writes_a_row(self, bsc, tmp_path):
+        """The control. Identical on the wire (every episode not_found) but the
+        providers answered, so this IS a measurement and must be recorded --
+        otherwise genuinely unsubtitled seasons are re-harvested forever."""
+        show = {"name": "Outage Show", "tmdb_id": 9203, "seasons": 1}
+        tally = bsc.RunTally()
+
+        with self._healthy_os_dead_scrapers(tmp_path, self._scheduler_run(())):
+            bsc._harvest_show(show, self._args(), tally, tmp_path)
+
+        rows = coverage_tracker.get_show_coverage(9203)
+        assert len(rows) == 1
+        assert rows[0]["coverage_ratio"] == 0.0
+        assert tally.seasons_degraded == 0

--- a/backend/tests/unit/test_provider_scheduler.py
+++ b/backend/tests/unit/test_provider_scheduler.py
@@ -417,3 +417,58 @@ class TestProviderHealth:
         assert run.results == {}
         assert run.failed_providers == []
         assert run.provider_health["addic7ed"].responded is False
+
+
+@pytest.mark.unit
+class TestProviderHealthSmallBatches:
+    """The breaker needs three consecutive failures to trip, but a batch can be
+    smaller than three. ``_fetch_episodes`` healing a precomputed gap typically
+    asks for one or two episodes, so a completely dead provider could never
+    trip within that call and the season was recorded as a real absence -- the
+    protection was weakest exactly where it is most often exercised."""
+
+    def test_single_job_dead_provider_is_still_failed(self, tmp_path):
+        job = _make_job(srt_target=tmp_path / "ep.srt")
+        run = run_jobs(
+            [job], workers={"addic7ed": _failing_client(ConnectionError("down"))}, timeout=5
+        )
+
+        health = run.provider_health["addic7ed"]
+        assert health.breaker_tripped is False, "one failure cannot trip a threshold of three"
+        assert health.responded is False
+        assert run.failed_providers == ["addic7ed"]
+
+    def test_two_jobs_dead_provider_is_still_failed(self, tmp_path):
+        jobs = [_make_job(episode=i, srt_target=tmp_path / f"ep{i}.srt") for i in (1, 2)]
+        run = run_jobs(
+            jobs, workers={"addic7ed": _failing_client(ConnectionError("down"))}, timeout=5
+        )
+        assert run.failed_providers == ["addic7ed"]
+
+    def test_a_provider_that_answered_once_is_not_failed_by_a_later_blip(self, tmp_path):
+        """The guard against over-flagging: a provider that answered at all is
+        reachable, so a subsequent exception is noise, not an outage. This is
+        the case that ruled out keying on ``transport_failures > 0`` alone."""
+        client = Mock()
+        client.get_best_subtitle.side_effect = [None, ConnectionError("blip"), None]
+        jobs = [_make_job(episode=i, srt_target=tmp_path / f"ep{i}.srt") for i in range(1, 4)]
+        run = run_jobs(jobs, workers={"addic7ed": client}, timeout=5)
+
+        health = run.provider_health["addic7ed"]
+        assert health.responded is True
+        assert health.transport_failures == 1
+        assert run.failed_providers == []
+
+    def test_never_asked_provider_is_not_failed(self, tmp_path):
+        """A registered provider the cascade never reached has no evidence
+        either way, and absence of evidence must not read as failure."""
+        job = _make_job(providers=["addic7ed"], srt_target=tmp_path / "ep.srt")
+        run = run_jobs(
+            job and [job],
+            workers={"addic7ed": _writing_client(), "tvsubtitles": _failing_client(OSError())},
+            timeout=5,
+        )
+
+        assert run.provider_health["tvsubtitles"].transport_failures == 0
+        assert run.provider_health["tvsubtitles"].responded is False
+        assert run.failed_providers == []

--- a/backend/tests/unit/test_provider_scheduler.py
+++ b/backend/tests/unit/test_provider_scheduler.py
@@ -68,14 +68,14 @@ class TestSingleProvider:
     def test_one_job_one_provider_success(self, tmp_path):
         job = _make_job(srt_target=tmp_path / "ep.srt")
         client = _writing_client()
-        results = run_jobs([job], workers={"addic7ed": client}, timeout=5)
+        results = run_jobs([job], workers={"addic7ed": client}, timeout=5).results
         assert results["S01E01"]["status"] == "downloaded"
         assert results["S01E01"]["source"] == "addic7ed"
         assert Path(results["S01E01"]["path"]).read_text().startswith("1\n")
 
     def test_one_job_one_provider_not_found(self, tmp_path):
         job = _make_job(srt_target=tmp_path / "ep.srt")
-        results = run_jobs([job], workers={"addic7ed": _missing_client()}, timeout=5)
+        results = run_jobs([job], workers={"addic7ed": _missing_client()}, timeout=5).results
         assert results["S01E01"]["status"] == "not_found"
         assert results["S01E01"]["source"] is None
 
@@ -88,7 +88,7 @@ class TestProviderCascade:
             srt_target=tmp_path / "ep.srt",
         )
         workers = {"addic7ed": _missing_client(), "podnapisi": _writing_client()}
-        results = run_jobs([job], workers=workers, timeout=5)
+        results = run_jobs([job], workers=workers, timeout=5).results
         assert results["S01E01"]["status"] == "downloaded"
         assert results["S01E01"]["source"] == "podnapisi"
 
@@ -102,7 +102,7 @@ class TestProviderCascade:
             "podnapisi": _missing_client(),
             "tvsubtitles": _missing_client(),
         }
-        results = run_jobs([job], workers=workers, timeout=5)
+        results = run_jobs([job], workers=workers, timeout=5).results
         assert results["S01E01"]["status"] == "not_found"
 
     def test_provider_exception_advances_to_next(self, tmp_path):
@@ -117,7 +117,7 @@ class TestProviderCascade:
             "addic7ed": _failing_client(RuntimeError("simulated 503")),
             "podnapisi": _writing_client(),
         }
-        results = run_jobs([job], workers=workers, timeout=5)
+        results = run_jobs([job], workers=workers, timeout=5).results
         assert results["S01E01"]["status"] == "downloaded"
         assert results["S01E01"]["source"] == "podnapisi"
 
@@ -141,7 +141,7 @@ class TestProviderCascade:
             srt_target=tmp_path / "ep.srt",
         )
         workers = {"addic7ed": client_bad, "podnapisi": _writing_client()}
-        results = run_jobs([job], workers=workers, timeout=5)
+        results = run_jobs([job], workers=workers, timeout=5).results
         assert results["S01E01"]["status"] == "downloaded"
         assert results["S01E01"]["source"] == "podnapisi"
 
@@ -155,7 +155,7 @@ class TestMissingWorker:
             providers=["does_not_exist", "addic7ed"],
             srt_target=tmp_path / "ep.srt",
         )
-        results = run_jobs([job], workers={"addic7ed": _writing_client()}, timeout=5)
+        results = run_jobs([job], workers={"addic7ed": _writing_client()}, timeout=5).results
         assert results["S01E01"]["status"] == "downloaded"
         assert results["S01E01"]["source"] == "addic7ed"
 
@@ -164,7 +164,7 @@ class TestMissingWorker:
             providers=["does_not_exist"],
             srt_target=tmp_path / "ep.srt",
         )
-        results = run_jobs([job], workers={"addic7ed": _writing_client()}, timeout=5)
+        results = run_jobs([job], workers={"addic7ed": _writing_client()}, timeout=5).results
         assert results["S01E01"]["status"] == "not_found"
 
 
@@ -185,7 +185,9 @@ class TestConcurrency:
         podnapisi = _writing_client(
             "1\n00:00:00,000 --> 00:00:02,000\nfrom P, padded to satisfy validator.\n"
         )
-        results = run_jobs(jobs, workers={"addic7ed": addic7ed, "podnapisi": podnapisi}, timeout=5)
+        results = run_jobs(
+            jobs, workers={"addic7ed": addic7ed, "podnapisi": podnapisi}, timeout=5
+        ).results
         assert results["S01E01"]["source"] == "addic7ed"
         assert results["S01E02"]["source"] == "podnapisi"
         assert results["S01E03"]["source"] == "addic7ed"
@@ -221,7 +223,7 @@ class TestConcurrency:
         workers = {"a": slow_client("A"), "b": slow_client("B"), "c": slow_client("C")}
 
         start = time.monotonic()
-        results = run_jobs(jobs, workers=workers, timeout=5)
+        results = run_jobs(jobs, workers=workers, timeout=5).results
         elapsed = time.monotonic() - start
 
         assert len(results) == 3
@@ -235,7 +237,7 @@ class TestConcurrency:
 @pytest.mark.unit
 class TestEmptyInput:
     def test_no_jobs_returns_empty(self):
-        results = run_jobs([], workers={"addic7ed": _missing_client()})
+        results = run_jobs([], workers={"addic7ed": _missing_client()}).results
         assert results == {}
 
 
@@ -307,9 +309,111 @@ class TestCircuitBreakerIntegration:
             )
             for i in range(1, 7)  # 6 jobs; default threshold is 3
         ]
-        results = run_jobs(jobs, workers={"addic7ed": addic7ed, "podnapisi": podnapisi}, timeout=5)
+        results = run_jobs(
+            jobs, workers={"addic7ed": addic7ed, "podnapisi": podnapisi}, timeout=5
+        ).results
         # Every job still resolved via the healthy fallback.
         assert all(results[f"S01E{i:02d}"]["source"] == "podnapisi" for i in range(1, 7))
         # But the dead provider was hit only `threshold` (3) times — jobs 4-6
         # skipped it entirely instead of each paying a failed call.
         assert addic7ed.get_best_subtitle.call_count == 3
+
+
+@pytest.mark.unit
+class TestProviderHealth:
+    """``run_jobs`` must distinguish "this provider had nothing" from "this
+    provider never answered". Without that, a season whose scrapers were all
+    down looks identical to a season nobody ever subtitled, gets recorded at
+    0% coverage, and is skip-listed for 30 days on the strength of an outage.
+    """
+
+    def test_missing_client_is_not_a_failure(self, tmp_path):
+        """A clean miss means the provider RESPONDED. It is reachable and
+        genuinely had nothing, which is a real measurement."""
+        job = _make_job(srt_target=tmp_path / "ep.srt")
+        run = run_jobs([job], workers={"addic7ed": _missing_client()}, timeout=5)
+
+        assert run.results["S01E01"]["status"] == "not_found"
+        assert run.failed_providers == []
+        health = run.provider_health["addic7ed"]
+        assert health.responded is True
+        assert health.transport_failures == 0
+        assert health.breaker_tripped is False
+
+    def test_down_provider_is_reported_failed(self, tmp_path):
+        """Enough consecutive transport failures to trip the breaker means the
+        provider never answered. The per-episode results are unchanged
+        (``not_found``) -- that is exactly why the old contract could not tell
+        this case apart."""
+        jobs = [_make_job(episode=i, srt_target=tmp_path / f"ep{i}.srt") for i in range(1, 6)]
+        run = run_jobs(
+            jobs,
+            workers={"addic7ed": _failing_client(ConnectionError("down"))},
+            timeout=5,
+        )
+
+        assert all(r["status"] == "not_found" for r in run.results.values())
+        assert run.failed_providers == ["addic7ed"]
+        health = run.provider_health["addic7ed"]
+        assert health.responded is False
+        assert health.breaker_tripped is True
+        assert health.transport_failures >= 3
+
+    def test_one_transient_failure_is_not_a_failed_provider(self, tmp_path):
+        """A single exception below the breaker threshold is routine scraper
+        noise. Flagging on it would mark nearly every season degraded, so no
+        coverage row would ever be written again."""
+        client = Mock()
+        client.get_best_subtitle.side_effect = [ConnectionError("blip"), None, None]
+        jobs = [_make_job(episode=i, srt_target=tmp_path / f"ep{i}.srt") for i in range(1, 4)]
+        run = run_jobs(jobs, workers={"addic7ed": client}, timeout=5)
+
+        health = run.provider_health["addic7ed"]
+        assert health.transport_failures == 1
+        assert health.breaker_tripped is False
+        assert run.failed_providers == []
+
+    def test_healthy_provider_alongside_dead_one(self, tmp_path):
+        """One dead scraper does not taint the other's verdict."""
+        jobs = [_make_job(episode=i, providers=["addic7ed", "tvsubtitles"]) for i in range(1, 6)]
+        for i, job in enumerate(jobs, start=1):
+            job.srt_target = tmp_path / f"ep{i}.srt"
+        run = run_jobs(
+            jobs,
+            workers={
+                "addic7ed": _failing_client(ConnectionError("down")),
+                "tvsubtitles": _writing_client(),
+            },
+            timeout=5,
+        )
+
+        assert all(r["status"] == "downloaded" for r in run.results.values())
+        assert run.failed_providers == ["addic7ed"]
+        assert run.provider_health["tvsubtitles"].responded is True
+
+    def test_breaker_starts_closed_every_run(self, tmp_path):
+        """``run_jobs`` builds a fresh Scheduler per call and
+        ``download_subtitles`` calls it once per season, so breaker state is
+        season-local: a provider can never be breaker-open for a season it
+        never attempted. Pinned because making breakers process-global (a
+        separate follow-up) would invalidate it, and the degraded rule would
+        then need a never-attempted case."""
+        jobs = [_make_job(episode=i, srt_target=tmp_path / f"a{i}.srt") for i in range(1, 6)]
+        first = run_jobs(jobs, workers={"addic7ed": _failing_client(ConnectionError())}, timeout=5)
+        assert first.provider_health["addic7ed"].breaker_tripped is True
+
+        second = run_jobs(
+            [_make_job(srt_target=tmp_path / "b.srt")],
+            workers={"addic7ed": _missing_client()},
+            timeout=5,
+        )
+        assert second.provider_health["addic7ed"].breaker_tripped is False
+        assert second.provider_health["addic7ed"].skipped_by_breaker == 0
+        assert second.failed_providers == []
+
+    def test_empty_job_list_reports_health_for_registered_workers(self):
+        """Shape stays total: no jobs means no failures, not a missing key."""
+        run = run_jobs([], workers={"addic7ed": _missing_client()})
+        assert run.results == {}
+        assert run.failed_providers == []
+        assert run.provider_health["addic7ed"].responded is False

--- a/backend/tests/unit/test_testing_service.py
+++ b/backend/tests/unit/test_testing_service.py
@@ -270,14 +270,20 @@ class TestDownloadSubtitles:
         _write_precomputed_cache(
             tmp_path, "Arrested Development", season=1, episode_codes=["S01E01", "S01E02"]
         )
-        mock_fetch_eps.return_value = {
-            3: {
-                "code": "S01E03",
-                "status": "downloaded",
-                "path": "x.srt",
-                "source": "addic7ed",
-            }
-        }
+        # (results, failed_providers) -- _fetch_episodes reports scraper
+        # reachability so the heal can tell "nobody has it" from "nobody
+        # answered".
+        mock_fetch_eps.return_value = (
+            {
+                3: {
+                    "code": "S01E03",
+                    "status": "downloaded",
+                    "path": "x.srt",
+                    "source": "addic7ed",
+                }
+            },
+            [],
+        )
 
         result = download_subtitles("Arrested Development", 1)
 

--- a/backend/tests/unit/test_testing_service_degraded.py
+++ b/backend/tests/unit/test_testing_service_degraded.py
@@ -645,3 +645,65 @@ class TestHealPrecomputedGapsDegradation:
 
         assert healed is skip
         assert healed["degraded"] is False
+
+
+@pytest.mark.unit
+class TestHealSingleGapWithRealScheduler:
+    """The heal path with the real scheduler, not a fabricated SchedulerRun.
+
+    A precomputed gap is usually ONE episode, which is fewer attempts than the
+    circuit breaker's three-failure threshold. This pins that a dead provider
+    is still reported on such a batch, because that is where the heal path's
+    protection is most often exercised and would otherwise be weakest.
+    """
+
+    @staticmethod
+    def _dead_client():
+        client = Mock()
+        client.get_best_subtitle.side_effect = ConnectionError("provider down")
+        return client
+
+    @staticmethod
+    def _missing_client():
+        client = Mock()
+        client.get_best_subtitle.return_value = None
+        return client
+
+    def test_one_episode_gap_with_dead_scrapers_is_degraded(self, tmp_path):
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "Addic7edClient", return_value=self._dead_client()),
+            patch.object(ts, "TVSubtitlesClient", return_value=self._dead_client()),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                _precomputed_skip(["S01E01"], tmp_path),
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert healed["degraded"] is True, (
+            "a single-episode gap cannot trip a three-failure breaker, so the "
+            "verdict has to come from 'raised every time and never answered'"
+        )
+
+    def test_one_episode_gap_with_healthy_scrapers_is_not_degraded(self, tmp_path):
+        """The control: identical on the wire (the gap stays unfilled) but both
+        providers answered, so the gap is a real one."""
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "Addic7edClient", return_value=self._missing_client()),
+            patch.object(ts, "TVSubtitlesClient", return_value=self._missing_client()),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                _precomputed_skip(["S01E01"], tmp_path),
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert healed["degraded"] is False

--- a/backend/tests/unit/test_testing_service_degraded.py
+++ b/backend/tests/unit/test_testing_service_degraded.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 import app.matcher.testing_service as ts
+from app.matcher.provider_scheduler import ProviderHealth, SchedulerRun
 
 
 @pytest.mark.unit
@@ -77,6 +78,22 @@ def _mock_config(tmp_path):
     return cfg
 
 
+def _scheduler_run(results=None, failed=(), registered=("addic7ed", "tvsubtitles")):
+    """Build a ``SchedulerRun`` the way ``run_jobs`` would, so tests that stub
+    the scheduler exercise the real return contract instead of a bare dict."""
+    health = {
+        name: ProviderHealth(
+            name=name,
+            responded=name not in failed,
+            transport_failures=3 if name in failed else 0,
+            breaker_tripped=name in failed,
+            skipped_by_breaker=0,
+        )
+        for name in registered
+    }
+    return SchedulerRun(results=results or {}, provider_health=health)
+
+
 @pytest.mark.unit
 class TestDownloadSubtitlesMidRunDegradation:
     """End-to-end coverage for the June 2026 failure mode: OpenSubtitles logs
@@ -97,7 +114,7 @@ class TestDownloadSubtitlesMidRunDegradation:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=Mock()),
             patch.object(ts, "os_api_call", side_effect=Exception("406 quota exceeded")),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -134,7 +151,7 @@ class TestDownloadSubtitlesMidRunDegradation:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=Mock()),
             patch.object(ts, "os_api_call", side_effect=Exception("406 quota exceeded")),
-            patch.object(ts, "run_jobs", return_value=scraper_hits),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run(scraper_hits)),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -168,7 +185,7 @@ class TestDownloadSubtitlesMidRunDegradation:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=Mock()),
             patch.object(ts, "os_api_call", side_effect=Exception("406 quota exceeded")),
-            patch.object(ts, "run_jobs", return_value=scraper_hits),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run(scraper_hits)),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -209,7 +226,7 @@ class TestDownloadSubtitlesMidRunDegradation:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=client),
             patch.object(ts, "os_api_call", side_effect=_fake_os_call),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
             # Read inside the patch context -- patch.object restores _OS on exit.
@@ -242,7 +259,7 @@ class TestDownloadSubtitlesMidRunDegradation:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=client),
             patch.object(ts, "os_api_call", side_effect=Exception("connection reset")),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -272,7 +289,7 @@ class TestDownloadSubtitlesLoginFailureDegradation:
             patch.object(ts, "fetch_season_details", return_value=1),
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=None),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -327,7 +344,7 @@ class TestDownloadSubtitlesOpenSubtitlesCredit:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=os_client),
             patch.object(ts, "os_api_call", side_effect=fake_os_api_call),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -374,7 +391,7 @@ class TestDownloadSubtitlesOpenSubtitlesCredit:
             patch.object(ts, "_precomputed_skip_result", return_value=None),
             patch.object(ts, "_get_os_client", return_value=os_client),
             patch.object(ts, "os_api_call", side_effect=fake_os_api_call),
-            patch.object(ts, "run_jobs", return_value={}),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
         ):
             result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
 
@@ -383,3 +400,248 @@ class TestDownloadSubtitlesOpenSubtitlesCredit:
         assert by_code["S01E01"]["source"] == "cache"
         assert by_code["S01E02"]["status"] == "downloaded"
         assert by_code["S01E02"]["source"] == "opensubtitles_api"
+
+
+@pytest.mark.unit
+class TestIsDegradedScrapers:
+    """The scraper half of the cascade. Before this, a season whose scrapers
+    were ALL down looked identical to a season nobody ever subtitled: every
+    episode ``not_found``, ``os_failed`` False, recorded at 0%, skip-listed
+    for 30 days. Same defect as the OpenSubtitles one, different door."""
+
+    def test_degraded_when_providers_failed_and_nothing_found(self):
+        episodes = [
+            {"code": "S01E01", "status": "not_found", "path": None, "source": None},
+            {"code": "S01E02", "status": "not_found", "path": None, "source": None},
+        ]
+        assert ts._is_degraded(os_failed=False, episodes=episodes, providers_failed=True) is True
+
+    def test_not_degraded_when_providers_healthy_and_nothing_found(self):
+        """The providers answered and had nothing. A real measurement, and it
+        SHOULD be recorded so a genuinely unsubtitled season stops being
+        re-harvested every run."""
+        episodes = [{"code": "S01E01", "status": "not_found", "path": None, "source": None}]
+        assert ts._is_degraded(os_failed=False, episodes=episodes, providers_failed=False) is False
+
+    def test_not_degraded_when_providers_failed_but_season_complete(self):
+        """One scraper dead, the other supplied every episode. There is no gap
+        left for the outage to have hidden, so the measurement stands. Same
+        reasoning the OpenSubtitles clause already uses."""
+        episodes = [
+            {"code": "S01E01", "status": "downloaded", "path": "/x.srt", "source": "tvsubtitles"},
+            {"code": "S01E02", "status": "cached", "path": "/y.srt", "source": "cache"},
+        ]
+        assert ts._is_degraded(os_failed=False, episodes=episodes, providers_failed=True) is False
+
+    def test_degraded_when_providers_failed_and_season_partial(self):
+        """A partial season after a provider went down cannot distinguish
+        "genuinely absent" from "was behind the dead provider". Over-flagging
+        costs one cheap retry; under-flagging costs a 30-day blind spot."""
+        episodes = [
+            {"code": "S01E01", "status": "downloaded", "path": "/x.srt", "source": "tvsubtitles"},
+            {"code": "S01E02", "status": "not_found", "path": None, "source": None},
+        ]
+        assert ts._is_degraded(os_failed=False, episodes=episodes, providers_failed=True) is True
+
+    def test_providers_failed_defaults_to_false(self):
+        """Existing callers that pass only the OpenSubtitles signal keep their
+        exact behaviour."""
+        episodes = [{"code": "S01E01", "status": "not_found", "path": None, "source": None}]
+        assert ts._is_degraded(os_failed=False, episodes=episodes) is False
+
+
+@pytest.mark.unit
+class TestDownloadSubtitlesScraperOutage:
+    """End-to-end for the second door: OpenSubtitles is healthy and simply has
+    nothing, while BOTH scrapers are down."""
+
+    def test_degraded_when_os_healthy_but_all_scrapers_down(self, tmp_path):
+        with (
+            patch.object(ts._OS, "failed", False),
+            patch(
+                "app.services.config_service.get_config_sync",
+                return_value=_mock_config(tmp_path),
+            ),
+            patch.object(ts, "fetch_show_details", return_value={"name": "Test Show"}),
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "fetch_season_episodes", return_value=[]),
+            patch.object(ts, "_precomputed_skip_result", return_value=None),
+            patch.object(ts, "_get_os_client", return_value=Mock()),
+            patch.object(ts, "os_api_call", return_value=Mock(data=[])),
+            patch.object(
+                ts,
+                "run_jobs",
+                return_value=_scheduler_run(failed=("addic7ed", "tvsubtitles")),
+            ),
+        ):
+            result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
+
+        assert all(ep["status"] == "not_found" for ep in result["episodes"])
+        assert result["degraded"] is True
+
+    def test_not_degraded_when_os_healthy_and_scrapers_merely_miss(self, tmp_path):
+        """The control for the test above: identical outcome on the wire (every
+        episode not_found) but the scrapers answered. This must still record,
+        or no season is ever measured again."""
+        with (
+            patch.object(ts._OS, "failed", False),
+            patch(
+                "app.services.config_service.get_config_sync",
+                return_value=_mock_config(tmp_path),
+            ),
+            patch.object(ts, "fetch_show_details", return_value={"name": "Test Show"}),
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "fetch_season_episodes", return_value=[]),
+            patch.object(ts, "_precomputed_skip_result", return_value=None),
+            patch.object(ts, "_get_os_client", return_value=Mock()),
+            patch.object(ts, "os_api_call", return_value=Mock(data=[])),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
+        ):
+            result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
+
+        assert all(ep["status"] == "not_found" for ep in result["episodes"])
+        assert result["degraded"] is False
+
+    def test_not_degraded_when_one_scraper_dead_but_season_complete(self, tmp_path):
+        hits = {
+            f"S01E{ep:02d}": {
+                "code": f"S01E{ep:02d}",
+                "status": "downloaded",
+                "path": str(tmp_path / f"Test Show - S01E{ep:02d}.srt"),
+                "source": "tvsubtitles",
+            }
+            for ep in (1, 2)
+        }
+        with (
+            patch.object(ts._OS, "failed", False),
+            patch(
+                "app.services.config_service.get_config_sync",
+                return_value=_mock_config(tmp_path),
+            ),
+            patch.object(ts, "fetch_show_details", return_value={"name": "Test Show"}),
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "fetch_season_episodes", return_value=[]),
+            patch.object(ts, "_precomputed_skip_result", return_value=None),
+            patch.object(ts, "_get_os_client", return_value=Mock()),
+            patch.object(ts, "os_api_call", return_value=Mock(data=[])),
+            patch.object(
+                ts, "run_jobs", return_value=_scheduler_run(results=hits, failed=("addic7ed",))
+            ),
+        ):
+            result = ts.download_subtitles("Test Show", 1, tmdb_id=999, use_precomputed=False)
+
+        assert result["degraded"] is False
+
+
+def _precomputed_skip(covered_codes, cache_dir):
+    """A precomputed-cache skip result, the shape ``_heal_precomputed_gaps``
+    receives and copies forward."""
+    return {
+        "show_name": "Test Show",
+        "season": 1,
+        "total_episodes": len(covered_codes),
+        "episodes": [
+            {"code": code, "status": "precomputed", "source": "precomputed"}
+            for code in covered_codes
+        ],
+        "cache_dir": str(cache_dir),
+        "degraded": False,
+    }
+
+
+@pytest.mark.unit
+class TestHealPrecomputedGapsDegradation:
+    """The precomputed-gap heal reaches the scrapers through the same door.
+    Its result dict inherits ``degraded: False`` from the skip it copies, so
+    a heal attempted while both scrapers were down used to report a confident
+    (and short) season."""
+
+    def test_degraded_when_heal_providers_down_and_gap_remains(self, tmp_path):
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(
+                ts,
+                "run_jobs",
+                return_value=_scheduler_run(failed=("addic7ed", "tvsubtitles")),
+            ),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                _precomputed_skip(["S01E01"], tmp_path),
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert [ep["status"] for ep in healed["episodes"]] == ["precomputed", "not_found"]
+        assert healed["degraded"] is True
+
+    def test_not_degraded_when_heal_providers_healthy_and_gap_remains(self, tmp_path):
+        """The providers answered and nobody has S01E02. A real measurement:
+        the gap is a hard one and should be recorded as such."""
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "run_jobs", return_value=_scheduler_run()),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                _precomputed_skip(["S01E01"], tmp_path),
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert healed["degraded"] is False
+
+    def test_not_degraded_when_providers_down_but_gap_filled(self, tmp_path):
+        """One dead scraper, the other supplied the missing episode. Nothing
+        is left unmeasured."""
+        srt = tmp_path / "Test Show - S01E02.srt"
+        hits = {
+            "S01E02": {
+                "code": "S01E02",
+                "status": "downloaded",
+                "path": str(srt),
+                "source": "tvsubtitles",
+            }
+        }
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(
+                ts,
+                "run_jobs",
+                return_value=_scheduler_run(results=hits, failed=("addic7ed",)),
+            ),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                _precomputed_skip(["S01E01"], tmp_path),
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert healed["degraded"] is False
+
+    def test_no_gap_leaves_skip_untouched(self, tmp_path):
+        """The fast path stays fast: a complete precomputed season never calls
+        the scrapers, so it can never be degraded by them."""
+        skip = _precomputed_skip(["S01E01", "S01E02"], tmp_path)
+        with (
+            patch.object(ts, "fetch_season_details", return_value=2),
+            patch.object(ts, "run_jobs", side_effect=AssertionError("must not fetch")),
+        ):
+            healed = ts._heal_precomputed_gaps(
+                skip,
+                "Test Show",
+                1,
+                tmdb_id=999,
+                cache_path=tmp_path,
+                config=_mock_config(tmp_path),
+            )
+
+        assert healed is skip
+        assert healed["degraded"] is False

--- a/docs/superpowers/plans/2026-08-31-subtitle-cache-harvester-repair.md
+++ b/docs/superpowers/plans/2026-08-31-subtitle-cache-harvester-repair.md
@@ -1048,6 +1048,11 @@ This is irreversible and returns ~978 seasons to the unmeasured pool, costing se
 
 ## Known gap, deliberately out of scope: the scrapers have no failure signal
 
+> **CLOSED 2026-09-03.** `run_jobs` now returns a `SchedulerRun` carrying per-provider
+> health, and `_is_degraded` takes a `providers_failed` axis alongside the OpenSubtitles
+> one. Design: `docs/superpowers/specs/2026-09-03-scraper-failure-signal-design.md`.
+> The analysis below is kept as the diagnosis that motivated it.
+
 `_is_degraded` covers the OpenSubtitles half of the cascade only. The scraper
 scheduler (`app/matcher/provider_scheduler.py`) emits exactly two per-episode
 statuses, `downloaded` and `not_found`, and its `_CircuitBreaker` trips after three

--- a/docs/superpowers/specs/2026-09-03-scraper-failure-signal-design.md
+++ b/docs/superpowers/specs/2026-09-03-scraper-failure-signal-design.md
@@ -1,0 +1,157 @@
+# Scraper Failure Signal Design
+
+**Date:** 2026-09-03
+**Status:** Approved, implementing
+**Closes:** the "Known gap, deliberately out of scope: the scrapers have no failure signal"
+section of `docs/superpowers/plans/2026-08-31-subtitle-cache-harvester-repair.md`.
+
+## Problem
+
+PR #631 taught the subtitle-cache harvester to decline to record a coverage row when a
+season could not actually be measured, on the principle that **no record beats a false
+zero**: absence means measure later, `0.0` means never retry for 30 days. But
+`_is_degraded` in `app/matcher/testing_service.py` covers the OpenSubtitles half of the
+cascade only, and says so in its own docstring.
+
+`app/matcher/provider_scheduler.py` emits exactly two per-episode statuses, `downloaded`
+and `not_found`. Its `_CircuitBreaker` trips after three consecutive transport failures
+and thereafter fast-skips the provider without changing the result shape. So when
+OpenSubtitles is healthy but BOTH Addic7ed and TVsubtitles are down:
+
+- every episode returns `not_found`
+- `os_failed` is False
+- the season records at 0%
+- `should_skip` suppresses it for 30 days
+
+That is the identical defect PR #631 repaired, reached through a different door.
+
+## Consumer audit
+
+`run_jobs` has exactly two production consumers, both in `testing_service.py`:
+
+| Site | Function | Role |
+|---|---|---|
+| `testing_service.py:381` | `_fetch_episodes` | precomputed-gap heal |
+| `testing_service.py:875` | `download_subtitles` | main season harvest |
+
+Plus 12 call sites in `tests/unit/test_provider_scheduler.py` and 7
+`patch.object(ts, "run_jobs", return_value={})` sites in
+`tests/unit/test_testing_service_degraded.py`.
+
+## Design
+
+### 1. Signal source: the breaker trip, not raw exception counts
+
+`_CircuitBreaker` already computes the needed distinction and throws it away.
+`record_failure` counts **only exceptions**; a clean miss or an unusable download calls
+`record_success` because the provider *responded*. That is exactly "this provider had
+nothing" versus "this provider never answered".
+
+A provider is **failed for this season** when its breaker tripped, or a job was
+fast-skipped because its breaker was open. Deliberately NOT "had at least one transport
+failure": a single transient scraper exception is routine, and flagging on it would mark
+nearly every season degraded, write no coverage rows at all, and walk straight into the
+other known gap ("a persistently degraded corpus is re-measured forever"). Three
+consecutive transport failures is an already-tuned "this provider is down" verdict.
+
+### 2. Combination rule
+
+Widen `_is_degraded`'s first gate; keep its second clause unchanged.
+
+```python
+def _is_degraded(os_failed, episodes, *, providers_failed=False):
+    if not (os_failed or providers_failed):
+        return False
+    if not episodes:
+        return True
+    return any(ep.get("status") not in RETRIEVED_STATUSES for ep in episodes)
+```
+
+This answers the partial-result question by inheritance rather than by new reasoning. If
+Addic7ed is dead but TVsubtitles served every episode, the season is complete: there is
+no gap an outage could be hiding, so it records normally. If the season is incomplete, we
+cannot distinguish "genuinely absent" from "was behind the dead provider", so we decline
+to measure.
+
+The PR #631 asymmetry holds here for the same reason it held there: over-flagging costs
+one cheap retry on the next run, under-flagging costs a 30-day blind spot.
+
+### 3. Breaker-open for a season never attempted
+
+Not reachable today. `run_jobs` constructs a fresh `Scheduler` per call and
+`download_subtitles` calls it once per season, so every breaker starts closed at season
+boundaries. A trip therefore always means "this provider went down *during this season*".
+A test pins this so it stays true.
+
+Making breakers process-global is a **genuinely independent** follow-up (it is a
+performance change: stop re-paying three timeouts per season for a provider already known
+down). It is not entangled with this change, but landing it would make this question
+live: a breaker tripped during season 3 would suppress attempts in season 4, and a
+never-attempted provider would then have to count as failed for that season under exactly
+the same asymmetry argument. Recorded in a code comment at the decision point.
+
+### 4. Return contract
+
+`run_jobs` returns a `SchedulerRun` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ProviderHealth:
+    name: str
+    responded: bool          # at least one non-exception response
+    transport_failures: int  # exceptions raised talking to the provider
+    breaker_tripped: bool    # breaker opened at some point this run
+    skipped_by_breaker: int  # jobs fast-skipped while the breaker was open
+
+@dataclass(frozen=True)
+class SchedulerRun:
+    results: dict[str, dict]
+    provider_health: dict[str, ProviderHealth]
+
+    @property
+    def failed_providers(self) -> list[str]: ...
+```
+
+Rejected alternative: a `dict` subclass carrying the health as an attribute. Zero test
+churn, but consumers would need `getattr(results, "failed_providers", ())`, so a mocked
+plain dict silently reads "no failures" -- reintroducing precisely the silent-underflag
+mode this change exists to remove. Breaking the stale mocks loudly is the point.
+
+`Scheduler.run` keeps returning the plain results dict (it is the internal collector);
+`Scheduler.provider_health()` is a new accessor and `run_jobs` composes the two.
+
+The health record is richer than the bare `set[str]` the predicate needs because the
+harvester-repair plan explicitly wanted a detection half: a WARNING naming the dead
+provider and its failure count is what lets an operator act before a misconfiguration
+runs for weeks.
+
+### 5. Heal path in scope
+
+`_fetch_episodes` (the precomputed-gap heal) is the same door: if its scrapers are down
+and gaps remain, `_heal_precomputed_gaps` still reports `degraded: False` because the
+value is copied from the precomputed skip dict. `_fetch_episodes` returns its provider
+health alongside the results, and `_heal_precomputed_gaps` sets `degraded=True` when
+providers failed AND episodes are still missing -- the same combination rule.
+
+## Testing
+
+Assert observable effects, not mock call counts, per what worked in PR #631:
+
+- `_is_degraded` truth table over the new `providers_failed` axis, including the
+  one-dead-one-healthy-but-complete case that must NOT degrade.
+- `run_jobs` against an always-raising fake client: `failed_providers` names it,
+  `breaker_tripped` is True, and the per-episode results are still `not_found` (shape
+  unchanged for existing consumers).
+- `run_jobs` against a client that only ever misses: `failed_providers` is empty
+  (responded, had nothing).
+- `download_subtitles` end to end with healthy OpenSubtitles and dead scrapers, asserting
+  `result["degraded"] is True` -- the exact scenario that is silently mis-recorded today.
+- Build-script level: `_should_record_coverage` declines, so no coverage row is written.
+
+Each new test is verified to fail against pre-change code.
+
+## Out of scope
+
+- Process-global breaker state (independent follow-up, see 3).
+- A degraded-run circuit breaker for the "persistently degraded corpus" runaway; still a
+  design decision, unchanged by this work.

--- a/docs/superpowers/specs/2026-09-03-scraper-failure-signal-design.md
+++ b/docs/superpowers/specs/2026-09-03-scraper-failure-signal-design.md
@@ -47,12 +47,26 @@ Plus 12 call sites in `tests/unit/test_provider_scheduler.py` and 7
 `record_success` because the provider *responded*. That is exactly "this provider had
 nothing" versus "this provider never answered".
 
-A provider is **failed for this season** when its breaker tripped, or a job was
-fast-skipped because its breaker was open. Deliberately NOT "had at least one transport
-failure": a single transient scraper exception is routine, and flagging on it would mark
-nearly every season degraded, write no coverage rows at all, and walk straight into the
-other known gap ("a persistently degraded corpus is re-measured forever"). Three
-consecutive transport failures is an already-tuned "this provider is down" verdict.
+A provider is **failed for this season** when its breaker tripped, a job was
+fast-skipped because its breaker was open, **or** it raised on every attempt and never
+once answered.
+
+The breaker is the primary signal because three consecutive transport failures is an
+already-tuned "this provider is down" verdict. The third clause exists because the
+breaker cannot see a small batch: it needs three consecutive failures, and
+`_fetch_episodes` healing a precomputed gap usually asks for one or two episodes, so a
+completely dead provider would never trip inside that call and the gap would be recorded
+as a genuine absence. That left the protection weakest exactly where the heal path
+exercises it most often.
+
+The rule is still deliberately NOT "had at least one transport failure". The
+`never answered` qualifier is what keeps the third clause honest: a lone exception
+partway through a season the provider is otherwise serving is routine noise, and flagging
+on it would mark nearly every season degraded, write no coverage rows at all, and walk
+straight into the other known gap ("a persistently degraded corpus is re-measured
+forever"). A provider that answered even once is reachable, so later blips do not condemn
+it, and a provider the cascade never reached has neither failures nor responses and stays
+unflagged.
 
 ### 2. Combination rule
 
@@ -144,6 +158,11 @@ Assert observable effects, not mock call counts, per what worked in PR #631:
   unchanged for existing consumers).
 - `run_jobs` against a client that only ever misses: `failed_providers` is empty
   (responded, had nothing).
+- `run_jobs` on batches of one and two jobs against a dead client: still reported failed,
+  below the breaker threshold. Plus the two over-flag guards -- a provider that answered
+  once then raised is not failed, and a provider never asked is not failed.
+- The heal path end to end through the REAL scheduler (not a fabricated `SchedulerRun`)
+  with a one-episode gap and dead clients.
 - `download_subtitles` end to end with healthy OpenSubtitles and dead scrapers, asserting
   `result["degraded"] is True` -- the exact scenario that is silently mis-recorded today.
 - Build-script level: `_should_record_coverage` declines, so no coverage row is written.


### PR DESCRIPTION
## What

Closes the scraper half of the harvester's degraded detection, the gap recorded as
deliberately out of scope in `docs/superpowers/plans/2026-08-31-subtitle-cache-harvester-repair.md`.

PR #631 taught the cache builder to decline to record a coverage row when a season could
not actually be measured: **no record beats a false zero**. But `_is_degraded` read only
the OpenSubtitles half of the cascade, and said so in its own docstring. With
OpenSubtitles healthy and BOTH Addic7ed and TVsubtitles down, every episode came back
`not_found`, `os_failed` was False, the season recorded at 0%, and `should_skip`
suppressed it for 30 days. Same defect, different door.

## How

**The scheduler already knew.** `_CircuitBreaker.record_failure` counts only exceptions;
a clean miss or an unusable download calls `record_success` because the provider
*responded*. That is exactly "had nothing" vs "never answered", and it was being thrown
away. `run_jobs` now returns a `SchedulerRun` (`.results` + `.provider_health`) instead of
a bare dict, and `_is_degraded` gains a `providers_failed` axis beside the OpenSubtitles
one.

Design decisions, with reasoning rather than guesses:

- **Keyed to the breaker trip, not to `transport_failures > 0`.** A lone scraper exception
  is routine. Flagging on it would degrade nearly every season, stop coverage being
  recorded at all, and walk straight into the other known gap ("a persistently degraded
  corpus is re-measured forever"). Three consecutive transport failures is the
  already-tuned "this provider is down" verdict.
- **Partial results follow PR #631's asymmetry, which I checked rather than assumed.**
  One dead scraper plus one healthy one that covered the whole season records normally:
  there is no gap left for the outage to have hidden. Incomplete after a provider went
  dark writes no row, because a partial season cannot tell "genuinely absent" from "was
  behind the dead provider". Over-flagging costs one cheap retry; under-flagging costs a
  30-day blind spot.
- **Breaker-open for a season never attempted is unreachable today**, because `run_jobs`
  builds a fresh `Scheduler` per call and `download_subtitles` calls it once per season.
  A test pins that. Making breakers process-global is a genuinely independent follow-up,
  but it would make the question live, so the reasoning is left in a comment at the
  decision point.
- **`SchedulerRun` is a dataclass, not a `dict` subclass carrying an attribute.** The
  subclass needs zero test churn, but a mocked plain `{}` would then silently report "no
  providers failed" through a `getattr` fallback, reintroducing the exact silent-underflag
  mode this closes. Breaking the seven stale mocks loudly is the point.
- **The precomputed-gap heal is included.** It copies `degraded: False` forward from the
  skip dict, so a heal attempted while the scrapers were down used to report a confident
  (and short) season. `_fetch_episodes` returns its provider health and
  `_heal_precomputed_gaps` applies the same rule.

## Testing

`_is_degraded` truth table over the new axis, `run_jobs` health against dead / missing /
transiently-failing / mixed clients, `download_subtitles` end to end for the outage and
its control, the heal path, and a build-script-level test that runs the real
`download_subtitles` under `_harvest_show` and asserts **no coverage row is written** for
a scraper outage while a healthy-but-empty run still writes its 0% row.

The three defect-catching tests were verified to fail against the pre-fix decision while
the six controls still pass, so they are not asserting `True`. No real cache build was
run; no OpenSubtitles quota consumed.

`uv run pytest tests/unit`: **3199 passed, 21 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
