### PR TITLE
feat: optionally back up a disc before ripping, and import existing backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Optionally back up a disc before ripping it.** Engram can write a full
+  decrypted MakeMKV copy of each disc to a folder you choose and then extract
+  from that copy instead of from the drive. The disc is read once, sequentially,
+  rather than once per title, which is much gentler on a scratched disc that has
+  no in-print replacement; the disc is released as soon as the copy finishes
+  rather than when the whole rip does; extraction from local storage is faster
+  and survives a marginal read; and the copy is kept for preservation, since
+  Engram never deletes one. Backups mirror your library layout and honour your
+  own naming settings. If anything prevents a backup, Engram rips directly from
+  the drive as before and says why on the job card, so turning this on cannot
+  make a disc less likely to finish. Off by default: enable it under Settings
+  and pick a backup folder. (#NNN)
+- **Import a disc backup you already have.** The Import button now recognises a
+  folder containing `BDMV` or `VIDEO_TS`, or an `.iso` file, and runs it through
+  the normal scan, identify, rip, match and organize pipeline instead of filing
+  it as finished media. Point it at a shelf of backups and it queues one job per
+  disc. (#NNN)
+
 ### Fixed
 
 - **The subtitle-cache builder no longer records a provider outage as missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,17 @@ Playwright-based E2E tests (10 spec files) that use simulation endpoints to test
   match than a genuine bonus disc, and the mis-file is invisible until someone browses the
   library. Independent of `always_review` — this is the floor, not the override.
 - **Job visibility invariant**: every job must be reachable from at least one view. `GET /api/jobs` (dashboard) caps *terminal* jobs at `RECENT_TERMINAL_JOB_LIMIT` (10) but exempts non-terminal ones, because `GET /api/jobs/history` defaults to COMPLETED/FAILED only. Without the exemption a `REVIEW_NEEDED` job aged out of the dashboard and appeared nowhere (the row was never deleted; nothing hard-deletes `DiscJob`). History honours an explicit `state` for any state plus `include_all_states=true` as the backstop. Guarded by `TestJobVisibilityInvariant` in `tests/unit/test_api_routes.py`, so re-narrowing either query fails a test.
+- **A job's MakeMKV source is a value, not a drive.** `DiscSource`
+  (`app/core/disc_source.py`) answers "is this a physical drive?" once, for eject, sentinel
+  re-arm, disc-hash, and the MakeMKV serialization lock. `DiscJob.source_spec` is the stored
+  form (`dev:E:` / `disc:N` / `file:<backup>` / `iso:<file>`); `None` means "legacy, derive
+  from `drive_id`", which `DiscSource.from_job` implements. Two traps: a `file:` source must
+  NOT share the physical drive's `lock_key`, or extracting a backup blocks the next disc
+  from being scanned; and a drive resolved to `disc:N` for `makemkvcon backup` keeps its
+  originating letter for locking (`DiscSource.for_drive_index`), or a backup and a scan of
+  the same drive would run two makemkvcon processes at once. Every scan/rip call site reads
+  the source, not `drive_id` (they did not, and the backup was silently ripping from the
+  ejected drive).
 - **Import path ownership**: a staging path is owned by an *in-flight* job (hard block, not overridable) and merely recorded by a *completed* one (soft block, overridable via `force_keys`). `FAILED` never blocks. Rules live in `app/services/import_guard.py`; `POST /api/import/start` returns `{job_ids, blocked[]}` and never 409s.
 - **ASR GPU runtime**: faster-whisper→CTranslate2 supports **NVIDIA CUDA only** (no Metal/ROCm), needing cuDNN 9 + cuBLAS (~1.2 GB). Those libs are NOT bundled — `app/matcher/cuda_runtime.py` downloads them on demand (opt-in) into `~/.engram/cuda/` and registers them (Windows `add_dll_directory`; Linux ordered `ctypes.CDLL` preload) before the first model load. The **effective** device is resolved ONCE at `job_manager.start()` via `set_asr_device()`; every call site reads it through `detect_asr_device()`, so the `/api/asr-status` badge, the match semaphore, and the model loader can't disagree (the badge no longer claims CUDA while silently on CPU). `gpu_detected()` is the raw hardware probe; `cuda_compute_type()` picks float16/int8_float16/float32 per `get_supported_compute_types` so Pascal GPUs don't fail. Endpoints: `POST /api/asr/gpu/enable|disable`. Dev: `uv sync -E gpu` installs the pip `nvidia.*` packages, which `register_cuda_runtime()` falls back to.
 - **Review playback is a handoff, never a transcode.** The media endpoint serves
@@ -386,6 +397,18 @@ Components use updated settings
   every disc in REVIEW_NEEDED instead of finalizing. Checked AFTER the escalation ladders
   (so the review opens with the matcher's best guess pre-filled) and gated on `has_matched`
   (a disc with nothing left to organize must not be parked, or the review page can't finish it).
+- **Disc backup**: `backup_before_rip` (bool, default false, `server_default 0`) plus
+  `backup_path`. When on, `IDENTIFYING` hands the disc to `BACKING_UP`, which copies it
+  whole to `<backup_path>` and then extracts from the copy, so the drive is released at
+  the end of the backup rather than at the end of the rip. **Every backup problem degrades
+  to a direct rip** (recorded in `backup_status` / `backup_status_reason`): enabling the
+  setting must never make a disc less likely to finish. The one exception is a backup whose
+  re-scan cannot be reconciled onto the stored title indices, which parks in
+  `REVIEW_NEEDED` because the disc has already been ejected. Engram never deletes a
+  completed backup; a retried backup keeps at most one stale `.partial` (see
+  `Extractor.backup_disc`). Routing lives in one place,
+  `identification_coordinator.next_state_after_identify`, because five sites hand a disc
+  onward and they must not drift.
 - **Discord notifications**: `discord_template_completed` / `discord_template_failed` /
   `discord_template_review` (customizable embed description, chevron `{{var}}` mustache
   syntax, see `app/core/discord_notifier.py::ALLOWED_TEMPLATE_VARS`; empty string = built-in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,7 @@ All WebSocket messages follow the format: `{"type": "...", "data": {...}}`
 | `subtitle_progress` | `{"job_id": int, "downloaded": int, "total": int, "failed": int}` | Subtitle download progress |
 | `title_discovered` | `{"job_id": int, "title": DiscTitle}` | New title found during ripping |
 | `rip_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Ripping progress update |
-| `backup_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Full-disc backup copy progress |
+| `backup_progress` | `job_id`, `current_bytes`, `total_bytes`, `speed`, `eta` (flat, not nested under `data`) | Full-disc backup copy progress |
 | `title_ripping_started` | `{"job_id": int, "title_id": int}` | Title ripping started |
 | `title_ripping_progress` | `{"job_id": int, "title_id": int, ...}` | Per-track ripping progress |
 | `title_matching_started` | `{"job_id": int, "title_id": int}` | Title matching started |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,6 +312,7 @@ All WebSocket messages follow the format: `{"type": "...", "data": {...}}`
 | `subtitle_progress` | `{"job_id": int, "downloaded": int, "total": int, "failed": int}` | Subtitle download progress |
 | `title_discovered` | `{"job_id": int, "title": DiscTitle}` | New title found during ripping |
 | `rip_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Ripping progress update |
+| `backup_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Full-disc backup copy progress |
 | `title_ripping_started` | `{"job_id": int, "title_id": int}` | Title ripping started |
 | `title_ripping_progress` | `{"job_id": int, "title_id": int, ...}` | Per-track ripping progress |
 | `title_matching_started` | `{"job_id": int, "title_id": int}` | Title matching started |

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -130,6 +130,10 @@ class JobResponse(BaseModel):
     # Null when no prompt is pending; set by identify_disc's B2 gates and
     # cleared by the answer endpoints / B4 rip-end convergence.
     identity_prompt_json: str | None = None
+    # backup_before_rip: "pending" while the whole-disc copy is in flight,
+    # then "completed" / "failed" / "skipped". Null when backup isn't in use
+    # for this job (the common case today).
+    backup_status: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -2718,6 +2722,15 @@ class SimulateDiscRequest(BaseModel):
     rip_speed_multiplier: int = 10
     force_review_needed: bool = False
     review_reason: str | None = None
+    simulate_backup: bool = False
+    """Park the job in BACKING_UP with a synthetic backup instead of RIPPING.
+
+    Broadcasts a few ``backup_progress`` messages, then STOPS in BACKING_UP
+    (no auto-advance, and ``simulate_ripping`` is ignored) so a test can
+    observe the phase before manually advancing the job to RIPPING via
+    ``POST /api/simulate/advance-job/{job_id}``. DEBUG-only; no real copy is
+    made and nothing is written to disk.
+    """
     identity_pending: str | None = None
     """Inject a walk-away identity prompt on the RIPPING job (DEBUG only).
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1118,6 +1118,13 @@ async def build_job_detail(job: DiscJob, session: AsyncSession) -> dict:
         "subtitles_failed": job.subtitles_failed,
         "staging_path": job.staging_path,
         "final_path": job.final_path,
+        # Disc backup. source_spec is included because it is the one field that
+        # says whether this job's MKVs came off the disc or out of the copy,
+        # which is the first thing to check when a rip looks wrong.
+        "source_spec": job.source_spec,
+        "backup_path": job.backup_path,
+        "backup_status": job.backup_status,
+        "backup_status_reason": job.backup_status_reason,
         "titles": titles,
     }
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3019,7 +3019,13 @@ async def import_browse(path: str = "") -> dict:
     directory names with a shallow direct-child
     MKV count, plus selectable .mkv files. Never returns file contents. Empty
     path returns the drive roots (Windows) or / and home (POSIX).
+
+    A directory holding BDMV/VIDEO_TS and a .iso file are reported as their own
+    types: they are scanned and extracted through the normal pipeline rather
+    than filed like ready-made MKVs.
     """
+    from app.core import import_scanner
+
     if not path:
         if os.name == "nt":
             # Probing 26 drive letters can each block for seconds on a stale
@@ -3043,6 +3049,14 @@ async def import_browse(path: str = "") -> dict:
         for entry in os.scandir(p):
             try:
                 if entry.is_dir(follow_symlinks=False):
+                    # Checked before the MKV count: a disc backup is not a
+                    # folder of media, and counting its (zero) MKVs would render
+                    # it as an empty, unimportable directory.
+                    if import_scanner.is_disc_image_dir(Path(entry.path)):
+                        entries.append(
+                            {"name": entry.name, "path": entry.path, "type": "disc_image"}
+                        )
+                        continue
                     count = 0
                     try:
                         for f in os.scandir(entry.path):
@@ -3055,6 +3069,8 @@ async def import_browse(path: str = "") -> dict:
                     )
                 elif entry.is_file(follow_symlinks=False) and entry.name.lower().endswith(".mkv"):
                     entries.append({"name": entry.name, "path": entry.path, "type": "mkv"})
+                elif entry.is_file(follow_symlinks=False) and entry.name.lower().endswith(".iso"):
+                    entries.append({"name": entry.name, "path": entry.path, "type": "iso"})
             except OSError:
                 continue
     except OSError as exc:
@@ -3094,7 +3110,12 @@ async def import_preview(req: ImportPathRequest) -> dict:
         "root": str(scan.root),
         "units": units,
         "loose_files": [str(f) for f in scan.loose_files],
-        "total_jobs": len(scan.units),
+        "disc_images": [
+            {"name": d.name, "path": str(d.path), "kind": d.kind, "total_bytes": d.total_bytes}
+            for d in scan.disc_images
+        ],
+        # Each disc image becomes its own job, exactly as each MKV unit does.
+        "total_jobs": len(scan.units) + len(scan.disc_images),
         "total_files": scan.total_files,
         "total_bytes": scan.total_bytes,
         "truncated": scan.truncated,
@@ -3127,14 +3148,46 @@ async def import_start(req: ImportStartRequest) -> ImportStartResponse:
         raise HTTPException(status_code=400, detail=f"Path does not exist: {req.path}")
 
     scan = await asyncio.to_thread(import_scanner.scan, p)
-    if not scan.units:
-        raise HTTPException(status_code=400, detail="No MKV files found to import")
+    if not scan.units and not scan.disc_images:
+        raise HTTPException(status_code=400, detail="No MKV files or disc backups found to import")
 
     root_str = str(scan.root)
     force_keys = set(req.force_keys)
     seen_keys: set[str] = set()
     job_ids: list[int] = []
     blocked: list[BlockedImportUnit] = []
+
+    # Disc backups and ISOs are not ready-made media: each one is scanned and
+    # extracted through the normal MakeMKV pipeline, so it carries a source_spec
+    # and no file manifest. Ownership is guarded exactly as an MKV unit is, on
+    # the image's own path.
+    for image in scan.disc_images:
+        image_path = str(image.path)
+        key = unit_key_for(image_path)
+        seen_keys.add(key)
+        result = await job_manager.create_job_from_staging(
+            staging_path=image_path,
+            content_type="unknown",
+            detected_title=image.name,
+            destination_mode=req.destination_mode,
+            drive_id="import",
+            source_spec=(f"iso:{image.path}" if image.kind == "iso" else f"file:{image.path}"),
+            force=key in force_keys,
+        )
+        if result.job_id is not None:
+            job_ids.append(result.job_id)
+        else:
+            blocked.append(
+                BlockedImportUnit(
+                    unit_key=key,
+                    show_name=image.name,
+                    season=None,
+                    display_path=image_path,
+                    reason=result.block,
+                    job_ids=list(result.blocking_job_ids),
+                )
+            )
+
     for unit in scan.units:
         files = [str(f) for f in unit.files]
         # The dedup path (and therefore unit_key) is the single file's parent, or

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -138,6 +138,10 @@ class JobResponse(BaseModel):
     # The dashboard needs both: backup_status decides whether to warn at all,
     # this says what to warn about.
     backup_status_reason: str | None = None
+    # What MakeMKV is pointed at. The one field that separates a disc-image
+    # import from an MKV import (both carry drive_id "import"), and the one
+    # that says whether a rip read the disc or the copy.
+    source_spec: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -134,6 +134,10 @@ class JobResponse(BaseModel):
     # then "completed" / "failed" / "skipped". Null when backup isn't in use
     # for this job (the common case today).
     backup_status: str | None = None
+    # Why the backup was skipped or failed, in prose the card can show as is.
+    # The dashboard needs both: backup_status decides whether to warn at all,
+    # this says what to warn about.
+    backup_status_reason: str | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -296,6 +296,10 @@ class ConfigResponse(BaseModel):
     timeout_ripping_seconds: int
     timeout_matching_seconds: int
     timeout_organizing_seconds: int
+    timeout_backing_up_seconds: int
+    # Disc backup
+    backup_before_rip: bool
+    backup_path: str
     # Drive behavior
     auto_eject_enabled: bool
     # Staging cleanup
@@ -397,6 +401,10 @@ class ConfigUpdate(BaseModel):
     timeout_ripping_seconds: int | None = None
     timeout_matching_seconds: int | None = None
     timeout_organizing_seconds: int | None = None
+    timeout_backing_up_seconds: int | None = None
+    # Disc backup
+    backup_before_rip: bool | None = None
+    backup_path: str | None = None
     # Drive behavior
     auto_eject_enabled: bool | None = None
     # Staging cleanup
@@ -1668,6 +1676,10 @@ async def get_config() -> ConfigResponse:
         timeout_ripping_seconds=config.timeout_ripping_seconds,
         timeout_matching_seconds=config.timeout_matching_seconds,
         timeout_organizing_seconds=config.timeout_organizing_seconds,
+        timeout_backing_up_seconds=config.timeout_backing_up_seconds,
+        # Disc backup
+        backup_before_rip=config.backup_before_rip,
+        backup_path=config.backup_path,
         # Drive behavior
         auto_eject_enabled=config.auto_eject_enabled,
         # Staging cleanup

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -320,6 +320,11 @@ class ConnectionManager:
         "ripping" from rip_progress would be reporting a phase that produces no
         MKV at all.
 
+        Flat, like every other message this class emits: the frontend reads
+        fields straight off the message and does no unwrapping, so a nested
+        "data" envelope silently produced an undefined job id and a progress
+        bar that never moved.
+
         Unlike broadcast_job_update, ``speed`` and ``eta`` are always present
         even when None. That method omits its optional fields because it is a
         partial patch over a whole job row, where a null would erase a value
@@ -332,13 +337,11 @@ class ConnectionManager:
         await self.broadcast(
             {
                 "type": "backup_progress",
-                "data": {
-                    "job_id": job_id,
-                    "current_bytes": current_bytes,
-                    "total_bytes": total_bytes,
-                    "speed": speed,
-                    "eta": eta,
-                },
+                "job_id": job_id,
+                "current_bytes": current_bytes,
+                "total_bytes": total_bytes,
+                "speed": speed,
+                "eta": eta,
             }
         )
 

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -319,6 +319,15 @@ class ConnectionManager:
         A distinct message type rather than rip_progress: a client that renders
         "ripping" from rip_progress would be reporting a phase that produces no
         MKV at all.
+
+        Unlike broadcast_job_update, ``speed`` and ``eta`` are always present
+        even when None. That method omits its optional fields because it is a
+        partial patch over a whole job row, where a null would erase a value
+        the client already had. This message is a self-contained progress
+        sample, so a null means "not known for this sample" and the client
+        coalesces it against what it is already showing. Expect ``speed`` to
+        stay None in practice: MakeMKV's backup reports a percentage, not a
+        byte rate, so there is no rate to derive without timing the samples.
         """
         await self.broadcast(
             {

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -305,6 +305,34 @@ class ConnectionManager:
             }
         )
 
+    async def broadcast_backup_progress(
+        self,
+        job_id: int,
+        *,
+        current_bytes: int,
+        total_bytes: int,
+        speed: str | None = None,
+        eta: int | None = None,
+    ) -> None:
+        """Broadcast disc-backup copy progress.
+
+        A distinct message type rather than rip_progress: a client that renders
+        "ripping" from rip_progress would be reporting a phase that produces no
+        MKV at all.
+        """
+        await self.broadcast(
+            {
+                "type": "backup_progress",
+                "data": {
+                    "job_id": job_id,
+                    "current_bytes": current_bytes,
+                    "total_bytes": total_bytes,
+                    "speed": speed,
+                    "eta": eta,
+                },
+            }
+        )
+
 
 # Singleton instance
 manager = ConnectionManager()

--- a/backend/app/core/backup_paths.py
+++ b/backend/app/core/backup_paths.py
@@ -11,8 +11,13 @@ import logging
 import shutil
 from pathlib import Path
 
-from app.core.organizer import sanitize_filename
-from app.models import ContentType, DiscJob
+from app.core.organizer import (
+    format_movie_folder,
+    format_season_folder,
+    format_tv_show_folder,
+    sanitize_filename,
+)
+from app.models import AppConfig, ContentType, DiscJob
 
 logger = logging.getLogger(__name__)
 
@@ -27,41 +32,61 @@ _ASSUMED_DISC_BYTES = 50 * 1024**3
 
 
 def _safe_name(raw: str) -> str:
-    """Sanitize one path component, reusing the Organizer's rules."""
+    """Sanitize one path component, reusing the Organizer's rules.
+
+    Returns "" when nothing survives sanitization, so each call site chooses
+    its own fallback instead of everyone sharing one sentinel string (a disc
+    genuinely labelled "Unknown" must not be treated the same as a title that
+    sanitized away to nothing).
+    """
     cleaned = sanitize_filename(raw or "")
     # sanitize_filename already strips '/' and '\\' along with the rest of the
     # Windows-illegal character set, which is what keeps a crafted title from
     # introducing a new path component and climbing out of the backup root.
-    return cleaned or "Unknown"
+    return cleaned
 
 
-def backup_destination(job: DiscJob, backup_root: str) -> Path | None:
+def _job_fallback(job: DiscJob) -> str:
+    """The "nothing nameable survived" fallback, shared by every branch."""
+    return f"job-{job.id}" if job.id else "job-unknown"
+
+
+def backup_destination(job: DiscJob, config: AppConfig) -> Path | None:
     """Compute where this job's backup should be written.
 
-    Returns None when no root is configured, which the caller reports as a
-    "not_configured" skip.
+    Builds the same folder shape the Organizer would for the library, using
+    the user's configured naming formats, so the backup shelf mirrors the
+    library layout and the two cannot drift.
+
+    Returns None when no config or no root is configured, which the caller
+    reports as a "not_configured" skip.
     """
-    if not backup_root:
+    if not config or not config.backup_path:
         return None
 
-    root = Path(backup_root).expanduser()
+    root = Path(config.backup_path).expanduser()
     name = job.tmdb_name or job.detected_title
 
     if job.content_type == ContentType.MOVIE and name:
-        folder = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
+        folder = format_movie_folder(config.naming_movie_format, name, job.tmdb_year, job.tmdb_id)
+        folder = folder or _job_fallback(job)
         return root / "Movies" / folder
 
     if job.content_type == ContentType.TV and name:
-        show = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
-        disc = _safe_name(job.discdb_disc_slug or f"Disc {job.disc_number or 1}")
+        show = format_tv_show_folder(config.naming_tv_show_format, name, job.tmdb_year, job.tmdb_id)
+        show = show or _job_fallback(job)
+        disc = _safe_name(job.discdb_disc_slug or f"Disc {job.disc_number or 1}") or _job_fallback(
+            job
+        )
         base = root / "TV" / show
         if job.detected_season is not None:
-            return base / f"Season {job.detected_season:02d}" / disc
+            season = format_season_folder(config.naming_season_format, job.detected_season)
+            return base / season / disc
         return base / disc
 
     label = _safe_name(job.volume_label) if job.volume_label else ""
-    if not label or label == "Unknown":
-        label = f"job-{job.id}" if job.id else "job-unknown"
+    if not label:
+        label = _job_fallback(job)
     return root / "Unidentified" / label
 
 

--- a/backend/app/core/backup_paths.py
+++ b/backend/app/core/backup_paths.py
@@ -1,0 +1,93 @@
+"""Where a disc backup goes, and whether there is room for it.
+
+Naming mirrors the library layout so a preservation shelf browses the same way
+the library does. Sanitization reuses the Organizer's helper rather than
+reimplementing it, so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from app.core.organizer import sanitize_filename
+from app.models import ContentType, DiscJob
+
+logger = logging.getLogger(__name__)
+
+# Free space must exceed the estimate by this factor. A backup carries the
+# container and filesystem overhead the per-title sizes do not.
+_SPACE_MARGIN = 1.15
+
+# Assumed disc size when the scan produced no usable sizes. A dual-layer
+# Blu-ray, so an unknown disc is treated as the largest realistic case rather
+# than waved through.
+_ASSUMED_DISC_BYTES = 50 * 1024**3
+
+
+def _safe_name(raw: str) -> str:
+    """Sanitize one path component, reusing the Organizer's rules."""
+    cleaned = sanitize_filename(raw or "")
+    # sanitize_filename already strips '/' and '\\' along with the rest of the
+    # Windows-illegal character set, which is what keeps a crafted title from
+    # introducing a new path component and climbing out of the backup root.
+    return cleaned or "Unknown"
+
+
+def backup_destination(job: DiscJob, backup_root: str) -> Path | None:
+    """Compute where this job's backup should be written.
+
+    Returns None when no root is configured, which the caller reports as a
+    "not_configured" skip.
+    """
+    if not backup_root:
+        return None
+
+    root = Path(backup_root).expanduser()
+    name = job.tmdb_name or job.detected_title
+
+    if job.content_type == ContentType.MOVIE and name:
+        folder = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
+        return root / "Movies" / folder
+
+    if job.content_type == ContentType.TV and name:
+        show = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
+        disc = _safe_name(job.discdb_disc_slug or f"Disc {job.disc_number or 1}")
+        base = root / "TV" / show
+        if job.detected_season is not None:
+            return base / f"Season {job.detected_season:02d}" / disc
+        return base / disc
+
+    label = _safe_name(job.volume_label) if job.volume_label else ""
+    if not label or label == "Unknown":
+        label = f"job-{job.id}" if job.id else "job-unknown"
+    return root / "Unidentified" / label
+
+
+def has_room_for_backup(dest: Path, needed_bytes: int) -> bool:
+    """Whether ``dest``'s filesystem has room for the backup, with margin.
+
+    Fails closed: an unreadable destination returns False and the caller falls
+    back to a direct rip. A false negative costs one direct rip; a false
+    positive costs a half-written 40 GB folder and a failed job.
+    """
+    estimate = needed_bytes if needed_bytes > 0 else _ASSUMED_DISC_BYTES
+    required = int(estimate * _SPACE_MARGIN)
+    # The destination itself may not exist yet, so measure the nearest existing
+    # ancestor: that is the filesystem the write will land on.
+    probe = dest
+    while not probe.exists() and probe.parent != probe:
+        probe = probe.parent
+    try:
+        free = shutil.disk_usage(probe).free
+    except (OSError, ValueError) as e:
+        logger.warning(f"Could not read free space at {probe}: {e}")
+        return False
+    if free < required:
+        logger.warning(
+            f"Not enough room for backup at {probe}: "
+            f"{free / 1024**3:.1f} GB free, {required / 1024**3:.1f} GB required"
+        )
+        return False
+    return True

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -48,6 +48,14 @@ class DiscSource:
     # Which MakeMKV scheme to emit for a DRIVE. Preserved rather than recomputed
     # so a caller that resolved "E:" to "disc:0" keeps that resolution.
     _scheme: str = "dev:"
+    # For a DRIVE that was resolved from a drive identifier to a MakeMKV disc
+    # index: the drive it came from, normalized ("E:", "/dev/sr0"). ``value``
+    # holds the index because that is what MakeMKV needs, so without this the
+    # originating drive would be unrecoverable and ``lock_key`` would have
+    # nothing to normalize to -- ``disc:0`` and ``dev:E:`` would key to
+    # different locks while naming one physical drive, and two makemkvcon
+    # processes would be free to stall each other on it.
+    _drive_id: str | None = None
 
     @classmethod
     def parse(cls, spec: str) -> DiscSource:
@@ -89,6 +97,29 @@ class DiscSource:
         if not drive_id or drive_id == "import":
             raise ValueError(f"Job has no MakeMKV source: drive_id={drive_id!r}, source_spec=None")
         return cls.parse(drive_id)
+
+    @classmethod
+    def for_drive_index(cls, drive: str, disc_spec: str) -> DiscSource:
+        """A physical drive addressed by its resolved MakeMKV disc index.
+
+        ``makemkvcon backup`` accepts only ``disc:N``, so a backup has to
+        address the drive that way. The originating drive identifier is kept
+        alongside it so the source still locks against the SAME key as the
+        plain ``dev:E:`` form: a backup and a sentinel scan of one physical
+        drive must contend, or two makemkvcon processes stall each other.
+
+        Args:
+            drive: the drive identifier the index was resolved from, in any
+                form ``parse`` accepts ("E:", "dev:E:", "/dev/sr0").
+            disc_spec: the resolved index, as ``"disc:0"`` or ``"0"``.
+        """
+        drive_source = cls.parse(drive)
+        if not drive_source.is_physical:
+            raise ValueError(f"Not a drive: {drive!r}")
+        index = disc_spec[len("disc:") :] if disc_spec.startswith("disc:") else disc_spec
+        if not index:
+            raise ValueError(f"Disc index spec has no value: {disc_spec!r}")
+        return cls(SourceKind.DRIVE, index, "disc:", drive_source.value)
 
     @classmethod
     def for_backup(cls, path: Path | str) -> DiscSource:
@@ -134,9 +165,13 @@ class DiscSource:
         A file source keys on its own path instead: two makemkvcon processes
         reading different backups do not contend, and a backup on drive E: must
         not block the optical drive at E:.
+
+        A drive resolved to a disc index (``for_drive_index``) keys on the
+        drive it was resolved FROM, not on the index: ``disc:0`` and ``dev:E:``
+        are one piece of hardware and must share one lock.
         """
         if self.is_physical:
-            return "drive:" + self.value.rstrip("\\")
+            return "drive:" + (self._drive_id or self.value).rstrip("\\")
         return "path:" + str(Path(self.value))
 
     def __str__(self) -> str:

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -139,6 +139,14 @@ class DiscSource:
             return "drive:" + self.value.rstrip("\\")
         return "path:" + str(Path(self.value))
 
+    def __str__(self) -> str:
+        """Render as the spec string.
+
+        A DiscSource is interpolated into log and error messages all over the
+        extractor, where the dataclass repr would be unreadable noise.
+        """
+        return self.spec
+
 
 # makemkvcon -r info disc:9999 lists drives without touching a disc. 9999 is
 # MakeMKV's documented "no such drive" index: the scan fails, but the DRV lines

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -108,6 +108,14 @@ class DiscSource:
         plain ``dev:E:`` form: a backup and a sentinel scan of one physical
         drive must contend, or two makemkvcon processes stall each other.
 
+        NOT round-trippable through ``parse``. The originating drive lives only
+        on the instance, so ``parse(source.spec)`` (i.e. ``parse("disc:0")``)
+        comes back with no ``_drive_id`` and a ``lock_key`` of ``"drive:0"``,
+        which is exactly the collision this constructor exists to avoid. So a
+        source built here must be constructed, never stored: do not write its
+        spec to ``DiscJob.source_spec``. Today nothing does, and a backup's
+        persisted source is the ``file:<dest>`` copy instead.
+
         Args:
             drive: the drive identifier the index was resolved from, in any
                 form ``parse`` accepts ("E:", "dev:E:", "/dev/sr0").

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -123,10 +123,12 @@ class DiscSource:
         """Key for the per-source MakeMKV serialization lock.
 
         Physical drives normalize so "E:", "dev:E:" and "dev:E:\\" contend for
-        one lock. A file source keys on its own path instead: two makemkvcon
-        processes reading different backups do not contend, and a backup on
-        drive E: must not block the optical drive at E:.
+        one lock. ``parse`` has already stripped the scheme by the time it
+        reaches ``value``, so only the trailing separator is left to normalize.
+        A file source keys on its own path instead: two makemkvcon processes
+        reading different backups do not contend, and a backup on drive E: must
+        not block the optical drive at E:.
         """
         if self.is_physical:
-            return "drive:" + self.value.replace("dev:", "").replace("disc:", "").rstrip("\\")
+            return "drive:" + self.value.rstrip("\\")
         return "path:" + str(Path(self.value))

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -6,15 +6,21 @@ first, so "is this source a physical drive?" was answered ad hoc with string
 tests at every call site that needed eject, sentinel re-arm, drive locking or
 progress labelling. This module is the single answer.
 
-Pure value object: no filesystem or subprocess access.
+Pure apart from ``resolve_disc_index``, which shells out to makemkvcon to map a
+drive letter to a MakeMKV disc index.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import re
+import subprocess
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # "iso:" is Engram's own spec kind, not a MakeMKV one: MakeMKV reads an ISO
 # through the same file: source as a folder. Keeping them distinct lets the UI
@@ -132,3 +138,72 @@ class DiscSource:
         if self.is_physical:
             return "drive:" + self.value.rstrip("\\")
         return "path:" + str(Path(self.value))
+
+
+# makemkvcon -r info disc:9999 lists drives without touching a disc. 9999 is
+# MakeMKV's documented "no such drive" index: the scan fails, but the DRV lines
+# describing every drive are printed first, which is all we want.
+_DRIVE_LISTING_INDEX = "disc:9999"
+
+# DRV:index,visible,enabled,flags,"drive name","disc name","device"
+_DRV_RE = re.compile(r'^DRV:(\d+),\d+,\d+,\d+,"[^"]*","[^"]*","([^"]*)"')
+
+_DRIVE_LISTING_TIMEOUT = 30.0
+
+
+def parse_drive_listing(output: str) -> dict[str, int]:
+    """Map each device identifier in a makemkvcon DRV listing to its disc index.
+
+    Slots with an empty device string are drives MakeMKV enumerated but cannot
+    use, and are omitted. A malformed line is skipped rather than raised on: a
+    single unparseable row must not cost us the whole mapping.
+    """
+    mapping: dict[str, int] = {}
+    for line in output.splitlines():
+        m = _DRV_RE.match(line.strip())
+        if not m:
+            continue
+        device = m.group(2).strip()
+        if device:
+            mapping[device] = int(m.group(1))
+    return mapping
+
+
+def _run_drive_listing(makemkv_path: str) -> str:
+    """Run the drive enumeration synchronously (called via asyncio.to_thread)."""
+    result = subprocess.run(
+        [makemkv_path, "-r", "info", _DRIVE_LISTING_INDEX],
+        capture_output=True,
+        text=True,
+        timeout=_DRIVE_LISTING_TIMEOUT,
+        check=False,
+    )
+    # Non-zero is expected: index 9999 does not exist. The DRV lines we want are
+    # printed before the failure, so stdout is used regardless of return code.
+    return result.stdout
+
+
+async def resolve_disc_index(drive: str, makemkv_path: str) -> str | None:
+    """Return the ``disc:N`` spec for a drive, or None if it cannot be resolved.
+
+    ``makemkvcon backup`` accepts only ``disc:N``, so a backup cannot start
+    without this. None is a normal outcome, not an error: the caller degrades to
+    a direct rip.
+    """
+    normalized = drive.replace("dev:", "").rstrip("\\")
+    try:
+        output = await asyncio.to_thread(_run_drive_listing, makemkv_path)
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(f"Could not enumerate MakeMKV drives: {e}", exc_info=True)
+        return None
+
+    mapping = parse_drive_listing(output)
+    for device, index in mapping.items():
+        if device.rstrip("\\").lower() == normalized.lower():
+            return f"disc:{index}"
+
+    logger.warning(
+        f"Drive {normalized} not found in MakeMKV drive listing "
+        f"(saw: {sorted(mapping)}); cannot back up"
+    )
+    return None

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -146,6 +146,11 @@ class DiscSource:
 _DRIVE_LISTING_INDEX = "disc:9999"
 
 # DRV:index,visible,enabled,flags,"drive name","disc name","device"
+# Known limitation: the quoted fields are matched with "[^"]*", so a drive or
+# disc name containing an escaped quote drops that whole line. The failure is
+# safe (the drive is simply missing from the mapping and the caller degrades to
+# a direct rip) but silent, so look here first if one specific drive will never
+# back up.
 _DRV_RE = re.compile(r'^DRV:(\d+),\d+,\d+,\d+,"[^"]*","[^"]*","([^"]*)"')
 
 _DRIVE_LISTING_TIMEOUT = 30.0
@@ -202,8 +207,19 @@ async def resolve_disc_index(drive: str, makemkv_path: str) -> str | None:
         if device.rstrip("\\").lower() == normalized.lower():
             return f"disc:{index}"
 
-    logger.warning(
-        f"Drive {normalized} not found in MakeMKV drive listing "
-        f"(saw: {sorted(mapping)}); cannot back up"
-    )
+    # An empty listing and a missing drive both end in None, but they are very
+    # different problems: no drives at all means MakeMKV itself is unusable
+    # (missing binary, expired licence, corrupt install), which would otherwise
+    # read in the logs exactly like the routine "this drive cannot be backed up"
+    # case that the caller degrades from every day.
+    if not mapping:
+        logger.warning(
+            "MakeMKV listed no drives at all; check that MakeMKV is installed "
+            f"and licensed. Cannot back up from {normalized}"
+        )
+    else:
+        logger.warning(
+            f"Drive {normalized} not found in MakeMKV drive listing "
+            f"(saw: {sorted(mapping)}); cannot back up"
+        )
     return None

--- a/backend/app/core/disc_source.py
+++ b/backend/app/core/disc_source.py
@@ -1,0 +1,132 @@
+"""What a job points MakeMKV at.
+
+MakeMKV accepts three source forms: ``dev:<drive or device>``, ``disc:<index>``
+and ``file:<path>`` (a backup folder or an ISO). Engram historically assumed the
+first, so "is this source a physical drive?" was answered ad hoc with string
+tests at every call site that needed eject, sentinel re-arm, drive locking or
+progress labelling. This module is the single answer.
+
+Pure value object: no filesystem or subprocess access.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+# "iso:" is Engram's own spec kind, not a MakeMKV one: MakeMKV reads an ISO
+# through the same file: source as a folder. Keeping them distinct lets the UI
+# and the import scanner say which one the user picked without re-stat-ing disk.
+_SCHEMES = ("dev:", "disc:", "file:", "iso:")
+
+# A bare Windows drive letter ("E:", "E:\") or a POSIX device path.
+_BARE_DRIVE_RE = re.compile(r"^(?:[A-Za-z]:\\?|/dev/[A-Za-z0-9/]+)$")
+
+
+class SourceKind(StrEnum):
+    """What kind of thing a job reads from."""
+
+    DRIVE = "drive"
+    BACKUP = "backup"
+    ISO = "iso"
+
+
+@dataclass(frozen=True)
+class DiscSource:
+    """A MakeMKV source, and the behaviour that depends on which kind it is."""
+
+    kind: SourceKind
+    value: str
+    # Which MakeMKV scheme to emit for a DRIVE. Preserved rather than recomputed
+    # so a caller that resolved "E:" to "disc:0" keeps that resolution.
+    _scheme: str = "dev:"
+
+    @classmethod
+    def parse(cls, spec: str) -> DiscSource:
+        """Build a source from a stored spec string or a bare drive identifier."""
+        if not spec:
+            raise ValueError("Empty disc source spec")
+
+        for scheme in _SCHEMES:
+            if spec.startswith(scheme):
+                # split on the FIRST colon only: "file:D:\backups\x" must keep
+                # its Windows drive-letter colon.
+                value = spec[len(scheme) :]
+                if not value:
+                    raise ValueError(f"Disc source spec has no value: {spec!r}")
+                if scheme == "file:":
+                    return cls(SourceKind.BACKUP, value)
+                if scheme == "iso:":
+                    return cls(SourceKind.ISO, value)
+                return cls(SourceKind.DRIVE, value, scheme)
+
+        if _BARE_DRIVE_RE.match(spec):
+            return cls(SourceKind.DRIVE, spec, "dev:")
+
+        raise ValueError(f"Unrecognized disc source spec: {spec!r}")
+
+    @classmethod
+    def from_job(cls, job) -> DiscSource:
+        """Build a source from a DiscJob, honouring legacy rows.
+
+        ``source_spec`` is None on every row written before this feature, where
+        the source was always the drive. A manual-import job (``drive_id ==
+        "import"``) has no MakeMKV source at all, so asking for one is a bug in
+        the caller rather than something to paper over.
+        """
+        spec = getattr(job, "source_spec", None)
+        if spec:
+            return cls.parse(spec)
+        drive_id = job.drive_id
+        if not drive_id or drive_id == "import":
+            raise ValueError(f"Job has no MakeMKV source: drive_id={drive_id!r}, source_spec=None")
+        return cls.parse(drive_id)
+
+    @classmethod
+    def for_backup(cls, path: Path | str) -> DiscSource:
+        """A source reading from a completed backup folder."""
+        return cls(SourceKind.BACKUP, str(path))
+
+    @property
+    def spec(self) -> str:
+        """The argument to hand makemkvcon."""
+        if self.kind is SourceKind.DRIVE:
+            return f"{self._scheme}{self.value}"
+        if self.kind is SourceKind.ISO:
+            return f"iso:{self.value}"
+        return f"file:{self.value}"
+
+    @property
+    def makemkv_arg(self) -> str:
+        """The argument makemkvcon actually accepts.
+
+        An ISO is read through the same ``file:`` source as a folder; the ISO
+        kind exists for Engram's own bookkeeping, not for MakeMKV's.
+        """
+        if self.kind is SourceKind.ISO:
+            return f"file:{self.value}"
+        return self.spec
+
+    @property
+    def is_physical(self) -> bool:
+        """Whether this source is a real optical drive.
+
+        Gates eject, sentinel re-arm, disc-hash computation and every other
+        behaviour that only makes sense for hardware.
+        """
+        return self.kind is SourceKind.DRIVE
+
+    @property
+    def lock_key(self) -> str:
+        """Key for the per-source MakeMKV serialization lock.
+
+        Physical drives normalize so "E:", "dev:E:" and "dev:E:\\" contend for
+        one lock. A file source keys on its own path instead: two makemkvcon
+        processes reading different backups do not contend, and a backup on
+        drive E: must not block the optical drive at E:.
+        """
+        if self.is_physical:
+            return "drive:" + self.value.replace("dev:", "").replace("disc:", "").rstrip("\\")
+        return "path:" + str(Path(self.value))

--- a/backend/app/core/discord_notifier.py
+++ b/backend/app/core/discord_notifier.py
@@ -49,6 +49,9 @@ RIPPED_EVENT = NotificationEvent("ripped", "Disc Ripped", "💿", 0x3B82F6)
 RIP_OUTCOME_COMPLETE = "Complete"
 RIP_OUTCOME_STOPPED_EARLY = "Stopped early"
 RIP_OUTCOME_RERIP = "Re-rip"
+# The disc is copied and out of the drive, which is what RIPPED_EVENT means.
+# Extraction then runs off the copy, so this fires long before any MKV exists.
+RIP_OUTCOME_BACKED_UP = "Backed up"
 
 ALLOWED_TEMPLATE_VARS = frozenset(
     {

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from app.core.analyst import TitleInfo
-from app.core.disc_source import DiscSource
+from app.core.disc_source import DiscSource, SourceKind
 from app.core.security import sanitize_log_value
 
 logger = logging.getLogger(__name__)
@@ -601,21 +601,42 @@ def _find_linux_mount_point(device: str) -> Path | None:
     return None
 
 
-def compute_content_hash(drive: str) -> str | None:
+def compute_content_hash(source: DiscSource | str) -> str | None:
     """Compute TheDiscDB-compatible ContentHash for a disc.
 
     The hash is MD5 of concatenated Int64 file sizes from BDMV/STREAM/*.m2ts
     (Blu-ray) or VIDEO_TS/* (DVD), sorted by filename. This matches the
     algorithm used by TheDiscDB's ImportBuddy tool.
 
+    A ``file:`` source (a MakeMKV backup folder) holds exactly that structure
+    with exactly those file sizes, so hashing the copy yields the same value as
+    hashing the disc it came from: an imported backup gets a TheDiscDB lookup
+    like any inserted disc. An ISO would have to be mounted first, so it
+    degrades to None.
+
     Args:
-        drive: Drive letter (e.g., "E:" or "E") on Windows, or device path
-               (e.g., "/dev/sr0") on Linux. On Linux the disc must be mounted
-               for the hash to be computed; returns None if not mounted.
+        source: A DiscSource, or a drive letter (e.g., "E:" or "E") on Windows
+                / a device path (e.g., "/dev/sr0") on Linux. On Linux the disc
+                must be mounted for the hash to be computed; returns None if
+                not mounted. A physical DiscSource is read through its own
+                value, which is the drive for every source ``from_job`` builds;
+                a source resolved to a bare ``disc:N`` index has no readable
+                path and returns None.
 
     Returns:
         Uppercase hex MD5 hash string, or None if disc structure not found
     """
+    if isinstance(source, DiscSource):
+        if source.kind is SourceKind.ISO:
+            logger.debug(f"ContentHash is not computable for an ISO source: {source}")
+            return None
+        if source.kind is SourceKind.BACKUP:
+            root = Path(source.value)
+            return _hash_disc_structure(root / "BDMV" / "STREAM", root / "VIDEO_TS", str(source))
+        drive = source.value
+    else:
+        drive = source
+
     if sys.platform != "win32":
         mount_point = _find_linux_mount_point(drive)
         if mount_point is None:
@@ -628,6 +649,17 @@ def compute_content_hash(drive: str) -> str | None:
         bdmv_path = Path(f"{clean_drive}:\\BDMV\\STREAM")
         dvd_path = Path(f"{clean_drive}:\\VIDEO_TS")
 
+    return _hash_disc_structure(bdmv_path, dvd_path, drive)
+
+
+def _hash_disc_structure(bdmv_path: Path, dvd_path: Path, label: str) -> str | None:
+    """MD5 the Int64 sizes of a disc structure's stream files.
+
+    ``label`` names the source in the log lines only. Shared by the drive and
+    backup-folder paths of :func:`compute_content_hash`: the structure is
+    identical either way, which is exactly why a backup hashes to the same
+    value as the disc it was copied from.
+    """
     target_path = None
     pattern = "*"
 
@@ -637,7 +669,7 @@ def compute_content_hash(drive: str) -> str | None:
     elif dvd_path.is_dir():
         target_path = dvd_path
     else:
-        logger.debug(f"No BDMV/STREAM or VIDEO_TS found on drive {drive}")
+        logger.debug(f"No BDMV/STREAM or VIDEO_TS found on {label}")
         return None
 
     try:
@@ -652,10 +684,10 @@ def compute_content_hash(drive: str) -> str | None:
             md5.update(struct.pack("<q", size))
 
         content_hash = md5.hexdigest().upper()
-        logger.info(f"Computed ContentHash for drive {drive}: {content_hash}")
+        logger.info(f"Computed ContentHash for {label}: {content_hash}")
         return content_hash
     except (OSError, PermissionError) as e:
-        logger.warning(f"Could not compute ContentHash for drive {drive}: {e}")
+        logger.warning(f"Could not compute ContentHash for {label}: {e}")
         return None
 
 

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -796,10 +796,29 @@ class MakeMKVExtractor:
         it wait for the drive lock would silently serialize work that is now
         genuinely independent.
         """
-        key = _as_source(source).lock_key
+        return self._lock_for(_as_source(source).lock_key)
+
+    def _lock_for(self, key: str) -> asyncio.Lock:
+        """Get or create the lock registered under ``key``."""
         if key not in self._source_locks:
             self._source_locks[key] = asyncio.Lock()
         return self._source_locks[key]
+
+    def _get_dest_lock(self, dest: Path) -> asyncio.Lock:
+        """Get or create the per-destination lock for a backup.
+
+        The source lock is not enough here. A backup destination is derived from
+        content identity (title, year, season, disc slug) with nothing
+        drive-specific in it, so two jobs in two different drives backing up the
+        same disc compute the SAME destination while taking DIFFERENT source
+        locks. The second one's stale-partial recovery cannot tell "debris from
+        an earlier failure" from "another job writing here right now", and would
+        rename a live ``.partial`` out from under a running makemkvcon.
+
+        Always taken after the source lock, never before, so the two orderings
+        cannot deadlock against each other.
+        """
+        return self._lock_for("dest:" + str(dest))
 
     async def scan_disc(
         self, source: DiscSource | str, log_dir: Path | None = None, *, job_id: int = 0
@@ -1717,7 +1736,17 @@ class MakeMKVExtractor:
                 f"waiting for it to finish"
             )
 
-        async with lock:
+        # Source AND destination: see _get_dest_lock for why the source lock
+        # alone lets two drives race on one .partial. Source first, always, so
+        # the lock ordering is consistent everywhere.
+        dest_lock = self._get_dest_lock(dest)
+        if dest_lock.locked():
+            logger.warning(
+                f"Backup destination {safe_dest} is already being written by "
+                f"another job, waiting for it to finish"
+            )
+
+        async with lock, dest_lock:
             self._cancelled_jobs.discard(job_id)
 
             try:

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -210,6 +210,66 @@ def _build_rip_commands(
     return [(idx, [*base, str(idx), output_dir]) for idx in title_indices]
 
 
+# PRGV:current,total,max is MakeMKV's global progress line. `current` is the
+# current operation's bar and `total` the overall one, both on the same `max`
+# scale (a fixed 65536 in practice): see the rip reader loop, which reads these
+# lines for liveness only and deliberately derives no per-title progress from
+# them.
+_PRGV_RE = re.compile(r"^PRGV:(\d+),(\d+),(\d+)")
+
+# MSG:code,flags,count,"message","format","param0",...: the already-formatted
+# human message is the FIRST quoted field, not the format string after it.
+_MSG_TEXT_RE = re.compile(r'^MSG:\d+,\d+,\d+,"([^"]*)"')
+
+
+def _build_backup_command(makemkv_path: str, source_spec: str, dest: str) -> list[str]:
+    """Build the argv for a full decrypted disc backup.
+
+    ``makemkvcon backup`` accepts only a ``disc:N`` source, never ``dev:`` and
+    never ``file:``. Rejecting anything else here turns a 40-minute mystery into
+    an immediate, named fallback.
+    """
+    if not source_spec.startswith("disc:"):
+        raise ValueError(
+            f"makemkvcon backup requires a disc:N source, got {source_spec!r}. "
+            f"Resolve it with disc_source.resolve_disc_index() first."
+        )
+    return [
+        makemkv_path,
+        "-r",
+        "--progress=-same",
+        "--decrypt",
+        "backup",
+        source_spec,
+        dest,
+    ]
+
+
+def _parse_backup_progress(line: str) -> float | None:
+    """Percentage from a PRGV line, or None if the line carries no progress.
+
+    Reads ``total/max``, the overall bar. ``current/max`` is the current
+    sub-operation and would sawtooth back to 0 repeatedly across one backup.
+    """
+    m = _PRGV_RE.match(line.strip())
+    if not m:
+        return None
+    _current, total, maximum = (int(g) for g in m.groups())
+    if maximum <= 0:
+        return None
+    return min(100.0, total / maximum * 100.0)
+
+
+def _last_msg_text(output: str) -> str | None:
+    """The text of the last MSG line in MakeMKV output, for error reporting."""
+    last = None
+    for line in output.splitlines():
+        m = _MSG_TEXT_RE.match(line.strip())
+        if m:
+            last = m.group(1)
+    return last
+
+
 def should_abort_all_pass(
     opened_native: int,
     disc_title_map: dict[int, int] | None,
@@ -325,6 +385,15 @@ class RipResult:
     # aborted_for_skip there is no per-title fallback pass afterward, because
     # the disc is no longer in the drive.
     aborted_for_eject: bool = False
+
+
+@dataclass
+class BackupResult:
+    """Result of a full-disc backup operation."""
+
+    success: bool
+    dest: Path | None = None
+    error_message: str | None = None
 
 
 class ScanTimeoutError(Exception):
@@ -1509,6 +1578,131 @@ class MakeMKVExtractor:
                 output_files=[],
                 error_message=str(e),
             )
+
+    def _run_backup_process(
+        self, cmd: list[str], on_line: Callable[[str], None], job_id: int
+    ) -> tuple[int, str]:
+        """Run makemkvcon backup, streaming stdout to ``on_line``.
+
+        A separate seam so tests can substitute it without a real subprocess.
+        Runs in a thread (Windows asyncio subprocess workaround), matching how
+        scan_disc and rip_titles already invoke MakeMKV.
+
+        The process is registered in ``self._processes`` for the duration, so
+        ``cancel()`` (and ``shutdown()``) can terminate a multi-hour backup the
+        same way they terminate a rip.
+        """
+        collected: list[str] = []
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        self._processes[job_id] = proc
+        try:
+            for line in proc.stdout or []:
+                if job_id in self._cancelled_jobs:
+                    _terminate_proc(proc, label=f"backup job {job_id}")
+                    break
+                collected.append(line)
+                on_line(line)
+        finally:
+            try:
+                proc.wait()
+            finally:
+                self._processes.pop(job_id, None)
+        return proc.returncode, "".join(collected)
+
+    async def backup_disc(
+        self,
+        source: DiscSource | str,
+        dest: Path,
+        progress_callback: Callable[[float], None] | None = None,
+        log_dir: Path | None = None,
+        *,
+        job_id: int = 0,
+    ) -> BackupResult:
+        """Write a full decrypted copy of the disc to ``dest``.
+
+        Writes to ``<dest>.partial`` and renames on success, so a killed or
+        crashed backup never leaves something that looks complete. On failure
+        the ``.partial`` is left in place: a partial backup of a dying disc has
+        salvage value, and discarding it is the user's call.
+        """
+        spec = _to_source_spec(source)
+
+        # Built before the lock is taken: an unusable source is a caller bug,
+        # and there is no reason to make it queue behind a live drive operation.
+        try:
+            cmd = _build_backup_command(str(self.makemkv_path), spec, str(dest) + ".partial")
+        except ValueError as e:
+            logger.error(f"Job {job_id}: cannot back up from {spec}: {e}")
+            return BackupResult(success=False, error_message=str(e))
+
+        partial = dest.with_name(dest.name + ".partial")
+
+        lock = self._get_source_lock(source)
+        if lock.locked():
+            logger.warning(
+                f"Source {source} is already in use by another MakeMKV operation, "
+                f"waiting for it to finish"
+            )
+
+        async with lock:
+            self._cancelled_jobs.discard(job_id)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Job {job_id}: backing up disc: {' '.join(cmd)}")
+
+            def on_line(line: str) -> None:
+                pct = _parse_backup_progress(line)
+                if pct is not None and progress_callback is not None:
+                    _safe_callback(progress_callback, pct, label="backup progress callback")
+
+            try:
+                returncode, output = await asyncio.to_thread(
+                    self._run_backup_process, cmd, on_line, job_id
+                )
+            except FileNotFoundError:
+                logger.error(f"MakeMKV not found at: {self.makemkv_path}")
+                return BackupResult(
+                    success=False, error_message=f"MakeMKV not found at {self.makemkv_path}"
+                )
+            except Exception as e:
+                logger.exception(f"Job {job_id}: error during disc backup")
+                return BackupResult(success=False, error_message=str(e))
+
+            if log_dir is not None and output:
+                # Same per-job log directory the scan and rip paths write into.
+                _save_makemkv_log(Path(log_dir) / "backup.log", output)
+
+            if job_id in self._cancelled_jobs:
+                self._cancelled_jobs.discard(job_id)
+                logger.info(f"Job {job_id}: backup cancelled by user")
+                return BackupResult(success=False, error_message="Backup cancelled by user")
+
+            if returncode != 0 or not partial.exists():
+                reason = _last_msg_text(output) or f"makemkvcon backup exited {returncode}"
+                logger.error(f"Job {job_id}: backup failed: {sanitize_log_value(reason)}")
+                return BackupResult(success=False, error_message=reason)
+
+            try:
+                if dest.exists():
+                    # Destination appeared while we were copying. Keep the
+                    # existing one and drop ours rather than clobbering a
+                    # complete backup with a fresh one.
+                    logger.warning(f"Job {job_id}: {dest} already exists; keeping it")
+                else:
+                    partial.rename(dest)
+            except OSError as e:
+                logger.error(f"Job {job_id}: could not finalize backup: {e}", exc_info=True)
+                return BackupResult(success=False, error_message=str(e))
+
+            logger.info(f"Job {job_id}: backup complete at {dest}")
+            return BackupResult(success=True, dest=dest)
 
     def skip_title_index(self, job_id: int, title_index: int) -> None:
         """Register a title_index to skip in the per-title rip loop for a job."""

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -17,9 +17,13 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from app.core.analyst import TitleInfo
 from app.core.security import sanitize_log_value
+
+if TYPE_CHECKING:
+    from app.core.disc_source import DiscSource
 
 logger = logging.getLogger(__name__)
 
@@ -62,14 +66,17 @@ STALL_POLL_INTERVAL = 5.0
 FS_POLL_INTERVAL = 3.0
 
 
-def _to_drive_spec(drive: str) -> str:
-    """Normalize a drive identifier into a MakeMKV drive spec.
+def _to_source_spec(source: "DiscSource | str") -> str:
+    """Normalize a source into the argument makemkvcon accepts.
 
-    Drive letters/device paths become ``dev:<drive>``; ``disc:N`` specs pass through.
+    Accepts a DiscSource, a bare drive identifier, or an already-schemed spec,
+    so existing call sites that pass ``job.drive_id`` keep working unchanged.
     """
-    if not drive.startswith("disc:"):
-        return f"dev:{drive}"
-    return drive
+    from app.core.disc_source import DiscSource
+
+    if isinstance(source, DiscSource):
+        return source.makemkv_arg
+    return DiscSource.parse(source).makemkv_arg
 
 
 def _is_stalled(now: float, last_progress: float, timeout: float) -> bool:
@@ -654,9 +661,9 @@ class MakeMKVExtractor:
         # finished file. Single-writer per job under the rip thread + async
         # skip calls; set mutation is atomic under the GIL.
         self._skipped_indices: dict[int, set[int]] = {}
-        # Per-drive locks prevent concurrent MakeMKV operations on the same drive.
-        # Two makemkvcon processes fighting over one drive causes both to stall/fail.
-        self._drive_locks: dict[str, asyncio.Lock] = {}
+        # Per-source locks prevent concurrent MakeMKV operations on one source.
+        # Two makemkvcon processes fighting over one drive causes both to stall.
+        self._source_locks: dict[str, asyncio.Lock] = {}
 
     @property
     def makemkv_path(self) -> Path:
@@ -667,48 +674,58 @@ class MakeMKVExtractor:
 
         return Path(get_config_sync().makemkv_path)
 
-    def _get_drive_lock(self, drive: str) -> asyncio.Lock:
-        """Get or create a per-drive lock to serialize MakeMKV operations."""
-        # Normalize drive key (e.g., "F:" and "dev:F:" should use same lock)
-        key = drive.replace("dev:", "").replace("disc:", "").rstrip("\\")
-        if key not in self._drive_locks:
-            self._drive_locks[key] = asyncio.Lock()
-        return self._drive_locks[key]
+    def _get_source_lock(self, source: "DiscSource | str") -> asyncio.Lock:
+        """Get or create the per-source lock serializing MakeMKV operations.
+
+        Two makemkvcon processes fighting over one optical drive stall both, so
+        every physical drive form keys to one lock. A backup or ISO keys on its
+        own path instead: reading a backup does not touch the drive, and making
+        it wait for the drive lock would silently serialize work that is now
+        genuinely independent.
+        """
+        from app.core.disc_source import DiscSource
+
+        parsed = source if isinstance(source, DiscSource) else DiscSource.parse(source)
+        key = parsed.lock_key
+        if key not in self._source_locks:
+            self._source_locks[key] = asyncio.Lock()
+        return self._source_locks[key]
 
     async def scan_disc(
-        self, drive: str, log_dir: Path | None = None, *, job_id: int = 0
+        self, source: "DiscSource | str", log_dir: Path | None = None, *, job_id: int = 0
     ) -> tuple[list[TitleInfo], str]:
-        """Scan a disc and return title information and the disc display name.
+        """Scan a source and return title information and the disc display name.
 
         Args:
-            drive: Drive letter (e.g., "E:") or disc index (e.g., "disc:0")
+            source: A DiscSource, a drive letter (e.g., "E:"), a disc index
+                (e.g., "disc:0") or a backup/ISO spec (e.g., "file:/backups/x")
             log_dir: Optional directory for saving MakeMKV scan logs
 
         Returns:
-            (titles, disc_name) — list of titles and the CINFO:2 disc display name
+            (titles, disc_name) - list of titles and the CINFO:2 disc display name
             (disc_name is empty string when not present in MakeMKV output)
         """
-        lock = self._get_drive_lock(drive)
+        lock = self._get_source_lock(source)
         if lock.locked():
             logger.warning(
-                f"Drive {drive} is already in use by another MakeMKV operation, "
+                f"Source {source} is already in use by another MakeMKV operation, "
                 f"waiting for it to finish"
             )
 
         async with lock:
-            return await self._scan_disc_unlocked(drive, log_dir=log_dir, job_id=job_id)
+            return await self._scan_disc_unlocked(source, log_dir=log_dir, job_id=job_id)
 
     async def _scan_disc_unlocked(
-        self, drive: str, log_dir: Path | None = None, *, job_id: int = 0
+        self, source: "DiscSource | str", log_dir: Path | None = None, *, job_id: int = 0
     ) -> tuple[list[TitleInfo], str]:
-        """Internal scan implementation (caller must hold drive lock)."""
-        drive_spec = _to_drive_spec(drive)
+        """Internal scan implementation (caller must hold the source lock)."""
+        source_spec = _to_source_spec(source)
 
         cmd = [
             str(self.makemkv_path),
             "-r",  # Robot mode (machine-readable output)
             "info",
-            drive_spec,
+            source_spec,
         ]
 
         start = time.monotonic()
@@ -763,15 +780,17 @@ class MakeMKVExtractor:
             return [], ""
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
-            logger.error(f"MakeMKV scan timed out after {elapsed:.1f}s for drive {drive}")
-            raise ScanTimeoutError(f"Disc scan timed out after 10 minutes on drive {drive}") from e
+            logger.error(f"MakeMKV scan timed out after {elapsed:.1f}s for source {source}")
+            raise ScanTimeoutError(
+                f"Disc scan timed out after 10 minutes on source {source}"
+            ) from e
         except Exception as e:
             logger.exception(f"Error scanning disc: {e}")
             return [], ""
 
     async def rip_titles(
         self,
-        drive: str,
+        source: "DiscSource | str",
         output_dir: Path,
         title_indices: list[int] | None = None,
         title_complete_callback: TitleCompleteCallback | None = None,
@@ -785,7 +804,7 @@ class MakeMKVExtractor:
         """Rip selected titles from a disc.
 
         Args:
-            drive: Drive letter or disc specification
+            source: A DiscSource, a drive letter, a disc index, or a backup/ISO spec
             output_dir: Directory to save MKV files
             title_indices: List of title indices to rip, or None for all
             title_complete_callback: Optional callback when a title finishes ripping
@@ -804,16 +823,16 @@ class MakeMKVExtractor:
         Returns:
             RipResult with success status and output files
         """
-        lock = self._get_drive_lock(drive)
+        lock = self._get_source_lock(source)
         if lock.locked():
             logger.warning(
-                f"Drive {drive} is already in use by another MakeMKV operation, "
+                f"Source {source} is already in use by another MakeMKV operation, "
                 f"waiting for it to finish"
             )
 
         async with lock:
             return await self._rip_titles_unlocked(
-                drive,
+                source,
                 output_dir,
                 title_indices,
                 title_complete_callback,
@@ -826,7 +845,7 @@ class MakeMKVExtractor:
 
     async def _rip_titles_unlocked(
         self,
-        drive: str,
+        source: "DiscSource | str",
         output_dir: Path,
         title_indices: list[int] | None = None,
         title_complete_callback: TitleCompleteCallback | None = None,
@@ -837,17 +856,17 @@ class MakeMKVExtractor:
         job_id: int = 0,
         disc_title_map: dict[int, int] | None = None,
     ) -> RipResult:
-        """Internal rip implementation (caller must hold drive lock)."""
+        """Internal rip implementation (caller must hold the source lock)."""
         self._cancelled_jobs.discard(job_id)
         self._ejected_jobs.discard(job_id)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        drive_spec = _to_drive_spec(drive)
+        source_spec = _to_source_spec(source)
 
         # Prepare commands to run
         commands = _build_rip_commands(
             str(self.makemkv_path),
-            drive_spec,
+            source_spec,
             str(output_dir),
             title_indices,
         )

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -1689,12 +1689,17 @@ class MakeMKVExtractor:
         the ``.partial`` is left in place: a partial backup of a dying disc has
         salvage value, and discarding it is the user's call.
 
-        Every attempt starts from a clean ``<dest>.partial`` working directory.
-        MakeMKV's behaviour on a non-empty backup target is unspecified (it
-        might resume, silently skip existing files, or fail in a way this code
-        would misreport as a generic "exited N"), so a stale ``.partial`` left
-        by a previous failed attempt is moved aside to ``<dest>.partial.previous``
-        before MakeMKV is launched. That keeps the most recent failed attempt
+        Every attempt starts from a clean ``<dest>.partial`` working directory,
+        and this is REQUIRED, not merely tidy. Verified against MakeMKV 1.18.3
+        on real hardware: a target directory that already exists is refused
+        outright, even when it is empty, with ``MSG:5068 "Folder ... already
+        contains a backup, please choose another folder"`` followed by
+        ``Backup failed``. So a stale ``.partial`` left by a previous failed
+        attempt is moved aside to ``<dest>.partial.previous`` before MakeMKV is
+        launched; without that, every retry of a failed backup would die
+        instantly on 5068. It also follows that this method must never
+        pre-create the ``.partial`` itself: only ``dest.parent`` is created
+        here. That keeps the most recent failed attempt
         around for salvage while dropping the older one: a disc that fails
         repeatedly would otherwise accumulate tens of gigabytes per attempt
         without bound. This debris is from a *failed* attempt, not a completed

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -1690,13 +1690,22 @@ class MakeMKVExtractor:
         (``timeout_backing_up_seconds``) is the unattended backstop.
         """
         spec = _to_source_spec(source)
+        # Every value interpolated into a log line below is user-influenced:
+        # job_id arrives on an API path, and the paths derive from the
+        # configured backup root and the disc's own metadata. A volume label
+        # can carry CR/LF, which would let a crafted disc forge log entries
+        # (py/log-injection), so they are sanitised once here and the safe
+        # locals are what the log calls use.
+        safe_job = sanitize_log_value(job_id)
+        safe_spec = sanitize_log_value(spec)
+        safe_dest = sanitize_log_value(dest)
 
         # Built before the lock is taken: an unusable source is a caller bug,
         # and there is no reason to make it queue behind a live drive operation.
         try:
             cmd = _build_backup_command(str(self.makemkv_path), spec, str(dest) + ".partial")
         except ValueError as e:
-            logger.error(f"Job {job_id}: cannot back up from {spec}: {e}")
+            logger.error(f"Job {safe_job}: cannot back up from {safe_spec}: {e}")
             return BackupResult(success=False, error_message=str(e))
 
         partial = dest.with_name(dest.name + ".partial")
@@ -1714,18 +1723,27 @@ class MakeMKVExtractor:
             try:
                 dest.parent.mkdir(parents=True, exist_ok=True)
             except OSError as e:
-                logger.error(f"Job {job_id}: could not create {dest.parent}: {e}", exc_info=True)
+                logger.error(
+                    f"Job {safe_job}: could not create {sanitize_log_value(dest.parent)}: {e}",
+                    exc_info=True,
+                )
                 return BackupResult(success=False, error_message=str(e))
 
             previous = dest.with_name(dest.name + ".partial.previous")
             if partial.exists():
                 if previous.exists():
                     shutil.rmtree(previous)
-                    logger.info(f"Job {job_id}: discarding older stale partial: {previous}")
+                    logger.info(
+                        f"Job {safe_job}: discarding older stale partial: "
+                        f"{sanitize_log_value(previous)}"
+                    )
                 partial.rename(previous)
-                logger.info(f"Job {job_id}: moved stale partial {partial} aside to {previous}")
+                logger.info(
+                    f"Job {safe_job}: moved stale partial "
+                    f"{sanitize_log_value(partial)} aside to {sanitize_log_value(previous)}"
+                )
 
-            logger.info(f"Job {job_id}: backing up disc: {' '.join(cmd)}")
+            logger.info(f"Job {safe_job}: backing up disc: {sanitize_log_value(' '.join(cmd))}")
 
             def on_line(line: str) -> None:
                 pct = _parse_backup_progress(line)
@@ -1742,7 +1760,7 @@ class MakeMKVExtractor:
                     success=False, error_message=f"MakeMKV not found at {self.makemkv_path}"
                 )
             except Exception as e:
-                logger.exception(f"Job {job_id}: error during disc backup")
+                logger.exception(f"Job {safe_job}: error during disc backup")
                 return BackupResult(success=False, error_message=str(e))
 
             if log_dir is not None and output:
@@ -1751,16 +1769,19 @@ class MakeMKVExtractor:
 
             if job_id in self._cancelled_jobs:
                 self._cancelled_jobs.discard(job_id)
-                logger.info(f"Job {job_id}: backup cancelled by user")
+                logger.info(f"Job {safe_job}: backup cancelled by user")
                 return BackupResult(success=False, error_message="Backup cancelled by user")
 
             if returncode != 0 or not partial.exists():
                 reason = _last_msg_text(output) or f"makemkvcon backup exited {returncode}"
                 kept_note = ""
                 if partial.exists():
-                    kept_note = f" The partial backup at {partial} was kept for salvage."
+                    kept_note = (
+                        f" The partial backup at {sanitize_log_value(partial)} "
+                        f"was kept for salvage."
+                    )
                 logger.error(
-                    f"Job {job_id}: backup failed: {sanitize_log_value(reason)}.{kept_note}"
+                    f"Job {safe_job}: backup failed: {sanitize_log_value(reason)}.{kept_note}"
                 )
                 return BackupResult(success=False, error_message=reason)
 
@@ -1772,16 +1793,16 @@ class MakeMKVExtractor:
                     # deleted, per the "most recent stale partial is preserved"
                     # rule above, and the next attempt will move it aside.
                     logger.warning(
-                        f"Job {job_id}: {dest} already exists; keeping it. "
-                        f"Our own copy is orphaned at {partial}."
+                        f"Job {safe_job}: {safe_dest} already exists; keeping it. "
+                        f"Our own copy is orphaned at {sanitize_log_value(partial)}."
                     )
                     return BackupResult(success=True, dest=dest, already_existed=True)
                 partial.rename(dest)
             except OSError as e:
-                logger.error(f"Job {job_id}: could not finalize backup: {e}", exc_info=True)
+                logger.error(f"Job {safe_job}: could not finalize backup: {e}", exc_info=True)
                 return BackupResult(success=False, error_message=str(e))
 
-            logger.info(f"Job {job_id}: backup complete at {dest}")
+            logger.info(f"Job {safe_job}: backup complete at {safe_dest}")
             return BackupResult(success=True, dest=dest)
 
     def skip_title_index(self, job_id: int, title_index: int) -> None:

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -17,13 +17,10 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from app.core.analyst import TitleInfo
+from app.core.disc_source import DiscSource
 from app.core.security import sanitize_log_value
-
-if TYPE_CHECKING:
-    from app.core.disc_source import DiscSource
 
 logger = logging.getLogger(__name__)
 
@@ -66,17 +63,27 @@ STALL_POLL_INTERVAL = 5.0
 FS_POLL_INTERVAL = 3.0
 
 
-def _to_source_spec(source: "DiscSource | str") -> str:
+def _as_source(source: DiscSource | str) -> DiscSource:
+    """Coerce a source argument into a DiscSource.
+
+    Call sites still pass a bare ``job.drive_id`` string, so every entry point
+    that takes a source accepts either form and normalizes here.
+    """
+    return source if isinstance(source, DiscSource) else DiscSource.parse(source)
+
+
+def _to_source_spec(source: DiscSource | str) -> str:
     """Normalize a source into the argument makemkvcon accepts.
 
     Accepts a DiscSource, a bare drive identifier, or an already-schemed spec,
     so existing call sites that pass ``job.drive_id`` keep working unchanged.
-    """
-    from app.core.disc_source import DiscSource
 
-    if isinstance(source, DiscSource):
-        return source.makemkv_arg
-    return DiscSource.parse(source).makemkv_arg
+    Raises:
+        ValueError: if *source* is a string that is not a recognized scheme
+            (``dev:``, ``disc:``, ``file:``, ``iso:``) and not a bare drive
+            identifier either.
+    """
+    return _as_source(source).makemkv_arg
 
 
 def _is_stalled(now: float, last_progress: float, timeout: float) -> bool:
@@ -674,7 +681,7 @@ class MakeMKVExtractor:
 
         return Path(get_config_sync().makemkv_path)
 
-    def _get_source_lock(self, source: "DiscSource | str") -> asyncio.Lock:
+    def _get_source_lock(self, source: DiscSource | str) -> asyncio.Lock:
         """Get or create the per-source lock serializing MakeMKV operations.
 
         Two makemkvcon processes fighting over one optical drive stall both, so
@@ -683,16 +690,13 @@ class MakeMKVExtractor:
         it wait for the drive lock would silently serialize work that is now
         genuinely independent.
         """
-        from app.core.disc_source import DiscSource
-
-        parsed = source if isinstance(source, DiscSource) else DiscSource.parse(source)
-        key = parsed.lock_key
+        key = _as_source(source).lock_key
         if key not in self._source_locks:
             self._source_locks[key] = asyncio.Lock()
         return self._source_locks[key]
 
     async def scan_disc(
-        self, source: "DiscSource | str", log_dir: Path | None = None, *, job_id: int = 0
+        self, source: DiscSource | str, log_dir: Path | None = None, *, job_id: int = 0
     ) -> tuple[list[TitleInfo], str]:
         """Scan a source and return title information and the disc display name.
 
@@ -716,7 +720,7 @@ class MakeMKVExtractor:
             return await self._scan_disc_unlocked(source, log_dir=log_dir, job_id=job_id)
 
     async def _scan_disc_unlocked(
-        self, source: "DiscSource | str", log_dir: Path | None = None, *, job_id: int = 0
+        self, source: DiscSource | str, log_dir: Path | None = None, *, job_id: int = 0
     ) -> tuple[list[TitleInfo], str]:
         """Internal scan implementation (caller must hold the source lock)."""
         source_spec = _to_source_spec(source)
@@ -780,9 +784,9 @@ class MakeMKVExtractor:
             return [], ""
         except subprocess.TimeoutExpired as e:
             elapsed = time.monotonic() - start
-            logger.error(f"MakeMKV scan timed out after {elapsed:.1f}s for source {source}")
+            logger.error(f"MakeMKV scan timed out after {elapsed:.1f}s for source {source_spec}")
             raise ScanTimeoutError(
-                f"Disc scan timed out after 10 minutes on source {source}"
+                f"Disc scan timed out after 10 minutes on source {source_spec}"
             ) from e
         except Exception as e:
             logger.exception(f"Error scanning disc: {e}")
@@ -790,7 +794,7 @@ class MakeMKVExtractor:
 
     async def rip_titles(
         self,
-        source: "DiscSource | str",
+        source: DiscSource | str,
         output_dir: Path,
         title_indices: list[int] | None = None,
         title_complete_callback: TitleCompleteCallback | None = None,
@@ -845,7 +849,7 @@ class MakeMKVExtractor:
 
     async def _rip_titles_unlocked(
         self,
-        source: "DiscSource | str",
+        source: DiscSource | str,
         output_dir: Path,
         title_indices: list[int] | None = None,
         title_complete_callback: TitleCompleteCallback | None = None,

--- a/backend/app/core/extractor.py
+++ b/backend/app/core/extractor.py
@@ -9,6 +9,7 @@ import contextlib
 import hashlib
 import logging
 import re
+import shutil
 import struct
 import subprocess
 import sys
@@ -394,6 +395,10 @@ class BackupResult:
     success: bool
     dest: Path | None = None
     error_message: str | None = None
+    # True when dest already existed and this run did not create it. The caller
+    # still has a usable backup at dest, but this run did not verify it: it is
+    # whatever was on disk already.
+    already_existed: bool = False
 
 
 class ScanTimeoutError(Exception):
@@ -1632,6 +1637,25 @@ class MakeMKVExtractor:
         crashed backup never leaves something that looks complete. On failure
         the ``.partial`` is left in place: a partial backup of a dying disc has
         salvage value, and discarding it is the user's call.
+
+        Every attempt starts from a clean ``<dest>.partial`` working directory.
+        MakeMKV's behaviour on a non-empty backup target is unspecified (it
+        might resume, silently skip existing files, or fail in a way this code
+        would misreport as a generic "exited N"), so a stale ``.partial`` left
+        by a previous failed attempt is moved aside to ``<dest>.partial.previous``
+        before MakeMKV is launched. That keeps the most recent failed attempt
+        around for salvage while dropping the older one: a disc that fails
+        repeatedly would otherwise accumulate tens of gigabytes per attempt
+        without bound. This debris is from a *failed* attempt, not a completed
+        backup, so Engram's "never delete a backup" rule (which is about
+        completed backups under the backup root) does not apply to it.
+
+        Deliberately has no stall watchdog, unlike ``rip_titles``. A backup is
+        a single sequential read of the whole disc with no per-title boundary
+        to skip to, so the rip's "kill it and move to the next title" recovery
+        has no analogue here. Cancellation is the escape hatch for an
+        interactive user, and the job-level phase watchdog
+        (``timeout_backing_up_seconds``) is the unattended backstop.
         """
         spec = _to_source_spec(source)
 
@@ -1654,7 +1678,21 @@ class MakeMKVExtractor:
 
         async with lock:
             self._cancelled_jobs.discard(job_id)
-            dest.parent.mkdir(parents=True, exist_ok=True)
+
+            try:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                logger.error(f"Job {job_id}: could not create {dest.parent}: {e}", exc_info=True)
+                return BackupResult(success=False, error_message=str(e))
+
+            previous = dest.with_name(dest.name + ".partial.previous")
+            if partial.exists():
+                if previous.exists():
+                    shutil.rmtree(previous)
+                    logger.info(f"Job {job_id}: discarding older stale partial: {previous}")
+                partial.rename(previous)
+                logger.info(f"Job {job_id}: moved stale partial {partial} aside to {previous}")
+
             logger.info(f"Job {job_id}: backing up disc: {' '.join(cmd)}")
 
             def on_line(line: str) -> None:
@@ -1686,17 +1724,27 @@ class MakeMKVExtractor:
 
             if returncode != 0 or not partial.exists():
                 reason = _last_msg_text(output) or f"makemkvcon backup exited {returncode}"
-                logger.error(f"Job {job_id}: backup failed: {sanitize_log_value(reason)}")
+                kept_note = ""
+                if partial.exists():
+                    kept_note = f" The partial backup at {partial} was kept for salvage."
+                logger.error(
+                    f"Job {job_id}: backup failed: {sanitize_log_value(reason)}.{kept_note}"
+                )
                 return BackupResult(success=False, error_message=reason)
 
             try:
                 if dest.exists():
-                    # Destination appeared while we were copying. Keep the
-                    # existing one and drop ours rather than clobbering a
-                    # complete backup with a fresh one.
-                    logger.warning(f"Job {job_id}: {dest} already exists; keeping it")
-                else:
-                    partial.rename(dest)
+                    # Destination appeared while we were copying (another attempt
+                    # finished first). Keep the existing directory as the usable
+                    # backup and leave ours at `partial` untouched: it is not
+                    # deleted, per the "most recent stale partial is preserved"
+                    # rule above, and the next attempt will move it aside.
+                    logger.warning(
+                        f"Job {job_id}: {dest} already exists; keeping it. "
+                        f"Our own copy is orphaned at {partial}."
+                    )
+                    return BackupResult(success=True, dest=dest, already_existed=True)
+                partial.rename(dest)
             except OSError as e:
                 logger.error(f"Job {job_id}: could not finalize backup: {e}", exc_info=True)
                 return BackupResult(success=False, error_message=str(e))

--- a/backend/app/core/import_scanner.py
+++ b/backend/app/core/import_scanner.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 import re
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 # Matches "Season 1", "season 01", "Season 12", etc. (mirrors the old watcher).
@@ -26,10 +26,22 @@ _SEASON_RE = re.compile(r"^[Ss]eason\s*0*(\d+)$")
 # not shows, so a "Show / Disc N / *.mkv" layout resolves to one show, not many.
 _DISC_RE = re.compile(r"^[Dd]isc\s*0*\d+$")
 
+# A directory holding one of these is a disc backup, not a folder of media.
+_DISC_IMAGE_MARKERS = ("BDMV", "VIDEO_TS")
+
 # Bound the walk so a user pointing at a huge tree (or a symlink loop) can't
 # hang the request. Surfaced as ImportScan.truncated when hit.
 _MAX_FILES = 5000
 _MAX_DEPTH = 12
+
+# Bound the best-effort size sum for a single disc image. A real BDMV/VIDEO_TS
+# backup has at most a few hundred entries (stat() is O(1) regardless of the
+# multi-GB size of each stream file), so this never triggers on a genuine
+# single-disc backup. It exists only to stop a pathological/misidentified tree
+# (e.g. a "BDMV" folder someone nested other data under) from turning an
+# interactive folder-picker scan into a slow recursive walk. When the cap is
+# hit we stop early and return the partial sum rather than blocking.
+_MAX_DISC_IMAGE_SIZE_ENTRIES = 2000
 
 
 @dataclass
@@ -41,6 +53,53 @@ class ImportUnit:
 
 
 @dataclass
+class DiscImageUnit:
+    """A disc backup folder or ISO file, to be scanned and extracted by MakeMKV."""
+
+    path: Path
+    name: str
+    kind: str  # "backup" | "iso"
+    total_bytes: int
+
+
+def is_disc_image_dir(path: Path) -> bool:
+    """Whether this directory is a MakeMKV disc backup."""
+    try:
+        return any((path / marker).is_dir() for marker in _DISC_IMAGE_MARKERS)
+    except OSError:
+        return False
+
+
+def _dir_size_bounded(root: Path) -> int:
+    """Best-effort recursive size of a directory, capped to stay interactive.
+
+    See _MAX_DISC_IMAGE_SIZE_ENTRIES for why this is bounded rather than a
+    plain recursive sum.
+    """
+    total = 0
+    count = 0
+    stack = [root]
+    while stack:
+        d = stack.pop()
+        try:
+            entries = list(os.scandir(d))
+        except OSError:
+            continue
+        for entry in entries:
+            if count >= _MAX_DISC_IMAGE_SIZE_ENTRIES:
+                return total
+            count += 1
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    stack.append(Path(entry.path))
+                elif entry.is_file(follow_symlinks=False):
+                    total += entry.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+@dataclass
 class ImportScan:
     root: Path
     units: list[ImportUnit]
@@ -48,6 +107,10 @@ class ImportScan:
     total_files: int
     total_bytes: int
     truncated: bool = False
+    # Disc backup folders (BDMV/VIDEO_TS) and .iso files found in the tree. These
+    # are scanned and extracted through the normal pipeline rather than filed, so
+    # they are kept separate from `units` (which are ready-made MKVs to move).
+    disc_images: list[DiscImageUnit] = field(default_factory=list)
     # True when the picked folder is a single title (holds media / Season / Disc
     # directly) rather than a parent-of-shows/library folder. Drives in-place
     # organize layout: a single-title pick organizes next to itself, not under a
@@ -100,13 +163,19 @@ def _season_from_path(file: Path, root: Path) -> int | None:
     return None
 
 
-def _iter_mkvs(root: Path) -> tuple[list[Path], bool]:
+def _iter_mkvs(root: Path) -> tuple[list[Path], list[DiscImageUnit], bool]:
     """Recursively collect .mkv files under root, bounded by count and depth.
 
     Skips symlinked directories and any file whose resolved path escapes root,
-    so a crafted symlink cannot surface outside files or cause a loop.
+    so a crafted symlink cannot surface outside files or cause a loop. A
+    directory that is itself a disc backup (BDMV/VIDEO_TS) is recorded as a
+    DiscImageUnit and NOT descended into: that short-circuit is what keeps a
+    backup's thousands of stream files out of the _MAX_FILES budget. A file
+    with a .iso suffix is likewise recorded as a DiscImageUnit rather than
+    skipped.
     """
     found: list[Path] = []
+    disc_images: list[DiscImageUnit] = []
     truncated = False
     root_resolved = root.resolve()
 
@@ -127,9 +196,19 @@ def _iter_mkvs(root: Path) -> tuple[list[Path], bool]:
                 return
             try:
                 if entry.is_dir(follow_symlinks=False):
-                    walk(Path(entry.path), depth + 1)
-                elif entry.is_file(follow_symlinks=False) and entry.name.lower().endswith(".mkv"):
                     p = Path(entry.path)
+                    if is_disc_image_dir(p):
+                        disc_images.append(DiscImageUnit(p, p.name, "backup", _dir_size_bounded(p)))
+                        continue
+                    walk(p, depth + 1)
+                elif entry.is_file(follow_symlinks=False):
+                    p = Path(entry.path)
+                    name_lower = entry.name.lower()
+                    if name_lower.endswith(".iso"):
+                        disc_images.append(DiscImageUnit(p, p.name, "iso", _safe_size(p)))
+                        continue
+                    if not name_lower.endswith(".mkv"):
+                        continue
                     try:
                         if not p.resolve().is_relative_to(root_resolved):
                             continue
@@ -140,7 +219,7 @@ def _iter_mkvs(root: Path) -> tuple[list[Path], bool]:
                 continue
 
     walk(root, 0)
-    return found, truncated
+    return found, disc_images, truncated
 
 
 def scan(path: Path) -> ImportScan:
@@ -149,6 +228,10 @@ def scan(path: Path) -> ImportScan:
 
     # Single-file target: one flat unit; show derived from the parent folder.
     if path.is_file():
+        if path.suffix.lower() == ".iso":
+            size = _safe_size(path)
+            image = DiscImageUnit(path, path.name, "iso", size)
+            return ImportScan(path.parent, [], [], 0, 0, False, disc_images=[image])
         if path.suffix.lower() != ".mkv":
             return ImportScan(path.parent, [], [], 0, 0, False)
         size = _safe_size(path)
@@ -156,6 +239,13 @@ def scan(path: Path) -> ImportScan:
         return ImportScan(path.parent, [unit], [], 1, size, False, picked_is_show=True)
 
     root = path
+
+    # The picked folder is itself a disc backup: it's a single disc image, not
+    # a folder of MKVs to walk.
+    if is_disc_image_dir(root):
+        size = _dir_size_bounded(root)
+        image = DiscImageUnit(root, root.name, "backup", size)
+        return ImportScan(root, [], [], 0, 0, False, disc_images=[image])
 
     # Third identity case: the user navigated INTO a "Season NN" folder and picked
     # it directly. Neither the "picked folder is a show" nor the "picked folder is
@@ -166,7 +256,7 @@ def scan(path: Path) -> ImportScan:
     picked_season_match = _SEASON_RE.match(root.name)
     picked_season = int(picked_season_match.group(1)) if picked_season_match else None
 
-    files, truncated = _iter_mkvs(root)
+    files, disc_images, truncated = _iter_mkvs(root)
 
     immediate_dirs = _safe_dirs(root)
     has_loose_top = any(f.parent == root for f in files)
@@ -223,6 +313,7 @@ def scan(path: Path) -> ImportScan:
         total_files,
         total_bytes,
         truncated,
+        disc_images=disc_images,
         picked_is_show=picked_is_show,
         picked_is_season=picked_season is not None,
     )

--- a/backend/app/core/updater.py
+++ b/backend/app/core/updater.py
@@ -645,6 +645,7 @@ class UpdateChecker:
         # not ghost-block an update restart.
         active_states = [
             JobState.IDENTIFYING,
+            JobState.BACKING_UP,
             JobState.RIPPING,
             JobState.MATCHING,
             JobState.ORGANIZING,

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -38,14 +38,13 @@ class AppConfig(SQLModel, table=True):
     staging_path: str = ""  # Platform-aware default set on first run
     library_movies_path: str = ""
     library_tv_path: str = ""
+    # Root for full decrypted disc backups. Empty means the feature cannot run,
+    # which the backup phase reports as skipped:not_configured rather than failing.
+    backup_path: str = ""
 
     # Episode Matcher Settings
     subtitles_cache_path: str = "~/.engram/cache"
     matcher_min_confidence: float = 0.6
-
-    # Root for full decrypted disc backups. Empty means the feature cannot run,
-    # which the backup phase reports as skipped:not_configured rather than failing.
-    backup_path: str = ""
 
     # Precomputed subtitle-vector cache (downloaded from GitHub Releases on first run).
     # server_default="1" so the column is added enabled for pre-existing databases.

--- a/backend/app/models/app_config.py
+++ b/backend/app/models/app_config.py
@@ -43,6 +43,10 @@ class AppConfig(SQLModel, table=True):
     subtitles_cache_path: str = "~/.engram/cache"
     matcher_min_confidence: float = 0.6
 
+    # Root for full decrypted disc backups. Empty means the feature cannot run,
+    # which the backup phase reports as skipped:not_configured rather than failing.
+    backup_path: str = ""
+
     # Precomputed subtitle-vector cache (downloaded from GitHub Releases on first run).
     # server_default="1" so the column is added enabled for pre-existing databases.
     precomputed_cache_enabled: bool = Field(
@@ -121,6 +125,12 @@ class AppConfig(SQLModel, table=True):
     timeout_organizing_seconds: int = Field(
         default=600, sa_column_kwargs={"server_default": text("600")}
     )
+    # A 40 GB sequential copy is slower than any other phase and, on the scratched
+    # discs this feature exists for, deliberately slow. Two hours of no output
+    # growth, not of wall clock.
+    timeout_backing_up_seconds: int = Field(
+        default=7200, sa_column_kwargs={"server_default": text("7200")}
+    )
 
     # Drive behavior
     auto_eject_enabled: bool = Field(default=True, sa_column_kwargs={"server_default": text("1")})
@@ -139,6 +149,11 @@ class AppConfig(SQLModel, table=True):
     # handles badly (segment-format cartoons, DVD orderings TMDB doesn't carry)
     # confirming each disc by hand beats discovering a mis-file after the move.
     always_review: bool = Field(default=False, sa_column_kwargs={"server_default": text("0")})
+
+    # Write a full decrypted disc copy under backup_path after identification and
+    # extract from that copy instead of the drive. server_default 0, like
+    # discord_notify_ripped: an opt-in feature must read a NULL as disabled.
+    backup_before_rip: bool = Field(default=False, sa_column_kwargs={"server_default": text("0")})
 
     # Naming conventions (Python format strings)
     naming_season_format: str = "Season {season:02d}"

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -97,12 +97,20 @@ class DiscJob(SQLModel, table=True):
     # Diverges from drive_id exactly once: after a successful backup, drive_id is
     # still the drive the disc came from while source_spec has become the copy.
     source_spec: str | None = Field(default=None)
-    # Where this job's backup landed. Kept for history and for re-import; Engram
-    # never deletes it.
+    # Where this job's backup landed. Kept for history and for re-import. No
+    # cleanup path touches it today, and that is deliberate: backups are the
+    # user's preservation copy, so any future cleanup must exclude this root
+    # explicitly rather than inheriting staging's rules.
     backup_path: str | None = Field(default=None)
-    # "pending" | "completed" | "failed:<reason>" | "skipped:<reason>".
-    # None means no backup was attempted (the feature is off).
+    # "pending" | "completed" | "failed" | "skipped". None means no backup was
+    # attempted (the feature is off). Mirrors subtitle_status: a small closed set
+    # of literals here, with the free-text explanation in its own column, so no
+    # consumer has to parse a delimiter out of a status.
     backup_status: str | None = Field(default=None)
+    # Why the backup failed or was skipped, e.g. "insufficient_space",
+    # "not_configured", "no_disc_index", "unsupported_disc", or a MakeMKV error
+    # string. None when backup_status is pending or completed.
+    backup_status_reason: str | None = Field(default=None)
 
     # Progress Tracking
     state: JobState = JobState.IDLE

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -107,9 +107,12 @@ class DiscJob(SQLModel, table=True):
     # of literals here, with the free-text explanation in its own column, so no
     # consumer has to parse a delimiter out of a status.
     backup_status: str | None = Field(default=None)
-    # Why the backup failed or was skipped, e.g. "insufficient_space",
-    # "not_configured", "no_disc_index", "unsupported_disc", or a MakeMKV error
-    # string. None when backup_status is pending or completed.
+    # Why the backup failed or was skipped, as a short sentence a person can
+    # read in a UI row ("no backup location is configured", or a MakeMKV error
+    # string). Deliberately prose for BOTH outcomes: a skip's short code
+    # ("not_configured") stays in the logs, because nothing machine-reads it and
+    # the history panel has no dictionary to expand it with. None when
+    # backup_status is pending or completed.
     backup_status_reason: str | None = Field(default=None)
 
     # Progress Tracking

--- a/backend/app/models/disc_job.py
+++ b/backend/app/models/disc_job.py
@@ -12,6 +12,7 @@ class JobState(StrEnum):
 
     IDLE = "idle"
     IDENTIFYING = "identifying"  # Scanning disc structure
+    BACKING_UP = "backing_up"  # Writing a full decrypted disc copy before extraction
     REVIEW_NEEDED = "review_needed"  # Human-in-the-Loop trigger
     RIPPING = "ripping"  # Active extraction
     MATCHING = "matching"  # Audio fingerprinting
@@ -89,6 +90,19 @@ class DiscJob(SQLModel, table=True):
     # a non-recursive glob, so files nested in Disc/ subfolders import correctly;
     # "root" is the in-place organize base for destination_mode == "in_place".
     import_manifest_json: str | None = Field(default=None)
+
+    # What MakeMKV is pointed at for this job: "dev:E:", "disc:0",
+    # "file:<backup folder>" or "iso:<file>". None on every row written before
+    # backup support, meaning "legacy: derive from drive_id" (DiscSource.from_job).
+    # Diverges from drive_id exactly once: after a successful backup, drive_id is
+    # still the drive the disc came from while source_spec has become the copy.
+    source_spec: str | None = Field(default=None)
+    # Where this job's backup landed. Kept for history and for re-import; Engram
+    # never deletes it.
+    backup_path: str | None = Field(default=None)
+    # "pending" | "completed" | "failed:<reason>" | "skipped:<reason>".
+    # None means no backup was attempted (the feature is off).
+    backup_status: str | None = Field(default=None)
 
     # Progress Tracking
     state: JobState = JobState.IDLE

--- a/backend/app/services/backup_reconcile.py
+++ b/backend/app/services/backup_reconcile.py
@@ -90,7 +90,26 @@ def _same_duration(a: int, b: int) -> bool:
 
 
 def _is_identical(db_titles: list[Any], scanned_titles: list[Any]) -> bool:
-    """True when the backup enumerated exactly what the disc scan did."""
+    """True when the backup enumerated exactly what the disc scan did.
+
+    Index and duration alone are not enough: two adjacent titles of similar
+    length that swapped position would satisfy both checks pair-for-pair while
+    holding each other's content. So whenever BOTH sides of a pair carry
+    identity metadata (``source_filename``/``segment_map``), that metadata
+    must also agree before the pair counts as identical. Only a pair with NO
+    metadata on either side (e.g. a DVD scan where neither field was ever
+    populated) skips that comparison and relies on index+duration alone, which
+    is the case this fast path exists for.
+
+    A pair where exactly one side carries metadata and the other doesn't is
+    treated as NOT identical, on purpose: a backup re-scan losing metadata the
+    disc scan had (or gaining metadata it lacked) means the two enumerations
+    disagree about what there is to compare, which is itself a sign they may
+    not correspond. Falling through to the fingerprint pass below is safe here
+    because that pass keys strictly on matching metadata; a one-sided pair
+    will fail to find a candidate there and correctly resolve to AMBIGUOUS
+    rather than a silent (and possibly wrong) IDENTICAL.
+    """
     if len(db_titles) != len(scanned_titles):
         return False
     for db, sc in zip(db_titles, scanned_titles, strict=True):
@@ -98,6 +117,19 @@ def _is_identical(db_titles: list[Any], scanned_titles: list[Any]) -> bool:
             db.duration_seconds, sc.duration_seconds
         ):
             return False
+        db_key = _identity_key(db.source_filename, db.segment_map)
+        sc_key = _identity_key(
+            getattr(sc, "source_filename", None), getattr(sc, "segment_map", None)
+        )
+        db_has_meta = db_key != ("", "")
+        sc_has_meta = sc_key != ("", "")
+        if db_has_meta and sc_has_meta:
+            if db_key != sc_key:
+                return False
+        elif db_has_meta != sc_has_meta:
+            return False
+        # else: neither side has metadata; index+duration (already checked
+        # above) is all there is, exactly as before this fix.
     return True
 
 
@@ -107,7 +139,14 @@ def reconcile_titles(db_titles: list[Any], scanned_titles: list[Any]) -> Reconci
     Returns IDENTICAL (reuse the stored indices), REMAPPED (with a
     ``{old: new}`` mapping to apply), or AMBIGUOUS (park the job for review;
     the ``reason`` is written to be shown to a person).
+
+    Both inputs are sorted by index internally, so callers need not pre-sort
+    either list (and a future change to either query's ORDER BY cannot change
+    this function's answer).
     """
+    db_titles = sorted(db_titles, key=lambda t: t.title_index)
+    scanned_titles = sorted(scanned_titles, key=lambda t: t.index)
+
     if not scanned_titles:
         return ReconcileResult(
             ReconcileOutcome.AMBIGUOUS,

--- a/backend/app/services/backup_reconcile.py
+++ b/backend/app/services/backup_reconcile.py
@@ -43,6 +43,11 @@ number is only recovered by re-parsing. Worst of all it is derived from
 MakeMKV's own numbering, which is exactly the thing a re-enumeration would
 change, so it cannot corroborate itself. ``source_filename``/``segment_map``
 name disc structure instead, which is what a byte copy preserves.
+
+It is, however, a rip *target*, so it cannot be left holding its disc-scan
+value once extraction reads the backup: see
+``job_manager._reconcile_backup_titles``, which re-derives it from the backup
+scan's ``disc_title`` for every row this module lines up.
 """
 
 from __future__ import annotations
@@ -100,6 +105,17 @@ def _is_identical(db_titles: list[Any], scanned_titles: list[Any]) -> bool:
     metadata on either side (e.g. a DVD scan where neither field was ever
     populated) skips that comparison and relies on index+duration alone, which
     is the case this fast path exists for.
+
+    ``disc_title`` (MakeMKV's suggested output filename, from which
+    ``DiscTitle.output_index`` is derived) is deliberately NOT compared here.
+    Two enumerations that agree on index, duration and disc structure but
+    suggest different ``_tNN`` numbers are still the same titles in the same
+    order, and failing them into the fingerprint pass would risk parking a
+    perfectly good backup as AMBIGUOUS. The stale-``output_index`` hazard that
+    difference would otherwise create is closed at the caller instead:
+    ``job_manager._reconcile_backup_titles`` re-derives ``output_index`` from
+    the backup scan for EVERY row, on the IDENTICAL path as well as the
+    REMAPPED one, so this function never has to be the thing that notices.
 
     A pair where exactly one side carries metadata and the other doesn't is
     treated as NOT identical, on purpose: a backup re-scan losing metadata the

--- a/backend/app/services/backup_reconcile.py
+++ b/backend/app/services/backup_reconcile.py
@@ -1,0 +1,182 @@
+"""Re-validate title indices after extraction moves from the disc to its backup.
+
+``DiscTitle`` rows are created from the *disc* scan and carry ``title_index``,
+which is what the rip command passes to MakeMKV. Extraction now runs against
+``file:<backup>``, so a re-scan may enumerate differently. A backup is a byte
+copy and almost always enumerates identically, but "almost always" is not a
+contract, and ripping the wrong index files an episode under another episode's
+name with no error anywhere: the mis-file is invisible until someone browses
+their library months later.
+
+So the reconciliation here is deliberately timid. It maps an index only when
+exactly one backup title can be it, and reports AMBIGUOUS otherwise. AMBIGUOUS
+is meant to park the job for human review, never to trigger a guess and never
+to fall back to the drive, which may already be ejected.
+
+Design notes
+------------
+
+**Identity signal.** A title is identified by ``(source_filename, segment_map)``
+plus a duration that agrees within a tolerance. ``source_filename`` (MakeMKV
+TINFO attr 16, e.g. ``00001.m2ts``) and ``segment_map`` (attr 26, e.g.
+``1,2,3``) name actual objects inside the disc structure, so a byte-identical
+backup reproduces them exactly while the enumeration position may shift. Both
+are routinely empty (DVDs, and any row scanned before those fields existed), so
+duration is not merely a tiebreaker: for a disc with no per-title metadata it is
+the only signal there is, and it must still be able to tell two titles apart.
+
+**Duration is compared, never hashed.** An earlier draft bucketed the duration
+into a hash key (``duration // tolerance``). That cannot express "within N
+seconds": bucketing puts 2600 and 2601 in different buckets whenever the
+boundary falls between them, so a one-second MakeMKV rounding difference read as
+a different title. Instead the ``(source_filename, segment_map)`` pair is the
+only hashed part of the key, and duration is checked with an explicit
+``abs(a - b) <= tolerance`` against each candidate that shares that pair.
+
+**Not ``output_index``.** ``DiscTitle.output_index`` is the disc-native ``_tNN``
+number and is a better *rip target* than ``title_index`` (see
+``ripping_helpers.expected_native_index``), but it is a poor *identity* signal
+here. It is nullable on legacy rows and wherever MakeMKV supplied no suggested
+filename, and the scan side does not carry a comparable field at all:
+``TitleInfo`` holds the raw suggested filename (``disc_title``), from which the
+number is only recovered by re-parsing. Worst of all it is derived from
+MakeMKV's own numbering, which is exactly the thing a re-enumeration would
+change, so it cannot corroborate itself. ``source_filename``/``segment_map``
+name disc structure instead, which is what a byte copy preserves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from loguru import logger
+
+# MakeMKV rounds durations, so titles within this many seconds are the same title.
+_DURATION_TOLERANCE_S = 2
+
+
+class ReconcileOutcome(StrEnum):
+    """How a backup re-scan lined up with the disc scan."""
+
+    IDENTICAL = "identical"
+    REMAPPED = "remapped"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass
+class ReconcileResult:
+    outcome: ReconcileOutcome
+    # {old title_index: new title_index}. Empty for IDENTICAL.
+    remap: dict[int, int] = field(default_factory=dict)
+    reason: str | None = None
+
+
+def _identity_key(source_filename: str | None, segment_map: str | None) -> tuple[str, str]:
+    """The hashable part of a title's identity, independent of enumeration order.
+
+    Duration is deliberately excluded: it needs a tolerance, and a tolerance
+    cannot be expressed as a hash bucket.
+    """
+    return (
+        (source_filename or "").strip().lower(),
+        (segment_map or "").strip(),
+    )
+
+
+def _same_duration(a: int, b: int) -> bool:
+    return abs(a - b) <= _DURATION_TOLERANCE_S
+
+
+def _is_identical(db_titles: list[Any], scanned_titles: list[Any]) -> bool:
+    """True when the backup enumerated exactly what the disc scan did."""
+    if len(db_titles) != len(scanned_titles):
+        return False
+    for db, sc in zip(db_titles, scanned_titles, strict=True):
+        if db.title_index != sc.index or not _same_duration(
+            db.duration_seconds, sc.duration_seconds
+        ):
+            return False
+    return True
+
+
+def reconcile_titles(db_titles: list[Any], scanned_titles: list[Any]) -> ReconcileResult:
+    """Line up stored ``DiscTitle`` rows against a fresh scan of the backup.
+
+    Returns IDENTICAL (reuse the stored indices), REMAPPED (with a
+    ``{old: new}`` mapping to apply), or AMBIGUOUS (park the job for review;
+    the ``reason`` is written to be shown to a person).
+    """
+    if not scanned_titles:
+        return ReconcileResult(
+            ReconcileOutcome.AMBIGUOUS,
+            reason=(
+                "The backup was scanned but no titles were found in it, so there is "
+                "nothing to rip from. The backup may be incomplete."
+            ),
+        )
+    if not db_titles:
+        return ReconcileResult(
+            ReconcileOutcome.AMBIGUOUS,
+            reason=(
+                "No titles were recorded for this disc, so the backup scan cannot be "
+                "checked against anything."
+            ),
+        )
+
+    # Fast path: the overwhelmingly common case, where the byte copy enumerates
+    # exactly as the disc did. Checked before any fingerprinting so that a disc
+    # with no per-title metadata at all still short-circuits cleanly.
+    if _is_identical(db_titles, scanned_titles):
+        return ReconcileResult(ReconcileOutcome.IDENTICAL)
+
+    buckets: dict[tuple[str, str], list[Any]] = {}
+    for sc in scanned_titles:
+        key = _identity_key(getattr(sc, "source_filename", None), getattr(sc, "segment_map", None))
+        buckets.setdefault(key, []).append(sc)
+
+    remap: dict[int, int] = {}
+    claimed: dict[int, int] = {}  # new index -> the stored index that claimed it
+    for db in db_titles:
+        key = _identity_key(db.source_filename, db.segment_map)
+        candidates = [
+            sc
+            for sc in buckets.get(key, [])
+            if _same_duration(db.duration_seconds, sc.duration_seconds)
+        ]
+        if not candidates:
+            return ReconcileResult(
+                ReconcileOutcome.AMBIGUOUS,
+                reason=(
+                    f"Track {db.title_index} ({db.duration_seconds}s) was not found in the "
+                    f"backup. The backup may be incomplete or may not match this disc."
+                ),
+            )
+        if len(candidates) > 1:
+            return ReconcileResult(
+                ReconcileOutcome.AMBIGUOUS,
+                reason=(
+                    f"Track {db.title_index} ({db.duration_seconds}s) matches "
+                    f"{len(candidates)} tracks in the backup that look identical, so "
+                    f"there is no way to tell which one to rip."
+                ),
+            )
+        winner = candidates[0].index
+        # Two stored rows can each be an unambiguous match for the SAME backup
+        # title (two rows one second apart both land inside one title's
+        # tolerance). Neither claim is wrong on its own, so only this check
+        # catches it.
+        if winner in claimed:
+            return ReconcileResult(
+                ReconcileOutcome.AMBIGUOUS,
+                reason=(
+                    f"Tracks {claimed[winner]} and {db.title_index} both match the same "
+                    f"track in the backup, so they cannot be told apart."
+                ),
+            )
+        claimed[winner] = db.title_index
+        remap[db.title_index] = winner
+
+    logger.info(f"Backup re-scan remapped {len(remap)} title indices")
+    return ReconcileResult(ReconcileOutcome.REMAPPED, remap=remap)

--- a/backend/app/services/event_broadcaster.py
+++ b/backend/app/services/event_broadcaster.py
@@ -86,6 +86,25 @@ class EventBroadcaster:
             job_id, JobState.COMPLETED.value, identity_prompt_json=identity_prompt_json
         )
 
+    # --- Backup Events ---
+
+    async def broadcast_backup_progress(
+        self,
+        job_id: int,
+        current_bytes: int,
+        total_bytes: int,
+        speed: str | None = None,
+        eta_seconds: int | None = None,
+    ) -> None:
+        """Broadcast disc-backup copy progress."""
+        await self._ws.broadcast_backup_progress(
+            job_id,
+            current_bytes=current_bytes,
+            total_bytes=total_bytes,
+            speed=speed,
+            eta=eta_seconds,
+        )
+
     # --- Title Discovery Events ---
 
     async def broadcast_titles_discovered(

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -76,7 +76,9 @@ def next_state_after_identify(config, drive_id: str) -> JobState:
     """
     if not config or not config.backup_before_rip or not config.backup_path:
         return JobState.RIPPING
-    if drive_id == "import":
+    # "import" and "staging" are both non-disc sentinels, not drive ids: there
+    # is no disc to copy, and an imported backup already is one.
+    if drive_id in ("import", "staging"):
         return JobState.RIPPING
     return JobState.BACKING_UP
 

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -16,6 +16,7 @@ from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
+from app.core.disc_source import DiscSource
 from app.core.extractor import MakeMKVExtractor, ScanTimeoutError, title_index_from_filename
 from app.core.fingerprint_disc_classifier import (
     identify_disc_via_network,
@@ -379,9 +380,20 @@ class IdentificationCoordinator:
                 try:
                     from app.core.discdb_exporter import get_makemkv_log_dir
 
+                    # The job's own source, not always the drive: a disc-image
+                    # import reads a backup folder or an ISO and has no drive at
+                    # all, and a legacy row (source_spec is None) still resolves
+                    # to drive_id.
                     titles, disc_name = await self._extractor.scan_disc(
-                        job.drive_id, log_dir=get_makemkv_log_dir(job_id), job_id=job_id
+                        DiscSource.from_job(job),
+                        log_dir=get_makemkv_log_dir(job_id),
+                        job_id=job_id,
                     )
+                except ValueError as e:
+                    await self._state_machine.transition_to_failed(
+                        job, session, f"Cannot scan this job: {e}"
+                    )
+                    return
                 except ScanTimeoutError:
                     await self._state_machine.transition_to_failed(
                         job,
@@ -1746,7 +1758,18 @@ class IdentificationCoordinator:
                     # insert that missed the hash. Cheap (glob + stat).
                     from app.core.extractor import compute_content_hash
 
-                    content_hash = await asyncio.to_thread(compute_content_hash, job.drive_id)
+                    # A backup folder holds the same BDMV/STREAM sizes as the
+                    # disc it was copied from, so hashing the copy yields the
+                    # same ContentHash and an imported backup still gets a
+                    # TheDiscDB lookup. A job with no MakeMKV source at all
+                    # simply has no hash.
+                    try:
+                        source = DiscSource.from_job(job)
+                    except ValueError:
+                        source = None
+                    content_hash = (
+                        await asyncio.to_thread(compute_content_hash, source) if source else None
+                    )
                     if content_hash:
                         job.content_hash = content_hash
 

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -1374,9 +1374,11 @@ class IdentificationCoordinator:
                     resume_action = "resolve_movie"
             else:
                 job.review_reason = None
-                job.state = JobState.RIPPING
-                target_state = JobState.RIPPING
-                resume_action = "start_rip"
+                # Pre-rip answer: the disc is still in the drive, so this is the
+                # one resume path that can still back it up first.
+                job.state = await self._next_state_after_identify(job.drive_id)
+                target_state = job.state
+                resume_action = "start_backup" if job.state == JobState.BACKING_UP else "start_rip"
 
             job.updated_at = datetime.now(UTC)
             await session.commit()
@@ -1575,10 +1577,11 @@ class IdentificationCoordinator:
                     target_state = job.state
                     resume_action = "resolve_movie"
             else:
-                # Pre-rip: go to RIPPING
-                job.state = JobState.RIPPING
-                target_state = JobState.RIPPING
-                resume_action = "start_rip"
+                # Pre-rip: the disc is still in the drive, so this is the one
+                # re-identify path that can still back it up first.
+                job.state = await self._next_state_after_identify(job.drive_id)
+                target_state = job.state
+                resume_action = "start_backup" if job.state == JobState.BACKING_UP else "start_rip"
 
             job.updated_at = datetime.now(UTC)
             await session.commit()

--- a/backend/app/services/identification_coordinator.py
+++ b/backend/app/services/identification_coordinator.py
@@ -63,6 +63,23 @@ PERMISSIVE_MIN_DURATION_SECONDS = 900
 _YEAR_RE = re.compile(r"(?<!\d)(?:19|20)\d{2}(?!\d)")
 
 
+def next_state_after_identify(config, drive_id: str) -> JobState:
+    """The state a freshly identified disc should enter.
+
+    One function rather than a condition repeated at each of the places
+    identification currently assigns JobState.RIPPING, so the sites cannot
+    drift. An import job is excluded because it already is a backup, and an
+    enabled-but-unconfigured backup is excluded because entering a phase whose
+    only possible action is to fall back would put a misleading BACKING UP on
+    the card for no reason.
+    """
+    if not config or not config.backup_before_rip or not config.backup_path:
+        return JobState.RIPPING
+    if drive_id == "import":
+        return JobState.RIPPING
+    return JobState.BACKING_UP
+
+
 def apply_permissive_title_selection(titles: list[DiscTitle]) -> None:
     """Select rip-worthy titles for a disc whose identity/type is unknown (B2).
 
@@ -282,6 +299,7 @@ class IdentificationCoordinator:
         self._on_match_task_done: callable = None
         self._check_job_completion: callable = None
         self._run_ripping: callable = None
+        self._run_backup: callable = None
         self._finalize_disc_job: callable = None
 
     def set_callbacks(
@@ -297,6 +315,7 @@ class IdentificationCoordinator:
         on_match_task_done,
         check_job_completion,
         run_ripping,
+        run_backup,
         finalize_disc_job,
     ) -> None:
         """Set cross-coordinator callbacks after all coordinators are constructed."""
@@ -310,7 +329,27 @@ class IdentificationCoordinator:
         self._on_match_task_done = on_match_task_done
         self._check_job_completion = check_job_completion
         self._run_ripping = run_ripping
+        self._run_backup = run_backup
         self._finalize_disc_job = finalize_disc_job
+
+    async def _next_state_after_identify(self, drive_id: str) -> JobState:
+        """Read the live config and pick RIPPING or BACKING_UP for this disc."""
+        from app.services.config_service import get_config
+
+        config = await get_config()
+        return next_state_after_identify(config, drive_id)
+
+    async def _hand_off_after_identify(self, job_id: int, state: JobState) -> None:
+        """Run the phase chosen by :func:`next_state_after_identify`.
+
+        Awaited rather than spawned, matching the direct ``_run_ripping`` await
+        every identification site already used; the backup coroutine registers
+        and log-tags itself.
+        """
+        if state is JobState.BACKING_UP:
+            await self._run_backup(job_id)
+        else:
+            await self._run_ripping(job_id)
 
     async def identify_disc(
         self, job_id: int, manual_identity: ManualIdentity | None = None
@@ -650,7 +689,8 @@ class IdentificationCoordinator:
 
                         await session.commit()
 
-                        job.state = JobState.RIPPING
+                        next_state = await self._next_state_after_identify(job.drive_id)
+                        job.state = next_state
                         await session.commit()
                         await ws_manager.broadcast_job_update(
                             job_id,
@@ -659,7 +699,7 @@ class IdentificationCoordinator:
                             detected_title=job.detected_title,
                         )
 
-                        await self._run_ripping(job_id)
+                        await self._hand_off_after_identify(job_id, next_state)
                         return
 
                     # Gate C (walk-away B2): identity is uncertain but we have a
@@ -694,8 +734,10 @@ class IdentificationCoordinator:
                         broadcast=False,
                     )
                 else:
-                    # High-confidence detection - auto-start ripping
-                    job.state = JobState.RIPPING
+                    # High-confidence detection - auto-start ripping (or the
+                    # backup that precedes it when backup_before_rip is on).
+                    next_state = await self._next_state_after_identify(job.drive_id)
+                    job.state = next_state
                     await session.commit()
 
                 # Both review and high-confidence paths broadcast the same job update.
@@ -723,7 +765,7 @@ class IdentificationCoordinator:
                         f"Job {job_id} identified as {analysis.content_type.value} "
                         f"(confidence: {analysis.confidence:.1%}) - auto-starting rip"
                     )
-                    await self._run_ripping(job_id)
+                    await self._hand_off_after_identify(job_id, next_state)
                     return
 
             except Exception as e:
@@ -772,13 +814,16 @@ class IdentificationCoordinator:
         like "label unreadable" / "merged without separators") and B4's
         rip-end convergence replays them as ``review_reason``, reproducing
         today's review UX for an unanswered prompt. The transition mirrors the
-        high-confidence auto-rip path (direct RIPPING + commit + broadcast +
-        ``_run_ripping``). Blocking kinds (``name``/``reidentify``) park
-        ripped titles in QUEUED via the B3 matching gate; ``season`` is a
-        shortcut CTA and titles dispatch normally.
+        high-confidence auto-rip path (the state chosen by
+        ``next_state_after_identify`` + commit + broadcast + the matching
+        coroutine, so an enabled backup precedes the rip here too). Blocking
+        kinds (``name``/``reidentify``) park ripped titles in QUEUED via the B3
+        matching gate; ``season`` is a shortcut CTA and titles dispatch
+        normally.
         """
         job.identity_prompt_json = json.dumps({"kind": kind, "reason": reason})
-        job.state = JobState.RIPPING
+        next_state = await self._next_state_after_identify(job.drive_id)
+        job.state = next_state
         await session.commit()
         await ws_manager.broadcast_job_update(
             job_id,
@@ -794,7 +839,7 @@ class IdentificationCoordinator:
             f"Job {job_id}: rip-first with an open identity question (kind={kind}) — "
             f"auto-starting rip"
         )
-        await self._run_ripping(job_id)
+        await self._hand_off_after_identify(job_id, next_state)
 
     async def _resolve_all_season_numbers(
         self, title: str, tmdb_id: int | None = None

--- a/backend/app/services/identity_prompts.py
+++ b/backend/app/services/identity_prompts.py
@@ -21,9 +21,13 @@ BLOCKING_KINDS = frozenset({"name", "reidentify"})
 # Resume contract between IdentificationCoordinator's answer endpoints
 # (set_name_and_resume / re_identify) and JobManager._apply_identity_resume_action.
 # Semantics are documented on IdentificationCoordinator.set_name_and_resume;
-# only "start_rip" may spawn a rip task (the double-rip hazard).
+# only "start_rip" and "start_backup" may spawn a rip task (the double-rip
+# hazard). They are the same pre-rip resume, split by whether backup_before_rip
+# is on: a disc parked for a name prompt still needs its backup once the user
+# answers, and routing both through "start_rip" silently skipped it.
 ResumeAction = Literal[
     "start_rip",
+    "start_backup",
     "dispatch_matches",
     "release_movie_titles",
     "resolve_movie",

--- a/backend/app/services/import_guard.py
+++ b/backend/app/services/import_guard.py
@@ -82,9 +82,24 @@ async def classify_staging_path(
     ``(None, [])`` when the path is free. In-flight beats completed: a path with
     both a finished and a live job is owned by the live one. Ids within a tier
     are returned in ascending order.
+
+    ``source_spec`` is matched as well as ``staging_path`` because a disc-image
+    import reads from the path and writes its extracted MKVs to a staging
+    directory of its own, so its row does NOT carry the image path in
+    ``staging_path``. Ownership still has to key on the image, which is what
+    ``unit_key_for`` hashes and what the user actually picked. The same clause
+    makes a completed disc backup that a live rip is still reading from
+    (``source_spec == "file:<backup>"``) block an import of that backup, which
+    is correct for the same reason.
     """
     result = await session.execute(
-        sa_select(DiscJob).where(DiscJob.staging_path == staging_path).order_by(DiscJob.id)
+        sa_select(DiscJob)
+        .where(
+            (DiscJob.staging_path == staging_path)
+            | (DiscJob.source_spec == f"file:{staging_path}")
+            | (DiscJob.source_spec == f"iso:{staging_path}")
+        )
+        .order_by(DiscJob.id)
     )
     jobs = list(result.scalars().all())
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -639,25 +639,26 @@ class JobManager:
 
     @staticmethod
     def _holds_disc_in_drive(job: DiscJob) -> bool:
-        """True if a job in a disc-required state really has the disc loaded.
+        """True if this job really has a disc loaded in a drive.
 
-        A RIPPING job reading from a backup copy does not: the drive was
-        released the moment the copy finished, which is the entire point of the
-        backup phase (the disc leaves the drive in minutes rather than hours).
-        Such a job is treated exactly like a post-eject MATCHING/ORGANIZING job
-        below: it no longer blocks the drive, but a re-insert of the SAME disc
-        still resolves to it rather than spawning a duplicate.
+        Deliberately asks the SOURCE, not the state. ``source_spec`` is pointed
+        at the copy by the same ``_record_backup_status`` call that precedes
+        ``_release_drive``, so "reads a copy" and "the tray is already open" are
+        the same fact, and reading the source gets the answer right in every
+        state rather than in most of them.
 
-        BACKING_UP is unaffected: ``source_spec`` is only pointed at the copy
-        once the copy has COMPLETED (see ``_record_backup_status``), so a job
-        that is still copying reports the drive it is reading, and still blocks.
+        An earlier version special-cased RIPPING and returned True for anything
+        else. That was wrong for the tail of ``_run_backup``: between the drive
+        release and ``_enter_ripping`` the job is still BACKING_UP with its
+        source already pointing at the copy, and re-scanning a full disc backup
+        is minutes, not instants. During that window a job with no disc reported
+        holding one, so an eject would cancel a backup that had actually
+        succeeded, and a genuinely new disc in the now-empty drive was refused.
 
         An unresolvable source (a row with neither ``source_spec`` nor a usable
         ``drive_id``) is treated as holding the drive: refusing a second job is
         the safe side of that guess.
         """
-        if job.state is not JobState.RIPPING:
-            return True
         try:
             return DiscSource.from_job(job).is_physical
         except ValueError:
@@ -2237,6 +2238,20 @@ class JobManager:
                     f"Watchdog: job {job.id} idle {idle:.0f}s in backing_up "
                     f"(timeout {timeout}s), falling back to a direct rip"
                 )
+                # Retire the in-flight _run_backup task BEFORE falling back, the
+                # same way reconcile_and_advance does. Killing only the
+                # subprocess is not enough: backup_disc would see the cancel
+                # flag, return a failed BackupResult, and that task would run
+                # its OWN _fall_back_to_direct_rip. Two independent fallbacks
+                # for one job, and since _enter_ripping has no idempotency guard
+                # and the state machine allows RIPPING -> RIPPING, the second
+                # spawns a second _run_ripping against the same staging dir and
+                # title rows. Cancelling first makes the task unwind on
+                # CancelledError (a BaseException, so its catch-all does not
+                # swallow it) instead of racing us.
+                task = self._active_jobs.pop(job.id, None)
+                if task is not None and not task.done():
+                    task.cancel()
                 # Stop the copy before the rip starts, or two makemkvcon
                 # processes fight over the drive.
                 await asyncio.to_thread(self._extractor.cancel, job.id)
@@ -3004,13 +3019,33 @@ class JobManager:
             from app.core.discord_notifier import RIP_OUTCOME_BACKED_UP
 
             drive_id, dest = outcome
-            # _release_drive is the documented single chokepoint for "Engram is
-            # done with this disc", and a completed backup satisfies it
-            # literally: the disc is copied, so it can leave the drive. It runs
-            # BEFORE reconciling so even an unreconcilable backup frees it.
-            await self._release_drive(job_id, drive_id, RIP_OUTCOME_BACKED_UP)
-            if await self._reconcile_backup_titles(job_id, dest):
-                await self._enter_ripping(job_id)
+            # The tail gets its OWN guard, and it degrades to review rather than
+            # to a direct rip. By here the copy has succeeded, so source_spec
+            # already points at it: a "direct rip" would read the copy with
+            # unreconciled title indices, which is precisely the silent
+            # mis-file reconciliation exists to prevent. Without this guard an
+            # exception below (a DB error in the reconcile commit, say) killed
+            # the task outright, leaving the job parked in BACKING_UP with no
+            # owner until the watchdog fell it back into exactly that rip.
+            try:
+                # _release_drive is the documented single chokepoint for "Engram
+                # is done with this disc", and a completed backup satisfies it
+                # literally: the disc is copied, so it can leave the drive. It
+                # runs BEFORE reconciling so even an unreconcilable backup frees
+                # it.
+                await self._release_drive(job_id, drive_id, RIP_OUTCOME_BACKED_UP)
+                if await self._reconcile_backup_titles(job_id, dest):
+                    await self._enter_ripping(job_id)
+            except Exception as e:
+                logger.exception(
+                    f"Job {sanitize_log_value(job_id)}: failed after the copy completed"
+                )
+                await self._park_backup_for_review(
+                    job_id,
+                    f"The disc was copied to {dest}, but Engram could not confirm "
+                    f"which title is which afterwards ({e}). The backup is safe; "
+                    f"re-run matching or re-import it to continue.",
+                )
 
     async def _copy_disc_to_backup(self, job_id: int) -> tuple[str, Path] | None:
         """Run the backup itself, returning ``(drive_id, dest)`` on success.
@@ -3201,6 +3236,22 @@ class JobManager:
         task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
+
+    async def _park_backup_for_review(self, job_id: int, reason: str) -> None:
+        """Park a job whose copy succeeded but whose follow-up did not.
+
+        Best-effort and never raises: it is the last stop on a path that is
+        already handling a failure, so a second failure here must not replace
+        one bad outcome with an unhandled exception.
+        """
+        try:
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                if job is None:
+                    return
+                await state_machine.transition_to_review(job, session, reason=reason)
+        except Exception:
+            logger.exception(f"Job {sanitize_log_value(job_id)}: could not park the job for review")
 
     async def _reconcile_backup_titles(self, job_id: int, dest: Path) -> bool:
         """Re-scan the backup and line its titles up with the stored ones.

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2869,14 +2869,18 @@ class JobManager:
             await self._skip_backup(job_id, "not_configured", "no backup location is configured")
             return None
 
-        if _has_existing_backup(dest):
+        # Both probes below touch the filesystem, and the backup shelf is
+        # routinely a network share or a spun-down external disk where a stat or
+        # a disk_usage can block for seconds. Off the event loop they go, for the
+        # same reason api.routes.import_browse does it.
+        if await asyncio.to_thread(_has_existing_backup, dest):
             logger.info(f"Job {safe_job}: reusing the existing backup at {dest}")
             await self._record_backup_status(
                 job_id, BACKUP_COMPLETED, dest=dest, use_as_source=True
             )
             return drive_id, dest
 
-        if not has_room_for_backup(dest, total_bytes):
+        if not await asyncio.to_thread(has_room_for_backup, dest, total_bytes):
             await self._skip_backup(
                 job_id, "insufficient_space", f"not enough free space for a backup at {dest}"
             )
@@ -2966,9 +2970,18 @@ class JobManager:
             job.updated_at = datetime.now(UTC)
             await session.commit()
 
-    async def _skip_backup(self, job_id: int, reason: str, detail: str) -> None:
-        """Record a backup that was never attempted, and rip from the drive."""
-        await self._fall_back_to_direct_rip(job_id, BACKUP_SKIPPED, reason, detail)
+    async def _skip_backup(self, job_id: int, code: str, detail: str) -> None:
+        """Record a backup that was never attempted, and rip from the drive.
+
+        ``detail`` (not ``code``) is what gets persisted. The failure path
+        already stores prose in ``backup_status_reason``, and the history detail
+        panel has no dictionary to expand "not_configured" with, so storing the
+        short code here meant a skipped backup could only be explained by
+        digging through logs. Nothing machine-reads the codes; they stay in the
+        log line for grepping.
+        """
+        logger.debug(f"Job {sanitize_log_value(job_id)}: backup skipped ({code})")
+        await self._fall_back_to_direct_rip(job_id, BACKUP_SKIPPED, detail, detail)
 
     async def _fall_back_to_direct_rip(
         self, job_id: int, status: str, reason: str, detail: str
@@ -3054,14 +3067,51 @@ class JobManager:
                 )
                 return False
 
-            if result.remap:
-                for row in rows:
-                    new_index = result.remap.get(row.title_index)
-                    if new_index is not None and new_index != row.title_index:
-                        row.title_index = new_index
-                        session.add(row)
+            # Both surviving outcomes rewrite the rip targets from the backup's
+            # own enumeration.
+            #
+            # title_index is not the only one that matters:
+            # ripping_helpers.expected_native_index PREFERS output_index, and
+            # every site that maps a produced "..._tNN.mkv" back onto a row goes
+            # through it. A remap that rewrote only title_index therefore left
+            # the resolution sites reading a stale disc-scan number: two titles
+            # the backup enumerated in the opposite order would resolve onto
+            # each other's rows, filing one episode under the other's name with
+            # no error anywhere, which is the exact mis-file this reconciliation
+            # exists to prevent.
+            #
+            # Clearing output_index instead was rejected: the fallback is
+            # title_index, and MakeMKV's native _tNN is not guaranteed to equal
+            # the scan-order index (issue #517). It is re-derived from the
+            # backup scan's suggested filename with the same helper
+            # identification_coordinator uses, so the two paths cannot drift.
+            # None is written when the backup scan supplied no suggested
+            # filename: that is the legitimate fall-back-to-title_index case.
+            #
+            # This runs on the IDENTICAL path too (where the mapping is the
+            # identity), because backup_reconcile._is_identical deliberately
+            # does not compare disc_title: a backup can enumerate identically
+            # and still suggest different _tNN numbers.
+            scanned_by_index = {sc.index: sc for sc in scanned}
+            changed = 0
+            for row in rows:
+                new_index = result.remap.get(row.title_index, row.title_index)
+                matched = scanned_by_index.get(new_index)
+                if matched is None:
+                    continue
+                native = title_index_from_filename(getattr(matched, "disc_title", "") or "")
+                if new_index == row.title_index and native == row.output_index:
+                    continue
+                row.title_index = new_index
+                row.output_index = native
+                session.add(row)
+                changed += 1
+            if changed:
                 await session.commit()
-                logger.info(f"Job {safe_job}: remapped {len(result.remap)} title indices")
+                logger.info(
+                    f"Job {safe_job}: rewrote {changed} title rows from the backup scan "
+                    f"({len(result.remap)} index remaps)"
+                )
 
         return True
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1023,6 +1023,11 @@ class JobManager:
 
         coro_factory = {
             "start_rip": self._run_ripping,
+            # Same pre-rip resume as "start_rip", but the disc gets copied
+            # first. The coordinator decides which by the same routing every
+            # other hand-off uses, so a name prompt answered with
+            # backup_before_rip on cannot silently skip the backup.
+            "start_backup": self._run_backup,
             "rerun_matching": self._rerun_matching,
             "resolve_movie": self._resume_movie_post_rip,
         }.get(action)

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -830,12 +830,22 @@ class JobManager:
         drive_id: str = "staging",
         import_manifest: dict | None = None,
         force: bool = False,
+        source_spec: str | None = None,
     ) -> StagingJobResult:
         """Create a job from pre-ripped MKV files in a staging directory.
 
         Returns a StagingJobResult: either a created job id, or the block tier and
         the ids of the jobs responsible for it. ``force`` suppresses the soft
         (ALREADY_IMPORTED) tier only and can never suppress the hard one.
+
+        ``source_spec`` marks the job as reading from a disc image (a MakeMKV
+        backup folder or an ISO) rather than from ready-made MKVs. That flips
+        which identification runs: the ordinary import shortcut
+        (``identify_from_staging``) exists precisely because the files already
+        exist, so it probes them and hands straight on to matching. A disc image
+        has no MKVs yet, so it takes ``identify_disc`` and the full scan,
+        identify, rip, match, organize pipeline instead. A job with no
+        ``source_spec`` is unaffected.
         """
         staging_dir = Path(staging_path)
 
@@ -880,6 +890,7 @@ class JobManager:
                     staging_path=str(staging_dir),
                     state=JobState.IDENTIFYING,
                     destination_mode=destination_mode,
+                    source_spec=source_spec,
                 )
 
                 if content_type in ("tv", "movie"):
@@ -912,9 +923,14 @@ class JobManager:
 
         await event_broadcaster.broadcast_drive_inserted(drive_id, volume_label)
 
-        task = asyncio.create_task(
-            with_job_log_context(job_id, self._identification.identify_from_staging(job_id))
+        # A disc image is scanned and extracted like any other disc; only a
+        # folder of finished MKVs may take the shortcut past ripping.
+        identification = (
+            self._identification.identify_disc(job_id)
+            if source_spec
+            else self._identification.identify_from_staging(job_id)
         )
+        task = asyncio.create_task(with_job_log_context(job_id, identification))
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2486,6 +2486,7 @@ class JobManager:
         state_flow = {
             JobState.IDLE: JobState.IDENTIFYING,
             JobState.IDENTIFYING: JobState.RIPPING,
+            JobState.BACKING_UP: JobState.RIPPING,
             JobState.RIPPING: JobState.MATCHING,
             JobState.MATCHING: JobState.ORGANIZING,
             JobState.ORGANIZING: JobState.COMPLETED,
@@ -2497,9 +2498,18 @@ class JobManager:
             if not job:
                 raise ValueError(f"Job {job_id} not found")
 
+            old_state = job.state
             next_state = state_flow.get(job.state)
             if not next_state:
                 raise ValueError(f"Cannot advance from state: {job.state}")
+
+            if old_state == JobState.BACKING_UP and next_state == JobState.RIPPING:
+                # Mirror _record_backup_status: mark the synthetic backup
+                # complete and point source_spec at it, so a simulated job
+                # behaves like the real backup-then-rip handoff.
+                job.backup_status = BACKUP_COMPLETED
+                if job.backup_path:
+                    job.source_spec = f"file:{job.backup_path}"
 
             job.state = next_state
             job.updated_at = datetime.now(UTC)
@@ -2523,6 +2533,7 @@ class JobManager:
         state_flow = {
             JobState.IDLE: JobState.IDENTIFYING,
             JobState.IDENTIFYING: JobState.RIPPING,
+            JobState.BACKING_UP: JobState.RIPPING,
             JobState.RIPPING: JobState.MATCHING,
             JobState.MATCHING: JobState.ORGANIZING,
             JobState.ORGANIZING: JobState.COMPLETED,
@@ -2534,9 +2545,15 @@ class JobManager:
             if not job:
                 raise ValueError(f"Job {job_id} not found")
 
+            old_state = job.state
             next_state = state_flow.get(job.state)
             if not next_state:
                 raise ValueError(f"Cannot advance from state: {job.state}")
+
+            if old_state == JobState.BACKING_UP and next_state == JobState.RIPPING:
+                job.backup_status = BACKUP_COMPLETED
+                if job.backup_path:
+                    job.source_spec = f"file:{job.backup_path}"
 
             ok = await state_machine.transition(job, next_state, session)
             if not ok:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -108,6 +108,7 @@ _STALE_PHASE_FAILURE_MESSAGES = {
     JobState.RIPPING: "Ripping stalled — no progress after {timeout}s",
     JobState.MATCHING: "Matching stalled — no progress after {timeout}s",
     JobState.ORGANIZING: "Organizing stalled — no progress after {timeout}s",
+    JobState.BACKING_UP: "Backup stalled: no progress after {timeout}s",
 }
 
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1029,7 +1029,9 @@ class JobManager:
         """Re-identify a job with user-corrected metadata.
 
         Same resume contract as :meth:`set_name_and_resume`: the coordinator
-        returns a ``resume_action`` and only ``"start_rip"`` spawns a rip task.
+        returns a ``resume_action``; only ``"start_rip"`` and ``"start_backup"``
+        spawn a rip task (they are the same pre-rip resume, split by whether
+        backup_before_rip is on).
         """
         # A real match (or re-rip) starts now — stop background prewarming.
         # cancel_for_job prevents future chunks; the in-flight thread still
@@ -1043,7 +1045,7 @@ class JobManager:
     async def _apply_identity_resume_action(self, job_id: int, action: ResumeAction) -> None:
         """Run the JobManager side of an identity answer (walk-away B5).
 
-        ``"start_rip"``/``"rerun_matching"``/``"resolve_movie"`` spawn a
+        ``"start_rip"``/``"start_backup"``/``"rerun_matching"``/``"resolve_movie"`` spawn a
         background task registered in ``_active_jobs``. ``"dispatch_matches"``
         and ``"release_movie_titles"`` act inline on already-running work — a
         mid-rip answer leaves the live rip task as the registered owner, so no
@@ -1467,7 +1469,16 @@ class JobManager:
 
         IDENTIFYING: eject and cancel. Nothing was produced to salvage.
 
-        Any other state: the drive is not held, so raise.
+        BACKING_UP: eject and cancel, like IDENTIFYING. A copy that stops
+        partway produces no MKVs, so there is nothing to salvage and nothing to
+        announce; the abandoned ``.partial`` is left on disk for the user to
+        judge. This branch exists because a full-disc copy can run for hours and
+        a user who wants their disc back must not have to wait it out.
+
+        Any other state: the drive is not held, so raise. So does a RIPPING job
+        reading from a backup copy: its disc came out when the copy finished, so
+        there is no tray to open and a second "ripped" notification for one disc
+        would be wrong.
 
         The two branches differ on notifications, deliberately: RIPPING routes
         through _release_drive and so sends the "ripped" Discord event with a
@@ -1486,9 +1497,20 @@ class JobManager:
                 raise ValueError(f"Job {job_id} not found")
             state = job.state
             drive_id = job.drive_id
+            holds_disc = self._holds_disc_in_drive(job)
 
-        if state not in (JobState.IDENTIFYING, JobState.RIPPING):
+        if state not in (JobState.IDENTIFYING, JobState.BACKING_UP, JobState.RIPPING):
             raise ValueError(f"Cannot eject a job in state: {state.value}")
+
+        # A rip reading a backup copy, or an imported image, has no disc in the
+        # drive. Ejecting would open an empty tray and send a second "ripped"
+        # notification for a disc that was already released at the end of its
+        # backup, which is the one double-notification path the phase creates.
+        if not holds_disc:
+            raise ValueError(
+                "This job is reading from a disc copy, so its disc was already "
+                "released when the copy finished."
+            )
 
         safe_job = sanitize_log_value(job_id)
         safe_drive = sanitize_log_value(drive_id)
@@ -1504,7 +1526,7 @@ class JobManager:
         if state == JobState.RIPPING:
             await asyncio.to_thread(self._extractor.eject_abort, job_id)
 
-        if state == JobState.IDENTIFYING:
+        if state in (JobState.IDENTIFYING, JobState.BACKING_UP):
             from app.core.sentinel import eject_disc
 
             ejected = False
@@ -1514,8 +1536,13 @@ class JobManager:
                 logger.warning(f"Job {safe_job}: eject of {safe_drive} raised: {e}")
             if ejected:
                 self._drive_monitor.notify_ejected(drive_id)
+            # cancel_job terminates the registered makemkvcon process, which for
+            # BACKING_UP is the copy itself. Its .partial is deliberately left
+            # on disk: a partial copy of a failing disc has salvage value, and
+            # discarding it is the user's call.
             await self.cancel_job(job_id)
-            logger.info(f"Job {safe_job}: ejected during identify, job cancelled")
+            phase = "identify" if state == JobState.IDENTIFYING else "backup"
+            logger.info(f"Job {safe_job}: ejected during {phase}, job cancelled")
             return {"ejected": ejected, "action": "job_cancelled"}
 
         from app.core.discord_notifier import RIP_OUTCOME_STOPPED_EARLY
@@ -2198,6 +2225,27 @@ class JobManager:
             return
         idle = now - last
         if idle >= timeout:
+            # A stalled BACKUP degrades to a direct rip rather than failing the
+            # job, because that is this feature's governing rule: turning the
+            # setting on must never make a disc less likely to finish. It bites
+            # hardest here, on the scratched disc the feature exists for.
+            # backup_disc deliberately has no per-operation stall watchdog and
+            # defers to this one, so without this branch the stall case had no
+            # fallback anywhere and reconcile_and_advance would fail the job.
+            if job.state == JobState.BACKING_UP:
+                logger.warning(
+                    f"Watchdog: job {job.id} idle {idle:.0f}s in backing_up "
+                    f"(timeout {timeout}s), falling back to a direct rip"
+                )
+                # Stop the copy before the rip starts, or two makemkvcon
+                # processes fight over the drive.
+                await asyncio.to_thread(self._extractor.cancel, job.id)
+                stall = f"stalled with no progress for {timeout}s"
+                await self._fall_back_to_direct_rip(
+                    job.id, BACKUP_FAILED, stall, f"the backup {stall}"
+                )
+                return
+
             logger.warning(
                 f"Watchdog: job {job.id} idle {idle:.0f}s in "
                 f"{job.state.value} (timeout {timeout}s) → auto-advancing"
@@ -2953,12 +3001,14 @@ class JobManager:
                 # Already fell back to a direct rip (or the job row is gone).
                 return
 
+            from app.core.discord_notifier import RIP_OUTCOME_BACKED_UP
+
             drive_id, dest = outcome
             # _release_drive is the documented single chokepoint for "Engram is
             # done with this disc", and a completed backup satisfies it
             # literally: the disc is copied, so it can leave the drive. It runs
             # BEFORE reconciling so even an unreconcilable backup frees it.
-            await self._release_drive(job_id, drive_id, "Backed up")
+            await self._release_drive(job_id, drive_id, RIP_OUTCOME_BACKED_UP)
             if await self._reconcile_backup_titles(job_id, dest):
                 await self._enter_ripping(job_id)
 
@@ -3062,6 +3112,16 @@ class JobManager:
                 job_id, BACKUP_FAILED, reason, f"the backup failed: {reason}"
             )
             return None
+
+        if result.already_existed:
+            # The destination appeared while this copy was running, so what is
+            # on disk is not the copy this run just made and verified. Keeping
+            # it is right (never clobber a complete backup) but it is worth
+            # saying, because the extraction that follows reads it.
+            logger.warning(
+                f"Job {safe_job}: {dest} already existed when the copy finished; "
+                f"extraction will read that, not this run's copy"
+            )
 
         final_dest = result.dest or dest
         await self._record_backup_status(
@@ -4665,7 +4725,10 @@ class JobManager:
 
     async def _cancel_jobs_for_drive(self, drive_letter: str) -> None:
         """Cancel jobs that need the disc; leave post-ripping jobs running."""
-        disc_required_states = [JobState.IDLE, JobState.IDENTIFYING]
+        # BACKING_UP belongs here: the copy is reading the disc that was just
+        # removed, so it cannot succeed and should not be left to discover that
+        # through a MakeMKV error minutes later.
+        disc_required_states = [JobState.IDLE, JobState.IDENTIFYING, JobState.BACKING_UP]
         async with async_session() as session:
             result = await session.execute(
                 select(DiscJob).where(

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -46,6 +46,7 @@ from app.services.finalization_coordinator import FinalizationCoordinator
 from app.services.identification_coordinator import (
     NO_TITLE_REVIEW_REASON,
     IdentificationCoordinator,
+    next_state_after_identify,
 )
 from app.services.identity_prompts import BLOCKING_KINDS, ResumeAction
 from app.services.import_guard import (
@@ -290,6 +291,7 @@ class JobManager:
             on_match_task_done=self._matching.on_match_task_done,
             check_job_completion=self._finalization.check_job_completion,
             run_ripping=self._run_ripping,
+            run_backup=self._run_backup,
             finalize_disc_job=self._finalization.finalize_disc_job,
         )
         self._finalization.set_callbacks(
@@ -1188,11 +1190,22 @@ class JobManager:
             if job.state not in (JobState.IDLE, JobState.REVIEW_NEEDED):
                 raise ValueError(f"Cannot start job in state: {job.state}")
 
-            job.state = JobState.RIPPING
+            # A resume from review honours backup_before_rip exactly as a
+            # fresh identification does; next_state_after_identify is the one
+            # place that decision is made.
+            from app.services.config_service import get_config
+
+            next_state = next_state_after_identify(await get_config(), job.drive_id)
+            job.state = next_state
             job.updated_at = datetime.now(UTC)
             await session.commit()
 
-            task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
+            coro = (
+                self._run_backup(job_id)
+                if next_state is JobState.BACKING_UP
+                else self._run_ripping(job_id)
+            )
+            task = asyncio.create_task(with_job_log_context(job_id, coro))
             task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
             self._active_jobs[job_id] = task
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -53,6 +53,7 @@ from app.services.import_guard import (
     ImportBlock,
     StagingJobResult,
     classify_staging_path,
+    unit_key_for,
 )
 from app.services.job_state_machine import JobStateMachine
 from app.services.manual_identity import arm_store
@@ -636,6 +637,32 @@ class JobManager:
             return job.content_hash == new_hash
         return job.volume_label == volume_label
 
+    @staticmethod
+    def _holds_disc_in_drive(job: DiscJob) -> bool:
+        """True if a job in a disc-required state really has the disc loaded.
+
+        A RIPPING job reading from a backup copy does not: the drive was
+        released the moment the copy finished, which is the entire point of the
+        backup phase (the disc leaves the drive in minutes rather than hours).
+        Such a job is treated exactly like a post-eject MATCHING/ORGANIZING job
+        below: it no longer blocks the drive, but a re-insert of the SAME disc
+        still resolves to it rather than spawning a duplicate.
+
+        BACKING_UP is unaffected: ``source_spec`` is only pointed at the copy
+        once the copy has COMPLETED (see ``_record_backup_status``), so a job
+        that is still copying reports the drive it is reading, and still blocks.
+
+        An unresolvable source (a row with neither ``source_spec`` nor a usable
+        ``drive_id``) is treated as holding the drive: refusing a second job is
+        the safe side of that guess.
+        """
+        if job.state is not JobState.RIPPING:
+            return True
+        try:
+            return DiscSource.from_job(job).is_physical
+        except ValueError:
+            return True
+
     async def _create_job_for_disc(self, drive_letter: str, volume_label: str) -> None:
         """Create a new job when a disc is inserted."""
         from app.services.config_service import get_config as get_db_config
@@ -716,13 +743,19 @@ class JobManager:
                 # RIPPING job can now legitimately coexist on one drive.
                 active_jobs = result.scalars().all()
 
+                # A RIPPING job reading from a backup copy is in disc_required_states
+                # but no longer holds the disc: the drive was released when the copy
+                # finished, which is the whole point of the backup phase. It is
+                # therefore treated exactly like a post-eject job, so a re-insert of
+                # the SAME disc still resolves to it instead of spawning a duplicate,
+                # while a genuinely new disc gets through.
                 blocking_job = next(
                     (
                         j
                         for j in active_jobs
-                        if j.state in disc_required_states
+                        if (j.state in disc_required_states and self._holds_disc_in_drive(j))
                         or (
-                            j.state in post_eject_states
+                            (j.state in post_eject_states or not self._holds_disc_in_drive(j))
                             and self._same_disc(j, volume_label, new_hash)
                         )
                     ),
@@ -852,23 +885,47 @@ class JobManager:
         if not volume_label:
             volume_label = staging_dir.name.upper().replace(" ", "_")
 
+        # ``source_spec`` is where MakeMKV reads FROM; ``staging_path`` is where
+        # the extracted MKVs are written TO. For a disc image those are two
+        # different places, so the image gets a staging directory of its own,
+        # derived exactly the way a disc job's is. Conflating them wrote the
+        # rip's MKVs into the user's preservation copy next to BDMV/, and for an
+        # .iso the path is a FILE, so the rip's mkdir(parents=True) raised
+        # FileExistsError and killed the job right after the scan.
+        #
+        # Ownership still keys on the image path, not on this new directory:
+        # that is what ``unit_key_for`` hashes and what the user picked. See
+        # classify_staging_path, which matches ``source_spec`` for exactly this.
+        dedup_path = str(staging_dir)
+        if source_spec:
+            from app.services.config_service import get_config as get_db_config
+
+            db_config = await get_db_config()
+            # The timestamp alone is not unique here: one /api/import/start call
+            # can create several image jobs within the same second.
+            stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            staging_dir = (
+                Path(db_config.staging_path).expanduser()
+                / f"image_{stamp}_{unit_key_for(dedup_path)[:8]}"
+            )
+
         # Hold a per-path lock across the dedup check and insert so two concurrent
         # callers (e.g. two API calls) for the same path can't both pass the guard
         # and insert duplicate jobs, mirroring _drive_locks on the disc path.
         # Widened slightly by this dedup change: retries of a path with only FAILED
         # rows now reach the check->insert that the guard used to short.
-        if str(staging_dir) not in self._staging_locks:
-            self._staging_locks[str(staging_dir)] = asyncio.Lock()
+        if dedup_path not in self._staging_locks:
+            self._staging_locks[dedup_path] = asyncio.Lock()
 
-        async with self._staging_locks[str(staging_dir)]:
+        async with self._staging_locks[dedup_path]:
             async with async_session() as session:
                 # Guard: a staging path is OWNED by an in-flight job and merely
                 # RECORDED by a finished one. See app/services/import_guard.py for
                 # why this is not the old `state != FAILED` rule, and why it is not
                 # a copy of the disc-side guard either.
-                block, blocking_ids = await classify_staging_path(session, str(staging_dir))
+                block, blocking_ids = await classify_staging_path(session, dedup_path)
                 forced = force and block is ImportBlock.ALREADY_IMPORTED
-                safe_path = str(staging_dir).replace("\n", "").replace("\r", "")
+                safe_path = dedup_path.replace("\n", "").replace("\r", "")
                 if block is not None and not forced:
                     logger.info(
                         "Import blocked for staging path %s (%s, blocking jobs %s)",

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1203,6 +1203,15 @@ class JobManager:
 
     async def start_ripping(self, job_id: int) -> None:
         """Start the ripping process for a job."""
+        # Read the config BEFORE opening the session. get_config opens one of its
+        # own, and this method is called from paths that already hold a session
+        # (the review-apply path does), so fetching it inside would be a third
+        # concurrent checkout against one SQLite file and leaves the caller's
+        # transaction in "prepared" state.
+        from app.services.config_service import get_config
+
+        config = await get_config()
+
         async with async_session() as session:
             job = await session.get(DiscJob, job_id)
             if not job:
@@ -1214,9 +1223,7 @@ class JobManager:
             # A resume from review honours backup_before_rip exactly as a
             # fresh identification does; next_state_after_identify is the one
             # place that decision is made.
-            from app.services.config_service import get_config
-
-            next_state = next_state_after_identify(await get_config(), job.drive_id)
+            next_state = next_state_after_identify(config, job.drive_id)
             job.state = next_state
             job.updated_at = datetime.now(UTC)
             await session.commit()

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -382,6 +382,7 @@ class JobManager:
         """
         stale_states = [
             JobState.IDENTIFYING,
+            JobState.BACKING_UP,
             JobState.RIPPING,
             JobState.MATCHING,
         ]
@@ -671,6 +672,7 @@ class JobManager:
                 disc_required_states = (
                     JobState.IDLE,
                     JobState.IDENTIFYING,
+                    JobState.BACKING_UP,
                     JobState.RIPPING,
                 )
                 post_eject_states = (JobState.MATCHING, JobState.ORGANIZING)
@@ -1999,6 +2001,7 @@ class JobManager:
         """Per-phase no-activity ceiling (seconds), or None for resting/untimed states."""
         return {
             JobState.IDENTIFYING: config.timeout_identifying_seconds,
+            JobState.BACKING_UP: config.timeout_backing_up_seconds,
             JobState.RIPPING: config.timeout_ripping_seconds,
             JobState.MATCHING: config.timeout_matching_seconds,
             JobState.ORGANIZING: config.timeout_organizing_seconds,
@@ -2088,6 +2091,7 @@ class JobManager:
 
         watched = (
             JobState.IDENTIFYING,
+            JobState.BACKING_UP,
             JobState.RIPPING,
             JobState.MATCHING,
             JobState.ORGANIZING,

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -24,6 +24,8 @@ from sqlmodel import select
 
 from app.api.websocket import manager as ws_manager
 from app.core.analyst import DiscAnalyst
+from app.core.backup_paths import backup_destination, has_room_for_backup
+from app.core.disc_source import DiscSource, resolve_disc_index
 from app.core.extractor import (
     STALL_FAILURE_REASON,
     MakeMKVExtractor,
@@ -37,6 +39,7 @@ from app.core.sentinel import DriveMonitor
 from app.database import async_session
 from app.models import TERMINAL_JOB_STATES, DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.backup_reconcile import ReconcileOutcome, reconcile_titles
 from app.services.cleanup_service import CleanupService
 from app.services.event_broadcaster import EventBroadcaster
 from app.services.finalization_coordinator import FinalizationCoordinator
@@ -160,6 +163,29 @@ def _is_rip_failure_review(title: "DiscTitle") -> bool:
     if not isinstance(details, dict):
         return False
     return details.get("error") in RIP_FAILURE_ERROR_CODES
+
+
+# DiscJob.backup_status values. "pending" is written before the copy starts, so
+# a backup interrupted by a crash is distinguishable from one never attempted.
+BACKUP_PENDING = "pending"
+BACKUP_COMPLETED = "completed"
+BACKUP_FAILED = "failed"
+BACKUP_SKIPPED = "skipped"
+
+
+def _has_existing_backup(dest: Path) -> bool:
+    """Whether a usable backup already sits at ``dest``.
+
+    Re-inserting a disc that was backed up last month must not cost another
+    40 GB, so a non-empty destination is adopted as-is rather than re-copied.
+    An unreadable destination answers False: the caller then takes the normal
+    route (check space, copy) instead of adopting a directory it cannot read.
+    """
+    try:
+        return dest.is_dir() and any(dest.iterdir())
+    except OSError as e:
+        logger.warning(f"Could not inspect existing backup at {dest}: {e}")
+        return False
 
 
 # Create domain-specific event broadcaster
@@ -2759,6 +2785,285 @@ class JobManager:
         )
         task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
         self._active_jobs[job_id] = task
+
+    # --- Backup phase (backup_before_rip) ---------------------------------
+
+    async def _run_backup(self, job_id: int) -> None:
+        """Copy the whole disc to the backup shelf, then rip from the copy.
+
+        Every backup problem degrades to a direct rip from the drive, which is
+        exactly what the job would have done with the setting off: turning
+        backups on must never make a disc less likely to finish. The single
+        exception is a backup that SUCCEEDED but whose re-scan cannot be
+        reconciled against the disc scan. That parks for review instead of
+        falling back, because the drive has already been released by then and
+        the disc may be out of it.
+
+        Self-tags its log context (see apply_review, #563) so the phase's lines
+        carry ``job=<id>`` however the coroutine was reached, not only when a
+        spawner wrapped it in ``with_job_log_context``.
+        """
+        with job_log_context(job_id):
+            try:
+                outcome = await self._copy_disc_to_backup(job_id)
+            except Exception as e:
+                # Catch-all on purpose: an unforeseen failure in the backup
+                # phase must still leave the job rippable, never dead.
+                # CancelledError is a BaseException, so a user cancel or a
+                # shutdown still propagates.
+                logger.exception(
+                    f"Job {sanitize_log_value(job_id)}: backup phase failed unexpectedly"
+                )
+                await self._fall_back_to_direct_rip(
+                    job_id, BACKUP_FAILED, str(e), f"the backup failed unexpectedly: {e}"
+                )
+                return
+
+            if outcome is None:
+                # Already fell back to a direct rip (or the job row is gone).
+                return
+
+            drive_id, dest = outcome
+            # _release_drive is the documented single chokepoint for "Engram is
+            # done with this disc", and a completed backup satisfies it
+            # literally: the disc is copied, so it can leave the drive. It runs
+            # BEFORE reconciling so even an unreconcilable backup frees it.
+            await self._release_drive(job_id, drive_id, "Backed up")
+            if await self._reconcile_backup_titles(job_id, dest):
+                await self._enter_ripping(job_id)
+
+    async def _copy_disc_to_backup(self, job_id: int) -> tuple[str, Path] | None:
+        """Run the backup itself, returning ``(drive_id, dest)`` on success.
+
+        Returns None when the job fell back to a direct rip (every failure
+        mode does) or when the job row has disappeared. Mirrors _run_ripping's
+        session discipline: a short-lived setup session, released before the
+        potentially multi-hour copy is awaited, so no aiosqlite connection is
+        held across it.
+        """
+        safe_job = sanitize_log_value(job_id)
+        loop = asyncio.get_running_loop()
+
+        from app.core.discdb_exporter import get_makemkv_log_dir
+        from app.services.config_service import get_config
+
+        config = await get_config()
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return None
+            drive_id = job.drive_id
+            titles = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+            # The disc-size estimate: the scan's per-title sizes are all we know
+            # before the copy starts.
+            total_bytes = sum(t.file_size_bytes or 0 for t in titles)
+            dest = backup_destination(job, config) if config else None
+        # Setup session released: nothing is held across the copy.
+
+        if dest is None:
+            await self._skip_backup(job_id, "not_configured", "no backup location is configured")
+            return None
+
+        if _has_existing_backup(dest):
+            logger.info(f"Job {safe_job}: reusing the existing backup at {dest}")
+            await self._record_backup_status(
+                job_id, BACKUP_COMPLETED, dest=dest, use_as_source=True
+            )
+            return drive_id, dest
+
+        if not has_room_for_backup(dest, total_bytes):
+            await self._skip_backup(
+                job_id, "insufficient_space", f"not enough free space for a backup at {dest}"
+            )
+            return None
+
+        disc_spec = await resolve_disc_index(drive_id, config.makemkv_path)
+        if not disc_spec:
+            await self._skip_backup(
+                job_id,
+                "no_disc_index",
+                f"MakeMKV could not address drive {sanitize_log_value(drive_id)} as a disc index",
+            )
+            return None
+
+        await self._record_backup_status(job_id, BACKUP_PENDING, dest=dest)
+
+        last_percent = -1
+
+        def on_progress(percent: float) -> None:
+            """Extractor-thread progress callback, throttled to whole percent.
+
+            A 40 GB copy emits progress constantly and every message fans out
+            to every connected client, so anything finer than one message per
+            percent is pure noise on the wire.
+            """
+            nonlocal last_percent
+            whole = int(percent)
+            if whole <= last_percent:
+                return
+            last_percent = whole
+            current = int(total_bytes * percent / 100) if total_bytes > 0 else 0
+            self._note_activity(job_id)
+            asyncio.run_coroutine_threadsafe(
+                event_broadcaster.broadcast_backup_progress(job_id, current, total_bytes),
+                loop,
+            )
+
+        result = await self._extractor.backup_disc(
+            DiscSource.for_drive_index(drive_id, disc_spec),
+            dest,
+            progress_callback=on_progress,
+            log_dir=get_makemkv_log_dir(job_id),
+            job_id=job_id,
+        )
+
+        if not result.success:
+            reason = result.error_message or "the backup did not complete"
+            await self._fall_back_to_direct_rip(
+                job_id, BACKUP_FAILED, reason, f"the backup failed: {reason}"
+            )
+            return None
+
+        final_dest = result.dest or dest
+        await self._record_backup_status(
+            job_id, BACKUP_COMPLETED, dest=final_dest, use_as_source=True
+        )
+        logger.info(f"Job {safe_job}: backed up to {final_dest}; extraction will read from it")
+        return drive_id, final_dest
+
+    async def _record_backup_status(
+        self,
+        job_id: int,
+        status: str,
+        reason: str | None = None,
+        *,
+        dest: Path | None = None,
+        use_as_source: bool = False,
+    ) -> None:
+        """Persist the backup's outcome on the job row (own short-lived session).
+
+        ``use_as_source`` is what actually redirects extraction: it points
+        ``source_spec`` at ``file:<dest>`` so every later MakeMKV call reads the
+        copy instead of the drive. Deliberately separate from writing
+        ``backup_path``, which is also written for a *pending* backup so a
+        crashed copy can still be found.
+        """
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+            job.backup_status = status
+            job.backup_status_reason = reason
+            if dest is not None:
+                job.backup_path = str(dest)
+                if use_as_source:
+                    job.source_spec = f"file:{dest}"
+            job.updated_at = datetime.now(UTC)
+            await session.commit()
+
+    async def _skip_backup(self, job_id: int, reason: str, detail: str) -> None:
+        """Record a backup that was never attempted, and rip from the drive."""
+        await self._fall_back_to_direct_rip(job_id, BACKUP_SKIPPED, reason, detail)
+
+    async def _fall_back_to_direct_rip(
+        self, job_id: int, status: str, reason: str, detail: str
+    ) -> None:
+        """Degrade to today's behaviour: rip straight from the disc.
+
+        The drive is deliberately NOT released here: extraction still needs the
+        disc in it. ``source_spec`` is left alone for the same reason.
+        """
+        logger.warning(f"Job {sanitize_log_value(job_id)}: {detail}; ripping from the disc instead")
+        await self._record_backup_status(job_id, status, reason)
+        await self._enter_ripping(job_id)
+
+    async def _enter_ripping(self, job_id: int) -> None:
+        """Transition to RIPPING and spawn the rip, exactly as start_ripping does."""
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+            if not await state_machine.transition(job, JobState.RIPPING, session):
+                logger.error(
+                    f"Job {sanitize_log_value(job_id)}: cannot enter RIPPING from "
+                    f"{job.state.value}; not starting the rip"
+                )
+                return
+
+        task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
+        task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
+        self._active_jobs[job_id] = task
+
+    async def _reconcile_backup_titles(self, job_id: int, dest: Path) -> bool:
+        """Re-scan the backup and line its titles up with the stored ones.
+
+        Returns True when the job may proceed to ripping (the enumeration was
+        identical, or it was remapped unambiguously and the rows were updated).
+        Returns False after parking the job in REVIEW_NEEDED: ripping the wrong
+        index files an episode under another episode's name with no error
+        anywhere, so a guess is never worth making.
+        """
+        safe_job = sanitize_log_value(job_id)
+
+        from app.core.discdb_exporter import get_makemkv_log_dir
+
+        try:
+            scanned, _ = await self._extractor.scan_disc(
+                DiscSource.for_backup(dest), log_dir=get_makemkv_log_dir(job_id), job_id=job_id
+            )
+        except Exception as e:
+            # Any scan failure (timeout, missing binary, unreadable copy) is
+            # treated as an empty scan, which reconcile_titles reports as
+            # AMBIGUOUS and so parks for review. Crashing here would leave the
+            # job stranded mid-phase instead.
+            logger.warning(f"Job {safe_job}: could not scan the backup at {dest}: {e}")
+            scanned = []
+
+        async with async_session() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(DiscTitle)
+                        .where(DiscTitle.job_id == job_id)
+                        .order_by(DiscTitle.title_index)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            result = reconcile_titles(list(rows), list(scanned))
+
+            if result.outcome is ReconcileOutcome.AMBIGUOUS:
+                job = await session.get(DiscJob, job_id)
+                if not job:
+                    return False
+                reason = (
+                    f"The disc was backed up to {dest}, but its tracks could not be matched "
+                    f"to the tracks Engram found on the disc, so it will not guess which "
+                    f"track to rip. {result.reason or ''} The backup itself is safe and "
+                    f"nothing has been deleted."
+                ).strip()
+                await state_machine.transition_to_review(job, session, reason=reason)
+                logger.warning(
+                    f"Job {safe_job}: the backup re-scan is unreconcilable; parked for review"
+                )
+                return False
+
+            if result.remap:
+                for row in rows:
+                    new_index = result.remap.get(row.title_index)
+                    if new_index is not None and new_index != row.title_index:
+                        row.title_index = new_index
+                        session.add(row)
+                await session.commit()
+                logger.info(f"Job {safe_job}: remapped {len(result.remap)} title indices")
+
+        return True
 
     async def _run_ripping(self, job_id: int) -> None:
         """Execute the ripping process.

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2651,6 +2651,17 @@ class JobManager:
                 )
                 return
 
+            # Re-rip reads whatever the job reads, not always the drive: after a
+            # backup the disc has already been ejected and source_spec points at
+            # the copy, so targeting drive_id would find an empty drive.
+            # Resolved BEFORE the state transition so a job with no MakeMKV
+            # source at all is never stranded in RIPPING.
+            try:
+                source = DiscSource.from_job(job)
+            except ValueError as e:
+                logger.error(f"Job {sanitize_log_value(job_id)}: cannot re-rip: {e}")
+                return
+
             # Un-hide a cleared job that is being actively re-processed.
             if job.cleared_at is not None:
                 job.cleared_at = None
@@ -2745,7 +2756,7 @@ class JobManager:
         stall_timeout = cfg.ripping_stall_timeout if cfg else 120.0
 
         result = await self._extractor.rip_titles(
-            drive_id,
+            source,
             staging_dir,
             title_indices=rip_indices,
             title_complete_callback=on_title_complete,
@@ -2773,7 +2784,11 @@ class JobManager:
         # would re-eject and contradict it with a "Re-rip" for a rip that was
         # aborted. Note an eject returns success=True, so the failure branch
         # above does not cover this.
-        if not result.aborted_for_eject:
+        #
+        # Gated on the source being physical for the same reason as the end of
+        # _run_ripping: a re-rip that read a backup folder or an ISO never held
+        # the drive, so there is nothing to eject and nothing to notify about.
+        if not result.aborted_for_eject and source.is_physical:
             from app.core.discord_notifier import RIP_OUTCOME_RERIP
 
             await self._release_drive(job_id, drive_id, RIP_OUTCOME_RERIP)
@@ -3174,6 +3189,15 @@ class JobManager:
                 # detached once this block exits, so nothing downstream touches it.
                 content_type = job.content_type
                 drive_id = job.drive_id
+                # What MakeMKV is pointed at, captured with the other scalars:
+                # after a backup this is the copy (file:<dest>), for a disc-image
+                # import it is the imported folder or ISO, and for a legacy row
+                # (source_spec is None) it resolves back to drive_id.
+                try:
+                    source = DiscSource.from_job(job)
+                except ValueError as e:
+                    await self._fail_job(job_id, f"Cannot rip this job: {e}")
+                    return
                 staging_path = job.staging_path
                 volume_label = job.volume_label
                 detected_title = job.detected_title
@@ -3472,7 +3496,7 @@ class JobManager:
                 from app.core.discdb_exporter import get_makemkv_log_dir
 
                 result = await self._extractor.rip_titles(
-                    drive_id,
+                    source,
                     output_dir,
                     title_indices=rip_indices,
                     title_complete_callback=on_title_complete,
@@ -3613,7 +3637,7 @@ class JobManager:
                     fallback_monitor.add_done_callback(_background_tasks.discard)
                     try:
                         result = await self._extractor.rip_titles(
-                            drive_id,
+                            source,
                             output_dir,
                             title_indices=[t.title_index for t in missing],
                             title_complete_callback=on_title_complete,
@@ -3670,7 +3694,13 @@ class JobManager:
             # `ejected_mid_rip` guards the notification as well as the eject: the
             # abort path already opened the tray AND already sent its own
             # "Stopped early" ping, so re-notifying here would double-fire.
-            if not ejected_mid_rip:
+            #
+            # Also gated on the source being physical: after a backup the disc
+            # was already ejected (and the RIPPED event already sent) at the end
+            # of the backup phase, and a disc-image import never held a drive at
+            # all. Releasing here would open a tray for a disc that is not in it
+            # and notify the user twice for one disc.
+            if not ejected_mid_rip and source.is_physical:
                 from app.core.discord_notifier import RIP_OUTCOME_COMPLETE
 
                 await self._release_drive(job_id, drive_id, RIP_OUTCOME_COMPLETE)

--- a/backend/app/services/job_state_machine.py
+++ b/backend/app/services/job_state_machine.py
@@ -21,14 +21,23 @@ class JobStateMachine:
     VALID_TRANSITIONS = {
         JobState.IDLE: {JobState.IDENTIFYING, JobState.FAILED},
         JobState.IDENTIFYING: {
+            JobState.BACKING_UP,  # backup_before_rip: copy the disc, then extract from it
             JobState.RIPPING,
             JobState.MATCHING,  # import/staging path skips RIPPING (files already exist)
             JobState.ORGANIZING,  # import/staging movie path skips RIPPING + matching
             JobState.REVIEW_NEEDED,
             JobState.FAILED,
         },
+        # No edge to MATCHING or ORGANIZING: a backup produces no MKVs, so a job
+        # that skipped RIPPING from here would have nothing to match or organize.
+        JobState.BACKING_UP: {
+            JobState.RIPPING,
+            JobState.REVIEW_NEEDED,
+            JobState.FAILED,
+        },
         JobState.REVIEW_NEEDED: {
             JobState.IDENTIFYING,  # Re-identify with corrected title
+            JobState.BACKING_UP,  # Answered a pre-rip prompt with backup enabled
             JobState.RIPPING,
             JobState.MATCHING,  # Re-match with corrected metadata (post-rip)
             JobState.COMPLETED,

--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -93,6 +93,7 @@ class SimulationService:
         detected_title = params.get("detected_title", default_title)
         detected_season = params.get("detected_season", 1)
         simulate_ripping = params.get("simulate_ripping", False)
+        simulate_backup = params.get("simulate_backup", False)
         rip_speed_multiplier = params.get("rip_speed_multiplier", 10)
         title_params = params.get("titles", [])
         identity_pending = params.get("identity_pending")
@@ -216,6 +217,37 @@ class SimulationService:
                     review_reason=job.review_reason,
                     total_titles=len(title_params),
                 )
+            elif simulate_backup:
+                # Park in BACKING_UP with a synthetic backup and STOP: no auto
+                # advance. The synthetic path follows the same
+                # staging_path-relative "sim_*" convention as the staging path
+                # above; nothing is written to disk and no real copy runs.
+                sim_backup_path = str(
+                    Path((await get_sim_config()).staging_path)
+                    / f"sim_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+                )
+                job.state = JobState.BACKING_UP
+                job.backup_status = "pending"
+                job.backup_path = sim_backup_path
+                await session.commit()
+                await ws_manager.broadcast_job_update(
+                    job.id,
+                    JobState.BACKING_UP.value,
+                    content_type=content_type.value,
+                    detected_title=detected_title,
+                    detected_season=effective_season,
+                    total_titles=len(title_params),
+                )
+
+                # A plausible disc-size estimate for progress broadcasts only,
+                # nothing is measured or copied.
+                sim_total_bytes = 40 * 1024 * 1024 * 1024
+                for pct in (25, 50, 75, 100):
+                    await asyncio.sleep(0.1)
+                    current_bytes = int(sim_total_bytes * pct / 100)
+                    await self._broadcaster.broadcast_backup_progress(
+                        job.id, current_bytes, sim_total_bytes
+                    )
             elif simulate_ripping:
                 # Apply identity_prompt_json before spawning the rip task so the
                 # RIPPING broadcast inside _simulate_ripping carries it.

--- a/backend/migrations/versions/02946b05fe8d_add_backup_columns.py
+++ b/backend/migrations/versions/02946b05fe8d_add_backup_columns.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
     op.add_column("disc_jobs", sa.Column("source_spec", sa.String(), nullable=True))
     op.add_column("disc_jobs", sa.Column("backup_path", sa.String(), nullable=True))
     op.add_column("disc_jobs", sa.Column("backup_status", sa.String(), nullable=True))
+    op.add_column("disc_jobs", sa.Column("backup_status_reason", sa.String(), nullable=True))
     op.add_column(
         "app_config",
         sa.Column("backup_path", sa.String(), nullable=False, server_default=sa.text("''")),
@@ -50,6 +51,7 @@ def downgrade() -> None:
         batch_op.drop_column("backup_before_rip")
         batch_op.drop_column("backup_path")
     with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("backup_status_reason")
         batch_op.drop_column("backup_status")
         batch_op.drop_column("backup_path")
         batch_op.drop_column("source_spec")

--- a/backend/migrations/versions/02946b05fe8d_add_backup_columns.py
+++ b/backend/migrations/versions/02946b05fe8d_add_backup_columns.py
@@ -1,0 +1,55 @@
+"""add backup columns
+
+Revision ID: 02946b05fe8d
+Revises: a4c81f6b2e39
+Create Date: 2026-09-05 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "02946b05fe8d"
+down_revision: str | Sequence[str] | None = "a4c81f6b2e39"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("disc_jobs", sa.Column("source_spec", sa.String(), nullable=True))
+    op.add_column("disc_jobs", sa.Column("backup_path", sa.String(), nullable=True))
+    op.add_column("disc_jobs", sa.Column("backup_status", sa.String(), nullable=True))
+    op.add_column(
+        "app_config",
+        sa.Column("backup_path", sa.String(), nullable=False, server_default=sa.text("''")),
+    )
+    # server_default 0: this is opt-in, so an upgraded row must come back OFF.
+    op.add_column(
+        "app_config",
+        sa.Column("backup_before_rip", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "app_config",
+        sa.Column(
+            "timeout_backing_up_seconds",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("7200"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("timeout_backing_up_seconds")
+        batch_op.drop_column("backup_before_rip")
+        batch_op.drop_column("backup_path")
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("backup_status")
+        batch_op.drop_column("backup_path")
+        batch_op.drop_column("source_spec")

--- a/backend/tests/integration/test_import_backup.py
+++ b/backend/tests/integration/test_import_backup.py
@@ -1,0 +1,233 @@
+"""Importing an existing disc backup runs the full pipeline, not a file move.
+
+A folder of finished MKVs is FILED into the library; a MakeMKV backup folder
+(BDMV/VIDEO_TS) or an .iso is SCANNED and EXTRACTED like any other disc. These
+tests pin both halves of that fork at the API seam.
+
+The identification coroutines are stubbed for the whole module: a real one would
+reach for makemkvcon (disc image) or ffprobe (MKV import), and a job that runs to
+a terminal state leaks a Discord-notification task holding a pooled connection.
+Stubbing also makes "which identification did this job get?" directly assertable,
+which is the behaviour under test.
+"""
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from app.api.routes import require_localhost_or_lan
+from app.database import async_session, init_db
+from app.main import app
+from app.models import DiscJob, JobState
+
+
+@pytest.fixture
+async def client():
+    # The import endpoints are guarded by require_localhost_or_lan; override it so
+    # these tests exercise the handlers regardless of peer/LAN config (the
+    # documented test pattern, mirroring test_import_endpoints.py).
+    app.dependency_overrides[require_localhost_or_lan] = lambda: None
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(require_localhost_or_lan, None)
+
+
+@pytest.fixture(autouse=True)
+async def identification_calls(monkeypatch):
+    """Stub identification and record which entry point each job took."""
+    from app.services.job_manager import job_manager
+
+    calls: dict[int, str] = {}
+
+    async def fake_identify_disc(job_id: int) -> None:
+        calls[job_id] = "identify_disc"
+
+    async def fake_identify_from_staging(job_id: int) -> None:
+        calls[job_id] = "identify_from_staging"
+
+    monkeypatch.setattr(job_manager._identification, "identify_disc", fake_identify_disc)
+    monkeypatch.setattr(
+        job_manager._identification, "identify_from_staging", fake_identify_from_staging
+    )
+    return calls
+
+
+@pytest.fixture(autouse=True)
+async def _clean_import_jobs():
+    # start creates real jobs; clean import rows around each test in this module.
+    await init_db()
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs WHERE drive_id = 'import'"))
+        await session.commit()
+    yield
+    async with async_session() as session:
+        await session.execute(text("DELETE FROM disc_titles"))
+        await session.execute(text("DELETE FROM disc_jobs WHERE drive_id = 'import'"))
+        await session.commit()
+
+
+def _bdmv(root: Path, name: str) -> Path:
+    d = root / name
+    (d / "BDMV" / "STREAM").mkdir(parents=True)
+    (d / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"x" * 10)
+    return d
+
+
+def _mkv(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"0" * 1024)
+
+
+class TestBrowse:
+    async def test_a_backup_folder_is_labelled_a_disc_image(self, client, tmp_path: Path):
+        _bdmv(tmp_path, "Inception (2010)")
+
+        res = await client.get("/api/import/browse", params={"path": str(tmp_path)})
+        assert res.status_code == 200
+        entries = {e["name"]: e for e in res.json()["entries"]}
+        assert entries["Inception (2010)"]["type"] == "disc_image"
+        # Not a folder of media, so it must not be given a media count.
+        assert "mkv_count" not in entries["Inception (2010)"]
+
+    async def test_an_iso_is_listed(self, client, tmp_path: Path):
+        (tmp_path / "Inception.ISO").write_bytes(b"x")
+
+        res = await client.get("/api/import/browse", params={"path": str(tmp_path)})
+        entries = {e["name"]: e["type"] for e in res.json()["entries"]}
+        assert entries["Inception.ISO"] == "iso"
+
+    async def test_a_plain_media_folder_is_still_a_dir(self, client, tmp_path: Path):
+        _mkv(tmp_path / "Season 1" / "a.mkv")
+
+        res = await client.get("/api/import/browse", params={"path": str(tmp_path)})
+        entries = {e["name"]: e for e in res.json()["entries"]}
+        assert entries["Season 1"]["type"] == "dir"
+        assert entries["Season 1"]["mkv_count"] == 1
+
+
+class TestPreview:
+    async def test_preview_reports_disc_images(self, client, tmp_path: Path):
+        d = _bdmv(tmp_path, "Inception (2010)")
+
+        res = await client.post("/api/import/preview", json={"path": str(tmp_path)})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["disc_images"] == [
+            {
+                "name": "Inception (2010)",
+                "path": str(d),
+                "kind": "backup",
+                "total_bytes": 10,
+            }
+        ]
+        # Each disc image becomes a job of its own.
+        assert body["total_jobs"] == 1
+
+    async def test_disc_images_and_units_both_count_as_jobs(self, client, tmp_path: Path):
+        _bdmv(tmp_path, "Inception (2010)")
+        _mkv(tmp_path / "Seinfeld" / "Season 4" / "e1.mkv")
+
+        res = await client.post("/api/import/preview", json={"path": str(tmp_path)})
+        body = res.json()
+        assert len(body["disc_images"]) == 1
+        assert len(body["units"]) == 1
+        assert body["total_jobs"] == 2
+
+
+class TestStart:
+    async def test_start_creates_an_identifying_job_pointed_at_the_backup(
+        self, client, tmp_path: Path, identification_calls
+    ):
+        d = _bdmv(tmp_path, "Inception (2010)")
+
+        res = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert res.status_code == 200
+        job_ids = res.json()["job_ids"]
+        assert len(job_ids) == 1
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_ids[0])
+        assert job is not None
+        assert job.source_spec == f"file:{d}"
+        assert job.drive_id == "import"
+        # It reads the image with MakeMKV instead of ingesting existing MKVs.
+        assert job.import_manifest_json is None
+        # It already is a backup: it must never enter BACKING_UP.
+        assert job.state != JobState.BACKING_UP
+        assert job.state == JobState.IDENTIFYING
+        # The full scan/rip pipeline, not the "files already exist" shortcut.
+        assert identification_calls[job_ids[0]] == "identify_disc"
+
+    async def test_an_iso_job_carries_an_iso_spec(self, client, tmp_path: Path):
+        iso = tmp_path / "Inception.iso"
+        iso.write_bytes(b"x")
+
+        res = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert res.status_code == 200
+        job_ids = res.json()["job_ids"]
+        assert len(job_ids) == 1
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_ids[0])
+        assert job is not None
+        assert job.source_spec == f"iso:{iso}"
+        assert job.state != JobState.BACKING_UP
+
+    async def test_a_second_import_of_a_live_backup_is_blocked(self, client, tmp_path: Path):
+        _bdmv(tmp_path, "Inception (2010)")
+
+        first = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert first.json()["job_ids"]
+
+        second = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        body = second.json()
+        assert body["job_ids"] == []
+        assert len(body["blocked"]) == 1
+        blocked = body["blocked"][0]
+        assert blocked["reason"] == "in_flight"
+        assert blocked["job_ids"] == first.json()["job_ids"]
+        assert blocked["unit_key"]
+
+    async def test_mkv_units_and_disc_images_both_get_jobs(
+        self, client, tmp_path: Path, identification_calls
+    ):
+        d = _bdmv(tmp_path, "Inception (2010)")
+        _mkv(tmp_path / "Seinfeld" / "Season 4" / "e1.mkv")
+
+        res = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert res.status_code == 200
+        job_ids = res.json()["job_ids"]
+        assert len(job_ids) == 2
+
+        async with async_session() as session:
+            jobs = [await session.get(DiscJob, jid) for jid in job_ids]
+
+        by_spec = {j.source_spec: j for j in jobs}
+        image_job = by_spec[f"file:{d}"]
+        mkv_job = by_spec[None]
+
+        # The disc image is scanned and extracted; the MKV unit is still filed
+        # through the untouched manual-import path.
+        assert image_job.import_manifest_json is None
+        assert identification_calls[image_job.id] == "identify_disc"
+        assert mkv_job.import_manifest_json is not None
+        assert identification_calls[mkv_job.id] == "identify_from_staging"
+
+    async def test_an_empty_folder_is_still_rejected(self, client, tmp_path: Path):
+        (tmp_path / "empty").mkdir()
+        res = await client.post("/api/import/start", json={"path": str(tmp_path / "empty")})
+        assert res.status_code == 400

--- a/backend/tests/integration/test_import_backup.py
+++ b/backend/tests/integration/test_import_backup.py
@@ -156,6 +156,11 @@ class TestStart:
         assert job is not None
         assert job.source_spec == f"file:{d}"
         assert job.drive_id == "import"
+        # The extracted MKVs must NOT land inside the user's preservation copy:
+        # staging is a directory of its own, distinct from the image.
+        assert job.staging_path is not None
+        assert Path(job.staging_path) != d
+        assert not Path(job.staging_path).is_relative_to(d)
         # It reads the image with MakeMKV instead of ingesting existing MKVs.
         assert job.import_manifest_json is None
         # It already is a backup: it must never enter BACKING_UP.
@@ -180,6 +185,49 @@ class TestStart:
         assert job is not None
         assert job.source_spec == f"iso:{iso}"
         assert job.state != JobState.BACKING_UP
+        # An .iso path is a FILE. If staging_path pointed at it, the rip's
+        # output_dir.mkdir(parents=True, exist_ok=True) would raise
+        # FileExistsError and the job would die straight after the scan.
+        assert job.staging_path is not None
+        assert Path(job.staging_path) != iso
+        assert not Path(job.staging_path).exists() or Path(job.staging_path).is_dir()
+
+    async def test_disc_image_staging_directories_are_writable_and_distinct(
+        self, client, tmp_path: Path, monkeypatch
+    ):
+        """Two images imported in one call get separate, mkdir-able staging dirs."""
+        from app.services import config_service
+
+        real_get_config = config_service.get_config
+        staging_root = tmp_path / "staging"
+
+        async def fake_get_config():
+            config = await real_get_config()
+            config.staging_path = str(staging_root)
+            return config
+
+        monkeypatch.setattr(config_service, "get_config", fake_get_config)
+
+        a = _bdmv(tmp_path / "src", "Inception (2010)")
+        b = _bdmv(tmp_path / "src", "Arrival (2016)")
+
+        res = await client.post(
+            "/api/import/start",
+            json={"path": str(tmp_path / "src"), "destination_mode": "library"},
+        )
+        job_ids = res.json()["job_ids"]
+        assert len(job_ids) == 2
+
+        async with async_session() as session:
+            jobs = [await session.get(DiscJob, jid) for jid in job_ids]
+
+        staging = {Path(j.staging_path) for j in jobs}
+        assert len(staging) == 2
+        for s in staging:
+            assert s not in (a, b)
+            # This is exactly what _rip_titles_unlocked does with it.
+            s.mkdir(parents=True, exist_ok=True)
+            assert s.is_dir()
 
     async def test_a_second_import_of_a_live_backup_is_blocked(self, client, tmp_path: Path):
         _bdmv(tmp_path, "Inception (2010)")

--- a/backend/tests/integration/test_movie_edition_workflow.py
+++ b/backend/tests/integration/test_movie_edition_workflow.py
@@ -327,7 +327,12 @@ async def test_movie_edition_prerip_workflow(
 
     # 1. Setup Job (REVIEW_NEEDED)
     job = DiscJob(
-        drive_id="TEST_DRIVE_PRERIP",
+        # A real drive identifier, not a synthetic label: this is the one
+        # test in this file that reaches _run_ripping, which resolves the
+        # job's MakeMKV source and fails the job fast when it cannot be
+        # parsed. Every drive_id the sentinel actually writes ("E:",
+        # "/dev/sr0") parses; an invented one does not.
+        drive_id="E:",
         volume_label="LOTR_PRERIP",
         content_type=ContentType.MOVIE,
         state=JobState.REVIEW_NEEDED,

--- a/backend/tests/integration/test_simulation.py
+++ b/backend/tests/integration/test_simulation.py
@@ -691,3 +691,64 @@ async def test_drain_cancels_match_tasks_without_routing_them_to_review():
     # failure of whatever match task is dispatched next.
     assert title_id not in job_manager._match_tasks
     assert title_id not in job_manager._suppress_match_done
+
+
+class TestSimulatedBackup:
+    @pytest.mark.asyncio
+    async def test_simulated_disc_passes_through_backing_up(self, client):
+        resp = await client.post(
+            "/api/simulate/insert-disc",
+            json={
+                "volume_label": "INCEPTION_2010",
+                "content_type": "movie",
+                "simulate_backup": True,
+                "simulate_ripping": False,
+            },
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+
+        # The simulated backup does not auto-advance, so the job rests here.
+        job = (await client.get(f"/api/jobs/{job_id}")).json()
+        assert job["state"] == "backing_up"
+        assert job["backup_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_advancing_a_simulated_backup_reaches_ripping(self, client):
+        resp = await client.post(
+            "/api/simulate/insert-disc",
+            json={
+                "volume_label": "INCEPTION_2010",
+                "content_type": "movie",
+                "simulate_backup": True,
+                "simulate_ripping": False,
+            },
+        )
+        job_id = resp.json()["job_id"]
+        await client.post(f"/api/simulate/advance-job/{job_id}")
+        job = (await client.get(f"/api/jobs/{job_id}")).json()
+        assert job["state"] == "ripping"
+        assert job["backup_status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_simulate_backup_defaults_off(self, client):
+        """simulate_backup must default False so every existing simulated disc
+
+        is unaffected: omitting it entirely must behave exactly like the
+        pre-existing simulate_ripping=False static-RIPPING path, never
+        parking in BACKING_UP.
+        """
+        resp = await client.post(
+            "/api/simulate/insert-disc",
+            json={
+                "volume_label": "INCEPTION_2010",
+                "content_type": "movie",
+                "simulate_ripping": False,
+            },
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+
+        job = (await client.get(f"/api/jobs/{job_id}")).json()
+        assert job["state"] == "ripping"
+        assert job["backup_status"] is None

--- a/backend/tests/integration/test_websocket_e2e.py
+++ b/backend/tests/integration/test_websocket_e2e.py
@@ -191,3 +191,49 @@ class TestWebSocketMessageShapes:
 
         finally:
             manager.broadcast = original_broadcast
+
+
+class TestBackupProgressContract:
+    """The parameter names must match across broadcaster, manager, and wire.
+
+    This chain has produced two production bugs already (error= vs
+    error_message=), so it is asserted end to end rather than per layer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_broadcaster_reaches_the_wire_with_the_documented_fields(self):
+        from unittest.mock import AsyncMock
+
+        from app.services.event_broadcaster import EventBroadcaster
+
+        ws = AsyncMock()
+        broadcaster = EventBroadcaster(ws)
+        await broadcaster.broadcast_backup_progress(
+            job_id=7, current_bytes=100, total_bytes=400, speed="2.5x", eta_seconds=90
+        )
+
+        ws.broadcast_backup_progress.assert_awaited_once_with(
+            7, current_bytes=100, total_bytes=400, speed="2.5x", eta=90
+        )
+
+    @pytest.mark.asyncio
+    async def test_manager_emits_the_documented_message_shape(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.api.websocket import ConnectionManager
+
+        mgr = ConnectionManager()
+        with patch.object(mgr, "broadcast", new=AsyncMock()) as bcast:
+            await mgr.broadcast_backup_progress(
+                7, current_bytes=100, total_bytes=400, speed="2.5x", eta=90
+            )
+
+        msg = bcast.await_args.args[0]
+        assert msg["type"] == "backup_progress"
+        assert msg["data"] == {
+            "job_id": 7,
+            "current_bytes": 100,
+            "total_bytes": 400,
+            "speed": "2.5x",
+            "eta": 90,
+        }

--- a/backend/tests/integration/test_websocket_e2e.py
+++ b/backend/tests/integration/test_websocket_e2e.py
@@ -228,9 +228,11 @@ class TestBackupProgressContract:
                 7, current_bytes=100, total_bytes=400, speed="2.5x", eta=90
             )
 
-        msg = bcast.await_args.args[0]
-        assert msg["type"] == "backup_progress"
-        assert msg["data"] == {
+        # Flat, like every other message this manager emits. The frontend reads
+        # fields straight off the message, so a nested "data" envelope produced
+        # an undefined job id and a progress bar that never moved.
+        assert bcast.await_args.args[0] == {
+            "type": "backup_progress",
             "job_id": 7,
             "current_bytes": 100,
             "total_bytes": 400,

--- a/backend/tests/unit/test_backup_columns.py
+++ b/backend/tests/unit/test_backup_columns.py
@@ -1,0 +1,36 @@
+"""The backup columns exist, default correctly, and read safely on legacy rows."""
+
+from app.models import AppConfig, DiscJob, JobState
+
+
+class TestDiscJobBackupColumns:
+    def test_new_job_has_no_source_spec(self):
+        # None means "legacy or drive-sourced"; DiscSource.from_job falls back.
+        assert DiscJob(drive_id="E:").source_spec is None
+
+    def test_new_job_has_no_backup_path_or_status(self):
+        job = DiscJob(drive_id="E:")
+        assert job.backup_path is None
+        assert job.backup_status is None
+
+
+class TestAppConfigBackupFields:
+    def test_backup_is_off_by_default(self):
+        # Opt-in: an upgraded row with NULL must read as disabled, which is why
+        # the column carries server_default 0 (see discord_notify_ripped).
+        assert AppConfig().backup_before_rip is False
+
+    def test_backup_path_defaults_empty(self):
+        assert AppConfig().backup_path == ""
+
+    def test_backing_up_has_its_own_timeout(self):
+        # A 40 GB sequential copy cannot share the ripping phase ceiling.
+        assert AppConfig().timeout_backing_up_seconds > 0
+
+
+class TestJobState:
+    def test_backing_up_exists_and_is_not_terminal(self):
+        from app.models import TERMINAL_JOB_STATES
+
+        assert JobState.BACKING_UP.value == "backing_up"
+        assert JobState.BACKING_UP not in TERMINAL_JOB_STATES

--- a/backend/tests/unit/test_backup_columns.py
+++ b/backend/tests/unit/test_backup_columns.py
@@ -153,3 +153,58 @@ class TestBackupConfigRoundTrip:
         }
         assert backup_fields <= set(ConfigUpdate.model_fields)
         assert backup_fields <= set(ConfigResponse.model_fields)
+
+
+class TestBackupFieldsInJobDetail:
+    """The diagnostics job detail carries the backup fields.
+
+    source_spec in particular: it is the one field that says whether a job's
+    MKVs came off the disc or out of the copy, which is the first thing to
+    check when a rip looks wrong.
+    """
+
+    @pytest.mark.asyncio
+    async def test_job_detail_reports_the_backup_fields(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.api.routes import build_job_detail
+
+        dest = str(tmp_path / "Inception (2010)")
+        job = DiscJob(
+            drive_id="E:",
+            source_spec=f"file:{dest}",
+            backup_path=dest,
+            backup_status="completed",
+        )
+        job.id = 1
+
+        # build_job_detail only uses the session to load this job's titles.
+        session = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result)
+
+        detail = await build_job_detail(job, session)
+
+        assert detail["source_spec"] == f"file:{dest}"
+        assert detail["backup_path"] == dest
+        assert detail["backup_status"] == "completed"
+        assert detail["backup_status_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_job_that_never_backed_up_reports_nulls(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from app.api.routes import build_job_detail
+
+        job = DiscJob(drive_id="E:")
+        job.id = 2
+        session = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result)
+
+        detail = await build_job_detail(job, session)
+
+        assert detail["source_spec"] is None
+        assert detail["backup_status"] is None

--- a/backend/tests/unit/test_backup_columns.py
+++ b/backend/tests/unit/test_backup_columns.py
@@ -117,3 +117,39 @@ class TestSchemaConvergence:
             db_mod.engine = original_engine
             db_mod.async_session = original_session_factory
             await scratch_engine.dispose()
+
+
+class TestBackupConfigRoundTrip:
+    """A new AppConfig field must also exist in ConfigUpdate and ConfigResponse.
+
+    Pydantic drops unknown keys silently, so a field missing from either schema
+    is accepted by the API, never stored, and never reported: the setting simply
+    does nothing. This project has a documented history of that exact three-way
+    drift, so the round trip is asserted rather than assumed.
+    """
+
+    def test_update_schema_accepts_the_backup_fields(self):
+        from app.api.routes import ConfigUpdate
+
+        update = ConfigUpdate(backup_before_rip=True, backup_path="/b")
+        assert update.backup_before_rip is True
+        assert update.backup_path == "/b"
+
+    def test_response_schema_carries_the_backup_fields(self):
+        from app.api.routes import ConfigResponse
+
+        assert "backup_before_rip" in ConfigResponse.model_fields
+        assert "backup_path" in ConfigResponse.model_fields
+        assert "timeout_backing_up_seconds" in ConfigResponse.model_fields
+
+    def test_every_backup_app_config_field_reaches_both_schemas(self):
+        # The guard that actually catches drift: enumerate the model rather
+        # than listing names a future field would not join.
+        from app.api.routes import ConfigResponse, ConfigUpdate
+        from app.models import AppConfig
+
+        backup_fields = {name for name in AppConfig.model_fields if name.startswith("backup_")} | {
+            "timeout_backing_up_seconds"
+        }
+        assert backup_fields <= set(ConfigUpdate.model_fields)
+        assert backup_fields <= set(ConfigResponse.model_fields)

--- a/backend/tests/unit/test_backup_columns.py
+++ b/backend/tests/unit/test_backup_columns.py
@@ -1,5 +1,9 @@
 """The backup columns exist, default correctly, and read safely on legacy rows."""
 
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
 from app.models import AppConfig, DiscJob, JobState
 
 
@@ -12,6 +16,9 @@ class TestDiscJobBackupColumns:
         job = DiscJob(drive_id="E:")
         assert job.backup_path is None
         assert job.backup_status is None
+
+    def test_new_job_has_no_backup_status_reason(self):
+        assert DiscJob(drive_id="E:").backup_status_reason is None
 
 
 class TestAppConfigBackupFields:
@@ -34,3 +41,79 @@ class TestJobState:
 
         assert JobState.BACKING_UP.value == "backing_up"
         assert JobState.BACKING_UP not in TERMINAL_JOB_STATES
+
+
+class TestSchemaConvergence:
+    """The new columns survive the real init_db() path, not just model construction.
+
+    Frozen builds skip Alembic entirely and converge through
+    _add_missing_columns(), so the model defaults have to be right on their own.
+    This is the risk the feature actually carries for an upgrading user.
+
+    Isolation: app.database reads settings.database_url once at import time into
+    a module-level `engine`, and app.database.init_db()'s Alembic path
+    (_run_alembic_upgrade) opens its OWN sync engine from settings.database_url
+    directly, so setting the DATABASE_URL env var alone would not redirect
+    either. Alembic's migrations/env.py is re-executed from disk on every
+    upgrade call (it is not cached in sys.modules across calls), so it also
+    re-reads settings.database_url fresh each time. Patching both
+    app.config.settings.database_url (monkeypatch, auto-restored) and
+    app.database.engine / app.database.async_session (manual, restored in
+    finally, matching the pattern in test_episode_ordering_migration.py) to a
+    fresh engine over a scratch file under tmp_path routes every one of these
+    paths at a throwaway database and never touches backend/engram.db.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_row_written_and_read_through_init_db_sees_the_new_columns(
+        self, tmp_path, monkeypatch
+    ):
+        import app.database as db_mod
+        from app.config import settings
+
+        db_path = tmp_path / "scratch-backup-columns.db"
+        scratch_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
+        monkeypatch.setattr(settings, "database_url", scratch_url)
+
+        scratch_engine = create_async_engine(scratch_url, connect_args={"check_same_thread": False})
+        scratch_session_factory = sessionmaker(
+            scratch_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        original_engine = db_mod.engine
+        original_session_factory = db_mod.async_session
+        db_mod.engine = scratch_engine
+        db_mod.async_session = scratch_session_factory
+        try:
+            await db_mod.init_db()
+
+            async with scratch_session_factory() as session:
+                job = DiscJob(drive_id="E:", volume_label="SCRATCH_DISC")
+                session.add(job)
+                await session.commit()
+                job_id = job.id
+
+                config = AppConfig()
+                session.add(config)
+                await session.commit()
+
+            # Fresh session, so this is a genuine read back through the schema
+            # init_db() converged, not the in-memory object we just built.
+            async with scratch_session_factory() as session:
+                reread_job = await session.get(DiscJob, job_id)
+                assert reread_job is not None
+                assert reread_job.volume_label == "SCRATCH_DISC"
+                assert reread_job.source_spec is None
+                assert reread_job.backup_path is None
+                assert reread_job.backup_status is None
+                assert reread_job.backup_status_reason is None
+
+                reread_config = await session.get(AppConfig, config.id)
+                assert reread_config is not None
+                assert reread_config.backup_before_rip is False
+                assert reread_config.backup_path == ""
+                assert reread_config.timeout_backing_up_seconds == 7200
+        finally:
+            db_mod.engine = original_engine
+            db_mod.async_session = original_session_factory
+            await scratch_engine.dispose()

--- a/backend/tests/unit/test_backup_disc.py
+++ b/backend/tests/unit/test_backup_disc.py
@@ -182,7 +182,27 @@ class TestBackupDisc:
         result = await _extractor().backup_disc("disc:0", dest, job_id=1)
 
         assert result.success is True
+        assert result.already_existed is True
         assert (dest / "BDMV" / "keep.txt").read_text(encoding="utf-8") == "original"
+
+    @pytest.mark.asyncio
+    async def test_an_uncreatable_destination_parent_fails_cleanly(self, tmp_path, monkeypatch):
+        # dest.parent needs to be a directory but a plain FILE already occupies
+        # that path, so mkdir(parents=True) raises OSError/NotADirectoryError on
+        # both Windows and POSIX. backup_disc must report this like every other
+        # failure mode instead of letting the exception escape.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("occupying the path", encoding="utf-8")
+        dest = blocker / "subdir" / "Movie"
+
+        def fake_run(cmd, on_line, job_id):  # pragma: no cover - must not run
+            raise AssertionError("MakeMKV must not be launched when the dest parent can't exist")
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is False
+        assert result.error_message
 
     @pytest.mark.asyncio
     async def test_the_log_is_written_next_to_the_scan_and_rip_logs(self, tmp_path, monkeypatch):
@@ -214,6 +234,68 @@ class TestBackupDisc:
         assert "cancel" in (result.error_message or "").lower()
         # The partial survives a cancel too: the user may resume or salvage it.
         assert (tmp_path / "X.partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_a_stale_partial_is_moved_aside_before_the_run(self, tmp_path, monkeypatch):
+        # Debris from a previous failed attempt at the same disc must not sit
+        # in MakeMKV's way: its behaviour against a non-empty target is
+        # unspecified.
+        stale = tmp_path / "X.partial"
+        (stale / "BDMV").mkdir(parents=True)
+        (stale / "BDMV" / "old.m2ts").write_text("stale bytes", encoding="utf-8")
+
+        seen_partial_at_launch = []
+
+        def fake_run(cmd, on_line, job_id):
+            seen_partial_at_launch.append((tmp_path / "X.partial").exists())
+            (tmp_path / "X.partial").mkdir(parents=True)
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", tmp_path / "X", job_id=1)
+
+        assert seen_partial_at_launch == [False]
+        assert result.success is True
+        previous = tmp_path / "X.partial.previous"
+        assert (previous / "BDMV" / "old.m2ts").read_text(encoding="utf-8") == "stale bytes"
+
+    @pytest.mark.asyncio
+    async def test_an_existing_partial_previous_is_replaced_by_the_newer_stale_partial(
+        self, tmp_path, monkeypatch
+    ):
+        # At most one stale partial is preserved, so a disc that fails
+        # repeatedly does not accumulate unbounded debris.
+        older_previous = tmp_path / "X.partial.previous"
+        (older_previous / "BDMV").mkdir(parents=True)
+        (older_previous / "BDMV" / "ancient.m2ts").write_text("ancient", encoding="utf-8")
+
+        newer_stale = tmp_path / "X.partial"
+        (newer_stale / "BDMV").mkdir(parents=True)
+        (newer_stale / "BDMV" / "recent.m2ts").write_text("recent", encoding="utf-8")
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", tmp_path / "X", job_id=1)
+
+        assert result.success is True
+        previous = tmp_path / "X.partial.previous"
+        assert (previous / "BDMV" / "recent.m2ts").read_text(encoding="utf-8") == "recent"
+        assert not (previous / "BDMV" / "ancient.m2ts").exists()
+
+    @pytest.mark.asyncio
+    async def test_no_stale_partial_leaves_partial_previous_untouched(self, tmp_path, monkeypatch):
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", tmp_path / "X", job_id=1)
+
+        assert result.success is True
+        assert not (tmp_path / "X.partial.previous").exists()
 
 
 class _FakeProc:
@@ -273,3 +355,4 @@ class TestBackupResult:
         r = BackupResult(success=True)
         assert r.dest is None
         assert r.error_message is None
+        assert r.already_existed is False

--- a/backend/tests/unit/test_backup_disc.py
+++ b/backend/tests/unit/test_backup_disc.py
@@ -1,5 +1,6 @@
 """makemkvcon backup wrapper."""
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -356,3 +357,50 @@ class TestBackupResult:
         assert r.dest is None
         assert r.error_message is None
         assert r.already_existed is False
+
+
+class TestDestinationLocking:
+    """Two drives backing up the same disc must not race on one .partial.
+
+    A backup destination comes from content identity with nothing drive-specific
+    in it, so two jobs in two drives compute the SAME destination while taking
+    DIFFERENT source locks. The loser's stale-partial recovery cannot tell
+    debris from a live copy, and would rename a running makemkvcon's output away.
+    """
+
+    def test_the_same_destination_shares_one_lock(self, tmp_path):
+        ex = _extractor()
+        assert ex._get_dest_lock(tmp_path / "X") is ex._get_dest_lock(tmp_path / "X")
+
+    def test_different_destinations_do_not_contend(self, tmp_path):
+        ex = _extractor()
+        assert ex._get_dest_lock(tmp_path / "X") is not ex._get_dest_lock(tmp_path / "Y")
+
+    def test_a_destination_lock_is_not_a_source_lock(self, tmp_path):
+        # Distinct namespaces: a backup whose destination happens to sit on
+        # drive E: must not contend with the optical drive at E:.
+        ex = _extractor()
+        assert ex._get_dest_lock(tmp_path / "X") is not ex._get_source_lock("E:")
+
+    @pytest.mark.asyncio
+    async def test_a_second_job_waits_for_the_destination(self, tmp_path, monkeypatch):
+        dest = tmp_path / "Inception (2010)"
+        started = []
+
+        def fake_run(self_or_cmd, *args, **kwargs):
+            started.append(dest)
+            (tmp_path / "Inception (2010).partial").mkdir(parents=True, exist_ok=True)
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", fake_run)
+        ex = _extractor()
+        # Hold the destination lock; the backup must not proceed past it.
+        held = ex._get_dest_lock(dest)
+        await held.acquire()
+        try:
+            task = asyncio.create_task(ex.backup_disc("disc:0", dest, job_id=1))
+            await asyncio.sleep(0.05)
+            assert started == [], "backup ran while another job held the destination"
+        finally:
+            held.release()
+        assert await asyncio.wait_for(task, timeout=5)

--- a/backend/tests/unit/test_backup_disc.py
+++ b/backend/tests/unit/test_backup_disc.py
@@ -1,0 +1,275 @@
+"""makemkvcon backup wrapper."""
+
+from pathlib import Path
+
+import pytest
+
+from app.core import extractor as extractor_module
+from app.core.extractor import (
+    BackupResult,
+    MakeMKVExtractor,
+    _build_backup_command,
+    _parse_backup_progress,
+)
+
+
+def _extractor() -> MakeMKVExtractor:
+    return MakeMKVExtractor(makemkv_path=Path("mmk"))
+
+
+@pytest.mark.unit
+class TestBuildBackupCommand:
+    def test_uses_the_disc_index_and_decrypt_flag(self):
+        cmd = _build_backup_command("mmk", "disc:0", "/b/out.partial")
+        assert cmd == [
+            "mmk",
+            "-r",
+            "--progress=-same",
+            "--decrypt",
+            "backup",
+            "disc:0",
+            "/b/out.partial",
+        ]
+
+    def test_refuses_a_dev_source(self):
+        # makemkvcon backup accepts only disc:N. Catching it here beats a
+        # confusing MakeMKV error 40 minutes into a job.
+        with pytest.raises(ValueError):
+            _build_backup_command("mmk", "dev:E:", "/b/out.partial")
+
+    def test_refuses_a_file_source(self):
+        # Backing a backup up again is never what the caller meant.
+        with pytest.raises(ValueError):
+            _build_backup_command("mmk", "file:/b/x", "/b/out.partial")
+
+
+@pytest.mark.unit
+class TestParseBackupProgress:
+    def test_reads_a_prgv_line(self):
+        # PRGV:current,total,max; `total` is the OVERALL bar, `current` the
+        # current sub-operation's, both on the fixed `max` scale. See the
+        # verbatim-log guard in test_rip_progress.py
+        # (TestMakeMKVRobotFormat::test_prgv_is_value_over_fixed_max_not_current_over_total),
+        # where a real line reads PRGV:36541,6084,65536: 55.8% through the title
+        # in hand, 9.3% through the disc.
+        assert _parse_backup_progress("PRGV:65536,32768,65536") == pytest.approx(50.0)
+
+    def test_the_current_operation_bar_is_ignored(self):
+        # `current` sawtooths back to 0 for every sub-operation of one backup,
+        # so reporting it as the backup's progress would run the bar backwards.
+        assert _parse_backup_progress("PRGV:0,32768,65536") == pytest.approx(50.0)
+        assert _parse_backup_progress("PRGV:65536,32768,65536") == pytest.approx(50.0)
+
+    def test_zero_max_is_ignored(self):
+        assert _parse_backup_progress("PRGV:0,0,0") is None
+
+    def test_non_progress_line_is_ignored(self):
+        assert _parse_backup_progress('MSG:1005,0,1,"Backup done"') is None
+
+    def test_a_total_above_max_is_clamped(self):
+        assert _parse_backup_progress("PRGV:0,70000,65536") == pytest.approx(100.0)
+
+
+@pytest.mark.unit
+class TestBackupDisc:
+    @pytest.mark.asyncio
+    async def test_success_renames_partial_to_final(self, tmp_path, monkeypatch):
+        dest = tmp_path / "Inception (2010)"
+
+        def fake_run(cmd, on_line, job_id):
+            partial = tmp_path / "Inception (2010).partial"
+            (partial / "BDMV").mkdir(parents=True)
+            on_line("PRGV:65536,65536,65536")
+            return 0, "PRGV:65536,65536,65536\n"
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = _extractor()
+        result = await ex.backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is True
+        assert result.dest == dest
+        assert dest.exists()
+        assert not (tmp_path / "Inception (2010).partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_failure_keeps_the_partial(self, tmp_path, monkeypatch):
+        # A partial backup of a dying disc has salvage value; the user decides
+        # whether to discard it, not Engram.
+        dest = tmp_path / "Scratched"
+
+        def fake_run(cmd, on_line, job_id):
+            partial = tmp_path / "Scratched.partial"
+            (partial / "BDMV").mkdir(parents=True)
+            return 1, 'MSG:5010,0,0,"Failed to read disc"\n'
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = _extractor()
+        result = await ex.backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is False
+        assert result.error_message
+        assert (tmp_path / "Scratched.partial").exists()
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_failure_reports_the_makemkv_message(self, tmp_path, monkeypatch):
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "S.partial").mkdir(parents=True)
+            return 1, 'MSG:5010,0,0,"Failed to read disc"\n'
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", tmp_path / "S", job_id=1)
+
+        assert result.error_message == "Failed to read disc"
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_receives_percentages(self, tmp_path, monkeypatch):
+        seen = []
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            on_line("PRGV:65536,16384,65536")
+            on_line("PRGV:65536,65536,65536")
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = _extractor()
+        await ex.backup_disc("disc:0", tmp_path / "X", progress_callback=seen.append, job_id=1)
+
+        assert seen == [pytest.approx(25.0), pytest.approx(100.0)]
+
+    @pytest.mark.asyncio
+    async def test_a_raising_progress_callback_does_not_fail_the_backup(
+        self, tmp_path, monkeypatch
+    ):
+        def boom(_pct):
+            raise RuntimeError("callback exploded")
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            on_line("PRGV:16384,65536,65536")
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc(
+            "disc:0", tmp_path / "X", progress_callback=boom, job_id=1
+        )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_a_non_disc_source_fails_immediately(self, tmp_path, monkeypatch):
+        def fake_run(cmd, on_line, job_id):  # pragma: no cover - must not run
+            raise AssertionError("MakeMKV must not be launched for a dev: source")
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("E:", tmp_path / "X", job_id=1)
+
+        assert result.success is False
+        assert "disc:N" in (result.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_an_existing_destination_is_not_clobbered(self, tmp_path, monkeypatch):
+        dest = tmp_path / "Already"
+        (dest / "BDMV").mkdir(parents=True)
+        (dest / "BDMV" / "keep.txt").write_text("original", encoding="utf-8")
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "Already.partial").mkdir(parents=True)
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await _extractor().backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is True
+        assert (dest / "BDMV" / "keep.txt").read_text(encoding="utf-8") == "original"
+
+    @pytest.mark.asyncio
+    async def test_the_log_is_written_next_to_the_scan_and_rip_logs(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            return 0, "PRGV:1,1,1\n"
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        await _extractor().backup_disc("disc:0", tmp_path / "X", log_dir=log_dir, job_id=1)
+
+        assert (log_dir / "backup.log").read_text(encoding="utf-8") == "PRGV:1,1,1\n"
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_backup_reports_cancellation(self, tmp_path, monkeypatch):
+        ex = _extractor()
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            # Stand in for cancel() terminating the subprocess mid-copy.
+            ex.cancel(job_id)
+            return 1, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        result = await ex.backup_disc("disc:0", tmp_path / "X", job_id=7)
+
+        assert result.success is False
+        assert "cancel" in (result.error_message or "").lower()
+        # The partial survives a cancel too: the user may resume or salvage it.
+        assert (tmp_path / "X.partial").exists()
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in for the real _run_backup_process."""
+
+    def __init__(self, lines):
+        self.stdout = iter(lines)
+        self.returncode = 0
+        self.pid = 4242
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = 1
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+@pytest.mark.unit
+class TestRunBackupProcessRegistration:
+    def test_the_process_is_registered_for_cancel_and_popped_after(self, monkeypatch):
+        ex = _extractor()
+        seen_registered = []
+        proc = _FakeProc(["PRGV:1,2,4\n"])
+        monkeypatch.setattr(extractor_module.subprocess, "Popen", lambda *a, **k: proc)
+
+        def on_line(_line):
+            # cancel() reaches the live process only if it was registered.
+            seen_registered.append(ex._processes.get(9))
+
+        returncode, output = ex._run_backup_process(["mmk"], on_line, 9)
+
+        assert seen_registered == [proc]
+        assert returncode == 0
+        assert output == "PRGV:1,2,4\n"
+        # Registry cleared so a later cancel cannot hit a dead process.
+        assert 9 not in ex._processes
+
+    def test_cancel_terminates_the_backup_process(self, monkeypatch):
+        ex = _extractor()
+        proc = _FakeProc(["PRGV:1,2,4\n", "PRGV:2,3,4\n"])
+        monkeypatch.setattr(extractor_module.subprocess, "Popen", lambda *a, **k: proc)
+
+        def on_line(_line):
+            ex.cancel(9)
+
+        returncode, _output = ex._run_backup_process(["mmk"], on_line, 9)
+
+        assert proc.terminated is True
+        assert returncode != 0
+
+
+@pytest.mark.unit
+class TestBackupResult:
+    def test_defaults(self):
+        r = BackupResult(success=True)
+        assert r.dest is None
+        assert r.error_message is None

--- a/backend/tests/unit/test_backup_paths.py
+++ b/backend/tests/unit/test_backup_paths.py
@@ -1,11 +1,11 @@
 """Backup destination naming and the free-space preflight."""
 
-import shutil
+import types
 from pathlib import Path
 from unittest.mock import patch
 
 from app.core.backup_paths import backup_destination, has_room_for_backup
-from app.models import ContentType, DiscJob
+from app.models import AppConfig, ContentType, DiscJob
 
 
 def _job(**kw) -> DiscJob:
@@ -14,20 +14,28 @@ def _job(**kw) -> DiscJob:
     return DiscJob(**base)
 
 
-def _usage(free: int) -> shutil._ntuple_diskusage:
-    return shutil._ntuple_diskusage(0, 0, free)
+def _config(**kw) -> AppConfig:
+    base = {"backup_path": "/b"}
+    base.update(kw)
+    return AppConfig(**base)
+
+
+def _usage(free: int) -> types.SimpleNamespace:
+    return types.SimpleNamespace(total=0, used=0, free=free)
 
 
 class TestBackupDestination:
     def test_movie_uses_name_and_year(self):
         job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception", tmdb_year=2010)
-        assert backup_destination(job, "/b") == Path("/b/Movies/Inception (2010)")
+        assert backup_destination(job, _config()) == Path("/b/Movies/Inception (2010)")
 
     def test_movie_without_year_omits_the_parenthetical(self):
         job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception")
-        assert backup_destination(job, "/b") == Path("/b/Movies/Inception")
+        assert backup_destination(job, _config()) == Path("/b/Movies/Inception")
 
     def test_tv_uses_show_season_and_disc(self):
+        # The default naming_tv_show_format is "{show}" (no year, matching the
+        # Organizer's own default), so the backup mirrors that exactly.
         job = _job(
             content_type=ContentType.TV,
             tmdb_name="Frasier",
@@ -35,7 +43,7 @@ class TestBackupDestination:
             detected_season=1,
             disc_number=2,
         )
-        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/Disc 2")
+        assert backup_destination(job, _config()) == Path("/b/TV/Frasier/Season 01/Disc 2")
 
     def test_tv_prefers_the_discdb_disc_slug(self):
         job = _job(
@@ -45,28 +53,82 @@ class TestBackupDestination:
             detected_season=1,
             discdb_disc_slug="S01D02",
         )
-        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/S01D02")
+        assert backup_destination(job, _config()) == Path("/b/TV/Frasier/Season 01/S01D02")
 
     def test_tv_without_a_season_still_files_under_the_show(self):
         job = _job(content_type=ContentType.TV, tmdb_name="Frasier", tmdb_year=1993)
-        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Disc 1")
+        assert backup_destination(job, _config()) == Path("/b/TV/Frasier/Disc 1")
+
+    def test_tv_show_naming_format_with_year_is_honored(self):
+        # A user who has opted the show folder into carrying the year sees
+        # that reflected in the backup shelf too.
+        job = _job(content_type=ContentType.TV, tmdb_name="Frasier", tmdb_year=1993)
+        config = _config(naming_tv_show_format="{show} ({year})")
+        assert backup_destination(job, config) == Path("/b/TV/Frasier (1993)/Disc 1")
 
     def test_unidentified_falls_back_to_the_volume_label(self):
         job = _job(content_type=ContentType.UNKNOWN, volume_label="THE_SWEETEST_THING")
-        assert backup_destination(job, "/b") == Path("/b/Unidentified/THE_SWEETEST_THING")
+        assert backup_destination(job, _config()) == Path("/b/Unidentified/THE_SWEETEST_THING")
 
     def test_unidentified_without_a_label_uses_the_job_id(self):
         job = _job(content_type=ContentType.UNKNOWN, volume_label="")
         job.id = 42
-        assert backup_destination(job, "/b") == Path("/b/Unidentified/job-42")
+        assert backup_destination(job, _config()) == Path("/b/Unidentified/job-42")
 
     def test_path_separators_in_a_title_cannot_escape_the_root(self):
         job = _job(content_type=ContentType.MOVIE, tmdb_name="../../etc/passwd")
-        dest = backup_destination(job, "/b")
+        dest = backup_destination(job, _config())
         assert Path("/b") in dest.parents
 
     def test_empty_root_is_rejected(self):
-        assert backup_destination(_job(), "") is None
+        assert backup_destination(_job(), _config(backup_path="")) is None
+
+    def test_custom_movie_naming_format_is_used(self):
+        # A format clearly different from the default ("{title} ({year})") so
+        # this is a pointed regression guard: the backup path must come from
+        # the Organizer's format_movie_folder, not a hardcoded shape.
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception", tmdb_year=2010)
+        config = _config(naming_movie_format="{title} [{year}]")
+        assert backup_destination(job, config) == Path("/b/Movies/Inception [2010]")
+
+    def test_custom_season_naming_format_is_used(self):
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Frasier",
+            tmdb_year=1993,
+            detected_season=1,
+            disc_number=2,
+        )
+        config = _config(naming_season_format="S{season:02d}")
+        assert backup_destination(job, config) == Path("/b/TV/Frasier/S01/Disc 2")
+
+    def test_movie_title_that_sanitizes_to_empty_falls_back_to_job_id(self):
+        # "???" is entirely made of Windows-illegal characters, so it sanitizes
+        # to "". That must not collapse to a bare "Unknown" folder (two such
+        # discs would collide); it must disambiguate by job id instead.
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="???")
+        job.id = 7
+        assert backup_destination(job, _config()) == Path("/b/Movies/job-7")
+
+    def test_tv_disc_with_no_resolvable_name_lands_in_unidentified(self):
+        # No tmdb_name/detected_title means `name` is falsy, so the TV branch
+        # never triggers regardless of detected_season/disc_number: those are
+        # deliberately dropped and the disc files under Unidentified by its
+        # volume label (or job id) instead.
+        job = _job(
+            content_type=ContentType.TV,
+            volume_label="SHOW_S1D1",
+            detected_season=1,
+            disc_number=1,
+        )
+        assert backup_destination(job, _config()) == Path("/b/Unidentified/SHOW_S1D1")
+
+    def test_a_disc_genuinely_labelled_unknown_keeps_that_label(self):
+        # A real volume label of "Unknown" sanitizes to "Unknown" (no illegal
+        # characters), so it must be used as-is rather than treated as if
+        # sanitization had emptied it out.
+        job = _job(content_type=ContentType.UNKNOWN, volume_label="Unknown")
+        assert backup_destination(job, _config()) == Path("/b/Unidentified/Unknown")
 
 
 class TestHasRoomForBackup:

--- a/backend/tests/unit/test_backup_paths.py
+++ b/backend/tests/unit/test_backup_paths.py
@@ -1,0 +1,90 @@
+"""Backup destination naming and the free-space preflight."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.backup_paths import backup_destination, has_room_for_backup
+from app.models import ContentType, DiscJob
+
+
+def _job(**kw) -> DiscJob:
+    base = {"drive_id": "E:", "volume_label": "DISC_LABEL"}
+    base.update(kw)
+    return DiscJob(**base)
+
+
+def _usage(free: int) -> shutil._ntuple_diskusage:
+    return shutil._ntuple_diskusage(0, 0, free)
+
+
+class TestBackupDestination:
+    def test_movie_uses_name_and_year(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception", tmdb_year=2010)
+        assert backup_destination(job, "/b") == Path("/b/Movies/Inception (2010)")
+
+    def test_movie_without_year_omits_the_parenthetical(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception")
+        assert backup_destination(job, "/b") == Path("/b/Movies/Inception")
+
+    def test_tv_uses_show_season_and_disc(self):
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Frasier",
+            tmdb_year=1993,
+            detected_season=1,
+            disc_number=2,
+        )
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/Disc 2")
+
+    def test_tv_prefers_the_discdb_disc_slug(self):
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Frasier",
+            tmdb_year=1993,
+            detected_season=1,
+            discdb_disc_slug="S01D02",
+        )
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/S01D02")
+
+    def test_tv_without_a_season_still_files_under_the_show(self):
+        job = _job(content_type=ContentType.TV, tmdb_name="Frasier", tmdb_year=1993)
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Disc 1")
+
+    def test_unidentified_falls_back_to_the_volume_label(self):
+        job = _job(content_type=ContentType.UNKNOWN, volume_label="THE_SWEETEST_THING")
+        assert backup_destination(job, "/b") == Path("/b/Unidentified/THE_SWEETEST_THING")
+
+    def test_unidentified_without_a_label_uses_the_job_id(self):
+        job = _job(content_type=ContentType.UNKNOWN, volume_label="")
+        job.id = 42
+        assert backup_destination(job, "/b") == Path("/b/Unidentified/job-42")
+
+    def test_path_separators_in_a_title_cannot_escape_the_root(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="../../etc/passwd")
+        dest = backup_destination(job, "/b")
+        assert Path("/b") in dest.parents
+
+    def test_empty_root_is_rejected(self):
+        assert backup_destination(_job(), "") is None
+
+
+class TestHasRoomForBackup:
+    def test_enough_space_passes(self, tmp_path):
+        with patch("shutil.disk_usage", return_value=_usage(100 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=40 * 1024**3) is True
+
+    def test_margin_is_applied(self, tmp_path):
+        # 40 GB needed x 1.15 = 46 GB; 42 GB free is not enough.
+        with patch("shutil.disk_usage", return_value=_usage(42 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=40 * 1024**3) is False
+
+    def test_unreadable_destination_fails_closed(self, tmp_path):
+        with patch("shutil.disk_usage", side_effect=OSError("gone")):
+            assert has_room_for_backup(tmp_path, needed_bytes=1) is False
+
+    def test_unknown_size_falls_back_to_a_full_bluray(self, tmp_path):
+        # needed_bytes 0 means the scan gave no sizes. Assume a 50 GB BD-DL
+        # rather than waving the check through.
+        with patch("shutil.disk_usage", return_value=_usage(10 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=0) is False

--- a/backend/tests/unit/test_backup_reconciliation.py
+++ b/backend/tests/unit/test_backup_reconciliation.py
@@ -49,6 +49,50 @@ class TestIdenticalEnumeration:
         assert result.outcome is ReconcileOutcome.REMAPPED
         assert result.remap == {0: 0}
 
+    def test_titles_with_no_metadata_on_either_side_are_identical(self):
+        # Pin the case the fast path exists for: a DVD scan where neither side
+        # ever carries source_filename/segment_map. Index + duration alone
+        # must still be enough so this doesn't fall into fingerprinting, which
+        # cannot distinguish anything here.
+        db = [_title(0, 2600), _title(1, 900)]
+        scan = [_scanned(0, 2600), _scanned(1, 900)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.IDENTICAL
+        assert result.remap == {}
+
+    def test_matching_metadata_in_same_positions_is_identical(self):
+        db = [_title(0, 2600, "00001.m2ts", "1,2"), _title(1, 2610, "00002.m2ts", "3,4")]
+        scan = [_scanned(0, 2600, "00001.m2ts", "1,2"), _scanned(1, 2610, "00002.m2ts", "3,4")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.IDENTICAL
+        assert result.remap == {}
+
+    def test_swapped_content_at_matching_indices_is_not_identical(self):
+        # THE silent-misfile regression guard: two adjacent, similar-length TV
+        # episodes whose content swapped position. Index and duration alone
+        # agree pair-for-pair, so the old fast path declared this IDENTICAL and
+        # each slot would then extract the OTHER episode's content with no
+        # error anywhere. source_filename disagreement must block the fast
+        # path; the fingerprint pass below then correctly untangles the swap.
+        db = [_title(0, 1320, "00001.m2ts"), _title(1, 1321, "00002.m2ts")]
+        scan = [_scanned(0, 1321, "00002.m2ts"), _scanned(1, 1320, "00001.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 1, 1: 0}
+
+    def test_metadata_present_on_only_one_side_is_not_identical(self):
+        # The backup rescan lost the source_filename the disc scan had. That
+        # disagreement about what there is to compare is itself a signal the
+        # two enumerations may not correspond, so this must not fast-path to
+        # IDENTICAL. The fingerprint pass below can't find a same-key
+        # candidate either (a title with metadata never matches a bucket keyed
+        # on an empty one), so this correctly resolves to AMBIGUOUS rather
+        # than a guess.
+        db = [_title(0, 2600, "00001.m2ts")]
+        scan = [_scanned(0, 2600)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.AMBIGUOUS
+
 
 class TestRemapped:
     def test_shifted_indices_remap_by_source_filename(self):
@@ -87,6 +131,18 @@ class TestRemapped:
         result = reconcile_titles(db, scan)
         assert result.outcome is ReconcileOutcome.REMAPPED
         assert result.remap == {0: 5, 1: 6, 2: 7}
+
+
+class TestOrderingIndependence:
+    def test_reversed_input_order_gives_the_same_outcome(self):
+        # reconcile_titles sorts both lists by index internally, so a caller's
+        # ORDER BY (or lack of one) cannot flip IDENTICAL into REMAPPED for
+        # otherwise unchanged content.
+        db = [_title(1, 2610), _title(0, 2600)]
+        scan = [_scanned(1, 2610), _scanned(0, 2600)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.IDENTICAL
+        assert result.remap == {}
 
 
 class TestAmbiguous:

--- a/backend/tests/unit/test_backup_reconciliation.py
+++ b/backend/tests/unit/test_backup_reconciliation.py
@@ -1,0 +1,123 @@
+"""Re-map DiscTitle.title_index onto a re-scan of the backup."""
+
+from app.core.extractor import TitleInfo
+from app.models import DiscTitle
+from app.services.backup_reconcile import ReconcileOutcome, reconcile_titles
+
+
+def _title(index: int, duration: int, source: str = "", segments: str = "") -> DiscTitle:
+    return DiscTitle(
+        job_id=1,
+        title_index=index,
+        duration_seconds=duration,
+        source_filename=source,
+        segment_map=segments,
+    )
+
+
+def _scanned(index: int, duration: int, source: str = "", segments: str = "") -> TitleInfo:
+    return TitleInfo(
+        index=index,
+        duration_seconds=duration,
+        source_filename=source,
+        segment_map=segments,
+        size_bytes=0,
+        chapter_count=0,
+    )
+
+
+class TestIdenticalEnumeration:
+    def test_same_order_and_durations_keeps_every_index(self):
+        db = [_title(0, 2600), _title(1, 2610)]
+        scan = [_scanned(0, 2600), _scanned(1, 2610)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.IDENTICAL
+        assert result.remap == {}
+
+    def test_small_duration_drift_still_counts_as_identical(self):
+        # MakeMKV rounds; a one-second difference is not a different disc.
+        db = [_title(0, 2600)]
+        scan = [_scanned(0, 2601)]
+        assert reconcile_titles(db, scan).outcome is ReconcileOutcome.IDENTICAL
+
+    def test_extra_title_in_the_backup_is_not_identical(self):
+        # Same first title, but the backup enumerates one more. Falls through to
+        # the fingerprint pass, which can still line the known title up.
+        db = [_title(0, 2600, "00001.m2ts")]
+        scan = [_scanned(0, 2600, "00001.m2ts"), _scanned(1, 900, "00002.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 0}
+
+
+class TestRemapped:
+    def test_shifted_indices_remap_by_source_filename(self):
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 2610, "00002.m2ts")]
+        scan = [_scanned(5, 2600, "00001.m2ts"), _scanned(6, 2610, "00002.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 5, 1: 6}
+
+    def test_segment_map_breaks_a_source_filename_tie(self):
+        db = [_title(0, 2600, "00001.m2ts", "1,2"), _title(1, 2600, "00001.m2ts", "3,4")]
+        scan = [
+            _scanned(9, 2600, "00001.m2ts", "3,4"),
+            _scanned(8, 2600, "00001.m2ts", "1,2"),
+        ]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 8, 1: 9}
+
+    def test_duration_drift_survives_a_shifted_index(self):
+        # Regression guard against bucketing the duration: 2600 and 2601 are the
+        # same title, but any integer bucket has a boundary somewhere and two
+        # values within tolerance can straddle it.
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 3599, "00002.m2ts")]
+        scan = [_scanned(5, 2601, "00001.m2ts"), _scanned(6, 3600, "00002.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 5, 1: 6}
+
+    def test_titles_without_source_metadata_remap_on_duration_alone(self):
+        # DVDs often carry no m2ts source filename or segment map. Those rows must
+        # not all collapse into one bucket and read as ambiguous when their
+        # durations tell them apart perfectly well.
+        db = [_title(0, 2600), _title(1, 3600), _title(2, 480)]
+        scan = [_scanned(6, 3600), _scanned(5, 2600), _scanned(7, 480)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 5, 1: 6, 2: 7}
+
+
+class TestAmbiguous:
+    def test_missing_title_is_ambiguous(self):
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 2610, "00002.m2ts")]
+        scan = [_scanned(0, 2600, "00001.m2ts")]
+        assert reconcile_titles(db, scan).outcome is ReconcileOutcome.AMBIGUOUS
+
+    def test_indistinguishable_titles_are_ambiguous(self):
+        db = [_title(0, 2600), _title(1, 2600)]
+        scan = [_scanned(7, 2600), _scanned(8, 2600)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.AMBIGUOUS
+        assert result.reason
+
+    def test_empty_scan_is_ambiguous(self):
+        assert reconcile_titles([_title(0, 2600)], []).outcome is ReconcileOutcome.AMBIGUOUS
+
+    def test_two_stored_titles_claiming_one_scanned_title_is_ambiguous(self):
+        # Both rows sit inside the tolerance of the single scanned title, so each
+        # one alone looks unambiguous. Only the collision check catches it.
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 2601, "00001.m2ts")]
+        scan = [_scanned(5, 2600, "00001.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.AMBIGUOUS
+        assert result.reason
+
+    def test_duration_beyond_tolerance_is_ambiguous(self):
+        db = [_title(0, 2600, "00001.m2ts")]
+        scan = [_scanned(5, 2650, "00001.m2ts")]
+        assert reconcile_titles(db, scan).outcome is ReconcileOutcome.AMBIGUOUS
+
+    def test_no_stored_titles_is_ambiguous(self):
+        assert reconcile_titles([], [_scanned(0, 2600)]).outcome is ReconcileOutcome.AMBIGUOUS

--- a/backend/tests/unit/test_backup_routing.py
+++ b/backend/tests/unit/test_backup_routing.py
@@ -1,0 +1,28 @@
+"""Identification hands a disc to BACKING_UP only when it should."""
+
+from app.models import AppConfig, JobState
+from app.services.identification_coordinator import next_state_after_identify
+
+
+class TestNextStateAfterIdentify:
+    def test_backup_disabled_goes_straight_to_ripping(self):
+        cfg = AppConfig(backup_before_rip=False, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.RIPPING
+
+    def test_backup_enabled_goes_to_backing_up(self):
+        cfg = AppConfig(backup_before_rip=True, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.BACKING_UP
+
+    def test_backup_enabled_without_a_root_still_rips(self):
+        # No root means nothing to write to; do not enter a phase that can only
+        # immediately fall back.
+        cfg = AppConfig(backup_before_rip=True, backup_path="")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.RIPPING
+
+    def test_an_import_job_never_backs_up(self):
+        # It already is a backup.
+        cfg = AppConfig(backup_before_rip=True, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="import") is JobState.RIPPING
+
+    def test_a_missing_config_rips(self):
+        assert next_state_after_identify(None, drive_id="E:") is JobState.RIPPING

--- a/backend/tests/unit/test_disc_source.py
+++ b/backend/tests/unit/test_disc_source.py
@@ -1,5 +1,6 @@
 """Unit tests for the DiscSource value object."""
 
+from dataclasses import FrozenInstanceError
 from unittest.mock import patch
 
 import pytest
@@ -77,6 +78,64 @@ class TestLockKey:
         a = DiscSource.parse("file:/backups/x")
         b = DiscSource.parse("file:/backups/x")
         assert a.lock_key == b.lock_key
+
+
+class TestForDriveIndex:
+    """A drive addressed by its resolved MakeMKV disc index.
+
+    ``makemkvcon backup`` accepts only ``disc:N``, but the resulting source
+    still names one physical drive, so it has to lock like one.
+    """
+
+    def test_makemkv_arg_is_the_disc_index_form(self):
+        s = DiscSource.for_drive_index("E:", "disc:0")
+        assert s.makemkv_arg == "disc:0"
+        assert s.spec == "disc:0"
+
+    def test_lock_key_matches_the_plain_drive_form(self):
+        # The whole point: a backup addressed as disc:0 must contend with a
+        # scan of the same drive addressed as dev:E:, or two makemkvcon
+        # processes stall each other on one drive.
+        assert (
+            DiscSource.parse("E:").lock_key == DiscSource.for_drive_index("E:", "disc:0").lock_key
+        )
+
+    def test_lock_key_normalizes_the_drive_form_it_was_given(self):
+        keys = {
+            DiscSource.for_drive_index(d, "disc:0").lock_key
+            for d in ("E:", "dev:E:", "dev:E:\\", "E:\\")
+        }
+        assert keys == {DiscSource.parse("E:").lock_key}
+
+    def test_a_different_drive_keeps_its_own_lock(self):
+        a = DiscSource.for_drive_index("E:", "disc:0")
+        b = DiscSource.for_drive_index("F:", "disc:1")
+        assert a.lock_key != b.lock_key
+
+    def test_linux_device_resolves_and_locks_like_its_drive(self):
+        s = DiscSource.for_drive_index("/dev/sr0", "disc:2")
+        assert s.makemkv_arg == "disc:2"
+        assert s.lock_key == DiscSource.parse("/dev/sr0").lock_key
+
+    def test_is_still_physical(self):
+        assert DiscSource.for_drive_index("E:", "disc:0").is_physical is True
+        assert DiscSource.for_drive_index("E:", "disc:0").kind is SourceKind.DRIVE
+
+    def test_bare_index_is_accepted(self):
+        assert DiscSource.for_drive_index("E:", "3").makemkv_arg == "disc:3"
+
+    def test_stays_frozen(self):
+        s = DiscSource.for_drive_index("E:", "disc:0")
+        with pytest.raises(FrozenInstanceError):
+            s.value = "9"  # type: ignore[misc]
+
+    def test_a_non_drive_source_is_rejected(self):
+        with pytest.raises(ValueError):
+            DiscSource.for_drive_index("file:/backups/x", "disc:0")
+
+    def test_an_empty_index_is_rejected(self):
+        with pytest.raises(ValueError):
+            DiscSource.for_drive_index("E:", "disc:")
 
 
 class TestFromJob:

--- a/backend/tests/unit/test_disc_source.py
+++ b/backend/tests/unit/test_disc_source.py
@@ -1,8 +1,10 @@
 """Unit tests for the DiscSource value object."""
 
+from unittest.mock import patch
+
 import pytest
 
-from app.core.disc_source import DiscSource, SourceKind
+from app.core.disc_source import DiscSource, SourceKind, parse_drive_listing, resolve_disc_index
 
 
 class TestParse:
@@ -101,3 +103,49 @@ class _FakeJob:
     def __init__(self, drive_id: str, source_spec: str | None):
         self.drive_id = drive_id
         self.source_spec = source_spec
+
+
+# Real makemkvcon -r info disc:9999 output shape. DRV lines are:
+# DRV:index,visible,enabled,flags,"drive name","disc name","device"
+_LISTING = (
+    'DRV:0,2,999,1,"BD-RE HL-DT-ST BH16NS40 1.05","THE_SWEETEST_THING","E:"\n'
+    'DRV:1,0,999,0,"","",""\n'
+    'DRV:2,2,999,1,"HL-DT-ST DVDRAM GH24","INCEPTION","F:"\n'
+    "TCOUNT:0\n"
+)
+
+
+class TestParseDriveListing:
+    def test_maps_device_to_index(self):
+        assert parse_drive_listing(_LISTING) == {"E:": 0, "F:": 2}
+
+    def test_ignores_empty_drive_slots(self):
+        assert "" not in parse_drive_listing(_LISTING)
+
+    def test_empty_output_maps_nothing(self):
+        assert parse_drive_listing("") == {}
+
+    def test_malformed_line_is_skipped_not_raised(self):
+        assert parse_drive_listing('DRV:garbage\nDRV:0,2,999,1,"n","d","E:"\n') == {"E:": 0}
+
+
+class TestResolveDiscIndex:
+    @pytest.mark.asyncio
+    async def test_resolves_a_known_drive(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("E:", makemkv_path="mmk") == "disc:0"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_on_windows_letters(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("e:", makemkv_path="mmk") == "disc:0"
+
+    @pytest.mark.asyncio
+    async def test_unknown_drive_returns_none(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("Z:", makemkv_path="mmk") is None
+
+    @pytest.mark.asyncio
+    async def test_subprocess_failure_returns_none(self):
+        with patch("app.core.disc_source._run_drive_listing", side_effect=OSError("boom")):
+            assert await resolve_disc_index("E:", makemkv_path="mmk") is None

--- a/backend/tests/unit/test_disc_source.py
+++ b/backend/tests/unit/test_disc_source.py
@@ -1,0 +1,103 @@
+"""Unit tests for the DiscSource value object."""
+
+import pytest
+
+from app.core.disc_source import DiscSource, SourceKind
+
+
+class TestParse:
+    def test_bare_drive_letter_is_a_drive(self):
+        s = DiscSource.parse("E:")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_dev_prefixed_drive_passes_through(self):
+        s = DiscSource.parse("dev:E:")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_linux_device_is_a_drive(self):
+        s = DiscSource.parse("/dev/sr0")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:/dev/sr0"
+
+    def test_disc_index_is_a_drive(self):
+        s = DiscSource.parse("disc:0")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "disc:0"
+
+    def test_file_spec_is_a_backup(self, tmp_path):
+        s = DiscSource.parse(f"file:{tmp_path}")
+        assert s.kind is SourceKind.BACKUP
+        assert s.spec == f"file:{tmp_path}"
+
+    def test_iso_spec_is_an_iso(self, tmp_path):
+        iso = tmp_path / "disc.iso"
+        s = DiscSource.parse(f"iso:{iso}")
+        assert s.kind is SourceKind.ISO
+        assert s.spec == f"iso:{iso}"
+
+    def test_windows_path_in_file_spec_survives_the_colon(self):
+        # "file:D:\\backups\\x" must not be split on the drive-letter colon.
+        s = DiscSource.parse("file:D:\\backups\\Inception (2010)")
+        assert s.kind is SourceKind.BACKUP
+        assert s.value == "D:\\backups\\Inception (2010)"
+
+    def test_empty_spec_is_rejected(self):
+        with pytest.raises(ValueError):
+            DiscSource.parse("")
+
+
+class TestPhysicality:
+    def test_drive_is_physical(self):
+        assert DiscSource.parse("E:").is_physical is True
+
+    def test_backup_is_not_physical(self):
+        assert DiscSource.parse("file:/backups/x").is_physical is False
+
+    def test_iso_is_not_physical(self):
+        assert DiscSource.parse("iso:/backups/x.iso").is_physical is False
+
+
+class TestLockKey:
+    def test_drive_forms_share_one_lock_key(self):
+        assert DiscSource.parse("E:").lock_key == DiscSource.parse("dev:E:").lock_key
+
+    def test_trailing_separator_does_not_split_the_lock(self):
+        assert DiscSource.parse("dev:E:\\").lock_key == DiscSource.parse("E:").lock_key
+
+    def test_a_backup_does_not_share_a_drive_lock(self):
+        drive = DiscSource.parse("E:")
+        backup = DiscSource.parse("file:E:\\backups\\x")
+        assert backup.lock_key != drive.lock_key
+
+    def test_two_backups_at_the_same_path_share_a_lock(self):
+        a = DiscSource.parse("file:/backups/x")
+        b = DiscSource.parse("file:/backups/x")
+        assert a.lock_key == b.lock_key
+
+
+class TestFromJob:
+    def test_source_spec_wins_when_present(self):
+        job = _FakeJob(drive_id="E:", source_spec="file:/backups/x")
+        s = DiscSource.from_job(job)
+        assert s.kind is SourceKind.BACKUP
+        assert s.value == "/backups/x"
+
+    def test_legacy_row_falls_back_to_drive_id(self):
+        job = _FakeJob(drive_id="E:", source_spec=None)
+        s = DiscSource.from_job(job)
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_import_drive_id_without_source_spec_is_rejected(self):
+        # A manual-import job has no MakeMKV source at all; asking for one is a bug.
+        job = _FakeJob(drive_id="import", source_spec=None)
+        with pytest.raises(ValueError):
+            DiscSource.from_job(job)
+
+
+class _FakeJob:
+    def __init__(self, drive_id: str, source_spec: str | None):
+        self.drive_id = drive_id
+        self.source_spec = source_spec

--- a/backend/tests/unit/test_disc_source.py
+++ b/backend/tests/unit/test_disc_source.py
@@ -149,3 +149,16 @@ class TestResolveDiscIndex:
     async def test_subprocess_failure_returns_none(self):
         with patch("app.core.disc_source._run_drive_listing", side_effect=OSError("boom")):
             assert await resolve_disc_index("E:", makemkv_path="mmk") is None
+
+
+class TestStr:
+    def test_a_drive_renders_as_its_spec(self):
+        assert str(DiscSource.parse("E:")) == "dev:E:"
+
+    def test_a_backup_renders_as_its_spec(self):
+        assert str(DiscSource.parse("file:/b/x")) == "file:/b/x"
+
+    def test_an_iso_renders_as_its_own_scheme_not_the_makemkv_arg(self):
+        # str() is for humans reading logs, so it shows what the user picked;
+        # makemkv_arg is what the subprocess needs.
+        assert str(DiscSource.parse("iso:/b/x.iso")) == "iso:/b/x.iso"

--- a/backend/tests/unit/test_extractor.py
+++ b/backend/tests/unit/test_extractor.py
@@ -23,7 +23,7 @@ from app.core.extractor import (
     _is_stalled,
     _safe_callback,
     _save_makemkv_log,
-    _to_drive_spec,
+    _to_source_spec,
     compute_content_hash,
     title_index_from_filename,
 )
@@ -34,7 +34,7 @@ def _extractor() -> MakeMKVExtractor:
 
 
 @pytest.mark.unit
-class TestToDriveSpec:
+class TestToSourceSpec:
     @pytest.mark.parametrize(
         "drive, expected",
         [
@@ -44,7 +44,7 @@ class TestToDriveSpec:
         ],
     )
     def test_normalization(self, drive, expected):
-        assert _to_drive_spec(drive) == expected
+        assert _to_source_spec(drive) == expected
 
 
 @pytest.mark.unit
@@ -354,11 +354,11 @@ class TestParseResolution:
 class TestDriveLock:
     def test_same_lock_for_equivalent_drive_specs(self):
         ex = _extractor()
-        assert ex._get_drive_lock("F:") is ex._get_drive_lock("dev:F:")
+        assert ex._get_source_lock("F:") is ex._get_source_lock("dev:F:")
 
     def test_different_drives_get_different_locks(self):
         ex = _extractor()
-        assert ex._get_drive_lock("F:") is not ex._get_drive_lock("disc:0")
+        assert ex._get_source_lock("F:") is not ex._get_source_lock("disc:0")
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_extractor.py
+++ b/backend/tests/unit/test_extractor.py
@@ -35,16 +35,11 @@ def _extractor() -> MakeMKVExtractor:
 
 @pytest.mark.unit
 class TestToSourceSpec:
-    @pytest.mark.parametrize(
-        "drive, expected",
-        [
-            ("E:", "dev:E:"),
-            ("/dev/sr0", "dev:/dev/sr0"),
-            ("disc:0", "disc:0"),
-        ],
-    )
-    def test_normalization(self, drive, expected):
-        assert _to_source_spec(drive) == expected
+    # The "E:" and "disc:0" cases live in test_extractor_source.py::TestToSourceSpec
+    # alongside the DiscSource-object and file-spec cases; this is the one form
+    # not covered there.
+    def test_posix_device_gets_a_dev_prefix(self):
+        assert _to_source_spec("/dev/sr0") == "dev:/dev/sr0"
 
 
 @pytest.mark.unit
@@ -351,12 +346,15 @@ class TestParseResolution:
 
 
 @pytest.mark.unit
-class TestDriveLock:
-    def test_same_lock_for_equivalent_drive_specs(self):
-        ex = _extractor()
-        assert ex._get_source_lock("F:") is ex._get_source_lock("dev:F:")
-
-    def test_different_drives_get_different_locks(self):
+class TestSourceLockKeying:
+    # test_same_lock_for_equivalent_drive_specs was removed here: it verbatim
+    # restated TestSourceLocking::test_drive_forms_share_one_lock in
+    # test_extractor_source.py.
+    def test_a_disc_index_currently_keys_separately_from_a_letter(self):
+        # This pins CURRENT behaviour, not a requirement: "F:" and "disc:0" may
+        # well be the same physical drive. A drive letter and its resolved
+        # disc:N index refer to the same hardware and are expected to share a
+        # lock once index resolution is wired up in a later task.
         ex = _extractor()
         assert ex._get_source_lock("F:") is not ex._get_source_lock("disc:0")
 

--- a/backend/tests/unit/test_extractor_source.py
+++ b/backend/tests/unit/test_extractor_source.py
@@ -29,6 +29,12 @@ class TestToSourceSpec:
     def test_iso_is_handed_to_makemkv_as_a_file_source(self):
         assert _to_source_spec(DiscSource.parse("iso:/b/x.iso")) == "file:/b/x.iso"
 
+    def test_an_unrecognized_spec_is_rejected(self):
+        # The old _to_drive_spec silently prefixed dev: to anything, which
+        # turned a typo into a confusing MakeMKV error much later.
+        with pytest.raises(ValueError):
+            _to_source_spec("not a drive or a path")
+
 
 @pytest.mark.unit
 class TestSourceLocking:

--- a/backend/tests/unit/test_extractor_source.py
+++ b/backend/tests/unit/test_extractor_source.py
@@ -1,0 +1,47 @@
+"""The Extractor accepts a DiscSource, not just a drive letter."""
+
+from pathlib import Path
+
+import pytest
+
+from app.core.disc_source import DiscSource
+from app.core.extractor import MakeMKVExtractor, _to_source_spec
+
+
+def _extractor() -> MakeMKVExtractor:
+    return MakeMKVExtractor(makemkv_path=Path("mmk"))
+
+
+@pytest.mark.unit
+class TestToSourceSpec:
+    def test_bare_drive_gets_a_dev_prefix(self):
+        assert _to_source_spec("E:") == "dev:E:"
+
+    def test_disc_index_passes_through(self):
+        assert _to_source_spec("disc:0") == "disc:0"
+
+    def test_file_spec_passes_through(self):
+        assert _to_source_spec("file:/backups/x") == "file:/backups/x"
+
+    def test_disc_source_object_is_accepted(self):
+        assert _to_source_spec(DiscSource.for_backup("/backups/x")) == "file:/backups/x"
+
+    def test_iso_is_handed_to_makemkv_as_a_file_source(self):
+        assert _to_source_spec(DiscSource.parse("iso:/b/x.iso")) == "file:/b/x.iso"
+
+
+@pytest.mark.unit
+class TestSourceLocking:
+    def test_drive_forms_share_one_lock(self):
+        ex = _extractor()
+        assert ex._get_source_lock("E:") is ex._get_source_lock("dev:E:")
+
+    def test_a_backup_does_not_take_the_drive_lock(self):
+        # Regression guard: extracting from a backup must not block the optical
+        # drive at the same letter from scanning the next disc.
+        ex = _extractor()
+        assert ex._get_source_lock("E:") is not ex._get_source_lock("file:E:\\backups\\x")
+
+    def test_the_same_backup_path_shares_one_lock(self):
+        ex = _extractor()
+        assert ex._get_source_lock("file:/b/x") is ex._get_source_lock("file:/b/x")

--- a/backend/tests/unit/test_identify_rip_first_gates.py
+++ b/backend/tests/unit/test_identify_rip_first_gates.py
@@ -529,3 +529,55 @@ class TestGateCUncorroboratedIdentity:
         assert not any(state == JobState.REVIEW_NEEDED.value for state, _ in gate_env)
         # identity_unconfirmed is not a collision, so subtitle prefetch ran.
         coord._start_subtitle_download.assert_called_once_with(job_id, "Ds9 Ok", 3, 580)
+
+
+@pytest.mark.unit
+class TestBackupRoutingWiring:
+    """The BACKING_UP routing is actually wired into identify_disc.
+
+    next_state_after_identify is unit-tested on its own in
+    tests/unit/test_backup_routing.py; these pin that identification really
+    consults it and spawns the matching coroutine, so the pure function cannot
+    be right while the disc still goes straight to the drive.
+    """
+
+    @staticmethod
+    def _coord_with_config(monkeypatch, *, backup_before_rip):
+        from app.models import AppConfig
+        from app.services import config_service
+
+        analysis = _make_analysis(ContentType.MOVIE, "Inception", season=None)
+        coord = _bare_coord(analysis, _GATE_TITLES, "INCEPTION_2010")
+        coord._run_backup = AsyncMock()
+
+        config = AppConfig(backup_before_rip=backup_before_rip, backup_path="/b")
+
+        async def fake_get_config():
+            return config
+
+        monkeypatch.setattr(config_service, "get_config", fake_get_config)
+        return coord
+
+    async def test_enabled_backup_enters_backing_up(self, gate_env, monkeypatch):
+        job_id = await _seed_identifying_job("INCEPTION_2010")
+        coord = self._coord_with_config(monkeypatch, backup_before_rip=True)
+
+        await coord.identify_disc(job_id)
+
+        job = await _reload_job(job_id)
+        assert job.state == JobState.BACKING_UP
+        coord._run_backup.assert_awaited_once_with(job_id)
+        coord._run_ripping.assert_not_awaited()
+        assert any(state == JobState.BACKING_UP.value for state, _ in gate_env)
+
+    async def test_disabled_backup_rips_exactly_as_before(self, gate_env, monkeypatch):
+        job_id = await _seed_identifying_job("INCEPTION_2010")
+        coord = self._coord_with_config(monkeypatch, backup_before_rip=False)
+
+        await coord.identify_disc(job_id)
+
+        job = await _reload_job(job_id)
+        assert job.state == JobState.RIPPING
+        coord._run_ripping.assert_awaited_once_with(job_id)
+        coord._run_backup.assert_not_awaited()
+        assert not any(state == JobState.BACKING_UP.value for state, _ in gate_env)

--- a/backend/tests/unit/test_import_scanner_disc_images.py
+++ b/backend/tests/unit/test_import_scanner_disc_images.py
@@ -1,0 +1,66 @@
+"""A backup folder or ISO is an import unit, not a folder to walk for MKVs."""
+
+from app.core import import_scanner
+
+
+def _bdmv(root, name):
+    d = root / name
+    (d / "BDMV" / "STREAM").mkdir(parents=True)
+    (d / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"x" * 10)
+    return d
+
+
+def _video_ts(root, name):
+    d = root / name
+    (d / "VIDEO_TS").mkdir(parents=True)
+    (d / "VIDEO_TS" / "VTS_01_1.VOB").write_bytes(b"x" * 10)
+    return d
+
+
+class TestDetection:
+    def test_bdmv_folder_is_a_disc_image(self, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["Inception (2010)"]
+        assert scan.disc_images[0].kind == "backup"
+
+    def test_video_ts_folder_is_a_disc_image(self, tmp_path):
+        _video_ts(tmp_path, "The Sweetest Thing")
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["The Sweetest Thing"]
+
+    def test_iso_file_is_a_disc_image(self, tmp_path):
+        (tmp_path / "Inception.iso").write_bytes(b"x" * 10)
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["Inception.iso"]
+        assert scan.disc_images[0].kind == "iso"
+
+    def test_picking_the_backup_folder_itself_yields_one_image(self, tmp_path):
+        d = _bdmv(tmp_path, "Inception (2010)")
+        scan = import_scanner.scan(d)
+        assert len(scan.disc_images) == 1
+
+    def test_nested_backups_are_all_found(self, tmp_path):
+        _bdmv(tmp_path / "TV" / "Frasier (1993)" / "Season 01", "S01D01")
+        _bdmv(tmp_path / "TV" / "Frasier (1993)" / "Season 01", "S01D02")
+        scan = import_scanner.scan(tmp_path)
+        assert sorted(d.name for d in scan.disc_images) == ["S01D01", "S01D02"]
+
+    def test_a_tree_can_hold_both_kinds(self, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        loose = tmp_path / "Frasier" / "Season 01"
+        loose.mkdir(parents=True)
+        (loose / "Frasier - S01E01.mkv").write_bytes(b"x" * 10)
+        scan = import_scanner.scan(tmp_path)
+        assert len(scan.disc_images) == 1
+        assert len(scan.units) == 1
+
+    def test_m2ts_files_do_not_count_toward_the_file_budget(self, tmp_path):
+        # The walk stops at the disc image, so a backup's thousands of stream
+        # files cannot truncate a scan of the folder above it.
+        d = _bdmv(tmp_path, "Big")
+        for i in range(50):
+            (d / "BDMV" / "STREAM" / f"{i:05d}.m2ts").write_bytes(b"x")
+        scan = import_scanner.scan(tmp_path)
+        assert scan.truncated is False
+        assert scan.total_files == 0

--- a/backend/tests/unit/test_import_tmdb_resolution.py
+++ b/backend/tests/unit/test_import_tmdb_resolution.py
@@ -130,7 +130,15 @@ def _build_coordinator(analysis, monkeypatch, *, signal):
     )
     monkeypatch.setattr(
         "app.services.config_service.get_config",
-        AsyncMock(return_value=SimpleNamespace(tmdb_api_key="testkey")),
+        AsyncMock(
+            return_value=SimpleNamespace(
+                tmdb_api_key="testkey",
+                # The resume path routes through next_state_after_identify,
+                # which reads both backup fields off the config.
+                backup_before_rip=False,
+                backup_path="",
+            )
+        ),
     )
 
     return coordinator, broadcaster_ws, module_ws
@@ -275,7 +283,15 @@ async def test_resolve_missing_tmdb_id_prefers_tv_for_box_set(monkeypatch):
     monkeypatch.setattr(idc_mod, "classify_from_tmdb", fake_classify, raising=False)
     monkeypatch.setattr(
         "app.services.config_service.get_config",
-        AsyncMock(return_value=SimpleNamespace(tmdb_api_key="testkey")),
+        AsyncMock(
+            return_value=SimpleNamespace(
+                tmdb_api_key="testkey",
+                # The resume path routes through next_state_after_identify,
+                # which reads both backup fields off the config.
+                backup_before_rip=False,
+                backup_path="",
+            )
+        ),
     )
 
     job = SimpleNamespace(

--- a/backend/tests/unit/test_job_source_routing.py
+++ b/backend/tests/unit/test_job_source_routing.py
@@ -1,0 +1,304 @@
+"""Every MakeMKV call site reads the JOB's source, not always the drive.
+
+``DiscJob.source_spec`` records what MakeMKV should be pointed at: ``dev:E:``
+for a drive, ``file:<path>`` for a backup folder or an imported disc image,
+``iso:<path>`` for an ISO. None means "legacy row, derive from ``drive_id``".
+
+Two failures live here. A completed backup sets ``source_spec`` to the copy and
+then EJECTS the disc, so a rip that still targeted ``drive_id`` read an emptied
+drive and the whole point of the feature never happened. And a disc-image
+import carries ``drive_id == "import"``, which is not a MakeMKV source at all.
+
+The end-of-rip drive release is gated on ``DiscSource.is_physical`` for the
+same reason: a non-physical source never held a drive, so ejecting again and
+re-sending the RIPPED notification would notify the user twice for one disc.
+
+Everything is patched at the extractor boundary; no makemkvcon ever runs.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+import app.services.identification_coordinator as idc
+from app.core.analyst import DiscAnalysisResult, TitleInfo
+from app.core.disc_source import DiscSource
+from app.core.extractor import RipResult, compute_content_hash
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.job_manager import job_manager
+from app.services.job_state_machine import JobStateMachine
+from tests.unit.conftest import _unit_session_factory
+
+_SCAN_TITLES = [
+    TitleInfo(index=0, duration_seconds=1500, size_bytes=2_000_000_000, chapter_count=7),
+    TitleInfo(index=1, duration_seconds=2700, size_bytes=4_000_000_000, chapter_count=12),
+]
+
+
+# --- identification -------------------------------------------------------
+
+
+def _analysis():
+    analysis = DiscAnalysisResult(content_type=ContentType.TV, confidence=0.9)
+    analysis.detected_name = "Show"
+    analysis.detected_season = 1
+    analysis.needs_review = False
+    analysis.review_reason = None
+    analysis.tmdb_id = 1234
+    analysis.tmdb_name = "Show"
+    analysis._tmdb_signal = None
+    analysis._discdb_signal = None
+    return analysis
+
+
+def _bare_coord():
+    """A coordinator with everything but the source resolution stubbed out."""
+    coord = idc.IdentificationCoordinator.__new__(idc.IdentificationCoordinator)
+    coord._extractor = SimpleNamespace(
+        scan_disc=AsyncMock(return_value=(_SCAN_TITLES, "SHOW_S1_D1"))
+    )
+    broadcaster = MagicMock()
+    broadcaster.broadcast_job_state_changed = AsyncMock()
+    broadcaster.broadcast_job_completed = AsyncMock()
+    broadcaster.broadcast_job_failed = AsyncMock()
+    coord._broadcaster = broadcaster
+    coord._state_machine = JobStateMachine(broadcaster)
+    coord._get_discdb_mappings = lambda job_id: []
+    coord._run_classification = AsyncMock(return_value=_analysis())
+    coord._run_ripping = AsyncMock()
+    coord._run_backup = AsyncMock()
+    coord._start_subtitle_download = Mock()
+    coord._start_subtitle_download_all_seasons = Mock()
+
+    async def _seasons(title, tmdb_id=None):
+        return [1]
+
+    coord._resolve_all_season_numbers = _seasons
+    return coord
+
+
+@pytest.fixture
+def identify_env(monkeypatch):
+    """The identify_disc environment: in-memory DB, no snapshots, no TMDB."""
+    monkeypatch.setattr(idc, "async_session", _unit_session_factory)
+
+    import app.core.snapshot as snapshot_mod
+
+    monkeypatch.setattr(snapshot_mod, "save_snapshot", lambda *a, **k: None)
+    monkeypatch.setattr(idc, "_resolve_show_year", lambda tmdb_id, signal=None: None)
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(idc.ws_manager, "broadcast_job_update", _noop)
+    monkeypatch.setattr(idc.ws_manager, "broadcast_titles_discovered", _noop)
+
+
+async def _seed_job(**kwargs) -> int:
+    fields = {
+        "drive_id": "E:",
+        "volume_label": "SHOW_S1_D1",
+        "state": JobState.IDENTIFYING,
+        "staging_path": "/tmp/staging",
+    }
+    fields.update(kwargs)
+    async with _unit_session_factory() as session:
+        job = DiscJob(**fields)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job.id
+
+
+def _scanned_source(coord) -> DiscSource:
+    args, _ = coord._extractor.scan_disc.await_args
+    return args[0]
+
+
+@pytest.mark.unit
+class TestIdentifyReadsTheJobSource:
+    async def test_backup_source_scans_the_copy(self, identify_env, tmp_path):
+        job_id = await _seed_job(source_spec=f"file:{tmp_path}")
+        coord = _bare_coord()
+
+        await coord.identify_disc(job_id)
+
+        source = _scanned_source(coord)
+        assert isinstance(source, DiscSource)
+        assert source.spec == f"file:{tmp_path}"
+        assert not source.is_physical
+
+    async def test_legacy_job_still_scans_the_drive(self, identify_env):
+        """Regression guard for every disc that predates source_spec."""
+        job_id = await _seed_job(drive_id="E:", source_spec=None)
+        coord = _bare_coord()
+
+        await coord.identify_disc(job_id)
+
+        assert _scanned_source(coord).spec == "dev:E:"
+
+    async def test_disc_image_import_does_not_raise(self, identify_env, tmp_path):
+        """drive_id == "import" is not a MakeMKV source; source_spec is."""
+        job_id = await _seed_job(drive_id="import", source_spec=f"file:{tmp_path}")
+        coord = _bare_coord()
+
+        await coord.identify_disc(job_id)
+
+        assert _scanned_source(coord).spec == f"file:{tmp_path}"
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+        assert job.state != JobState.FAILED
+
+    async def test_sourceless_job_fails_cleanly(self, identify_env):
+        """No drive and no spec: fail with a message, never an unhandled raise."""
+        job_id = await _seed_job(drive_id="import", source_spec=None)
+        coord = _bare_coord()
+
+        await coord.identify_disc(job_id)
+
+        coord._extractor.scan_disc.assert_not_awaited()
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+        assert job.state == JobState.FAILED
+
+
+# --- ripping --------------------------------------------------------------
+
+
+class _RecordingExtractor:
+    """Captures the source rip_titles was pointed at; rips nothing."""
+
+    def __init__(self):
+        self.sources: list = []
+
+    def skip_title_index(self, job_id, idx):
+        pass
+
+    def unskip_title_index(self, job_id, idx):
+        pass
+
+    async def rip_titles(self, source, output_dir, **kw):
+        self.sources.append(source)
+        return RipResult(success=True, output_files=[Path("x.mkv")])
+
+
+async def _seed_rip_job(staging: Path, **kwargs) -> int:
+    fields = {
+        "drive_id": "Z:",
+        "volume_label": "SHOW_S1_D1",
+        "state": JobState.RIPPING,
+        "content_type": ContentType.TV,
+        "staging_path": str(staging),
+        "total_titles": 2,
+    }
+    fields.update(kwargs)
+    async with _unit_session_factory() as session:
+        job = DiscJob(**fields)
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        for idx in (1, 2):
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=idx,
+                    output_index=idx,
+                    duration_seconds=1300,
+                    file_size_bytes=4096,
+                    state=TitleState.PENDING,
+                    is_selected=True,
+                )
+            )
+        await session.commit()
+        return job.id
+
+
+@pytest.fixture
+def rip_env(monkeypatch, tmp_path):
+    """Patched extractor + drive release; the staging dir the rip writes to."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    ext = _RecordingExtractor()
+    release = AsyncMock(return_value=True)
+    monkeypatch.setattr(job_manager, "_extractor", ext)
+    monkeypatch.setattr(job_manager, "_release_drive", release)
+    # Belt and braces: nothing may reach a real tray, whatever the gate does.
+    monkeypatch.setattr("app.core.sentinel.eject_disc", lambda *a, **k: None)
+    return SimpleNamespace(staging=staging, ext=ext, release=release)
+
+
+@pytest.mark.unit
+class TestRipReadsTheJobSource:
+    async def test_backup_source_rips_the_copy_and_holds_the_tray(self, rip_env, tmp_path):
+        backup = tmp_path / "backup"
+        backup.mkdir()
+        job_id = await _seed_rip_job(rip_env.staging, source_spec=f"file:{backup}")
+
+        await job_manager._run_ripping(job_id)
+
+        assert rip_env.ext.sources, "rip_titles was never called"
+        source = rip_env.ext.sources[0]
+        assert isinstance(source, DiscSource)
+        assert source.spec == f"file:{backup}"
+        # The disc left the drive at the end of the backup phase, which already
+        # sent its own RIPPED event. Releasing again would double-notify.
+        rip_env.release.assert_not_awaited()
+
+    async def test_legacy_job_still_rips_the_drive_and_releases_it(self, rip_env):
+        """Regression guard: source_spec is None on every pre-feature row."""
+        job_id = await _seed_rip_job(rip_env.staging, drive_id="Z:", source_spec=None)
+
+        await job_manager._run_ripping(job_id)
+
+        assert rip_env.ext.sources[0].spec == "dev:Z:"
+        rip_env.release.assert_awaited_once()
+        assert rip_env.release.await_args.args[1] == "Z:"
+
+    async def test_disc_image_import_does_not_raise(self, rip_env, tmp_path):
+        image = tmp_path / "image"
+        image.mkdir()
+        job_id = await _seed_rip_job(
+            rip_env.staging, drive_id="import", source_spec=f"file:{image}"
+        )
+
+        await job_manager._run_ripping(job_id)
+
+        assert rip_env.ext.sources[0].spec == f"file:{image}"
+        rip_env.release.assert_not_awaited()
+
+
+# --- content hash ---------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestContentHashFromABackup:
+    """A backup folder holds the same BDMV/STREAM sizes as the disc it copied,
+    so it hashes to the same ContentHash and still gets a TheDiscDB lookup."""
+
+    @staticmethod
+    def _make_backup(root: Path) -> Path:
+        stream = root / "BDMV" / "STREAM"
+        stream.mkdir(parents=True)
+        (stream / "00000.m2ts").write_bytes(b"a" * 32)
+        (stream / "00001.m2ts").write_bytes(b"b" * 64)
+        return root
+
+    def test_backup_folder_hashes(self, tmp_path):
+        root = self._make_backup(tmp_path / "backup")
+
+        value = compute_content_hash(DiscSource.for_backup(root))
+
+        assert value and len(value) == 32
+        assert value == value.upper()
+
+    def test_iso_degrades_to_none(self, tmp_path):
+        iso = tmp_path / "disc.iso"
+        iso.write_bytes(b"not really an iso")
+
+        assert compute_content_hash(DiscSource.parse(f"iso:{iso}")) is None
+
+    def test_missing_structure_degrades_to_none(self, tmp_path):
+        assert compute_content_hash(DiscSource.for_backup(tmp_path)) is None

--- a/backend/tests/unit/test_rerip.py
+++ b/backend/tests/unit/test_rerip.py
@@ -174,10 +174,68 @@ async def test_rerip_titles_transitions_deletes_and_rips(monkeypatch, tmp_path):
     await job_manager.rerip_titles(job_id, [title_id])
 
     assert captured["indices"] == [2]
-    assert captured["drive"] == "F:"
+    # A legacy row (source_spec is None) still resolves to the drive.
+    assert captured["drive"].spec == "dev:F:"
     assert not stale.exists()  # stale file deleted before re-rip
     t = await _reload(title_id)
     assert t.rerip_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_rerip_after_a_backup_reads_the_copy_and_leaves_the_tray_alone(monkeypatch, tmp_path):
+    """The disc is gone by then: a backed-up job re-rips from the copy.
+
+    And the drive release is skipped, because the tray was already opened (and
+    the RIPPED event already sent) at the end of the backup phase.
+    """
+    from app.core.extractor import RipResult
+    from app.services.job_manager import job_manager
+
+    monkeypatch.setattr(ws_manager, "broadcast_title_update", AsyncMock())
+    monkeypatch.setattr(ws_manager, "broadcast_job_update", AsyncMock())
+
+    backup = tmp_path / "backup"
+    backup.mkdir()
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="F:",
+            volume_label="SHOW_S2D1",
+            content_type=ContentType.TV,
+            state=JobState.REVIEW_NEEDED,
+            staging_path=str(tmp_path),
+            content_hash="ABC123",
+            source_spec=f"file:{backup}",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        title = DiscTitle(
+            job_id=job.id,
+            title_index=2,
+            duration_seconds=2819,
+            state=TitleState.REVIEW,
+            rerip_attempts=0,
+            match_details=json.dumps({"error": "incomplete_rip", "rerip_eligible": True}),
+        )
+        session.add(title)
+        await session.commit()
+        await session.refresh(title)
+        job_id, title_id = job.id, title.id
+
+    captured = {}
+
+    async def fake_rip_titles(source, output_dir, title_indices=None, **kw):
+        captured["source"] = source
+        return RipResult(success=True, output_files=[], error_message=None, stalled_titles=None)
+
+    release = AsyncMock(return_value=True)
+    monkeypatch.setattr(job_manager._extractor, "rip_titles", fake_rip_titles)
+    monkeypatch.setattr(job_manager, "_release_drive", release)
+
+    await job_manager.rerip_titles(job_id, [title_id])
+
+    assert captured["source"].spec == f"file:{backup}"
+    release.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_run_backup.py
+++ b/backend/tests/unit/test_run_backup.py
@@ -579,3 +579,90 @@ class TestHoldsDiscInDrive:
         # Refusing a second job is the safe side of the guess.
         job = DiscJob(drive_id="", state=JobState.RIPPING)
         assert JobManager._holds_disc_in_drive(job) is True
+
+
+class TestEjectDuringBackup:
+    """A user must be able to get their disc back out of a long copy.
+
+    A full-disc backup can run for hours. Before this, the Eject button was
+    offered during BACKING_UP but the backend rejected the state, so the button
+    was dead for the whole phase.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ejecting_during_a_backup_cancels_the_job(self, monkeypatch):
+        job_id = await _seed()
+        cancelled = []
+
+        monkeypatch.setattr(sys.modules["app.core.sentinel"], "eject_disc", lambda drive: True)
+        monkeypatch.setattr(
+            job_manager, "cancel_job", AsyncMock(side_effect=lambda jid: cancelled.append(jid))
+        )
+        monkeypatch.setattr(job_manager._drive_monitor, "notify_ejected", MagicMock())
+
+        result = await job_manager.eject_disc_for_job(job_id)
+
+        assert result == {"ejected": True, "action": "job_cancelled"}
+        assert cancelled == [job_id]
+
+    @pytest.mark.asyncio
+    async def test_a_backup_sourced_rip_has_no_disc_to_eject(self, monkeypatch):
+        # The disc came out when the copy finished. Ejecting would open an empty
+        # tray and send a second "ripped" notification for one disc.
+        job_id = await _seed()
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            job.state = JobState.RIPPING
+            job.source_spec = "file:/b/Show/Season 01/S01D01"
+            await session.commit()
+
+        release = AsyncMock()
+        monkeypatch.setattr(job_manager, "_release_drive", release)
+
+        with pytest.raises(ValueError, match="already released"):
+            await job_manager.eject_disc_for_job(job_id)
+
+        release.assert_not_awaited()
+
+
+class TestStalledBackupDegrades:
+    """A stalled copy falls back to a direct rip instead of failing the job.
+
+    This is the feature's governing rule and it bites hardest here: the disc
+    most likely to stall a copy is the scratched one the feature exists for, so
+    failing the job would make enabling the setting actively worse than leaving
+    it off. backup_disc has no per-operation stall watchdog and defers to this
+    job-level one, so this branch is the only fallback the stall case has.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_stalled_backup_ends_in_ripping_not_failed(self, monkeypatch):
+        job_id = await _seed()
+        enter_ripping = AsyncMock()
+        monkeypatch.setattr(job_manager, "_enter_ripping", enter_ripping)
+        cancel = MagicMock()
+        monkeypatch.setattr(job_manager._extractor, "cancel", cancel)
+
+        config = SimpleNamespace(
+            timeout_identifying_seconds=0,
+            timeout_backing_up_seconds=60,
+            timeout_ripping_seconds=0,
+            timeout_matching_seconds=0,
+            timeout_organizing_seconds=0,
+        )
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            # Idle well past the ceiling.
+            job_manager._last_activity[job_id] = 0.0
+            await job_manager._watchdog_check_job(job, config, now=10_000.0)
+
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+
+        assert job.state is not JobState.FAILED
+        assert job.backup_status == "failed"
+        assert "stalled" in (job.backup_status_reason or "")
+        enter_ripping.assert_awaited_once_with(job_id)
+        # The copy must be stopped before the rip starts, or two makemkvcon
+        # processes fight over one drive.
+        cancel.assert_called_once_with(job_id)

--- a/backend/tests/unit/test_run_backup.py
+++ b/backend/tests/unit/test_run_backup.py
@@ -15,7 +15,7 @@ spawns a Discord notification task that leaks a pooled connection in tests.
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,6 +23,7 @@ from app.core.extractor import BackupResult
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
 from app.services.job_manager import job_manager
+from app.services.ripping_helpers import expected_native_index
 from tests.unit.conftest import _unit_session_factory
 
 _JM = sys.modules["app.services.job_manager"]
@@ -56,7 +57,8 @@ def spies(monkeypatch, tmp_path):
     monkeypatch.setattr(_JM.event_broadcaster, "broadcast_backup_progress", broadcast)
 
     # Module-level names are looked up on the module, not through the singleton.
-    monkeypatch.setattr(_JM, "has_room_for_backup", lambda dest, needed: True)
+    has_room = MagicMock(return_value=True)
+    monkeypatch.setattr(_JM, "has_room_for_backup", has_room)
     monkeypatch.setattr(_JM, "resolve_disc_index", AsyncMock(return_value="disc:0"))
 
     config = SimpleNamespace(
@@ -73,6 +75,7 @@ def spies(monkeypatch, tmp_path):
         backup_disc=backup_disc,
         scan_disc=scan_disc,
         broadcast=broadcast,
+        has_room=has_room,
         config=config,
     )
 
@@ -86,7 +89,14 @@ def dest(monkeypatch, tmp_path, spies):
     return target
 
 
-async def _seed(*, indices=(0, 1), durations=(2600, 2601)) -> int:
+async def _seed(*, indices=(0, 1), durations=(2600, 2601), output_indices=None) -> int:
+    """Seed a job with two titles, as a modern disc scan would leave them.
+
+    ``output_index`` is populated on purpose: identification_coordinator sets it
+    on every scan, and ``ripping_helpers.expected_native_index`` PREFERS it over
+    ``title_index``. A seed that left it None made every resolution site fall
+    back to ``title_index`` and so hid the stale-``output_index`` bug entirely.
+    """
     async with _unit_session_factory() as session:
         job = DiscJob(
             drive_id="E:",
@@ -100,11 +110,13 @@ async def _seed(*, indices=(0, 1), durations=(2600, 2601)) -> int:
         session.add(job)
         await session.commit()
         await session.refresh(job)
-        for idx, dur in zip(indices, durations, strict=True):
+        outs = output_indices if output_indices is not None else indices
+        for idx, dur, out in zip(indices, durations, outs, strict=True):
             session.add(
                 DiscTitle(
                     job_id=job.id,
                     title_index=idx,
+                    output_index=out,
                     duration_seconds=dur,
                     file_size_bytes=5 * 1024**3,
                     state=TitleState.PENDING,
@@ -122,13 +134,26 @@ async def _load(job_id: int) -> DiscJob:
 
 
 class _ScannedTitle:
-    """Shape of extractor.TitleInfo as reconcile_titles reads it."""
+    """Shape of extractor.TitleInfo as reconcile_titles reads it.
 
-    def __init__(self, index: int, duration: int, source_filename: str, segment_map: str):
+    ``disc_title`` is MakeMKV's suggested output filename (TINFO attr 27); it is
+    what ``output_index`` is derived from, on the disc scan and on the backup
+    re-scan alike.
+    """
+
+    def __init__(
+        self,
+        index: int,
+        duration: int,
+        source_filename: str,
+        segment_map: str,
+        disc_title: str | None = None,
+    ):
         self.index = index
         self.duration_seconds = duration
         self.source_filename = source_filename
         self.segment_map = segment_map
+        self.disc_title = f"SHOW_t{index:02d}.mkv" if disc_title is None else disc_title
 
 
 def _matching_scan():
@@ -136,6 +161,18 @@ def _matching_scan():
         _ScannedTitle(0, 2600, "00000.m2ts", "1"),
         _ScannedTitle(1, 2601, "00001.m2ts", "2"),
     ]
+
+
+async def _titles(job_id: int) -> list[DiscTitle]:
+    async with _unit_session_factory() as session:
+        from sqlmodel import select
+
+        rows = (
+            (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+            .scalars()
+            .all()
+        )
+        return sorted(rows, key=lambda r: r.id)
 
 
 class TestFallbackMatrix:
@@ -150,7 +187,7 @@ class TestFallbackMatrix:
 
         job = await _load(job_id)
         assert job.backup_status == "skipped"
-        assert job.backup_status_reason == "not_configured"
+        assert job.backup_status_reason == "no backup location is configured"
         assert job.source_spec is None
         assert job.state == JobState.RIPPING
         spies.release.assert_not_called()
@@ -165,7 +202,7 @@ class TestFallbackMatrix:
 
         job = await _load(job_id)
         assert job.backup_status == "skipped"
-        assert job.backup_status_reason == "insufficient_space"
+        assert "not enough free space" in job.backup_status_reason
         assert job.source_spec is None
         assert job.state == JobState.RIPPING
         spies.release.assert_not_called()
@@ -180,7 +217,7 @@ class TestFallbackMatrix:
 
         job = await _load(job_id)
         assert job.backup_status == "skipped"
-        assert job.backup_status_reason == "no_disc_index"
+        assert "could not address drive E:" in job.backup_status_reason
         assert job.source_spec is None
         assert job.state == JobState.RIPPING
         spies.release.assert_not_called()
@@ -260,6 +297,9 @@ class TestSuccess:
         await job_manager._run_backup(job_id)
 
         spies.backup_disc.assert_not_called()
+        # Nothing is about to be written, so the (potentially slow, potentially
+        # networked) free-space probe must not run either.
+        spies.has_room.assert_not_called()
         job = await _load(job_id)
         assert job.backup_status == "completed"
         assert job.source_spec == f"file:{dest}"
@@ -301,6 +341,101 @@ class TestSuccess:
         assert sorted(r.title_index for r in rows) == [7, 9]
         job = await _load(job_id)
         assert job.state == JobState.RIPPING
+
+
+class TestRemapRewritesTheRipTarget:
+    """A remap must move ``output_index`` too, or files land on the wrong rows.
+
+    ``ripping_helpers.expected_native_index`` PREFERS ``output_index`` over
+    ``title_index``, and every site that maps a produced ``..._tNN.mkv`` back
+    onto a ``DiscTitle`` goes through it. So these assertions are deliberately
+    on ``expected_native_index``, not on ``title_index``: rewriting only the
+    latter leaves the resolution path reading the stale disc-scan number, which
+    is the silent mis-file this whole module exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_swapped_pair_does_not_invert_onto_each_other(self, spies, dest):
+        # The backup enumerated the two titles in the opposite order: the
+        # content of scan-index 0 is the backup's title 1 and vice versa.
+        spies.scan_disc.return_value = (
+            [
+                _ScannedTitle(0, 2601, "00001.m2ts", "2"),
+                _ScannedTitle(1, 2600, "00000.m2ts", "1"),
+            ],
+            "",
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        rows = await _titles(job_id)
+        by_source = {r.source_filename: r for r in rows}
+        a, b = by_source["00000.m2ts"], by_source["00001.m2ts"]
+        # Row A's content is title 1 in the backup, row B's is title 0.
+        assert (a.title_index, b.title_index) == (1, 0)
+        # Without the output_index rewrite these would still read (0, 1), and
+        # LABEL_t01.mkv (A's content) would resolve onto row B.
+        assert expected_native_index(a) == 1
+        assert expected_native_index(b) == 0
+
+    @pytest.mark.asyncio
+    async def test_a_scan_with_no_suggested_filename_falls_back_to_title_index(self, spies, dest):
+        spies.scan_disc.return_value = (
+            [
+                _ScannedTitle(7, 2600, "00000.m2ts", "1", disc_title=""),
+                _ScannedTitle(9, 2601, "00001.m2ts", "2", disc_title=""),
+            ],
+            "",
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        rows = await _titles(job_id)
+        assert [r.output_index for r in rows] == [None, None]
+        # None is the legitimate fallback case, not a stale number.
+        assert sorted(expected_native_index(r) for r in rows) == [7, 9]
+
+    @pytest.mark.asyncio
+    async def test_an_identical_scan_still_refreshes_the_native_numbers(self, spies, dest):
+        # Same order, same durations, same disc structure: reconcile_titles
+        # reports IDENTICAL. But the backup suggests different _tNN numbers,
+        # and _is_identical deliberately does not compare disc_title, so the
+        # refresh has to happen unconditionally at the caller.
+        spies.scan_disc.return_value = (
+            [
+                _ScannedTitle(0, 2600, "00000.m2ts", "1", disc_title="SHOW_t04.mkv"),
+                _ScannedTitle(1, 2601, "00001.m2ts", "2", disc_title="SHOW_t05.mkv"),
+            ],
+            "",
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        rows = await _titles(job_id)
+        assert [r.title_index for r in rows] == [0, 1]
+        assert [expected_native_index(r) for r in rows] == [4, 5]
+
+    @pytest.mark.asyncio
+    async def test_an_offset_numbered_backup_keeps_its_native_numbers(self, spies, dest):
+        # Issue #517: a disc whose native _tNN does not equal its scan index.
+        # Clearing output_index instead of recomputing it would fall back to
+        # title_index and look for the wrong files.
+        spies.scan_disc.return_value = (
+            [
+                _ScannedTitle(0, 2600, "00000.m2ts", "1", disc_title="SHOW_t01.mkv"),
+                _ScannedTitle(1, 2601, "00001.m2ts", "2", disc_title="SHOW_t02.mkv"),
+            ],
+            "",
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        rows = await _titles(job_id)
+        assert [expected_native_index(r) for r in rows] == [1, 2]
 
 
 class TestUnreconcilableBackup:
@@ -353,6 +488,23 @@ class TestProgressThrottling:
 
         # One message per whole percent crossed: 0, 1, 2, 3.
         assert spies.broadcast.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_a_repeated_or_backwards_percentage_says_nothing_new(self, spies, dest):
+        # MakeMKV re-reports the current percent, and a multi-pass copy can even
+        # step backwards. Neither is news, so neither reaches the wire.
+        async def _fake_backup(source, target, progress_callback=None, log_dir=None, job_id=0):
+            for pct in (5.0, 5.0, 5.7, 3.0, 0.0, 5.9):
+                progress_callback(pct)
+            return BackupResult(success=True, dest=target)
+
+        spies.backup_disc.side_effect = _fake_backup
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        assert spies.broadcast.call_count == 1
 
     @pytest.mark.asyncio
     async def test_progress_is_reported_in_bytes_against_the_disc_estimate(self, spies, dest):

--- a/backend/tests/unit/test_run_backup.py
+++ b/backend/tests/unit/test_run_backup.py
@@ -1,0 +1,395 @@
+"""The BACKING_UP phase: copy the disc, then rip from the copy.
+
+The governing rule is that every backup problem degrades to a direct rip from
+the drive, which is exactly what the job would have done with the setting off.
+Turning backups on must never make a disc less likely to finish. The one
+exception is a backup that succeeded but cannot be reconciled against the disc
+scan: that parks for review, because the drive has already been released and
+the disc may be out of it.
+
+Everything external is patched at its boundary. No makemkvcon is ever launched.
+Every job here stays NON-terminal on purpose: a job reaching COMPLETED/FAILED
+spawns a Discord notification task that leaks a pooled connection in tests.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.extractor import BackupResult
+from app.models import DiscJob, JobState
+from app.models.disc_job import ContentType, DiscTitle, TitleState
+from app.services.job_manager import job_manager
+from tests.unit.conftest import _unit_session_factory
+
+_JM = sys.modules["app.services.job_manager"]
+
+
+@pytest.fixture(autouse=True)
+def _quiet_ws(monkeypatch):
+    """No websocket traffic, and no real broadcaster fan-out."""
+    from app.api.websocket import manager as ws_manager
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(ws_manager, "broadcast_job_update", _noop)
+    monkeypatch.setattr(ws_manager, "broadcast_job_state_changed", _noop, raising=False)
+
+
+@pytest.fixture
+def spies(monkeypatch, tmp_path):
+    """Patch every boundary _run_backup touches, and hand back the spies."""
+    release = AsyncMock(return_value=True)
+    run_ripping = AsyncMock(return_value=None)
+    backup_disc = AsyncMock(return_value=BackupResult(success=True, dest=tmp_path / "dest"))
+    scan_disc = AsyncMock(return_value=([], ""))
+    broadcast = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(job_manager, "_release_drive", release)
+    monkeypatch.setattr(job_manager, "_run_ripping", run_ripping)
+    monkeypatch.setattr(job_manager._extractor, "backup_disc", backup_disc)
+    monkeypatch.setattr(job_manager._extractor, "scan_disc", scan_disc)
+    monkeypatch.setattr(_JM.event_broadcaster, "broadcast_backup_progress", broadcast)
+
+    # Module-level names are looked up on the module, not through the singleton.
+    monkeypatch.setattr(_JM, "has_room_for_backup", lambda dest, needed: True)
+    monkeypatch.setattr(_JM, "resolve_disc_index", AsyncMock(return_value="disc:0"))
+
+    config = SimpleNamespace(
+        makemkv_path="makemkvcon",
+        auto_eject_enabled=False,
+        # Keeps the REVIEW_NEEDED Discord observer a clean no-op.
+        discord_webhook_url=None,
+    )
+    monkeypatch.setattr("app.services.config_service.get_config", AsyncMock(return_value=config))
+
+    return SimpleNamespace(
+        release=release,
+        run_ripping=run_ripping,
+        backup_disc=backup_disc,
+        scan_disc=scan_disc,
+        broadcast=broadcast,
+        config=config,
+    )
+
+
+@pytest.fixture
+def dest(monkeypatch, tmp_path, spies):
+    """The computed backup destination, patched to a tmp path."""
+    target = tmp_path / "backups" / "TV" / "Show" / "Disc 1"
+    monkeypatch.setattr(_JM, "backup_destination", lambda job, config: target)
+    spies.backup_disc.return_value = BackupResult(success=True, dest=target)
+    return target
+
+
+async def _seed(*, indices=(0, 1), durations=(2600, 2601)) -> int:
+    async with _unit_session_factory() as session:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="SHOW_S1_D1",
+            content_type=ContentType.TV,
+            state=JobState.BACKING_UP,
+            detected_title="Show",
+            detected_season=1,
+            staging_path="/tmp/staging/job",
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        for idx, dur in zip(indices, durations, strict=True):
+            session.add(
+                DiscTitle(
+                    job_id=job.id,
+                    title_index=idx,
+                    duration_seconds=dur,
+                    file_size_bytes=5 * 1024**3,
+                    state=TitleState.PENDING,
+                    source_filename=f"0000{idx}.m2ts",
+                    segment_map=str(idx + 1),
+                )
+            )
+        await session.commit()
+        return job.id
+
+
+async def _load(job_id: int) -> DiscJob:
+    async with _unit_session_factory() as session:
+        return await session.get(DiscJob, job_id)
+
+
+class _ScannedTitle:
+    """Shape of extractor.TitleInfo as reconcile_titles reads it."""
+
+    def __init__(self, index: int, duration: int, source_filename: str, segment_map: str):
+        self.index = index
+        self.duration_seconds = duration
+        self.source_filename = source_filename
+        self.segment_map = segment_map
+
+
+def _matching_scan():
+    return [
+        _ScannedTitle(0, 2600, "00000.m2ts", "1"),
+        _ScannedTitle(1, 2601, "00001.m2ts", "2"),
+    ]
+
+
+class TestFallbackMatrix:
+    """Every backup problem degrades to a direct rip, never to a failed job."""
+
+    @pytest.mark.asyncio
+    async def test_no_backup_location_configured(self, spies, monkeypatch):
+        monkeypatch.setattr(_JM, "backup_destination", lambda job, config: None)
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "not_configured"
+        assert job.source_spec is None
+        assert job.state == JobState.RIPPING
+        spies.release.assert_not_called()
+        spies.backup_disc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_insufficient_space(self, spies, dest, monkeypatch):
+        monkeypatch.setattr(_JM, "has_room_for_backup", lambda d, needed: False)
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "insufficient_space"
+        assert job.source_spec is None
+        assert job.state == JobState.RIPPING
+        spies.release.assert_not_called()
+        spies.backup_disc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drive_has_no_resolvable_disc_index(self, spies, dest, monkeypatch):
+        monkeypatch.setattr(_JM, "resolve_disc_index", AsyncMock(return_value=None))
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "no_disc_index"
+        assert job.source_spec is None
+        assert job.state == JobState.RIPPING
+        spies.release.assert_not_called()
+        spies.backup_disc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backup_itself_failed(self, spies, dest):
+        spies.backup_disc.return_value = BackupResult(
+            success=False, error_message="disc read error at 43%"
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "failed"
+        assert job.backup_status_reason == "disc read error at 43%"
+        # The copy is unusable, so extraction must still read the disc.
+        assert job.source_spec is None
+        assert job.state == JobState.RIPPING
+        spies.release.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_error_still_degrades(self, spies, dest):
+        spies.backup_disc.side_effect = RuntimeError("kaboom")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "failed"
+        assert "kaboom" in job.backup_status_reason
+        assert job.state == JobState.RIPPING
+        spies.release.assert_not_called()
+
+
+class TestSuccess:
+    @pytest.mark.asyncio
+    async def test_success_redirects_extraction_and_releases_the_drive(self, spies, dest):
+        spies.backup_disc.return_value = BackupResult(success=True, dest=dest)
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.backup_status == "completed"
+        assert job.backup_status_reason is None
+        assert job.backup_path == str(dest)
+        assert job.source_spec == f"file:{dest}"
+        assert job.state == JobState.RIPPING
+
+        spies.release.assert_awaited_once()
+        assert spies.release.await_args.args == (job_id, "E:", "Backed up")
+
+    @pytest.mark.asyncio
+    async def test_the_backup_is_addressed_by_disc_index_but_locks_as_the_drive(self, spies, dest):
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        source = spies.backup_disc.await_args.args[0]
+        assert source.makemkv_arg == "disc:0"
+        # The lock that matters is the physical drive's, not the index's.
+        from app.core.disc_source import DiscSource
+
+        assert source.lock_key == DiscSource.parse("E:").lock_key
+
+    @pytest.mark.asyncio
+    async def test_an_existing_backup_is_reused_not_recopied(self, spies, dest):
+        dest.mkdir(parents=True)
+        (dest / "BDMV").mkdir()
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        spies.backup_disc.assert_not_called()
+        job = await _load(job_id)
+        assert job.backup_status == "completed"
+        assert job.source_spec == f"file:{dest}"
+        assert job.state == JobState.RIPPING
+        spies.release.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_an_empty_destination_directory_is_not_a_backup(self, spies, dest):
+        dest.mkdir(parents=True)
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        spies.backup_disc.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_remapped_scan_rewrites_the_stored_indices(self, spies, dest):
+        # The backup enumerated the same two titles in the other order.
+        spies.scan_disc.return_value = (
+            [
+                _ScannedTitle(7, 2600, "00000.m2ts", "1"),
+                _ScannedTitle(9, 2601, "00001.m2ts", "2"),
+            ],
+            "",
+        )
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        async with _unit_session_factory() as session:
+            from sqlmodel import select
+
+            rows = (
+                (await session.execute(select(DiscTitle).where(DiscTitle.job_id == job_id)))
+                .scalars()
+                .all()
+            )
+        assert sorted(r.title_index for r in rows) == [7, 9]
+        job = await _load(job_id)
+        assert job.state == JobState.RIPPING
+
+
+class TestUnreconcilableBackup:
+    """A good copy that cannot be lined up parks for review, never guesses."""
+
+    @pytest.mark.asyncio
+    async def test_empty_scan_parks_for_review(self, spies, dest):
+        spies.scan_disc.return_value = ([], "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        assert str(dest) in job.review_reason
+        assert "safe" in job.review_reason
+        # The backup succeeded, so the source is still the copy and the drive
+        # was still released.
+        assert job.source_spec == f"file:{dest}"
+        spies.release.assert_awaited_once()
+        spies.run_ripping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_raising_scan_is_treated_as_an_empty_one(self, spies, dest):
+        spies.scan_disc.side_effect = OSError("backup folder vanished")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        job = await _load(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        spies.run_ripping.assert_not_called()
+
+
+class TestProgressThrottling:
+    @pytest.mark.asyncio
+    async def test_sub_percent_callbacks_are_collapsed(self, spies, dest):
+        percentages = [0.1, 0.2, 0.9, 1.0, 1.4, 1.9, 2.0, 2.5, 3.0]
+
+        async def _fake_backup(source, target, progress_callback=None, log_dir=None, job_id=0):
+            for pct in percentages:
+                progress_callback(pct)
+            return BackupResult(success=True, dest=target)
+
+        spies.backup_disc.side_effect = _fake_backup
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        # One message per whole percent crossed: 0, 1, 2, 3.
+        assert spies.broadcast.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_progress_is_reported_in_bytes_against_the_disc_estimate(self, spies, dest):
+        async def _fake_backup(source, target, progress_callback=None, log_dir=None, job_id=0):
+            progress_callback(50.0)
+            return BackupResult(success=True, dest=target)
+
+        spies.backup_disc.side_effect = _fake_backup
+        spies.scan_disc.return_value = (_matching_scan(), "")
+        job_id = await _seed()
+
+        await job_manager._run_backup(job_id)
+
+        total = 2 * 5 * 1024**3
+        assert spies.broadcast.call_args.args == (job_id, total // 2, total)
+
+
+class TestExistingBackupProbe:
+    def test_a_missing_path_is_not_a_backup(self, tmp_path):
+        assert _JM._has_existing_backup(tmp_path / "nope") is False
+
+    def test_a_file_is_not_a_backup(self, tmp_path):
+        f = tmp_path / "x"
+        f.write_text("hi")
+        assert _JM._has_existing_backup(f) is False
+
+    def test_a_non_empty_directory_is_a_backup(self, tmp_path):
+        d = tmp_path / "d"
+        (d / "BDMV").mkdir(parents=True)
+        assert _JM._has_existing_backup(d) is True
+
+    def test_an_unreadable_destination_answers_false(self, monkeypatch, tmp_path):
+        d = tmp_path / "d"
+        d.mkdir()
+
+        def _boom(self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _boom)
+        assert _JM._has_existing_backup(d) is False

--- a/backend/tests/unit/test_run_backup.py
+++ b/backend/tests/unit/test_run_backup.py
@@ -12,6 +12,7 @@ Every job here stays NON-terminal on purpose: a job reaching COMPLETED/FAILED
 spawns a Discord notification task that leaks a pooled connection in tests.
 """
 
+import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -575,6 +576,18 @@ class TestHoldsDiscInDrive:
         job = DiscJob(drive_id="E:", state=JobState.BACKING_UP)
         assert JobManager._holds_disc_in_drive(job) is True
 
+    def test_a_finished_copy_stops_holding_it_before_the_state_moves(self):
+        # The window between _release_drive and _enter_ripping: the copy is done
+        # and the tray is open, but the job is still BACKING_UP. Answering from
+        # the state alone said "holding", which would cancel a succeeded backup
+        # on an eject and refuse a genuinely new disc in the empty drive.
+        job = DiscJob(
+            drive_id="E:",
+            state=JobState.BACKING_UP,
+            source_spec="file:/b/Show/Season 01/S01D01",
+        )
+        assert JobManager._holds_disc_in_drive(job) is False
+
     def test_an_unresolvable_source_is_assumed_to_hold_it(self):
         # Refusing a second job is the safe side of the guess.
         job = DiscJob(drive_id="", state=JobState.RIPPING)
@@ -666,3 +679,81 @@ class TestStalledBackupDegrades:
         # The copy must be stopped before the rip starts, or two makemkvcon
         # processes fight over one drive.
         cancel.assert_called_once_with(job_id)
+
+
+class TestWatchdogDoesNotDoubleRip:
+    """A stalled backup must produce exactly one rip, not two.
+
+    Killing only the subprocess left the in-flight _run_backup task alive; it
+    would see the cancel flag, return a failed BackupResult, and run its OWN
+    fallback. Two fallbacks for one job, and since _enter_ripping has no
+    idempotency guard and the state machine allows RIPPING to RIPPING, the
+    second spawned a second _run_ripping against the same staging dir.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_in_flight_backup_task_is_cancelled_first(self, monkeypatch):
+        job_id = await _seed()
+        monkeypatch.setattr(job_manager, "_enter_ripping", AsyncMock())
+        monkeypatch.setattr(job_manager._extractor, "cancel", MagicMock())
+
+        async def _never_finishes():
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_never_finishes())
+        job_manager._active_jobs[job_id] = task
+
+        config = SimpleNamespace(
+            timeout_identifying_seconds=0,
+            timeout_backing_up_seconds=60,
+            timeout_ripping_seconds=0,
+            timeout_matching_seconds=0,
+            timeout_organizing_seconds=0,
+        )
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+            job_manager._last_activity[job_id] = 0.0
+            await job_manager._watchdog_check_job(job, config, now=10_000.0)
+
+        assert task.cancelled() or task.cancelling() or task.done()
+        # And it is no longer the registered owner, so its unwind cannot clobber
+        # the rip task the fallback installs.
+        assert job_manager._active_jobs.get(job_id) is not task
+        task.cancel()
+
+
+class TestPostCopyFailureParksForReview:
+    """A failure after the copy degrades to review, never to a direct rip.
+
+    By that point source_spec already points at the copy, so a "direct rip"
+    would read it with unreconciled indices: the exact silent mis-file
+    reconciliation exists to prevent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_reconcile_error_parks_instead_of_ripping(self, monkeypatch, tmp_path):
+        job_id = await _seed()
+        dest = tmp_path / "Inception (2010)"
+
+        monkeypatch.setattr(
+            job_manager,
+            "_copy_disc_to_backup",
+            AsyncMock(return_value=("E:", dest)),
+        )
+        monkeypatch.setattr(job_manager, "_release_drive", AsyncMock(return_value=True))
+        monkeypatch.setattr(
+            job_manager,
+            "_reconcile_backup_titles",
+            AsyncMock(side_effect=RuntimeError("database is locked")),
+        )
+        enter_ripping = AsyncMock()
+        monkeypatch.setattr(job_manager, "_enter_ripping", enter_ripping)
+
+        await job_manager._run_backup(job_id)
+
+        async with _unit_session_factory() as session:
+            job = await session.get(DiscJob, job_id)
+
+        assert job.state is JobState.REVIEW_NEEDED
+        assert "database is locked" in (job.review_reason or "")
+        enter_ripping.assert_not_awaited()

--- a/backend/tests/unit/test_run_backup.py
+++ b/backend/tests/unit/test_run_backup.py
@@ -22,7 +22,7 @@ import pytest
 from app.core.extractor import BackupResult
 from app.models import DiscJob, JobState
 from app.models.disc_job import ContentType, DiscTitle, TitleState
-from app.services.job_manager import job_manager
+from app.services.job_manager import JobManager, job_manager
 from app.services.ripping_helpers import expected_native_index
 from tests.unit.conftest import _unit_session_factory
 
@@ -545,3 +545,37 @@ class TestExistingBackupProbe:
 
         monkeypatch.setattr(Path, "iterdir", _boom)
         assert _JM._has_existing_backup(d) is False
+
+
+class TestHoldsDiscInDrive:
+    """Whether a job in a disc-required state really has the disc loaded.
+
+    This is the decision the disc-insert guard consumes to decide if a new disc
+    is refused. It matters because the backup phase releases the drive the
+    moment the copy finishes, so a RIPPING job reading the copy must stop
+    blocking the tray: otherwise the feature's headline benefit (swap discs in
+    minutes rather than hours) does not happen.
+    """
+
+    def test_a_rip_from_the_drive_holds_it(self):
+        job = DiscJob(drive_id="E:", state=JobState.RIPPING)
+        assert JobManager._holds_disc_in_drive(job) is True
+
+    def test_a_rip_from_a_backup_does_not_hold_it(self):
+        job = DiscJob(drive_id="E:", state=JobState.RIPPING, source_spec="file:/b/Inception (2010)")
+        assert JobManager._holds_disc_in_drive(job) is False
+
+    def test_a_rip_from_an_iso_does_not_hold_it(self):
+        job = DiscJob(drive_id="import", state=JobState.RIPPING, source_spec="iso:/b/x.iso")
+        assert JobManager._holds_disc_in_drive(job) is False
+
+    def test_a_job_still_copying_holds_it(self):
+        # source_spec is only pointed at the copy once the copy has COMPLETED,
+        # so a BACKING_UP job reports the drive it is reading and still blocks.
+        job = DiscJob(drive_id="E:", state=JobState.BACKING_UP)
+        assert JobManager._holds_disc_in_drive(job) is True
+
+    def test_an_unresolvable_source_is_assumed_to_hold_it(self):
+        # Refusing a second job is the safe side of the guess.
+        job = DiscJob(drive_id="", state=JobState.RIPPING)
+        assert JobManager._holds_disc_in_drive(job) is True

--- a/backend/tests/unit/test_state_machine.py
+++ b/backend/tests/unit/test_state_machine.py
@@ -405,3 +405,27 @@ class TestStateTransitionSequences:
 
             # Reset for next iteration
             sample_job.state = JobState.IDLE
+
+
+class TestBackingUpTransitions:
+    def test_identifying_can_enter_backing_up(self):
+        assert JobState.BACKING_UP in JobStateMachine.VALID_TRANSITIONS[JobState.IDENTIFYING]
+
+    def test_backing_up_can_start_ripping(self):
+        assert JobState.RIPPING in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_can_park_for_review(self):
+        # Reconciliation failure parks here; it must not fall back to the drive,
+        # which may already be ejected.
+        assert JobState.REVIEW_NEEDED in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_can_fail(self):
+        assert JobState.FAILED in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_cannot_skip_straight_to_matching(self):
+        # There are no MKVs yet. Skipping RIPPING would strand the job.
+        assert JobState.MATCHING not in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_review_can_return_to_backing_up(self):
+        # A disc parked for a name prompt still needs its backup once answered.
+        assert JobState.BACKING_UP in JobStateMachine.VALID_TRANSITIONS[JobState.REVIEW_NEEDED]

--- a/backend/tests/unit/test_stuck_job_recovery.py
+++ b/backend/tests/unit/test_stuck_job_recovery.py
@@ -663,6 +663,7 @@ async def test_watchdog_review_needed_is_resting_state(tmp_path):
 def test_phase_timeout_reads_config():
     cfg = AppConfig()
     assert job_manager._phase_timeout(cfg, JobState.IDENTIFYING) == cfg.timeout_identifying_seconds
+    assert job_manager._phase_timeout(cfg, JobState.BACKING_UP) == cfg.timeout_backing_up_seconds
     assert job_manager._phase_timeout(cfg, JobState.RIPPING) == cfg.timeout_ripping_seconds
     assert job_manager._phase_timeout(cfg, JobState.MATCHING) == cfg.timeout_matching_seconds
     assert job_manager._phase_timeout(cfg, JobState.ORGANIZING) == cfg.timeout_organizing_seconds

--- a/backend/tests/unit/test_watchdog_cancel_attribution.py
+++ b/backend/tests/unit/test_watchdog_cancel_attribution.py
@@ -155,6 +155,7 @@ async def test_watchdog_passes_stall_specific_failure_message(rip_env, monkeypat
     monkeypatch.setattr(job_manager, "_rip_task_alive", lambda jid: False)
     config = SimpleNamespace(
         timeout_identifying_seconds=0,
+        timeout_backing_up_seconds=0,
         timeout_ripping_seconds=1200,
         timeout_matching_seconds=0,
         timeout_organizing_seconds=0,

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -260,6 +260,55 @@ never deleted regardless of this setting (the source folder is yours). See
 
 Disable `auto_eject_enabled` if you want to keep the disc in the drive after ripping — for example, to manually verify the output or to re-rip a title without re-inserting the disc. Applies to both normal rips and re-rips triggered from the review queue.
 
+### Disc Backup
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `backup_before_rip` | Copy the whole disc to a separate folder first, then extract from that copy | `false` |
+| `backup_path` | Where those copies go | (empty) |
+
+With this on, Engram writes a full decrypted MakeMKV copy of each disc under
+`backup_path` after identifying it, then extracts your MKVs from that copy
+instead of from the drive. Three things change:
+
+- **The disc is read once, sequentially**, instead of once per title. That is
+  much gentler on a scratched or fragile disc.
+- **The disc comes out of the drive as soon as the copy finishes**, not when the
+  whole rip finishes, so you can swap discs sooner.
+- **You keep the copy.** Engram never deletes a completed backup. It is yours to
+  move to a preservation server or re-import later.
+
+The cost is time and space: a Blu-ray backup is typically 25 to 50 GB and adds a
+full pass over the disc before extraction starts.
+
+Backups mirror your library layout, so the shelf browses the way your library
+does:
+
+```
+backups/
+  Movies/
+    Inception (2010)/
+  TV/
+    Frasier/
+      Season 01/
+        S01D01/
+  Unidentified/
+    THE_SWEETEST_THING/
+```
+
+The folder names come from your own naming settings, so if you customise
+`naming_movie_format` or `naming_tv_show_format` the backups follow.
+
+If anything prevents a backup (no folder configured, not enough free space, a
+disc MakeMKV cannot address, or a copy that fails partway) **Engram rips
+directly from the drive instead and tells you why on the job card.** Turning
+this on cannot make a disc less likely to finish.
+
+You can also point the **Import** button at a backup you already have. A folder
+containing `BDMV` or `VIDEO_TS`, or an `.iso` file, is recognised as a disc
+image and run through the normal scan, identify, rip, match and organize
+pipeline. Point it at a whole shelf of backups and it queues one job per disc.
+
 ### Naming Conventions
 
 Out of the box, organized files follow these patterns:

--- a/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
+++ b/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
@@ -884,6 +884,19 @@ git commit -m "feat(backup): add BACKING_UP state and backup columns"
 - Create: `backend/app/core/backup_paths.py`
 - Test: `backend/tests/unit/test_backup_paths.py`
 
+> **Superseded during review.** The code listed below hardcodes `Name (Year)` and
+> `Season NN`, which was wrong: library naming is user-configurable through
+> `naming_movie_format`, `naming_tv_show_format` and `naming_season_format`, and
+> the Organizer builds its folders with `format_movie_folder`,
+> `format_tv_show_folder` and `format_season_folder`. Hardcoding the default
+> shape gave a user with a custom format a backup tree that no longer mirrored
+> their library, which is the one thing this module exists to prevent. The
+> shipped implementation takes `backup_destination(job, config)` (an `AppConfig`,
+> not a root string) and delegates to those three helpers. Note the consequence:
+> the default `naming_tv_show_format` is `"{show}"`, so a TV backup folder
+> carries no year by default, exactly as the library folder does not. See
+> commit `af801b57`.
+
 - [ ] **Step 1: Write the failing tests**
 
 Create `backend/tests/unit/test_backup_paths.py`:
@@ -2109,7 +2122,7 @@ Add the method next to `_run_ripping`:
                 )
 
             config = await get_config()
-            dest = backup_destination(job, config.backup_path if config else "")
+            dest = backup_destination(job, config)
             if dest is None:
                 await _fall_back("skipped", "not_configured")
                 return

--- a/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
+++ b/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
@@ -3578,3 +3578,49 @@ Two deliberate deviations from the spec, both improvements found while planning:
 
 1. The spec's frontend section assumed a new UI state. Task 17 instead repurposes the orphaned `archiving_iso` / `isoProgress` scaffolding, which no backend code has ever emitted. Adding an eleventh state beside a dead tenth one would create exactly the drift `discState.ts` warns about.
 2. `next_state_after_identify` returns `RIPPING` when `backup_before_rip` is on but `backup_path` is empty, rather than entering `BACKING_UP` and immediately falling back. The `skipped` / `not_configured` path in `_run_backup` remains as the backstop for a root that is emptied mid-job, so both are covered.
+
+---
+
+## Execution record: where this plan was wrong
+
+Two gaps were found during execution that the plan itself caused. Recording
+them because they are the useful part of the retrospective.
+
+**1. The plan set `source_spec` but never made anything read it (Task 14b).**
+Task 10 correctly recorded `source_spec = file:<backup>` and released the
+drive. But every MakeMKV call site still passed `job.drive_id`: the scan in
+`identification_coordinator`, and three separate `rip_titles` calls in
+`job_manager`. `DiscSource.from_job` existed and was referenced only in a
+comment. So the shipped feature would have ejected the disc and then tried to
+rip from the now-empty drive, and a disc-image import would have raised on
+`drive_id == "import"`. The whole point of the feature did not happen. Caught
+by an implementer who flagged it as an out-of-scope concern rather than
+silently working around it. Fixed in `d4d7376b`, which also gated the
+end-of-rip drive release on `DiscSource.is_physical` so one disc no longer
+produces two "ripped" notifications.
+
+Lesson: a plan that writes a field must name the task that reads it.
+
+**2. The plan missed a fifth hand-off site (the pre-rip resume).**
+Task 11 converted the three identification sites and `start_ripping`, but
+`_apply_identity_resume_action` carries its own dispatch table with
+`"start_rip"` hardcoded to `_run_ripping`. A disc parked before ripping for a
+name prompt therefore skipped its backup entirely once the user answered. That
+is precisely the case the `REVIEW_NEEDED -> BACKING_UP` state edge was added
+for, and nothing was using it. Fixed in `c4b7c249` by splitting the pre-rip
+resume into `"start_rip"` and `"start_backup"`.
+
+Lesson: `grep` for the state assignment finds the sites that set state; it does
+not find the dispatch tables that decide what runs next.
+
+**Also corrected during review, in order:** the `_parse_backup_progress`
+fixtures contradicted their own formula (a verbatim rip log already in the
+suite settled it); `backup_status` encoded its reason after a colon, which
+three consumers would have had to parse, replaced with the
+`subtitle_status`/`subtitle_error_message` shape already in the model;
+`backup_paths` hardcoded the default folder shape instead of delegating to the
+Organizer's configurable naming helpers; `_reconcile_backup_titles` rewrote
+`title_index` but not `output_index`, which `expected_native_index` prefers, so
+a swapped pair would have inverted files onto each other's rows; and the
+reconciler's fast path declared IDENTICAL on index and duration alone, ignoring
+the `source_filename` evidence that proved a swap.

--- a/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
+++ b/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
@@ -1,0 +1,3528 @@
+# Disc Backup Before Rip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Optionally write a full decrypted MakeMKV backup of a disc to a separate root after identification, extract MKVs from that backup instead of from the drive, and let the user import an existing backup folder or ISO through the manual import modal.
+
+**Architecture:** A job's MakeMKV source becomes a value (`DiscSource`: drive, backup folder, or ISO) rather than an assumed drive letter, stored as a `source_spec` string on `DiscJob`. A new `JobState.BACKING_UP` sits between `IDENTIFYING` and `RIPPING`; on success it rewrites `source_spec` to `file:<backup>` and releases the drive early. Every backup problem degrades to today's direct rip, so enabling the setting can never make a disc less likely to finish.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLModel + aiosqlite, Alembic, asyncio subprocess wrapping `makemkvcon`, pytest. Frontend: React 18 + TypeScript, Vite, vitest + React Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md`
+
+---
+
+## Working agreements
+
+- All backend commands run from `backend/`. Always `uv run ...`, never bare `python`/`pytest`.
+- All frontend commands run from `frontend/`.
+- Never delete `backend/engram.db`.
+- Never start a server with `--reload`.
+- Do not write em dashes in code comments, docstrings, or docs.
+- Commit after every task. Commit messages reference the feature, not the task number.
+- Do not run the full backend unit suite in one go inside an agent (it exceeds 300 s). Run the specific test files named in each task.
+
+## File structure
+
+**New backend files**
+
+| File | Responsibility |
+| --- | --- |
+| `backend/app/core/disc_source.py` | The `DiscSource` value object and `resolve_disc_index()`. Pure except the one subprocess call. |
+| `backend/app/core/backup_paths.py` | Backup destination naming and the free-space preflight. Pure. |
+| `backend/migrations/versions/<rev>_add_backup_columns.py` | Alembic migration for the three `disc_jobs` columns and two `app_config` columns. |
+| `backend/tests/unit/test_disc_source.py` | Unit tests for `disc_source`. |
+| `backend/tests/unit/test_backup_paths.py` | Unit tests for `backup_paths`. |
+| `backend/tests/unit/test_backup_disc.py` | Unit tests for `Extractor.backup_disc` and its argv builder. |
+| `backend/tests/unit/test_backup_reconciliation.py` | Unit tests for post-backup title reconciliation. |
+| `backend/tests/unit/test_import_scanner_disc_images.py` | Unit tests for disc-image detection. |
+
+**Modified backend files**
+
+| File | Change |
+| --- | --- |
+| `backend/app/models/disc_job.py` | `JobState.BACKING_UP`; `source_spec`, `backup_path`, `backup_status` columns. |
+| `backend/app/models/app_config.py` | `backup_before_rip`, `backup_path`, `timeout_backing_up_seconds`. |
+| `backend/app/core/extractor.py` | `_to_source_spec`, `DiscSource`-aware locking, `backup_disc()`, `BackupResult`. |
+| `backend/app/core/import_scanner.py` | `DiscImageUnit` detection and short-circuit. |
+| `backend/app/services/job_state_machine.py` | New transitions. |
+| `backend/app/services/job_manager.py` | `_run_backup`, reconciliation, `_release_drive` outcome, `_phase_timeout`. |
+| `backend/app/services/identification_coordinator.py` | Route to `BACKING_UP` instead of `RIPPING` when enabled. |
+| `backend/app/services/event_broadcaster.py`, `backend/app/api/websocket.py` | `backup_progress` message. |
+| `backend/app/services/simulation_service.py` | `simulate_backup`. |
+| `backend/app/api/routes.py` | Config schemas, import browse/preview/start, job detail. |
+
+**Modified frontend files**
+
+| File | Change |
+| --- | --- |
+| `frontend/src/app/components/DiscCard.tsx` | Rename the orphaned `archiving_iso` state to `backing_up`; `backupProgress`; backup-status note. |
+| `frontend/src/app/components/discState.ts` | Rename the state key and relabel. |
+| `frontend/src/types/adapters.ts` | Map `backing_up`. |
+| `frontend/src/components/ConfigWizard.tsx` | Toggle and path picker. |
+| `frontend/src/components/ImportModal.tsx` | Disc-image and ISO entries. |
+| `frontend/src/components/HistoryPage/` | Backup path and status in the detail panel. |
+
+**Important pre-existing condition:** `archiving_iso` and `isoProgress` already exist in the frontend (`DiscCard.tsx:18`, `DiscCard.tsx:72`, `DiscCard.tsx:676`, `discState.ts:31`) but no backend code emits them and only `mockData.ts` feeds them. They are orphaned design-era scaffolding. Task 18 repurposes them rather than adding an eleventh state, because a dead `ARCHIVING` state sitting next to a live `BACKING UP` state is exactly the drift the comments in `discState.ts` warn about.
+
+---
+
+## Task 1: `DiscSource` value object
+
+**Files:**
+- Create: `backend/app/core/disc_source.py`
+- Test: `backend/tests/unit/test_disc_source.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_disc_source.py`:
+
+```python
+"""Unit tests for the DiscSource value object."""
+
+import pytest
+
+from app.core.disc_source import DiscSource, SourceKind
+
+
+class TestParse:
+    def test_bare_drive_letter_is_a_drive(self):
+        s = DiscSource.parse("E:")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_dev_prefixed_drive_passes_through(self):
+        s = DiscSource.parse("dev:E:")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_linux_device_is_a_drive(self):
+        s = DiscSource.parse("/dev/sr0")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:/dev/sr0"
+
+    def test_disc_index_is_a_drive(self):
+        s = DiscSource.parse("disc:0")
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "disc:0"
+
+    def test_file_spec_is_a_backup(self, tmp_path):
+        s = DiscSource.parse(f"file:{tmp_path}")
+        assert s.kind is SourceKind.BACKUP
+        assert s.spec == f"file:{tmp_path}"
+
+    def test_iso_spec_is_an_iso(self, tmp_path):
+        iso = tmp_path / "disc.iso"
+        s = DiscSource.parse(f"iso:{iso}")
+        assert s.kind is SourceKind.ISO
+        assert s.spec == f"iso:{iso}"
+
+    def test_windows_path_in_file_spec_survives_the_colon(self):
+        # "file:D:\\backups\\x" must not be split on the drive-letter colon.
+        s = DiscSource.parse("file:D:\\backups\\Inception (2010)")
+        assert s.kind is SourceKind.BACKUP
+        assert s.value == "D:\\backups\\Inception (2010)"
+
+    def test_empty_spec_is_rejected(self):
+        with pytest.raises(ValueError):
+            DiscSource.parse("")
+
+
+class TestPhysicality:
+    def test_drive_is_physical(self):
+        assert DiscSource.parse("E:").is_physical is True
+
+    def test_backup_is_not_physical(self):
+        assert DiscSource.parse("file:/backups/x").is_physical is False
+
+    def test_iso_is_not_physical(self):
+        assert DiscSource.parse("iso:/backups/x.iso").is_physical is False
+
+
+class TestLockKey:
+    def test_drive_forms_share_one_lock_key(self):
+        assert DiscSource.parse("E:").lock_key == DiscSource.parse("dev:E:").lock_key
+
+    def test_trailing_separator_does_not_split_the_lock(self):
+        assert DiscSource.parse("dev:E:\\").lock_key == DiscSource.parse("E:").lock_key
+
+    def test_a_backup_does_not_share_a_drive_lock(self):
+        drive = DiscSource.parse("E:")
+        backup = DiscSource.parse("file:E:\\backups\\x")
+        assert backup.lock_key != drive.lock_key
+
+    def test_two_backups_at_the_same_path_share_a_lock(self):
+        a = DiscSource.parse("file:/backups/x")
+        b = DiscSource.parse("file:/backups/x")
+        assert a.lock_key == b.lock_key
+
+
+class TestFromJob:
+    def test_source_spec_wins_when_present(self):
+        job = _FakeJob(drive_id="E:", source_spec="file:/backups/x")
+        s = DiscSource.from_job(job)
+        assert s.kind is SourceKind.BACKUP
+        assert s.value == "/backups/x"
+
+    def test_legacy_row_falls_back_to_drive_id(self):
+        job = _FakeJob(drive_id="E:", source_spec=None)
+        s = DiscSource.from_job(job)
+        assert s.kind is SourceKind.DRIVE
+        assert s.spec == "dev:E:"
+
+    def test_import_drive_id_without_source_spec_is_rejected(self):
+        # A manual-import job has no MakeMKV source at all; asking for one is a bug.
+        job = _FakeJob(drive_id="import", source_spec=None)
+        with pytest.raises(ValueError):
+            DiscSource.from_job(job)
+
+
+class _FakeJob:
+    def __init__(self, drive_id: str, source_spec: str | None):
+        self.drive_id = drive_id
+        self.source_spec = source_spec
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_disc_source.py -q
+```
+
+Expected: collection error, `ModuleNotFoundError: No module named 'app.core.disc_source'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/app/core/disc_source.py`:
+
+```python
+"""What a job points MakeMKV at.
+
+MakeMKV accepts three source forms: ``dev:<drive or device>``, ``disc:<index>``
+and ``file:<path>`` (a backup folder or an ISO). Engram historically assumed the
+first, so "is this source a physical drive?" was answered ad hoc with string
+tests at every call site that needed eject, sentinel re-arm, drive locking or
+progress labelling. This module is the single answer.
+
+Pure, apart from :func:`resolve_disc_index`, which shells out to makemkvcon.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+# "iso:" is Engram's own spec kind, not a MakeMKV one: MakeMKV reads an ISO
+# through the same file: source as a folder. Keeping them distinct lets the UI
+# and the import scanner say which one the user picked without re-stat-ing disk.
+_SCHEMES = ("dev:", "disc:", "file:", "iso:")
+
+# A bare Windows drive letter ("E:", "E:\") or a POSIX device path.
+_BARE_DRIVE_RE = re.compile(r"^(?:[A-Za-z]:\\?|/dev/[A-Za-z0-9/]+)$")
+
+
+class SourceKind(StrEnum):
+    """What kind of thing a job reads from."""
+
+    DRIVE = "drive"
+    BACKUP = "backup"
+    ISO = "iso"
+
+
+@dataclass(frozen=True)
+class DiscSource:
+    """A MakeMKV source, and the behaviour that depends on which kind it is."""
+
+    kind: SourceKind
+    value: str
+    # Which MakeMKV scheme to emit for a DRIVE. Preserved rather than recomputed
+    # so a caller that resolved "E:" to "disc:0" keeps that resolution.
+    _scheme: str = "dev:"
+
+    @classmethod
+    def parse(cls, spec: str) -> DiscSource:
+        """Build a source from a stored spec string or a bare drive identifier."""
+        if not spec:
+            raise ValueError("Empty disc source spec")
+
+        for scheme in _SCHEMES:
+            if spec.startswith(scheme):
+                # split on the FIRST colon only: "file:D:\backups\x" must keep
+                # its Windows drive-letter colon.
+                value = spec[len(scheme) :]
+                if not value:
+                    raise ValueError(f"Disc source spec has no value: {spec!r}")
+                if scheme == "file:":
+                    return cls(SourceKind.BACKUP, value)
+                if scheme == "iso:":
+                    return cls(SourceKind.ISO, value)
+                return cls(SourceKind.DRIVE, value, scheme)
+
+        if _BARE_DRIVE_RE.match(spec):
+            return cls(SourceKind.DRIVE, spec, "dev:")
+
+        raise ValueError(f"Unrecognized disc source spec: {spec!r}")
+
+    @classmethod
+    def from_job(cls, job) -> DiscSource:
+        """Build a source from a DiscJob, honouring legacy rows.
+
+        ``source_spec`` is None on every row written before this feature, where
+        the source was always the drive. A manual-import job (``drive_id ==
+        "import"``) has no MakeMKV source at all, so asking for one is a bug in
+        the caller rather than something to paper over.
+        """
+        spec = getattr(job, "source_spec", None)
+        if spec:
+            return cls.parse(spec)
+        drive_id = job.drive_id
+        if not drive_id or drive_id == "import":
+            raise ValueError(
+                f"Job has no MakeMKV source: drive_id={drive_id!r}, source_spec=None"
+            )
+        return cls.parse(drive_id)
+
+    @classmethod
+    def for_backup(cls, path: Path | str) -> DiscSource:
+        """A source reading from a completed backup folder."""
+        return cls(SourceKind.BACKUP, str(path))
+
+    @property
+    def spec(self) -> str:
+        """The argument to hand makemkvcon."""
+        if self.kind is SourceKind.DRIVE:
+            return f"{self._scheme}{self.value}"
+        if self.kind is SourceKind.ISO:
+            return f"iso:{self.value}"
+        return f"file:{self.value}"
+
+    @property
+    def makemkv_arg(self) -> str:
+        """The argument makemkvcon actually accepts.
+
+        An ISO is read through the same ``file:`` source as a folder; the ISO
+        kind exists for Engram's own bookkeeping, not for MakeMKV's.
+        """
+        if self.kind is SourceKind.ISO:
+            return f"file:{self.value}"
+        return self.spec
+
+    @property
+    def is_physical(self) -> bool:
+        """Whether this source is a real optical drive.
+
+        Gates eject, sentinel re-arm, disc-hash computation and every other
+        behaviour that only makes sense for hardware.
+        """
+        return self.kind is SourceKind.DRIVE
+
+    @property
+    def lock_key(self) -> str:
+        """Key for the per-source MakeMKV serialization lock.
+
+        Physical drives normalize so "E:", "dev:E:" and "dev:E:\\" contend for
+        one lock. A file source keys on its own path instead: two makemkvcon
+        processes reading different backups do not contend, and a backup on
+        drive E: must not block the optical drive at E:.
+        """
+        if self.is_physical:
+            return "drive:" + self.value.replace("dev:", "").replace("disc:", "").rstrip("\\")
+        return "path:" + str(Path(self.value))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_disc_source.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/disc_source.py tests/unit/test_disc_source.py && uv run ruff format app/core/disc_source.py tests/unit/test_disc_source.py
+git add backend/app/core/disc_source.py backend/tests/unit/test_disc_source.py
+git commit -m "feat(backup): add DiscSource value object for drive/backup/ISO sources"
+```
+
+---
+
+## Task 2: Resolve a drive to a MakeMKV disc index
+
+`makemkvcon backup` accepts only `disc:N`, never `dev:E:`. Engram has never needed this mapping.
+
+**Files:**
+- Modify: `backend/app/core/disc_source.py`
+- Modify: `backend/tests/unit/test_disc_source.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_disc_source.py`:
+
+```python
+from unittest.mock import patch
+
+from app.core.disc_source import parse_drive_listing, resolve_disc_index
+
+# Real makemkvcon -r info disc:9999 output shape. DRV lines are:
+# DRV:index,visible,enabled,flags,"drive name","disc name","device"
+_LISTING = (
+    'DRV:0,2,999,1,"BD-RE HL-DT-ST BH16NS40 1.05","THE_SWEETEST_THING","E:"\n'
+    'DRV:1,0,999,0,"","",""\n'
+    'DRV:2,2,999,1,"HL-DT-ST DVDRAM GH24","INCEPTION","F:"\n'
+    "TCOUNT:0\n"
+)
+
+
+class TestParseDriveListing:
+    def test_maps_device_to_index(self):
+        assert parse_drive_listing(_LISTING) == {"E:": 0, "F:": 2}
+
+    def test_ignores_empty_drive_slots(self):
+        assert "" not in parse_drive_listing(_LISTING)
+
+    def test_empty_output_maps_nothing(self):
+        assert parse_drive_listing("") == {}
+
+    def test_malformed_line_is_skipped_not_raised(self):
+        assert parse_drive_listing('DRV:garbage\nDRV:0,2,999,1,"n","d","E:"\n') == {"E:": 0}
+
+
+class TestResolveDiscIndex:
+    @pytest.mark.asyncio
+    async def test_resolves_a_known_drive(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("E:", makemkv_path="mmk") == "disc:0"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_on_windows_letters(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("e:", makemkv_path="mmk") == "disc:0"
+
+    @pytest.mark.asyncio
+    async def test_unknown_drive_returns_none(self):
+        with patch("app.core.disc_source._run_drive_listing", return_value=_LISTING):
+            assert await resolve_disc_index("Z:", makemkv_path="mmk") is None
+
+    @pytest.mark.asyncio
+    async def test_subprocess_failure_returns_none(self):
+        with patch("app.core.disc_source._run_drive_listing", side_effect=OSError("boom")):
+            assert await resolve_disc_index("E:", makemkv_path="mmk") is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_disc_source.py -q -k "DriveListing or DiscIndex"
+```
+
+Expected: `ImportError: cannot import name 'parse_drive_listing'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `backend/app/core/disc_source.py`:
+
+```python
+import asyncio
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# makemkvcon -r info disc:9999 lists drives without touching a disc. 9999 is
+# MakeMKV's documented "no such drive" index: the scan fails, but the DRV lines
+# describing every drive are printed first, which is all we want.
+_DRIVE_LISTING_INDEX = "disc:9999"
+
+# DRV:index,visible,enabled,flags,"drive name","disc name","device"
+_DRV_RE = re.compile(r'^DRV:(\d+),\d+,\d+,\d+,"[^"]*","[^"]*","([^"]*)"')
+
+_DRIVE_LISTING_TIMEOUT = 30.0
+
+
+def parse_drive_listing(output: str) -> dict[str, int]:
+    """Map each device identifier in a makemkvcon DRV listing to its disc index.
+
+    Slots with an empty device string are drives MakeMKV enumerated but cannot
+    use, and are omitted. A malformed line is skipped rather than raised on: a
+    single unparseable row must not cost us the whole mapping.
+    """
+    mapping: dict[str, int] = {}
+    for line in output.splitlines():
+        m = _DRV_RE.match(line.strip())
+        if not m:
+            continue
+        device = m.group(2).strip()
+        if device:
+            mapping[device] = int(m.group(1))
+    return mapping
+
+
+def _run_drive_listing(makemkv_path: str) -> str:
+    """Run the drive enumeration synchronously (called via asyncio.to_thread)."""
+    result = subprocess.run(
+        [makemkv_path, "-r", "info", _DRIVE_LISTING_INDEX],
+        capture_output=True,
+        text=True,
+        timeout=_DRIVE_LISTING_TIMEOUT,
+        check=False,
+    )
+    # Non-zero is expected: index 9999 does not exist. The DRV lines we want are
+    # printed before the failure, so stdout is used regardless of return code.
+    return result.stdout
+
+
+async def resolve_disc_index(drive: str, makemkv_path: str) -> str | None:
+    """Return the ``disc:N`` spec for a drive, or None if it cannot be resolved.
+
+    ``makemkvcon backup`` accepts only ``disc:N``, so a backup cannot start
+    without this. None is a normal outcome, not an error: the caller degrades to
+    a direct rip.
+    """
+    normalized = drive.replace("dev:", "").rstrip("\\")
+    try:
+        output = await asyncio.to_thread(_run_drive_listing, makemkv_path)
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(f"Could not enumerate MakeMKV drives: {e}", exc_info=True)
+        return None
+
+    mapping = parse_drive_listing(output)
+    for device, index in mapping.items():
+        if device.rstrip("\\").lower() == normalized.lower():
+            return f"disc:{index}"
+
+    logger.warning(
+        f"Drive {normalized} not found in MakeMKV drive listing "
+        f"(saw: {sorted(mapping)}); cannot back up"
+    )
+    return None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_disc_source.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/disc_source.py tests/unit/test_disc_source.py && uv run ruff format app/core/disc_source.py tests/unit/test_disc_source.py
+git add backend/app/core/disc_source.py backend/tests/unit/test_disc_source.py
+git commit -m "feat(backup): resolve a drive letter to a MakeMKV disc index"
+```
+
+---
+
+## Task 3: Thread `DiscSource` through the Extractor
+
+**Files:**
+- Modify: `backend/app/core/extractor.py:65-72` (`_to_drive_spec`), `:670-676` (`_get_drive_lock`), `:678-700` (`scan_disc`), `:772-826` (`rip_titles`)
+- Test: `backend/tests/unit/test_extractor_source.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_extractor_source.py`:
+
+```python
+"""The Extractor accepts a DiscSource, not just a drive letter."""
+
+from app.core.disc_source import DiscSource
+from app.core.extractor import MakeMKVExtractor, _to_source_spec
+
+
+class TestToSourceSpec:
+    def test_bare_drive_gets_a_dev_prefix(self):
+        assert _to_source_spec("E:") == "dev:E:"
+
+    def test_disc_index_passes_through(self):
+        assert _to_source_spec("disc:0") == "disc:0"
+
+    def test_file_spec_passes_through(self):
+        assert _to_source_spec("file:/backups/x") == "file:/backups/x"
+
+    def test_disc_source_object_is_accepted(self):
+        assert _to_source_spec(DiscSource.for_backup("/backups/x")) == "file:/backups/x"
+
+    def test_iso_is_handed_to_makemkv_as_a_file_source(self):
+        assert _to_source_spec(DiscSource.parse("iso:/b/x.iso")) == "file:/b/x.iso"
+
+
+class TestSourceLocking:
+    def test_drive_forms_share_one_lock(self):
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        assert ex._get_source_lock("E:") is ex._get_source_lock("dev:E:")
+
+    def test_a_backup_does_not_take_the_drive_lock(self):
+        # Regression guard: extracting from a backup must not block the optical
+        # drive at the same letter from scanning the next disc.
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        assert ex._get_source_lock("E:") is not ex._get_source_lock("file:E:\\backups\\x")
+
+    def test_the_same_backup_path_shares_one_lock(self):
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        assert ex._get_source_lock("file:/b/x") is ex._get_source_lock("file:/b/x")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_extractor_source.py -q
+```
+
+Expected: `ImportError: cannot import name '_to_source_spec'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/extractor.py`, replace `_to_drive_spec` (line 65) with:
+
+```python
+def _to_source_spec(source: "DiscSource | str") -> str:
+    """Normalize a source into the argument makemkvcon accepts.
+
+    Accepts a DiscSource, a bare drive identifier, or an already-schemed spec,
+    so existing call sites that pass ``job.drive_id`` keep working unchanged.
+    """
+    from app.core.disc_source import DiscSource
+
+    if isinstance(source, DiscSource):
+        return source.makemkv_arg
+    return DiscSource.parse(source).makemkv_arg
+```
+
+Replace `_get_drive_lock` (line 670) with:
+
+```python
+    def _get_source_lock(self, source: "DiscSource | str") -> asyncio.Lock:
+        """Get or create the per-source lock serializing MakeMKV operations.
+
+        Two makemkvcon processes fighting over one optical drive stall both, so
+        every physical drive form keys to one lock. A backup or ISO keys on its
+        own path instead: reading a backup does not touch the drive, and making
+        it wait for the drive lock would silently serialize work that is now
+        genuinely independent.
+        """
+        from app.core.disc_source import DiscSource
+
+        parsed = source if isinstance(source, DiscSource) else DiscSource.parse(source)
+        key = parsed.lock_key
+        if key not in self._source_locks:
+            self._source_locks[key] = asyncio.Lock()
+        return self._source_locks[key]
+```
+
+In `__init__` (line 659), rename the attribute:
+
+```python
+        # Per-source locks prevent concurrent MakeMKV operations on one source.
+        # Two makemkvcon processes fighting over one drive causes both to stall.
+        self._source_locks: dict[str, asyncio.Lock] = {}
+```
+
+Then update every internal reference: `scan_disc`, `rip_titles` and their `_unlocked` twins call `self._get_source_lock(...)` and `_to_source_spec(...)`. Widen the parameter type on `scan_disc`, `_scan_disc_unlocked`, `rip_titles` and `_rip_titles_unlocked` from `drive: str` to `source: "DiscSource | str"`, keeping the positional order so no call site needs to change. Update the docstrings to say "source" rather than "drive".
+
+Add at the top of the module, under the existing imports:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.disc_source import DiscSource
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_extractor_source.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the existing extractor tests to verify nothing regressed**
+
+```bash
+cd backend && uv run pytest tests/unit -q -k "extractor or rip"
+```
+
+Expected: all pass. If any test patches or asserts on `_to_drive_spec` or `_get_drive_lock` by name, update the test to the new name; those are the only two renames.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/extractor.py tests/unit/test_extractor_source.py && uv run ruff format app/core/extractor.py tests/unit/test_extractor_source.py
+git add backend/app/core/extractor.py backend/tests/unit/test_extractor_source.py backend/tests/unit
+git commit -m "refactor(backup): make the Extractor source-shaped rather than drive-shaped"
+```
+
+---
+
+## Task 4: Database columns and migration
+
+**Files:**
+- Modify: `backend/app/models/disc_job.py`
+- Modify: `backend/app/models/app_config.py`
+- Create: `backend/migrations/versions/<rev>_add_backup_columns.py`
+- Test: `backend/tests/unit/test_backup_columns.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/test_backup_columns.py`:
+
+```python
+"""The backup columns exist, default correctly, and read safely on legacy rows."""
+
+from app.models import AppConfig, DiscJob, JobState
+
+
+class TestDiscJobBackupColumns:
+    def test_new_job_has_no_source_spec(self):
+        # None means "legacy or drive-sourced"; DiscSource.from_job falls back.
+        assert DiscJob(drive_id="E:").source_spec is None
+
+    def test_new_job_has_no_backup_path_or_status(self):
+        job = DiscJob(drive_id="E:")
+        assert job.backup_path is None
+        assert job.backup_status is None
+
+
+class TestAppConfigBackupFields:
+    def test_backup_is_off_by_default(self):
+        # Opt-in: an upgraded row with NULL must read as disabled, which is why
+        # the column carries server_default 0 (see discord_notify_ripped).
+        assert AppConfig().backup_before_rip is False
+
+    def test_backup_path_defaults_empty(self):
+        assert AppConfig().backup_path == ""
+
+    def test_backing_up_has_its_own_timeout(self):
+        # A 40 GB sequential copy cannot share the ripping phase ceiling.
+        assert AppConfig().timeout_backing_up_seconds > 0
+
+
+class TestJobState:
+    def test_backing_up_exists_and_is_not_terminal(self):
+        from app.models import TERMINAL_JOB_STATES
+
+        assert JobState.BACKING_UP.value == "backing_up"
+        assert JobState.BACKING_UP not in TERMINAL_JOB_STATES
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_columns.py -q
+```
+
+Expected: `AttributeError: type object 'DiscJob' has no attribute 'source_spec'` (or the `JobState.BACKING_UP` equivalent).
+
+- [ ] **Step 3: Add the model fields**
+
+In `backend/app/models/disc_job.py`, add to the `JobState` enum after `IDENTIFYING`:
+
+```python
+    BACKING_UP = "backing_up"  # Writing a full decrypted disc copy before extraction
+```
+
+Add to `DiscJob`, in the Paths block after `import_manifest_json`:
+
+```python
+    # What MakeMKV is pointed at for this job: "dev:E:", "disc:0",
+    # "file:<backup folder>" or "iso:<file>". None on every row written before
+    # backup support, meaning "legacy: derive from drive_id" (DiscSource.from_job).
+    # Diverges from drive_id exactly once: after a successful backup, drive_id is
+    # still the drive the disc came from while source_spec has become the copy.
+    source_spec: str | None = Field(default=None)
+    # Where this job's backup landed. Kept for history and for re-import; Engram
+    # never deletes it.
+    backup_path: str | None = Field(default=None)
+    # "pending" | "completed" | "failed:<reason>" | "skipped:<reason>".
+    # None means no backup was attempted (the feature is off).
+    backup_status: str | None = Field(default=None)
+```
+
+In `backend/app/models/app_config.py`, add next to the other path fields (near line 43):
+
+```python
+    # Root for full decrypted disc backups. Empty means the feature cannot run,
+    # which the backup phase reports as skipped:not_configured rather than failing.
+    backup_path: str = ""
+```
+
+Add next to `always_review` (near line 141):
+
+```python
+    # Write a full decrypted disc copy under backup_path after identification and
+    # extract from that copy instead of the drive. server_default 0, like
+    # discord_notify_ripped: an opt-in feature must read a NULL as disabled.
+    backup_before_rip: bool = Field(default=False, sa_column_kwargs={"server_default": text("0")})
+```
+
+Add next to the other phase timeouts (near line 121), matching their `Field(...)` shape:
+
+```python
+    # A 40 GB sequential copy is slower than any other phase and, on the scratched
+    # discs this feature exists for, deliberately slow. Two hours of no output
+    # growth, not of wall clock.
+    timeout_backing_up_seconds: int = Field(
+        default=7200, sa_column_kwargs={"server_default": text("7200")}
+    )
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_columns.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Generate the migration**
+
+Find the current head, then write the migration by hand (do not autogenerate; autogenerate against a live dev DB picks up unrelated drift):
+
+```bash
+cd backend && uv run alembic heads
+```
+
+Create `backend/migrations/versions/<newrev>_add_backup_columns.py`, replacing `<HEAD>` with the revision printed above and `<newrev>` with a fresh 12-hex-character id:
+
+```python
+"""Add disc backup columns.
+
+Revision ID: <newrev>
+Revises: <HEAD>
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "<newrev>"
+down_revision: str | Sequence[str] | None = "<HEAD>"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("disc_jobs", sa.Column("source_spec", sa.String(), nullable=True))
+    op.add_column("disc_jobs", sa.Column("backup_path", sa.String(), nullable=True))
+    op.add_column("disc_jobs", sa.Column("backup_status", sa.String(), nullable=True))
+    op.add_column(
+        "app_config",
+        sa.Column("backup_path", sa.String(), nullable=False, server_default=sa.text("''")),
+    )
+    # server_default 0: this is opt-in, so an upgraded row must come back OFF.
+    op.add_column(
+        "app_config",
+        sa.Column(
+            "backup_before_rip", sa.Boolean(), nullable=False, server_default=sa.text("0")
+        ),
+    )
+    op.add_column(
+        "app_config",
+        sa.Column(
+            "timeout_backing_up_seconds",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("7200"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("app_config", schema=None) as batch_op:
+        batch_op.drop_column("timeout_backing_up_seconds")
+        batch_op.drop_column("backup_before_rip")
+        batch_op.drop_column("backup_path")
+    with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("backup_status")
+        batch_op.drop_column("backup_path")
+        batch_op.drop_column("source_spec")
+```
+
+This revision contains only `add_column` calls, which is required: `_run_alembic_upgrade`'s duplicate-column self-heal stamps a whole revision as applied when any `ADD COLUMN` in it collides with `_add_missing_columns`, so mixing other DDL into this revision would let that DDL be silently skipped.
+
+- [ ] **Step 6: Verify the migration applies to a scratch database**
+
+```bash
+cd backend && DATABASE_URL="sqlite+aiosqlite:///./scratch-backup-migration.db" uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())" && rm -f scratch-backup-migration.db
+```
+
+Expected: exits 0, logs `Database initialized successfully`. Never point this at `engram.db`.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/models tests/unit/test_backup_columns.py migrations/versions && uv run ruff format app/models tests/unit/test_backup_columns.py migrations/versions
+git add backend/app/models backend/migrations/versions backend/tests/unit/test_backup_columns.py
+git commit -m "feat(backup): add BACKING_UP state and backup columns"
+```
+
+---
+
+## Task 5: Backup destination naming
+
+**Files:**
+- Create: `backend/app/core/backup_paths.py`
+- Test: `backend/tests/unit/test_backup_paths.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_backup_paths.py`:
+
+```python
+"""Backup destination naming and the free-space preflight."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from app.core.backup_paths import backup_destination, has_room_for_backup
+from app.models import ContentType, DiscJob
+
+
+def _job(**kw) -> DiscJob:
+    base = {"drive_id": "E:", "volume_label": "DISC_LABEL"}
+    base.update(kw)
+    return DiscJob(**base)
+
+
+class TestBackupDestination:
+    def test_movie_uses_name_and_year(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception", tmdb_year=2010)
+        assert backup_destination(job, "/b") == Path("/b/Movies/Inception (2010)")
+
+    def test_movie_without_year_omits_the_parenthetical(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="Inception")
+        assert backup_destination(job, "/b") == Path("/b/Movies/Inception")
+
+    def test_tv_uses_show_season_and_disc(self):
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Frasier",
+            tmdb_year=1993,
+            detected_season=1,
+            disc_number=2,
+        )
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/Disc 2")
+
+    def test_tv_prefers_the_discdb_disc_slug(self):
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Frasier",
+            tmdb_year=1993,
+            detected_season=1,
+            discdb_disc_slug="S01D02",
+        )
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Season 01/S01D02")
+
+    def test_tv_without_a_season_still_files_under_the_show(self):
+        job = _job(content_type=ContentType.TV, tmdb_name="Frasier", tmdb_year=1993)
+        assert backup_destination(job, "/b") == Path("/b/TV/Frasier (1993)/Disc 1")
+
+    def test_unidentified_falls_back_to_the_volume_label(self):
+        job = _job(content_type=ContentType.UNKNOWN, volume_label="THE_SWEETEST_THING")
+        assert backup_destination(job, "/b") == Path("/b/Unidentified/THE_SWEETEST_THING")
+
+    def test_unidentified_without_a_label_uses_the_job_id(self):
+        job = _job(content_type=ContentType.UNKNOWN, volume_label="")
+        job.id = 42
+        assert backup_destination(job, "/b") == Path("/b/Unidentified/job-42")
+
+    def test_path_separators_in_a_title_cannot_escape_the_root(self):
+        job = _job(content_type=ContentType.MOVIE, tmdb_name="../../etc/passwd")
+        dest = backup_destination(job, "/b")
+        assert Path("/b") in dest.parents
+
+    def test_empty_root_is_rejected(self):
+        assert backup_destination(_job(), "") is None
+
+
+class TestHasRoomForBackup:
+    def test_enough_space_passes(self, tmp_path):
+        with patch("shutil.disk_usage", return_value=(0, 0, 100 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=40 * 1024**3) is True
+
+    def test_margin_is_applied(self, tmp_path):
+        # 40 GB needed x 1.15 = 46 GB; 42 GB free is not enough.
+        with patch("shutil.disk_usage", return_value=(0, 0, 42 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=40 * 1024**3) is False
+
+    def test_unreadable_destination_fails_closed(self, tmp_path):
+        with patch("shutil.disk_usage", side_effect=OSError("gone")):
+            assert has_room_for_backup(tmp_path, needed_bytes=1) is False
+
+    def test_unknown_size_falls_back_to_a_full_bluray(self, tmp_path):
+        # needed_bytes 0 means the scan gave no sizes. Assume a 50 GB BD-DL
+        # rather than waving the check through.
+        with patch("shutil.disk_usage", return_value=(0, 0, 10 * 1024**3)):
+            assert has_room_for_backup(tmp_path, needed_bytes=0) is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_paths.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'app.core.backup_paths'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/app/core/backup_paths.py`:
+
+```python
+"""Where a disc backup goes, and whether there is room for it.
+
+Naming mirrors the library layout so a preservation shelf browses the same way
+the library does. Sanitization reuses the Organizer's helper rather than
+reimplementing it, so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from app.models import ContentType, DiscJob
+
+logger = logging.getLogger(__name__)
+
+# Free space must exceed the estimate by this factor. A backup carries the
+# container and filesystem overhead the per-title sizes do not.
+_SPACE_MARGIN = 1.15
+
+# Assumed disc size when the scan produced no usable sizes. A dual-layer
+# Blu-ray, so an unknown disc is treated as the largest realistic case rather
+# than waved through.
+_ASSUMED_DISC_BYTES = 50 * 1024**3
+
+
+def _safe_name(raw: str) -> str:
+    """Sanitize one path component, reusing the Organizer's rules."""
+    from app.core.organizer import sanitize_filename
+
+    cleaned = sanitize_filename(raw or "").strip().strip(".")
+    # sanitize_filename handles the illegal-character set; separators are
+    # stripped here as well so a crafted title cannot introduce a new path
+    # component and climb out of the backup root.
+    cleaned = cleaned.replace("/", "_").replace("\\", "_")
+    return cleaned or "Unknown"
+
+
+def backup_destination(job: DiscJob, backup_root: str) -> Path | None:
+    """Compute where this job's backup should be written.
+
+    Returns None when no root is configured, which the caller reports as
+    skipped:not_configured.
+    """
+    if not backup_root:
+        return None
+
+    root = Path(backup_root).expanduser()
+    name = job.tmdb_name or job.detected_title
+
+    if job.content_type == ContentType.MOVIE and name:
+        folder = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
+        return root / "Movies" / folder
+
+    if job.content_type == ContentType.TV and name:
+        show = f"{_safe_name(name)} ({job.tmdb_year})" if job.tmdb_year else _safe_name(name)
+        disc = _safe_name(job.discdb_disc_slug or f"Disc {job.disc_number or 1}")
+        base = root / "TV" / show
+        if job.detected_season is not None:
+            return base / f"Season {job.detected_season:02d}" / disc
+        return base / disc
+
+    label = _safe_name(job.volume_label) if job.volume_label else ""
+    if not label or label == "Unknown":
+        label = f"job-{job.id}" if job.id else "job-unknown"
+    return root / "Unidentified" / label
+
+
+def has_room_for_backup(dest: Path, needed_bytes: int) -> bool:
+    """Whether ``dest``'s filesystem has room for the backup, with margin.
+
+    Fails closed: an unreadable destination returns False and the caller falls
+    back to a direct rip. A false negative costs one direct rip; a false
+    positive costs a half-written 40 GB folder and a failed job.
+    """
+    estimate = needed_bytes if needed_bytes > 0 else _ASSUMED_DISC_BYTES
+    required = int(estimate * _SPACE_MARGIN)
+    # The destination itself may not exist yet, so measure the nearest existing
+    # ancestor: that is the filesystem the write will land on.
+    probe = dest
+    while not probe.exists() and probe.parent != probe:
+        probe = probe.parent
+    try:
+        free = shutil.disk_usage(probe).free
+    except (OSError, ValueError) as e:
+        logger.warning(f"Could not read free space at {probe}: {e}")
+        return False
+    if free < required:
+        logger.warning(
+            f"Not enough room for backup at {probe}: "
+            f"{free / 1024**3:.1f} GB free, {required / 1024**3:.1f} GB required"
+        )
+        return False
+    return True
+```
+
+If `sanitize_filename` does not exist in `app/core/organizer.py` under that name, use whatever the Organizer's existing name-sanitization helper is called and adjust the import. Do not write a second sanitizer.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_paths.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/backup_paths.py tests/unit/test_backup_paths.py && uv run ruff format app/core/backup_paths.py tests/unit/test_backup_paths.py
+git add backend/app/core/backup_paths.py backend/tests/unit/test_backup_paths.py
+git commit -m "feat(backup): compute backup destinations and preflight free space"
+```
+
+---
+
+## Task 6: `Extractor.backup_disc()`
+
+**Files:**
+- Modify: `backend/app/core/extractor.py`
+- Test: `backend/tests/unit/test_backup_disc.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_backup_disc.py`:
+
+```python
+"""makemkvcon backup wrapper."""
+
+import pytest
+
+from app.core.extractor import (
+    BackupResult,
+    MakeMKVExtractor,
+    _build_backup_command,
+    _parse_backup_progress,
+)
+
+
+class TestBuildBackupCommand:
+    def test_uses_the_disc_index_and_decrypt_flag(self):
+        cmd = _build_backup_command("mmk", "disc:0", "/b/out.partial")
+        assert cmd == ["mmk", "-r", "--progress=-same", "--decrypt", "backup", "disc:0", "/b/out.partial"]
+
+    def test_refuses_a_dev_source(self):
+        # makemkvcon backup accepts only disc:N. Catching it here beats a
+        # confusing MakeMKV error 40 minutes into a job.
+        with pytest.raises(ValueError):
+            _build_backup_command("mmk", "dev:E:", "/b/out.partial")
+
+
+class TestParseBackupProgress:
+    def test_reads_a_prgv_line(self):
+        # PRGV:current,total,max
+        assert _parse_backup_progress("PRGV:32768,65536,65536") == pytest.approx(50.0)
+
+    def test_zero_max_is_ignored(self):
+        assert _parse_backup_progress("PRGV:0,0,0") is None
+
+    def test_non_progress_line_is_ignored(self):
+        assert _parse_backup_progress('MSG:1005,0,1,"Backup done"') is None
+
+
+class TestBackupDisc:
+    @pytest.mark.asyncio
+    async def test_success_renames_partial_to_final(self, tmp_path, monkeypatch):
+        dest = tmp_path / "Inception (2010)"
+
+        def fake_run(cmd, on_line, job_id):
+            partial = tmp_path / "Inception (2010).partial"
+            (partial / "BDMV").mkdir(parents=True)
+            on_line("PRGV:65536,65536,65536")
+            return 0, "PRGV:65536,65536,65536\n"
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        result = await ex.backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is True
+        assert dest.exists()
+        assert not (tmp_path / "Inception (2010).partial").exists()
+
+    @pytest.mark.asyncio
+    async def test_failure_keeps_the_partial(self, tmp_path, monkeypatch):
+        # A partial backup of a dying disc has salvage value; the user decides
+        # whether to discard it, not Engram.
+        dest = tmp_path / "Scratched"
+
+        def fake_run(cmd, on_line, job_id):
+            partial = tmp_path / "Scratched.partial"
+            (partial / "BDMV").mkdir(parents=True)
+            return 1, "MSG:5010,0,0,\"Failed to read disc\"\n"
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        result = await ex.backup_disc("disc:0", dest, job_id=1)
+
+        assert result.success is False
+        assert result.error_message
+        assert (tmp_path / "Scratched.partial").exists()
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_receives_percentages(self, tmp_path, monkeypatch):
+        seen = []
+
+        def fake_run(cmd, on_line, job_id):
+            (tmp_path / "X.partial").mkdir(parents=True)
+            on_line("PRGV:16384,65536,65536")
+            on_line("PRGV:65536,65536,65536")
+            return 0, ""
+
+        monkeypatch.setattr(MakeMKVExtractor, "_run_backup_process", staticmethod(fake_run))
+        ex = MakeMKVExtractor(makemkv_path="mmk")
+        await ex.backup_disc("disc:0", tmp_path / "X", progress_callback=seen.append, job_id=1)
+
+        assert seen == [pytest.approx(25.0), pytest.approx(100.0)]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_disc.py -q
+```
+
+Expected: `ImportError: cannot import name 'BackupResult'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/extractor.py`, add next to `RipResult` (line 289):
+
+```python
+@dataclass
+class BackupResult:
+    """Result of a full-disc backup operation."""
+
+    success: bool
+    dest: Path | None = None
+    error_message: str | None = None
+```
+
+Add near `_build_rip_commands` (line 180):
+
+```python
+# PRGV:current,total,max is MakeMKV's global progress line.
+_PRGV_RE = re.compile(r"^PRGV:(\d+),(\d+),(\d+)")
+
+
+def _build_backup_command(makemkv_path: str, source_spec: str, dest: str) -> list[str]:
+    """Build the argv for a full decrypted disc backup.
+
+    ``makemkvcon backup`` accepts only a ``disc:N`` source, never ``dev:``.
+    Rejecting a dev spec here turns a 40-minute mystery into an immediate,
+    named fallback.
+    """
+    if not source_spec.startswith("disc:"):
+        raise ValueError(
+            f"makemkvcon backup requires a disc:N source, got {source_spec!r}. "
+            f"Resolve it with disc_source.resolve_disc_index() first."
+        )
+    return [
+        makemkv_path,
+        "-r",
+        "--progress=-same",
+        "--decrypt",
+        "backup",
+        source_spec,
+        dest,
+    ]
+
+
+def _parse_backup_progress(line: str) -> float | None:
+    """Percentage from a PRGV line, or None if the line carries no progress."""
+    m = _PRGV_RE.match(line.strip())
+    if not m:
+        return None
+    _current, total, maximum = (int(g) for g in m.groups())
+    if maximum <= 0:
+        return None
+    return min(100.0, total / maximum * 100.0)
+```
+
+Add the method to `MakeMKVExtractor`:
+
+```python
+    @staticmethod
+    def _run_backup_process(cmd: list[str], on_line, job_id: int) -> tuple[int, str]:
+        """Run makemkvcon backup, streaming stdout to ``on_line``.
+
+        A separate staticmethod so tests can substitute it without a real
+        subprocess. Runs in a thread (Windows asyncio subprocess workaround),
+        matching how scan_disc and rip_titles already invoke MakeMKV.
+        """
+        collected: list[str] = []
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+        )
+        try:
+            for line in proc.stdout or []:
+                collected.append(line)
+                on_line(line)
+        finally:
+            proc.wait()
+        return proc.returncode, "".join(collected)
+
+    async def backup_disc(
+        self,
+        source: "DiscSource | str",
+        dest: Path,
+        progress_callback=None,
+        log_dir: Path | None = None,
+        *,
+        job_id: int = 0,
+    ) -> BackupResult:
+        """Write a full decrypted copy of the disc to ``dest``.
+
+        Writes to ``<dest>.partial`` and renames on success, so a killed or
+        crashed backup never leaves something that looks complete. On failure
+        the ``.partial`` is left in place: a partial backup of a dying disc has
+        salvage value, and discarding it is the user's call.
+        """
+        spec = _to_source_spec(source)
+        partial = dest.with_name(dest.name + ".partial")
+
+        lock = self._get_source_lock(source)
+        async with lock:
+            try:
+                cmd = _build_backup_command(str(self.makemkv_path), spec, str(partial))
+            except ValueError as e:
+                return BackupResult(success=False, error_message=str(e))
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Job {job_id}: backing up disc: {' '.join(cmd)}")
+
+            def on_line(line: str) -> None:
+                pct = _parse_backup_progress(line)
+                if pct is not None and progress_callback is not None:
+                    _safe_callback(progress_callback, pct, label="backup progress")
+
+            returncode, output = await asyncio.to_thread(
+                self._run_backup_process, cmd, on_line, job_id
+            )
+
+            if log_dir is not None:
+                _save_makemkv_log(Path(log_dir) / f"backup_job{job_id}.log", output)
+
+            if returncode != 0 or not partial.exists():
+                reason = _last_msg_text(output) or f"makemkvcon backup exited {returncode}"
+                logger.error(f"Job {job_id}: backup failed: {reason}")
+                return BackupResult(success=False, error_message=reason)
+
+            try:
+                if dest.exists():
+                    # Destination appeared while we were copying. Keep the
+                    # existing one and drop ours rather than clobbering a
+                    # complete backup with a fresh one.
+                    logger.warning(f"Job {job_id}: {dest} already exists; keeping it")
+                else:
+                    partial.rename(dest)
+            except OSError as e:
+                logger.error(f"Job {job_id}: could not finalize backup: {e}", exc_info=True)
+                return BackupResult(success=False, error_message=str(e))
+
+            logger.info(f"Job {job_id}: backup complete at {dest}")
+            return BackupResult(success=True, dest=dest)
+```
+
+Add the helper next to `_extract_created_mkv`:
+
+```python
+def _last_msg_text(output: str) -> str | None:
+    """The text of the last MSG line in MakeMKV output, for error reporting."""
+    last = None
+    for line in output.splitlines():
+        if line.startswith("MSG:"):
+            parts = line.split(",", 4)
+            if len(parts) >= 5:
+                last = parts[4].strip().strip('"')
+    return last
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_disc.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd backend && uv run ruff check app/core/extractor.py tests/unit/test_backup_disc.py && uv run ruff format app/core/extractor.py tests/unit/test_backup_disc.py
+git add backend/app/core/extractor.py backend/tests/unit/test_backup_disc.py
+git commit -m "feat(backup): add makemkvcon backup wrapper with partial-rename safety"
+```
+
+---
+
+## Task 7: State machine transitions and phase timeout
+
+**Files:**
+- Modify: `backend/app/services/job_state_machine.py:22-56`
+- Modify: `backend/app/services/job_manager.py:1998-2005`
+- Test: `backend/tests/unit/test_job_state_machine.py` (existing file, add cases)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/unit/test_job_state_machine.py`:
+
+```python
+class TestBackingUpTransitions:
+    def test_identifying_can_enter_backing_up(self):
+        assert JobState.BACKING_UP in JobStateMachine.VALID_TRANSITIONS[JobState.IDENTIFYING]
+
+    def test_backing_up_can_start_ripping(self):
+        assert JobState.RIPPING in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_can_park_for_review(self):
+        # Reconciliation failure parks here; it must not fall back to the drive,
+        # which may already be ejected.
+        assert JobState.REVIEW_NEEDED in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_can_fail(self):
+        assert JobState.FAILED in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_backing_up_cannot_skip_straight_to_matching(self):
+        # There are no MKVs yet. Skipping RIPPING would strand the job.
+        assert JobState.MATCHING not in JobStateMachine.VALID_TRANSITIONS[JobState.BACKING_UP]
+
+    def test_review_can_return_to_backing_up(self):
+        # A disc parked for a name prompt still needs its backup once answered.
+        assert JobState.BACKING_UP in JobStateMachine.VALID_TRANSITIONS[JobState.REVIEW_NEEDED]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_job_state_machine.py -q -k BackingUp
+```
+
+Expected: `KeyError: <JobState.BACKING_UP>` or an assertion failure.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/services/job_state_machine.py`, edit `VALID_TRANSITIONS`:
+
+```python
+        JobState.IDENTIFYING: {
+            JobState.BACKING_UP,  # backup_before_rip: copy the disc, then extract from it
+            JobState.RIPPING,
+            JobState.MATCHING,  # import/staging path skips RIPPING (files already exist)
+            JobState.ORGANIZING,  # import/staging movie path skips RIPPING + matching
+            JobState.REVIEW_NEEDED,
+            JobState.FAILED,
+        },
+        # No edge to MATCHING or ORGANIZING: a backup produces no MKVs, so a job
+        # that skipped RIPPING from here would have nothing to match or organize.
+        JobState.BACKING_UP: {
+            JobState.RIPPING,
+            JobState.REVIEW_NEEDED,
+            JobState.FAILED,
+        },
+        JobState.REVIEW_NEEDED: {
+            JobState.IDENTIFYING,  # Re-identify with corrected title
+            JobState.BACKING_UP,  # Answered a pre-rip prompt with backup enabled
+            JobState.RIPPING,
+            JobState.MATCHING,  # Re-match with corrected metadata (post-rip)
+            JobState.COMPLETED,
+            JobState.FAILED,
+        },
+```
+
+In `backend/app/services/job_manager.py`, extend `_phase_timeout`:
+
+```python
+    def _phase_timeout(config, state: JobState) -> int | None:
+        """Per-phase no-activity ceiling (seconds), or None for resting/untimed states."""
+        return {
+            JobState.IDENTIFYING: config.timeout_identifying_seconds,
+            JobState.BACKING_UP: config.timeout_backing_up_seconds,
+            JobState.RIPPING: config.timeout_ripping_seconds,
+            JobState.MATCHING: config.timeout_matching_seconds,
+            JobState.ORGANIZING: config.timeout_organizing_seconds,
+        }.get(state)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_job_state_machine.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/services/job_state_machine.py app/services/job_manager.py && uv run ruff format app/services/job_state_machine.py app/services/job_manager.py
+git add backend/app/services/job_state_machine.py backend/app/services/job_manager.py backend/tests/unit/test_job_state_machine.py
+git commit -m "feat(backup): wire BACKING_UP into the state machine and watchdog"
+```
+
+---
+
+## Task 8: `backup_progress` WebSocket message
+
+**Files:**
+- Modify: `backend/app/api/websocket.py`
+- Modify: `backend/app/services/event_broadcaster.py`
+- Test: `backend/tests/integration/test_websocket_e2e.py` (existing file, add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/integration/test_websocket_e2e.py`:
+
+```python
+class TestBackupProgressContract:
+    """The parameter names must match across broadcaster, manager, and wire.
+
+    This chain has produced two production bugs already (error= vs
+    error_message=), so it is asserted end to end rather than per layer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_broadcaster_reaches_the_wire_with_the_documented_fields(self):
+        from unittest.mock import AsyncMock
+
+        from app.services.event_broadcaster import EventBroadcaster
+
+        ws = AsyncMock()
+        broadcaster = EventBroadcaster(ws)
+        await broadcaster.broadcast_backup_progress(
+            job_id=7, current_bytes=100, total_bytes=400, speed="2.5x", eta_seconds=90
+        )
+
+        ws.broadcast_backup_progress.assert_awaited_once_with(
+            7, current_bytes=100, total_bytes=400, speed="2.5x", eta=90
+        )
+
+    @pytest.mark.asyncio
+    async def test_manager_emits_the_documented_message_shape(self):
+        from unittest.mock import AsyncMock, patch
+
+        from app.api.websocket import ConnectionManager
+
+        mgr = ConnectionManager()
+        with patch.object(mgr, "broadcast", new=AsyncMock()) as bcast:
+            await mgr.broadcast_backup_progress(
+                7, current_bytes=100, total_bytes=400, speed="2.5x", eta=90
+            )
+
+        msg = bcast.await_args.args[0]
+        assert msg["type"] == "backup_progress"
+        assert msg["data"] == {
+            "job_id": 7,
+            "current_bytes": 100,
+            "total_bytes": 400,
+            "speed": "2.5x",
+            "eta": 90,
+        }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd backend && uv run pytest tests/integration/test_websocket_e2e.py -q -k BackupProgress
+```
+
+Expected: `AttributeError: 'ConnectionManager' object has no attribute 'broadcast_backup_progress'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/api/websocket.py`, add to `ConnectionManager`:
+
+```python
+    async def broadcast_backup_progress(
+        self,
+        job_id: int,
+        *,
+        current_bytes: int,
+        total_bytes: int,
+        speed: str | None = None,
+        eta: int | None = None,
+    ) -> None:
+        """Broadcast disc-backup copy progress.
+
+        A distinct message type rather than rip_progress: a client that renders
+        "ripping" from rip_progress would be reporting a phase that produces no
+        MKV at all.
+        """
+        await self.broadcast(
+            {
+                "type": "backup_progress",
+                "data": {
+                    "job_id": job_id,
+                    "current_bytes": current_bytes,
+                    "total_bytes": total_bytes,
+                    "speed": speed,
+                    "eta": eta,
+                },
+            }
+        )
+```
+
+In `backend/app/services/event_broadcaster.py`, add:
+
+```python
+    async def broadcast_backup_progress(
+        self,
+        job_id: int,
+        current_bytes: int,
+        total_bytes: int,
+        speed: str | None = None,
+        eta_seconds: int | None = None,
+    ) -> None:
+        """Broadcast disc-backup copy progress."""
+        await self._ws.broadcast_backup_progress(
+            job_id,
+            current_bytes=current_bytes,
+            total_bytes=total_bytes,
+            speed=speed,
+            eta=eta_seconds,
+        )
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd backend && uv run pytest tests/integration/test_websocket_e2e.py -q -k BackupProgress
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/api/websocket.py app/services/event_broadcaster.py && uv run ruff format app/api/websocket.py app/services/event_broadcaster.py
+git add backend/app/api/websocket.py backend/app/services/event_broadcaster.py backend/tests/integration/test_websocket_e2e.py
+git commit -m "feat(backup): add backup_progress websocket message"
+```
+
+---
+
+## Task 9: Post-backup title reconciliation
+
+**Files:**
+- Create: `backend/app/services/backup_reconcile.py`
+- Test: `backend/tests/unit/test_backup_reconciliation.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_backup_reconciliation.py`:
+
+```python
+"""Re-map DiscTitle.title_index onto a re-scan of the backup."""
+
+from app.core.extractor import TitleInfo
+from app.models import DiscTitle
+from app.services.backup_reconcile import ReconcileOutcome, reconcile_titles
+
+
+def _title(index: int, duration: int, source: str = "", segments: str = "") -> DiscTitle:
+    return DiscTitle(
+        job_id=1,
+        title_index=index,
+        duration_seconds=duration,
+        source_filename=source,
+        segment_map=segments,
+    )
+
+
+def _scanned(index: int, duration: int, source: str = "", segments: str = "") -> TitleInfo:
+    return TitleInfo(
+        index=index,
+        duration_seconds=duration,
+        source_filename=source,
+        segment_map=segments,
+        file_size_bytes=0,
+        chapter_count=0,
+    )
+
+
+class TestIdenticalEnumeration:
+    def test_same_order_and_durations_keeps_every_index(self):
+        db = [_title(0, 2600), _title(1, 2610)]
+        scan = [_scanned(0, 2600), _scanned(1, 2610)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.IDENTICAL
+        assert result.remap == {}
+
+    def test_small_duration_drift_still_counts_as_identical(self):
+        # MakeMKV rounds; a one-second difference is not a different disc.
+        db = [_title(0, 2600)]
+        scan = [_scanned(0, 2601)]
+        assert reconcile_titles(db, scan).outcome is ReconcileOutcome.IDENTICAL
+
+
+class TestRemapped:
+    def test_shifted_indices_remap_by_source_filename(self):
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 2610, "00002.m2ts")]
+        scan = [_scanned(5, 2600, "00001.m2ts"), _scanned(6, 2610, "00002.m2ts")]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 5, 1: 6}
+
+    def test_segment_map_breaks_a_source_filename_tie(self):
+        db = [_title(0, 2600, "00001.m2ts", "1,2"), _title(1, 2600, "00001.m2ts", "3,4")]
+        scan = [
+            _scanned(9, 2600, "00001.m2ts", "3,4"),
+            _scanned(8, 2600, "00001.m2ts", "1,2"),
+        ]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.REMAPPED
+        assert result.remap == {0: 8, 1: 9}
+
+
+class TestAmbiguous:
+    def test_missing_title_is_ambiguous(self):
+        db = [_title(0, 2600, "00001.m2ts"), _title(1, 2610, "00002.m2ts")]
+        scan = [_scanned(0, 2600, "00001.m2ts")]
+        assert reconcile_titles(db, scan).outcome is ReconcileOutcome.AMBIGUOUS
+
+    def test_indistinguishable_titles_are_ambiguous(self):
+        db = [_title(0, 2600), _title(1, 2600)]
+        scan = [_scanned(7, 2600), _scanned(8, 2600)]
+        result = reconcile_titles(db, scan)
+        assert result.outcome is ReconcileOutcome.AMBIGUOUS
+        assert result.reason
+
+    def test_empty_scan_is_ambiguous(self):
+        assert reconcile_titles([_title(0, 2600)], []).outcome is ReconcileOutcome.AMBIGUOUS
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_reconciliation.py -q
+```
+
+Expected: `ModuleNotFoundError: No module named 'app.services.backup_reconcile'`.
+
+If `TitleInfo` does not carry `source_filename`, `segment_map`, `file_size_bytes` or `chapter_count` under those names, read its definition in `app/core/extractor.py` and adjust both the test helper and the implementation to the real field names before continuing.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/app/services/backup_reconcile.py`:
+
+```python
+"""Re-validate title indices after extraction moves from the disc to its backup.
+
+DiscTitle rows are created from the *disc* scan and carry ``title_index``, which
+is what the rip command passes to MakeMKV. Extraction now runs against
+``file:<backup>``, so a re-scan may enumerate differently. A backup is a byte
+copy and almost always enumerates identically, but "almost always" is not a
+contract, and ripping the wrong index files an episode under another episode's
+name with no error anywhere.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+logger = logging.getLogger(__name__)
+
+# MakeMKV rounds durations, so titles within this many seconds are the same title.
+_DURATION_TOLERANCE_S = 2
+
+
+class ReconcileOutcome(StrEnum):
+    """How a backup re-scan lined up with the disc scan."""
+
+    IDENTICAL = "identical"
+    REMAPPED = "remapped"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass
+class ReconcileResult:
+    outcome: ReconcileOutcome
+    # {old title_index: new title_index}. Empty for IDENTICAL.
+    remap: dict[int, int] = field(default_factory=dict)
+    reason: str | None = None
+
+
+def _fingerprint(source_filename: str | None, segment_map: str | None, duration: int) -> tuple:
+    """Identity of a title independent of its enumeration position."""
+    return (
+        (source_filename or "").strip().lower(),
+        (segment_map or "").strip(),
+        duration // (_DURATION_TOLERANCE_S + 1),
+    )
+
+
+def reconcile_titles(db_titles, scanned_titles) -> ReconcileResult:
+    """Line up stored DiscTitle rows against a fresh scan of the backup."""
+    if not scanned_titles:
+        return ReconcileResult(
+            ReconcileOutcome.AMBIGUOUS, reason="the backup scan returned no titles"
+        )
+
+    if len(db_titles) == len(scanned_titles) and all(
+        abs(db.duration_seconds - sc.duration_seconds) <= _DURATION_TOLERANCE_S
+        and db.title_index == sc.index
+        for db, sc in zip(db_titles, scanned_titles, strict=True)
+    ):
+        return ReconcileResult(ReconcileOutcome.IDENTICAL)
+
+    buckets: dict[tuple, list] = {}
+    for sc in scanned_titles:
+        buckets.setdefault(
+            _fingerprint(
+                getattr(sc, "source_filename", None),
+                getattr(sc, "segment_map", None),
+                sc.duration_seconds,
+            ),
+            [],
+        ).append(sc)
+
+    remap: dict[int, int] = {}
+    for db in db_titles:
+        key = _fingerprint(db.source_filename, db.segment_map, db.duration_seconds)
+        candidates = buckets.get(key, [])
+        if len(candidates) != 1:
+            return ReconcileResult(
+                ReconcileOutcome.AMBIGUOUS,
+                reason=(
+                    f"title {db.title_index} matched {len(candidates)} titles in the "
+                    f"backup scan; cannot tell which one to extract"
+                ),
+            )
+        remap[db.title_index] = candidates[0].index
+
+    logger.info(f"Backup re-scan remapped {len(remap)} title indices")
+    return ReconcileResult(ReconcileOutcome.REMAPPED, remap=remap)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_reconciliation.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/services/backup_reconcile.py tests/unit/test_backup_reconciliation.py && uv run ruff format app/services/backup_reconcile.py tests/unit/test_backup_reconciliation.py
+git add backend/app/services/backup_reconcile.py backend/tests/unit/test_backup_reconciliation.py
+git commit -m "feat(backup): reconcile title indices against a backup re-scan"
+```
+
+---
+
+## Task 10: `JobManager._run_backup`
+
+**Files:**
+- Modify: `backend/app/services/job_manager.py`
+- Test: `backend/tests/unit/test_run_backup.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_run_backup.py`:
+
+```python
+"""The backup phase, and its fallback matrix."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlmodel import select
+
+from app.core.extractor import BackupResult
+from app.database import async_session
+from app.models import ContentType, DiscJob, JobState
+from app.services.job_manager import job_manager
+
+
+async def _make_job(**kw) -> int:
+    async with async_session() as s:
+        job = DiscJob(
+            drive_id="E:",
+            volume_label="INCEPTION",
+            content_type=ContentType.MOVIE,
+            tmdb_name="Inception",
+            tmdb_year=2010,
+            state=JobState.BACKING_UP,
+            **kw,
+        )
+        s.add(job)
+        await s.commit()
+        await s.refresh(job)
+        return job.id
+
+
+async def _reload(job_id: int) -> DiscJob:
+    async with async_session() as s:
+        return await s.get(DiscJob, job_id)
+
+
+class TestFallbacks:
+    @pytest.mark.asyncio
+    async def test_unconfigured_root_skips_to_ripping(self, tmp_path):
+        job_id = await _make_job()
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path="", backup_before_rip=True)
+        )), patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+        job = await _reload(job_id)
+        assert job.backup_status == "skipped:not_configured"
+        assert job.state == JobState.RIPPING
+
+    @pytest.mark.asyncio
+    async def test_insufficient_space_skips_to_ripping(self, tmp_path):
+        job_id = await _make_job()
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch("app.services.job_manager.has_room_for_backup", return_value=False), \
+             patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+        job = await _reload(job_id)
+        assert job.backup_status == "skipped:insufficient_space"
+        assert job.state == JobState.RIPPING
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_disc_index_skips_to_ripping(self, tmp_path):
+        job_id = await _make_job()
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch("app.services.job_manager.has_room_for_backup", return_value=True), \
+             patch("app.services.job_manager.resolve_disc_index", new=AsyncMock(return_value=None)), \
+             patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+        job = await _reload(job_id)
+        assert job.backup_status == "skipped:no_disc_index"
+        assert job.state == JobState.RIPPING
+
+    @pytest.mark.asyncio
+    async def test_backup_failure_falls_back_and_records_the_reason(self, tmp_path):
+        job_id = await _make_job()
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch("app.services.job_manager.has_room_for_backup", return_value=True), \
+             patch("app.services.job_manager.resolve_disc_index", new=AsyncMock(return_value="disc:0")), \
+             patch.object(job_manager.extractor, "backup_disc", new=AsyncMock(
+                 return_value=BackupResult(success=False, error_message="read error")
+             )), patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+        job = await _reload(job_id)
+        assert job.backup_status.startswith("failed:")
+        assert "read error" in job.backup_status
+        assert job.state == JobState.RIPPING
+        # The drive was never released: extraction still needs the disc.
+        assert job.source_spec is None
+
+
+class TestSuccess:
+    @pytest.mark.asyncio
+    async def test_success_repoints_the_source_and_releases_the_drive(self, tmp_path):
+        job_id = await _make_job()
+        dest = tmp_path / "Movies" / "Inception (2010)"
+        release = AsyncMock(return_value=True)
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch("app.services.job_manager.has_room_for_backup", return_value=True), \
+             patch("app.services.job_manager.resolve_disc_index", new=AsyncMock(return_value="disc:0")), \
+             patch.object(job_manager.extractor, "backup_disc", new=AsyncMock(
+                 return_value=BackupResult(success=True, dest=dest)
+             )), patch.object(job_manager, "_release_drive", new=release), \
+             patch.object(job_manager, "_reconcile_backup_titles", new=AsyncMock(return_value=True)), \
+             patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+
+        job = await _reload(job_id)
+        assert job.backup_status == "completed"
+        assert job.backup_path == str(dest)
+        assert job.source_spec == f"file:{dest}"
+        assert job.state == JobState.RIPPING
+        release.assert_awaited_once()
+        assert release.await_args.kwargs.get("outcome") == "Backed up" or \
+               release.await_args.args[2] == "Backed up"
+
+    @pytest.mark.asyncio
+    async def test_existing_destination_is_reused_without_recopying(self, tmp_path):
+        # Re-inserting a disc backed up last month must not cost another 40 GB.
+        dest = tmp_path / "Movies" / "Inception (2010)"
+        (dest / "BDMV").mkdir(parents=True)
+        job_id = await _make_job()
+        backup = AsyncMock()
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch.object(job_manager.extractor, "backup_disc", new=backup), \
+             patch.object(job_manager, "_release_drive", new=AsyncMock()), \
+             patch.object(job_manager, "_reconcile_backup_titles", new=AsyncMock(return_value=True)), \
+             patch.object(job_manager, "_run_ripping", new=AsyncMock()):
+            await job_manager._run_backup(job_id)
+
+        backup.assert_not_awaited()
+        job = await _reload(job_id)
+        assert job.backup_status == "completed"
+        assert job.source_spec == f"file:{dest}"
+
+    @pytest.mark.asyncio
+    async def test_unreconcilable_backup_parks_for_review(self, tmp_path):
+        job_id = await _make_job()
+        dest = tmp_path / "Movies" / "Inception (2010)"
+        with patch("app.services.config_service.get_config", new=AsyncMock(
+            return_value=_config(backup_path=str(tmp_path), backup_before_rip=True)
+        )), patch("app.services.job_manager.has_room_for_backup", return_value=True), \
+             patch("app.services.job_manager.resolve_disc_index", new=AsyncMock(return_value="disc:0")), \
+             patch.object(job_manager.extractor, "backup_disc", new=AsyncMock(
+                 return_value=BackupResult(success=True, dest=dest)
+             )), patch.object(job_manager, "_release_drive", new=AsyncMock()), \
+             patch.object(job_manager, "_reconcile_backup_titles", new=AsyncMock(return_value=False)), \
+             patch.object(job_manager, "_run_ripping", new=AsyncMock()) as rip:
+            await job_manager._run_backup(job_id)
+
+        job = await _reload(job_id)
+        assert job.state == JobState.REVIEW_NEEDED
+        rip.assert_not_awaited()
+
+
+def _config(**kw):
+    from app.models import AppConfig
+
+    return AppConfig(**kw)
+```
+
+Add whatever `setup_db` / clean-database fixture the neighbouring unit tests use (copy the autouse fixture from `tests/unit/test_api_routes.py`) so these rows do not leak between tests. Keep every job non-terminal, so no terminal Discord task leaks a pooled connection.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_run_backup.py -q
+```
+
+Expected: `AttributeError: 'JobManager' object has no attribute '_run_backup'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/services/job_manager.py`, add these module-level imports near the other `app.core` imports:
+
+```python
+from app.core.backup_paths import backup_destination, has_room_for_backup
+from app.core.disc_source import DiscSource, resolve_disc_index
+```
+
+Add the method next to `_run_ripping`:
+
+```python
+    async def _run_backup(self, job_id: int) -> None:
+        """Copy the whole disc to backup_path, then hand off to extraction.
+
+        Every problem here degrades to today's behaviour (a direct rip from the
+        drive) rather than failing the job: turning the setting on must never
+        make a disc less likely to finish. The single exception is a backup that
+        succeeded but whose re-scan cannot be reconciled, which parks for review
+        instead of falling back, because by then the disc may already be ejected.
+        """
+        from app.services.config_service import get_config
+
+        safe_job = sanitize_log_value(job_id)
+
+        async def _record(status: str, *, path: str | None = None, spec: str | None = None):
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                if not job:
+                    return
+                job.backup_status = status
+                if path is not None:
+                    job.backup_path = path
+                if spec is not None:
+                    job.source_spec = spec
+                job.updated_at = datetime.now(UTC)
+                await session.commit()
+
+        async def _fall_back(status: str) -> None:
+            logger.warning(f"Job {safe_job}: {status}; ripping directly from the drive")
+            await _record(status)
+            await self._enter_ripping(job_id)
+
+        try:
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                if not job:
+                    return
+                drive_id = job.drive_id
+                total_bytes = sum(
+                    t.file_size_bytes
+                    for t in (
+                        await session.execute(
+                            select(DiscTitle).where(DiscTitle.job_id == job_id)
+                        )
+                    ).scalars()
+                )
+
+            config = await get_config()
+            dest = backup_destination(job, config.backup_path if config else "")
+            if dest is None:
+                await _fall_back("skipped:not_configured")
+                return
+
+            # Already backed up (a re-inserted disc, or a retried job). Reuse it
+            # rather than spending another 40 GB and 25 minutes.
+            if dest.exists() and any(dest.iterdir()):
+                logger.info(f"Job {safe_job}: reusing existing backup at {dest}")
+                await _record("completed", path=str(dest), spec=f"file:{dest}")
+                await self._release_drive(job_id, drive_id, "Backed up")
+                if await self._reconcile_backup_titles(job_id, dest):
+                    await self._enter_ripping(job_id)
+                return
+
+            if not has_room_for_backup(dest, total_bytes):
+                await _fall_back("skipped:insufficient_space")
+                return
+
+            disc_spec = await resolve_disc_index(drive_id, str(self.extractor.makemkv_path))
+            if disc_spec is None:
+                await _fall_back("skipped:no_disc_index")
+                return
+
+            await _record("pending", path=str(dest))
+
+            last_pct = -1.0
+
+            def on_progress(pct: float) -> None:
+                nonlocal last_pct
+                # One broadcast per whole percent: a 40 GB copy emits PRGV
+                # constantly and every message fans out to every client.
+                if pct - last_pct < 1.0:
+                    return
+                last_pct = pct
+                asyncio.create_task(
+                    self._broadcaster.broadcast_backup_progress(
+                        job_id,
+                        current_bytes=int(total_bytes * pct / 100),
+                        total_bytes=total_bytes,
+                    )
+                )
+
+            result = await self.extractor.backup_disc(
+                DiscSource.parse(disc_spec),
+                dest,
+                progress_callback=on_progress,
+                log_dir=Path(job.staging_path) if job.staging_path else None,
+                job_id=job_id,
+            )
+
+            if not result.success:
+                await _fall_back(f"failed:{result.error_message or 'unknown error'}")
+                return
+
+            await _record("completed", path=str(result.dest), spec=f"file:{result.dest}")
+            # The disc is copied and out of our way. This is the RIPPED_EVENT
+            # milestone: hardware done, not media produced.
+            await self._release_drive(job_id, drive_id, "Backed up")
+
+            if not await self._reconcile_backup_titles(job_id, result.dest):
+                return
+
+            await self._enter_ripping(job_id)
+
+        except Exception as e:
+            logger.error(f"Job {safe_job}: backup phase crashed: {e}", exc_info=True)
+            await _fall_back(f"failed:{e}")
+
+    async def _enter_ripping(self, job_id: int) -> None:
+        """Transition into RIPPING and start the rip task."""
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                return
+            job.state = JobState.RIPPING
+            job.updated_at = datetime.now(UTC)
+            await session.commit()
+            await ws_manager.broadcast_job_update(job_id, job.state.value)
+        task = asyncio.create_task(with_job_log_context(job_id, self._run_ripping(job_id)))
+        task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
+        self._active_jobs[job_id] = task
+
+    async def _reconcile_backup_titles(self, job_id: int, dest: Path) -> bool:
+        """Re-scan the backup and re-map title indices. False means parked.
+
+        Extraction from the backup uses stored title indices, so they must be
+        re-validated against the copy rather than assumed. A backup that cannot
+        be reconciled parks for review: falling back to the drive is not an
+        option, because the disc has already been released.
+        """
+        from app.services.backup_reconcile import ReconcileOutcome, reconcile_titles
+
+        source = DiscSource.for_backup(dest)
+        try:
+            scanned, _name = await self.extractor.scan_disc(source, job_id=job_id)
+        except Exception as e:
+            logger.error(f"Job {job_id}: could not scan the backup: {e}", exc_info=True)
+            scanned = []
+
+        async with async_session() as session:
+            db_titles = list(
+                (
+                    await session.execute(
+                        select(DiscTitle)
+                        .where(DiscTitle.job_id == job_id)
+                        .order_by(DiscTitle.title_index)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            result = reconcile_titles(db_titles, scanned)
+
+            if result.outcome is ReconcileOutcome.AMBIGUOUS:
+                job = await session.get(DiscJob, job_id)
+                reason = (
+                    f"The disc backup does not line up with the disc scan "
+                    f"({result.reason}). The backup is safe at {dest}; "
+                    f"re-run matching or re-import it to continue."
+                )
+                await self._state_machine.transition_to_review(job, session, reason=reason)
+                return False
+
+            for title in db_titles:
+                new_index = result.remap.get(title.title_index)
+                if new_index is not None and new_index != title.title_index:
+                    title.title_index = new_index
+                    session.add(title)
+            await session.commit()
+        return True
+```
+
+If `transition_to_review` has a different signature on `JobStateMachine`, match the call to the one `identification_coordinator.py` already uses.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_run_backup.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/services/job_manager.py tests/unit/test_run_backup.py && uv run ruff format app/services/job_manager.py tests/unit/test_run_backup.py
+git add backend/app/services/job_manager.py backend/tests/unit/test_run_backup.py
+git commit -m "feat(backup): add the BACKING_UP phase with a full fallback matrix"
+```
+
+---
+
+## Task 11: Route identification into `BACKING_UP`
+
+**Files:**
+- Modify: `backend/app/services/identification_coordinator.py:652-654`, `:697-699`, `:781-783`
+- Modify: `backend/app/services/job_manager.py:1152-1168` (`start_ripping`)
+- Test: `backend/tests/unit/test_backup_routing.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_backup_routing.py`:
+
+```python
+"""Identification hands a disc to BACKING_UP only when it should."""
+
+import pytest
+
+from app.models import AppConfig, JobState
+from app.services.identification_coordinator import next_state_after_identify
+
+
+class TestNextStateAfterIdentify:
+    def test_backup_disabled_goes_straight_to_ripping(self):
+        cfg = AppConfig(backup_before_rip=False, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.RIPPING
+
+    def test_backup_enabled_goes_to_backing_up(self):
+        cfg = AppConfig(backup_before_rip=True, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.BACKING_UP
+
+    def test_backup_enabled_without_a_root_still_rips(self):
+        # No root means nothing to write to; do not enter a phase that can only
+        # immediately fall back.
+        cfg = AppConfig(backup_before_rip=True, backup_path="")
+        assert next_state_after_identify(cfg, drive_id="E:") is JobState.RIPPING
+
+    def test_an_import_job_never_backs_up(self):
+        # It already is a backup.
+        cfg = AppConfig(backup_before_rip=True, backup_path="/b")
+        assert next_state_after_identify(cfg, drive_id="import") is JobState.RIPPING
+
+    def test_a_missing_config_rips(self):
+        assert next_state_after_identify(None, drive_id="E:") is JobState.RIPPING
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_routing.py -q
+```
+
+Expected: `ImportError: cannot import name 'next_state_after_identify'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `backend/app/services/identification_coordinator.py`, at module level:
+
+```python
+def next_state_after_identify(config, drive_id: str) -> JobState:
+    """The state a freshly identified disc should enter.
+
+    One function rather than a condition repeated at each of the three places
+    identification currently assigns JobState.RIPPING, so the three cannot
+    drift. An import job is excluded because it already is a backup, and an
+    enabled-but-unconfigured backup is excluded because entering a phase whose
+    only possible action is to fall back would put a misleading BACKING UP on
+    the card for no reason.
+    """
+    if not config or not config.backup_before_rip or not config.backup_path:
+        return JobState.RIPPING
+    if drive_id == "import":
+        return JobState.RIPPING
+    return JobState.BACKING_UP
+```
+
+Then at each of the three sites that currently set `job.state = JobState.RIPPING` (lines 653, 698 and 781), replace with:
+
+```python
+                        job.state = next_state_after_identify(config, job.drive_id)
+```
+
+using whatever config object is already in scope at that point (each of those blocks already loads config; if one does not, call `await get_config()` there). After the commit and broadcast at each site, the coordinator currently spawns `_run_ripping`. Change that spawn to branch:
+
+```python
+                        runner = (
+                            self._job_manager._run_backup
+                            if job.state == JobState.BACKING_UP
+                            else self._job_manager._run_ripping
+                        )
+                        task = asyncio.create_task(with_job_log_context(job_id, runner(job_id)))
+```
+
+Match the existing task-registration lines around each site rather than inventing new ones.
+
+In `job_manager.start_ripping`, honour the same routing so a review resume backs up too:
+
+```python
+    async def start_ripping(self, job_id: int) -> None:
+        """Start ripping, backing the disc up first when configured."""
+        from app.services.config_service import get_config
+
+        async with async_session() as session:
+            job = await session.get(DiscJob, job_id)
+            if not job:
+                raise ValueError(f"Job {job_id} not found")
+
+            if job.state not in (JobState.IDLE, JobState.REVIEW_NEEDED):
+                raise ValueError(f"Cannot start job in state: {job.state}")
+
+            from app.services.identification_coordinator import next_state_after_identify
+
+            config = await get_config()
+            job.state = next_state_after_identify(config, job.drive_id)
+            job.updated_at = datetime.now(UTC)
+            await session.commit()
+            runner = self._run_backup if job.state == JobState.BACKING_UP else self._run_ripping
+
+            task = asyncio.create_task(with_job_log_context(job_id, runner(job_id)))
+            task.add_done_callback(lambda t, jid=job_id: self._on_task_done(t, jid))
+            self._active_jobs[job_id] = task
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_backup_routing.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the pipeline tests to verify the default path is unchanged**
+
+```bash
+cd backend && uv run pytest tests/pipeline -q
+```
+
+Expected: all pass, since `backup_before_rip` defaults to False. If a pipeline test fails with `no such table`, run `uv run python -c "import asyncio; from app.database import init_db; asyncio.run(init_db())"` first: a fresh worktree DB is often a zero-byte stub.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend && uv run ruff check app/services && uv run ruff format app/services
+git add backend/app/services backend/tests/unit/test_backup_routing.py
+git commit -m "feat(backup): route identified discs into BACKING_UP when enabled"
+```
+
+---
+
+## Task 12: Config API surface
+
+**Files:**
+- Modify: `backend/app/api/routes.py` (`ConfigUpdate`, `ConfigResponse`)
+- Test: `backend/tests/unit/test_api_routes.py` (existing file, add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_api_routes.py`:
+
+```python
+class TestBackupConfigRoundTrip:
+    """A new AppConfig field must also exist in ConfigUpdate and ConfigResponse.
+
+    Pydantic drops unknown keys silently, so a field missing from either schema
+    is accepted by the API, never stored, and never reported: the setting simply
+    does nothing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_backup_settings_round_trip(self, client, tmp_path):
+        resp = await client.put(
+            "/api/config",
+            json={"backup_before_rip": True, "backup_path": str(tmp_path)},
+        )
+        assert resp.status_code == 200
+
+        got = await client.get("/api/config")
+        assert got.status_code == 200
+        body = got.json()
+        assert body["backup_before_rip"] is True
+        assert body["backup_path"] == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_backup_defaults_are_reported(self, client):
+        body = (await client.get("/api/config")).json()
+        assert "backup_before_rip" in body
+        assert "backup_path" in body
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd backend && uv run pytest tests/unit/test_api_routes.py -q -k BackupConfig
+```
+
+Expected: `KeyError: 'backup_before_rip'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/api/routes.py`, add to `ConfigUpdate`:
+
+```python
+    backup_before_rip: bool | None = None
+    backup_path: str | None = None
+    timeout_backing_up_seconds: int | None = None
+```
+
+Add to `ConfigResponse`, matching the style of the neighbouring fields:
+
+```python
+    backup_before_rip: bool = False
+    backup_path: str = ""
+    timeout_backing_up_seconds: int = 7200
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd backend && uv run pytest tests/unit/test_api_routes.py -q -k BackupConfig
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/api/routes.py && uv run ruff format app/api/routes.py
+git add backend/app/api/routes.py backend/tests/unit/test_api_routes.py
+git commit -m "feat(backup): expose backup settings through the config API"
+```
+
+---
+
+## Task 13: Disc-image detection in the import scanner
+
+**Files:**
+- Modify: `backend/app/core/import_scanner.py`
+- Test: `backend/tests/unit/test_import_scanner_disc_images.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/unit/test_import_scanner_disc_images.py`:
+
+```python
+"""A backup folder or ISO is an import unit, not a folder to walk for MKVs."""
+
+from app.core import import_scanner
+
+
+def _bdmv(root, name):
+    d = root / name
+    (d / "BDMV" / "STREAM").mkdir(parents=True)
+    (d / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"x" * 10)
+    return d
+
+
+def _video_ts(root, name):
+    d = root / name
+    (d / "VIDEO_TS").mkdir(parents=True)
+    (d / "VIDEO_TS" / "VTS_01_1.VOB").write_bytes(b"x" * 10)
+    return d
+
+
+class TestDetection:
+    def test_bdmv_folder_is_a_disc_image(self, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["Inception (2010)"]
+        assert scan.disc_images[0].kind == "backup"
+
+    def test_video_ts_folder_is_a_disc_image(self, tmp_path):
+        _video_ts(tmp_path, "The Sweetest Thing")
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["The Sweetest Thing"]
+
+    def test_iso_file_is_a_disc_image(self, tmp_path):
+        (tmp_path / "Inception.iso").write_bytes(b"x" * 10)
+        scan = import_scanner.scan(tmp_path)
+        assert [d.name for d in scan.disc_images] == ["Inception.iso"]
+        assert scan.disc_images[0].kind == "iso"
+
+    def test_picking_the_backup_folder_itself_yields_one_image(self, tmp_path):
+        d = _bdmv(tmp_path, "Inception (2010)")
+        scan = import_scanner.scan(d)
+        assert len(scan.disc_images) == 1
+
+    def test_nested_backups_are_all_found(self, tmp_path):
+        _bdmv(tmp_path / "TV" / "Frasier (1993)" / "Season 01", "S01D01")
+        _bdmv(tmp_path / "TV" / "Frasier (1993)" / "Season 01", "S01D02")
+        scan = import_scanner.scan(tmp_path)
+        assert sorted(d.name for d in scan.disc_images) == ["S01D01", "S01D02"]
+
+    def test_a_tree_can_hold_both_kinds(self, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        loose = tmp_path / "Frasier" / "Season 01"
+        loose.mkdir(parents=True)
+        (loose / "Frasier - S01E01.mkv").write_bytes(b"x" * 10)
+        scan = import_scanner.scan(tmp_path)
+        assert len(scan.disc_images) == 1
+        assert len(scan.units) == 1
+
+    def test_m2ts_files_do_not_count_toward_the_file_budget(self, tmp_path):
+        # The walk stops at the disc image, so a backup's thousands of stream
+        # files cannot truncate a scan of the folder above it.
+        d = _bdmv(tmp_path, "Big")
+        for i in range(50):
+            (d / "BDMV" / "STREAM" / f"{i:05d}.m2ts").write_bytes(b"x")
+        scan = import_scanner.scan(tmp_path)
+        assert scan.truncated is False
+        assert scan.total_files == 0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/unit/test_import_scanner_disc_images.py -q
+```
+
+Expected: `AttributeError: 'ImportScan' object has no attribute 'disc_images'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `backend/app/core/import_scanner.py`, add:
+
+```python
+# A directory holding one of these is a disc backup, not a folder of media.
+_DISC_IMAGE_MARKERS = ("BDMV", "VIDEO_TS")
+
+
+@dataclass
+class DiscImageUnit:
+    """A disc backup folder or ISO file, to be scanned and extracted by MakeMKV."""
+
+    path: Path
+    name: str
+    kind: str  # "backup" | "iso"
+    total_bytes: int
+
+
+def is_disc_image_dir(path: Path) -> bool:
+    """Whether this directory is a MakeMKV disc backup."""
+    try:
+        return any((path / marker).is_dir() for marker in _DISC_IMAGE_MARKERS)
+    except OSError:
+        return False
+
+
+def _dir_size(path: Path) -> int:
+    """Total bytes under a directory, best effort."""
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for name in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, name))
+            except OSError:
+                continue
+    return total
+```
+
+Add `disc_images: list[DiscImageUnit] = field(default_factory=list)` to `ImportScan` (import `field` from `dataclasses`).
+
+In the walk, before recursing into a directory, check `is_disc_image_dir(d)`. If true, append a `DiscImageUnit` and do **not** descend: that short-circuit is what keeps a backup's stream files out of the `_MAX_FILES` budget. Treat any file whose suffix is `.iso` (case-insensitive) as a `DiscImageUnit` with `kind="iso"`. If the picked root is itself a disc image, return a scan holding exactly that one unit and no MKV units.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/unit/test_import_scanner_disc_images.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the existing scanner tests to verify nothing regressed**
+
+```bash
+cd backend && uv run pytest tests/unit -q -k import_scanner
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend && uv run ruff check app/core/import_scanner.py tests/unit/test_import_scanner_disc_images.py && uv run ruff format app/core/import_scanner.py tests/unit/test_import_scanner_disc_images.py
+git add backend/app/core/import_scanner.py backend/tests/unit/test_import_scanner_disc_images.py
+git commit -m "feat(backup): detect disc backups and ISOs in the import scanner"
+```
+
+---
+
+## Task 14: Import a backup through the API
+
+**Files:**
+- Modify: `backend/app/api/routes.py:3000-3054` (`import_browse`), `:3057-3088` (`import_preview`), `:3092-3182` (`import_start`)
+- Modify: `backend/app/services/job_manager.py` (`create_job_from_staging`)
+- Test: `backend/tests/integration/test_import_backup.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/integration/test_import_backup.py`:
+
+```python
+"""Importing an existing disc backup runs the full pipeline, not a file move."""
+
+import pytest
+
+from app.database import async_session
+from app.models import DiscJob, JobState
+
+
+def _bdmv(root, name):
+    d = root / name
+    (d / "BDMV" / "STREAM").mkdir(parents=True)
+    (d / "BDMV" / "STREAM" / "00001.m2ts").write_bytes(b"x" * 10)
+    return d
+
+
+class TestBrowse:
+    @pytest.mark.asyncio
+    async def test_a_backup_folder_is_labelled_a_disc_image(self, client, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        resp = await client.get("/api/import/browse", params={"path": str(tmp_path)})
+        assert resp.status_code == 200
+        kinds = {e["name"]: e["type"] for e in resp.json()["entries"]}
+        assert kinds["Inception (2010)"] == "disc_image"
+
+    @pytest.mark.asyncio
+    async def test_an_iso_is_listed(self, client, tmp_path):
+        (tmp_path / "Inception.iso").write_bytes(b"x")
+        resp = await client.get("/api/import/browse", params={"path": str(tmp_path)})
+        kinds = {e["name"]: e["type"] for e in resp.json()["entries"]}
+        assert kinds["Inception.iso"] == "iso"
+
+
+class TestPreview:
+    @pytest.mark.asyncio
+    async def test_preview_reports_disc_images(self, client, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        resp = await client.post("/api/import/preview", json={"path": str(tmp_path)})
+        body = resp.json()
+        assert body["disc_images"] == [
+            {"name": "Inception (2010)", "path": str(tmp_path / "Inception (2010)"),
+             "kind": "backup", "total_bytes": 10}
+        ]
+        assert body["total_jobs"] == 1
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_start_creates_an_identifying_job_pointed_at_the_backup(self, client, tmp_path):
+        d = _bdmv(tmp_path, "Inception (2010)")
+        resp = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert resp.status_code == 200
+        job_ids = resp.json()["job_ids"]
+        assert len(job_ids) == 1
+
+        async with async_session() as s:
+            job = await s.get(DiscJob, job_ids[0])
+        assert job.source_spec == f"file:{d}"
+        assert job.drive_id == "import"
+        # It already is a backup: it must never enter BACKING_UP.
+        assert job.state != JobState.BACKING_UP
+
+    @pytest.mark.asyncio
+    async def test_an_iso_job_carries_an_iso_spec(self, client, tmp_path):
+        iso = tmp_path / "Inception.iso"
+        iso.write_bytes(b"x")
+        resp = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        async with async_session() as s:
+            job = await s.get(DiscJob, resp.json()["job_ids"][0])
+        assert job.source_spec == f"iso:{iso}"
+
+    @pytest.mark.asyncio
+    async def test_a_second_import_of_a_live_backup_is_blocked(self, client, tmp_path):
+        _bdmv(tmp_path, "Inception (2010)")
+        first = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert first.json()["job_ids"]
+        second = await client.post(
+            "/api/import/start", json={"path": str(tmp_path), "destination_mode": "library"}
+        )
+        assert second.json()["job_ids"] == []
+        assert second.json()["blocked"][0]["reason"] == "in_flight"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd backend && uv run pytest tests/integration/test_import_backup.py -q
+```
+
+Expected: `KeyError: 'disc_image'` or a `disc_images` KeyError.
+
+- [ ] **Step 3: Write the implementation**
+
+In `import_browse`, inside the `entry.is_dir(...)` branch, check the disc-image marker before counting MKVs:
+
+```python
+                if entry.is_dir(follow_symlinks=False):
+                    if import_scanner.is_disc_image_dir(Path(entry.path)):
+                        entries.append(
+                            {"name": entry.name, "path": entry.path, "type": "disc_image"}
+                        )
+                        continue
+```
+
+and add an ISO arm next to the `.mkv` file arm:
+
+```python
+                elif entry.is_file(follow_symlinks=False) and entry.name.lower().endswith(".iso"):
+                    entries.append({"name": entry.name, "path": entry.path, "type": "iso"})
+```
+
+Import `import_scanner` at the top of `import_browse` the same way `import_preview` does.
+
+In `import_preview`, add to the returned dict:
+
+```python
+        "disc_images": [
+            {"name": d.name, "path": str(d.path), "kind": d.kind, "total_bytes": d.total_bytes}
+            for d in scan.disc_images
+        ],
+```
+
+and change `"total_jobs": len(scan.units)` to `"total_jobs": len(scan.units) + len(scan.disc_images)`.
+
+In `import_start`, relax the empty guard and add a disc-image loop before the existing unit loop:
+
+```python
+    if not scan.units and not scan.disc_images:
+        raise HTTPException(status_code=400, detail="No MKV files or disc backups found to import")
+
+    for image in scan.disc_images:
+        staging = str(image.path)
+        key = unit_key_for(staging)
+        seen_keys.add(key)
+        result = await job_manager.create_job_from_staging(
+            staging_path=staging,
+            content_type="unknown",
+            detected_title=image.name,
+            destination_mode=req.destination_mode,
+            drive_id="import",
+            # The job reads from the image with MakeMKV rather than ingesting
+            # existing MKVs, so it carries a source spec and no file manifest.
+            source_spec=f"iso:{image.path}" if image.kind == "iso" else f"file:{image.path}",
+            force=key in force_keys,
+        )
+        if result.job_id is not None:
+            job_ids.append(result.job_id)
+        else:
+            blocked.append(
+                BlockedImportUnit(
+                    unit_key=key,
+                    show_name=image.name,
+                    season=None,
+                    display_path=staging,
+                    reason=result.block,
+                    job_ids=list(result.blocking_job_ids),
+                )
+            )
+```
+
+In `job_manager.create_job_from_staging`, add a `source_spec: str | None = None` keyword and persist it on the new `DiscJob`. When `source_spec` is set, the job must enter `IDENTIFYING` and run the normal scan-and-rip pipeline rather than the existing "files already exist" shortcut that jumps to `MATCHING`. Follow the branch that `drive_id == "import"` already takes and add the source-spec case beside it.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd backend && uv run pytest tests/integration/test_import_backup.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the existing import tests to verify nothing regressed**
+
+```bash
+cd backend && uv run pytest tests -q -k "import"
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd backend && uv run ruff check app/api/routes.py app/services/job_manager.py && uv run ruff format app/api/routes.py app/services/job_manager.py
+git add backend/app/api/routes.py backend/app/services/job_manager.py backend/tests/integration/test_import_backup.py
+git commit -m "feat(backup): import an existing disc backup or ISO through the import modal"
+```
+
+---
+
+## Task 15: Diagnostics and job detail
+
+**Files:**
+- Modify: `backend/app/api/routes.py` (`build_job_detail`)
+- Test: `backend/tests/unit/test_diagnostics.py` (existing file, add case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/test_diagnostics.py`:
+
+```python
+class TestBackupFieldsInJobDetail:
+    @pytest.mark.asyncio
+    async def test_backup_fields_are_reported(self, client, tmp_path):
+        from app.database import async_session
+        from app.models import DiscJob, JobState
+
+        async with async_session() as s:
+            job = DiscJob(
+                drive_id="E:",
+                state=JobState.COMPLETED,
+                backup_path=str(tmp_path / "Inception (2010)"),
+                backup_status="completed",
+                source_spec=f"file:{tmp_path / 'Inception (2010)'}",
+            )
+            s.add(job)
+            await s.commit()
+            await s.refresh(job)
+            job_id = job.id
+
+        body = (await client.get(f"/api/jobs/{job_id}/detail")).json()
+        assert body["backup_status"] == "completed"
+        assert body["backup_path"].endswith("Inception (2010)")
+        assert body["source_spec"].startswith("file:")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd backend && uv run pytest tests/unit/test_diagnostics.py -q -k BackupFields
+```
+
+Expected: `KeyError: 'backup_status'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `build_job_detail`, add `backup_status`, `backup_path` and `source_spec` to the job dict alongside the other `DiscJob` scalars. The bundle's markdown summary and log collection need no change: `_run_backup` logs inside `with_job_log_context`, so its lines already carry the `job=<id>` tag the bundle greps, and `backup_disc` writes `backup_job<id>.log` into the same log dir the scan and rip logs use.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd backend && uv run pytest tests/unit/test_diagnostics.py -q -k BackupFields
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/api/routes.py && uv run ruff format app/api/routes.py
+git add backend/app/api/routes.py backend/tests/unit/test_diagnostics.py
+git commit -m "feat(backup): report backup fields in job detail and diagnostics"
+```
+
+---
+
+## Task 16: Simulation support
+
+**Files:**
+- Modify: `backend/app/services/simulation_service.py`
+- Modify: `backend/app/api/routes.py` (the insert-disc request model)
+- Test: `backend/tests/integration/test_simulation.py` (existing file, add case)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/integration/test_simulation.py`:
+
+```python
+class TestSimulatedBackup:
+    @pytest.mark.asyncio
+    async def test_simulated_disc_passes_through_backing_up(self, client):
+        resp = await client.post(
+            "/api/simulate/insert-disc",
+            json={
+                "volume_label": "INCEPTION_2010",
+                "content_type": "movie",
+                "simulate_backup": True,
+                "simulate_ripping": False,
+            },
+        )
+        assert resp.status_code == 200
+        job_id = resp.json()["job_id"]
+
+        # The simulated backup does not auto-advance, so the job rests here.
+        job = (await client.get(f"/api/jobs/{job_id}")).json()
+        assert job["state"] == "backing_up"
+        assert job["backup_status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_advancing_a_simulated_backup_reaches_ripping(self, client):
+        resp = await client.post(
+            "/api/simulate/insert-disc",
+            json={
+                "volume_label": "INCEPTION_2010",
+                "content_type": "movie",
+                "simulate_backup": True,
+                "simulate_ripping": False,
+            },
+        )
+        job_id = resp.json()["job_id"]
+        await client.post(f"/api/simulate/advance-job/{job_id}")
+        job = (await client.get(f"/api/jobs/{job_id}")).json()
+        assert job["state"] == "ripping"
+        assert job["backup_status"] == "completed"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd backend && uv run pytest tests/integration/test_simulation.py -q -k SimulatedBackup
+```
+
+Expected: the job reports `ripping` or `identifying`, not `backing_up`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add `simulate_backup: bool = False` to the simulate-insert-disc request model in `routes.py`. In `SimulationService`, when `simulate_backup` is set, park the created job in `JobState.BACKING_UP` with `backup_status="pending"` and a synthetic `backup_path`, broadcast a few `backup_progress` messages, and leave it there. In the service's advance handler, add a `BACKING_UP` arm that sets `backup_status="completed"`, sets `source_spec` to the synthetic backup path, and transitions to `RIPPING`. Keep every one of these code paths inside `SimulationService`, as the other simulation methods are, and behind the existing DEBUG gate.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd backend && uv run pytest tests/integration/test_simulation.py -q -k SimulatedBackup
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && uv run ruff check app/services/simulation_service.py app/api/routes.py && uv run ruff format app/services/simulation_service.py app/api/routes.py
+git add backend/app/services/simulation_service.py backend/app/api/routes.py backend/tests/integration/test_simulation.py
+git commit -m "feat(backup): simulate the BACKING_UP phase for E2E without 40GB"
+```
+
+---
+
+## Task 17: Frontend state, replacing the orphaned `archiving_iso`
+
+`archiving_iso` and `isoProgress` exist only in the frontend and only mock data feeds them. Repurpose rather than adding an eleventh state.
+
+**Files:**
+- Modify: `frontend/src/app/components/DiscCard.tsx:18`, `:72`, `:676-695`
+- Modify: `frontend/src/app/components/discState.ts:31`, `:56`, `:52`
+- Modify: `frontend/src/types/adapters.ts:11-23`
+- Modify: `frontend/src/app/utils/mockData.ts`
+- Modify: `frontend/src/app/components/DiscCard.test.tsx:369-376`, `frontend/src/app/components/discState.test.ts:8`
+- Test: `frontend/src/types/__tests__/adapters.test.ts` (add cases; create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the adapters test file:
+
+```tsx
+import { mapJobStateToDiscState } from '../adapters';
+
+describe('mapJobStateToDiscState', () => {
+  it('maps backing_up to the backing_up disc state', () => {
+    expect(mapJobStateToDiscState('backing_up')).toBe('backing_up');
+  });
+
+  it('still maps ripping', () => {
+    expect(mapJobStateToDiscState('ripping')).toBe('ripping');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npm run test:unit -- adapters
+```
+
+Expected: TypeScript error, `'backing_up' is not assignable to Job['state']`, or the assertion returns `'idle'`.
+
+If `node_modules` is missing, run `npm install` first, then `git checkout package-lock.json` before committing: the install rewrites the lock with a large unrelated diff.
+
+- [ ] **Step 3: Write the implementation**
+
+In `frontend/src/app/components/DiscCard.tsx:18`, rename the state and the progress field:
+
+```tsx
+export type DiscState = "idle" | "scanning" | "review_needed" | "backing_up" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
+```
+
+```tsx
+  /** Percentage of the full-disc backup copied, when state is "backing_up". */
+  backupProgress?: number;
+```
+
+Replace the ISO block at `:676`:
+
+```tsx
+              {/* Full-disc backup */}
+              {disc.state === "backing_up" && disc.backupProgress !== undefined && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      fontFamily: sv.mono,
+                      fontSize: 12,
+                      color: sv.magenta,
+                      letterSpacing: "0.2em",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    <Database size={14} />
+                    <span>› BACKING UP DISC…</span>
+                  </div>
+                  <SvProgressBar progress={disc.backupProgress} color="magenta" label="DISC BACKUP" />
+                </div>
+              )}
+```
+
+In `discState.ts:31`, rename the key and label:
+
+```tsx
+  backing_up:     { label: "BACKING UP",    badgeState: "matching", color: sv.purple,   glow: sv.purple,   icon: IcoLibrary },
+```
+
+Rename it in `ACTIVE_PIPELINE_STATES` too, and update the two comments at `:52` and the `discState.test.ts:8` reference from `archiving_iso` to `backing_up`.
+
+In `adapters.ts`, add the mapping:
+
+```tsx
+    'identifying': 'scanning',
+    'backing_up': 'backing_up',
+```
+
+and add `'backing_up'` to the `Job['state']` union in `frontend/src/types/` wherever the backend states are declared.
+
+In `mockData.ts`, rename `isoProgress` to `backupProgress` at all four call sites, and any `state: 'archiving_iso'` to `'backing_up'`. Do the same in `DiscCard.test.tsx:369-376`, keeping the comment's meaning (this state is what distinguishes `ACTIVE_PIPELINE_STATES` from the settled ones).
+
+- [ ] **Step 4: Run the tests and the type check**
+
+```bash
+cd frontend && npm run test:unit && npm run build
+```
+
+Expected: tests pass and the build type-checks clean. `npm run build` runs `tsc`, which is what catches a missed rename.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && npm run lint
+git add frontend/src
+git commit -m "feat(backup): render the BACKING UP phase, replacing the orphaned ISO state"
+```
+
+---
+
+## Task 18: Wire `backup_progress` into the dashboard
+
+**Files:**
+- Modify: `frontend/src/app/hooks/useJobManagement.ts`
+- Test: `frontend/src/app/hooks/__tests__/useJobManagement.test.ts` (add case; create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('applies backup_progress to the matching job', () => {
+  // The message carries bytes, not a percentage: the card renders the bar,
+  // so the conversion belongs here rather than on the wire.
+  const jobs = [{ id: 7, state: 'backing_up', progress_percent: 0 }] as never;
+  const next = applyBackupProgress(jobs, {
+    job_id: 7, current_bytes: 25, total_bytes: 100, speed: '2.5x', eta: 90,
+  });
+  expect(next[0].progress_percent).toBe(25);
+  expect(next[0].current_speed).toBe('2.5x');
+  expect(next[0].eta_seconds).toBe(90);
+});
+
+it('ignores backup_progress for an unknown job', () => {
+  const jobs = [{ id: 7, state: 'backing_up', progress_percent: 0 }] as never;
+  expect(applyBackupProgress(jobs, {
+    job_id: 99, current_bytes: 1, total_bytes: 2, speed: null, eta: null,
+  })).toBe(jobs);
+});
+
+it('treats a zero total as no progress rather than dividing by zero', () => {
+  const jobs = [{ id: 7, state: 'backing_up', progress_percent: 0 }] as never;
+  const next = applyBackupProgress(jobs, {
+    job_id: 7, current_bytes: 0, total_bytes: 0, speed: null, eta: null,
+  });
+  expect(next[0].progress_percent).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npm run test:unit -- useJobManagement
+```
+
+Expected: `applyBackupProgress is not defined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Export the pure reducer from `useJobManagement.ts`:
+
+```tsx
+/** Fold a backup_progress message into the job list. Returns the same array
+ *  reference when nothing matched, so React skips the re-render. */
+export function applyBackupProgress(jobs: Job[], data: BackupProgressMessage): Job[] {
+  const idx = jobs.findIndex(j => j.id === data.job_id);
+  if (idx === -1) return jobs;
+  const pct = data.total_bytes > 0
+    ? Math.min(100, Math.round((data.current_bytes / data.total_bytes) * 100))
+    : 0;
+  const next = [...jobs];
+  next[idx] = {
+    ...next[idx],
+    progress_percent: pct,
+    current_speed: data.speed ?? next[idx].current_speed,
+    eta_seconds: data.eta ?? next[idx].eta_seconds,
+  };
+  return next;
+}
+```
+
+Then add a `case 'backup_progress':` arm to the WebSocket message switch that calls it, and pass `backupProgress: job.progress_percent` through `transformJobToDiscData` when the job state is `backing_up`.
+
+- [ ] **Step 4: Run the tests and build**
+
+```bash
+cd frontend && npm run test:unit && npm run build
+```
+
+Expected: pass and clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && npm run lint
+git add frontend/src
+git commit -m "feat(backup): drive the backup progress bar from backup_progress events"
+```
+
+---
+
+## Task 19: Config wizard controls
+
+**Files:**
+- Modify: `frontend/src/components/ConfigWizard.tsx`
+- Test: `frontend/src/components/ConfigWizard.test.tsx` (add cases)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('shows the backup path field when backup before rip is enabled', async () => {
+  render(<ConfigWizard {...defaultProps} />);
+  const toggle = await screen.findByLabelText(/back up disc before ripping/i);
+  expect(screen.queryByLabelText(/backup folder/i)).not.toBeInTheDocument();
+  await userEvent.click(toggle);
+  expect(await screen.findByLabelText(/backup folder/i)).toBeInTheDocument();
+});
+
+it('sends both backup fields on save', async () => {
+  const onSave = vi.fn();
+  render(<ConfigWizard {...defaultProps} onSave={onSave} />);
+  await userEvent.click(await screen.findByLabelText(/back up disc before ripping/i));
+  await userEvent.type(await screen.findByLabelText(/backup folder/i), 'D:\\backups');
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(onSave).toHaveBeenCalledWith(
+    expect.objectContaining({ backup_before_rip: true, backup_path: 'D:\\backups' }),
+  );
+});
+```
+
+Adapt `defaultProps` and the save-button query to whatever the existing tests in this file already use.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npm run test:unit -- ConfigWizard
+```
+
+Expected: `Unable to find a label with the text of: /back up disc before ripping/i`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the toggle to the paths/preferences section, following the shape of the existing `always_review` toggle, with help text: "Write a full copy of each disc to a separate folder, then extract from that copy. Slower per disc and uses tens of gigabytes, but the disc is read once and the copy is kept." Reveal a `backup_path` picker when the toggle is on, using the same `PathStatusHint` treatment as the library roots. Include both keys in the payload the wizard PUTs to `/api/config`.
+
+- [ ] **Step 4: Run the tests and build**
+
+```bash
+cd frontend && npm run test:unit -- ConfigWizard && npm run build
+```
+
+Expected: pass and clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && npm run lint
+git add frontend/src/components/ConfigWizard.tsx frontend/src/components/ConfigWizard.test.tsx
+git commit -m "feat(backup): add backup settings to the config wizard"
+```
+
+---
+
+## Task 20: Import modal and history surfaces
+
+**Files:**
+- Modify: `frontend/src/components/ImportModal.tsx`
+- Modify: `frontend/src/components/HistoryPage/` (the detail panel component)
+- Modify: `frontend/src/app/components/DiscCard/DiscMetadata.tsx`
+- Test: `frontend/src/components/ImportModal.test.tsx` (add cases)
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it('renders a disc backup entry distinctly from a folder', async () => {
+  mockBrowse({ entries: [
+    { name: 'Inception (2010)', path: '/b/Inception (2010)', type: 'disc_image' },
+    { name: 'Frasier', path: '/b/Frasier', type: 'dir', mkv_count: 3 },
+  ]});
+  render(<ImportModal {...defaultProps} />);
+  expect(await screen.findByText(/disc backup/i)).toBeInTheDocument();
+});
+
+it('summarises disc images in the preview', async () => {
+  mockPreview({ units: [], disc_images: [
+    { name: 'Inception (2010)', path: '/b/Inception (2010)', kind: 'backup', total_bytes: 40e9 },
+  ], total_jobs: 1, total_files: 0, total_bytes: 40e9, loose_files: [], root: '/b' });
+  render(<ImportModal {...defaultProps} />);
+  // The user must know this is scanned and extracted, not filed.
+  expect(await screen.findByText(/will be scanned and extracted/i)).toBeInTheDocument();
+});
+```
+
+Adapt `mockBrowse` / `mockPreview` to the fetch-mocking helpers this file already uses.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npm run test:unit -- ImportModal
+```
+
+Expected: `Unable to find an element with the text: /disc backup/i`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `ImportModal.tsx`, render `disc_image` and `iso` entries with a distinct icon and a "DISC BACKUP" / "ISO" tag, and add a preview line reading "N disc backup(s) will be scanned and extracted" so the user knows this path runs MakeMKV rather than filing existing MKVs. Include disc images in the selection and confirmation counts.
+
+In the History detail panel, render the backup path and status next to the other job paths. Render a warning row when `backup_status` starts with `skipped:` or `failed:`, mapping the suffix to plain text ("No backup folder configured", "Not enough free space", "MakeMKV could not enumerate the drive", "This disc type cannot be backed up", "Backup failed: <reason>").
+
+In `DiscMetadata.tsx`, show the same one-line note on the card for a live job.
+
+- [ ] **Step 4: Run the tests and build**
+
+```bash
+cd frontend && npm run test:unit && npm run build
+```
+
+Expected: pass and clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && npm run lint
+git add frontend/src
+git commit -m "feat(backup): surface disc backups in the import modal and history"
+```
+
+---
+
+## Task 21: End-to-end tests
+
+**Files:**
+- Create: `frontend/e2e/disc-backup.spec.ts`
+
+- [ ] **Step 1: Write the E2E spec**
+
+```ts
+import { test, expect } from '@playwright/test';
+import { resetAllJobs } from './helpers';
+
+test.describe('disc backup before rip', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetAllJobs(request);
+  });
+
+  test('a simulated disc shows BACKING UP, then RIPPING', async ({ page, request }) => {
+    await page.goto('/');
+    await request.post('/api/simulate/insert-disc', {
+      data: {
+        volume_label: 'INCEPTION_2010',
+        content_type: 'movie',
+        simulate_backup: true,
+        simulate_ripping: false,
+      },
+    });
+
+    const card = page.getByTestId('disc-card').first();
+    await expect(card.getByText('BACKING UP')).toBeVisible();
+    await expect(card.getByText(/BACKING UP DISC/i)).toBeVisible();
+
+    const jobId = await card.getAttribute('data-job-id');
+    await request.post(`/api/simulate/advance-job/${jobId}`);
+    await expect(card.getByText('RIPPING')).toBeVisible();
+  });
+
+  test('a backup folder appears in the import modal', async ({ page }) => {
+    // e2e/fixtures/backups/Inception (2010)/BDMV/STREAM/ holds a single tiny
+    // .m2ts, which is all the detector needs: no media is required.
+    await page.goto('/');
+    await page.getByRole('button', { name: /import/i }).click();
+    await page.getByLabel(/path/i).fill('e2e/fixtures/backups');
+    await expect(page.getByText(/disc backup/i)).toBeVisible();
+  });
+});
+```
+
+Match the existing specs' selectors and `resetAllJobs` helper import; if `disc-card` has no `data-testid`, use the selector the neighbouring specs use.
+
+- [ ] **Step 2: Create the fixture**
+
+```bash
+cd frontend && mkdir -p "e2e/fixtures/backups/Inception (2010)/BDMV/STREAM" && printf 'x' > "e2e/fixtures/backups/Inception (2010)/BDMV/STREAM/00001.m2ts"
+```
+
+- [ ] **Step 3: Run the E2E spec**
+
+Start the backend with `DEBUG=true` on a port of your choosing, point the frontend proxy at it, then:
+
+```bash
+cd frontend && npm run test:e2e -- disc-backup.spec.ts
+```
+
+Expected: both tests pass. Screenshots and modal interaction can leave a stuck `opacity-0` overlay under automation; that is a known pre-existing condition, not a regression from this work.
+
+- [ ] **Step 4: Stop the servers you started**
+
+```powershell
+Get-NetTCPConnection -LocalPort <your backend port>,<your vite port> -State Listen -ErrorAction SilentlyContinue |
+  Select-Object -ExpandProperty OwningProcess -Unique |
+  ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e
+git commit -m "test(backup): E2E coverage for the backup phase and backup import"
+```
+
+---
+
+## Task 22: Documentation and changelog
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/` (the configuration page)
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+Add to the WebSocket message table:
+
+| `backup_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Full-disc backup copy progress |
+
+Add to Key Configuration Fields:
+
+- **Disc backup**: `backup_before_rip` (bool, default false, `server_default 0`) plus `backup_path`. When on, a disc is copied whole to `<backup_path>` after identification and extracted from the copy, and the drive is released at the end of `BACKING_UP` rather than at the end of `RIPPING`. Every failure degrades to a direct rip (see `backup_status`); the one exception is a backup whose re-scan cannot be reconciled onto the stored title indices, which parks in `REVIEW_NEEDED` because the disc has already been ejected. Backups are never deleted by Engram.
+
+Add to Key Patterns:
+
+- **A job's source is a value, not a drive.** `DiscSource` (`app/core/disc_source.py`) is the single answer to "is this a physical drive?", which gates eject, sentinel re-arm and, critically, the MakeMKV lock key: a `file:` source must not contend for the optical drive's lock, or extracting from a backup would block the next disc from being scanned. `source_spec` on `DiscJob` is the stored form, `None` meaning "legacy: derive from `drive_id`".
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+
+```markdown
+### Added
+
+- Optional full-disc backup before ripping. Engram can write a complete decrypted MakeMKV copy of each disc to a separate folder, then extract from that copy instead of the drive: the disc is read once and released as soon as the copy finishes, extraction is faster and survives marginal reads, and the backup is kept for preservation. Off by default; enable it under Settings with a backup folder. (#NNN)
+- Existing disc backups and ISO files can be imported from the manual import modal, which scans and extracts them through the normal pipeline. Pointing at a folder of backups queues every disc under it. (#NNN)
+```
+
+Replace `#NNN` with the PR number once the PR exists.
+
+- [ ] **Step 3: Update the docs configuration page**
+
+Document both settings and the backup folder layout (`Movies/Name (Year)/`, `TV/Show (Year)/Season NN/Disc slug/`, `Unidentified/<label>/`), and state plainly that Engram never deletes a backup.
+
+- [ ] **Step 4: Verify the docs build**
+
+```bash
+uv run --with mkdocs-material --with "mkdocstrings[python]" mkdocs build
+```
+
+Run from the repository root, not `backend/`. Expected: builds with the usual 18 warnings and no new ones. Do not add `--strict`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md CHANGELOG.md docs
+git commit -m "docs(backup): document disc backup before rip and backup import"
+```
+
+---
+
+## Task 23: Full verification before the PR
+
+- [ ] **Step 1: Run the backend unit tier**
+
+```bash
+cd backend && uv run pytest tests/unit -q
+```
+
+Expected: all pass. This takes several minutes; run it in the main session rather than inside a subagent.
+
+- [ ] **Step 2: Run the integration and pipeline tiers**
+
+```bash
+cd backend && uv run pytest tests/integration tests/pipeline -q
+```
+
+Expected: all pass. Note that `tests/integration/test_workflow.py` runs against the real app database and can move files into the real library, so run it only when that is acceptable.
+
+- [ ] **Step 3: Lint the backend**
+
+```bash
+cd backend && uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Build and lint the frontend**
+
+```bash
+cd frontend && npm run build && npm run lint && npm run test:unit
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Confirm the default path is untouched**
+
+With `backup_before_rip` off (the default), simulate a disc and confirm it goes `identifying -> ripping` with no `BACKING_UP` and `backup_status` still `None`:
+
+```bash
+curl -X POST localhost:8000/api/simulate/insert-disc -H "Content-Type: application/json" -d '{"volume_label":"INCEPTION_2010","content_type":"movie","simulate_ripping":true}'
+```
+
+- [ ] **Step 6: Real-disc verification, exactly one backend running**
+
+Verify, and record the answers in the spec's Open Questions section:
+
+1. A Blu-ray with the setting on: the backup lands at the expected path, the tray opens when the backup finishes rather than when extraction finishes, and extraction reads from the backup.
+2. A DVD with the setting on: does `makemkvcon backup` accept it? If not, confirm the job records `skipped:unsupported_disc` and rips directly.
+3. Whether `makemkvcon backup` emits `PRGV` lines. If it does not, the progress bar will sit at zero, and `_run_backup` needs the filesystem-polling fallback that `_run_ripping` already demonstrates.
+4. An existing backup folder and an ISO imported through the modal.
+
+- [ ] **Step 7: Stop this session's servers**
+
+```powershell
+Get-NetTCPConnection -LocalPort <your ports> -State Listen -ErrorAction SilentlyContinue |
+  Select-Object -ExpandProperty OwningProcess -Unique |
+  ForEach-Object { Stop-Process -Id $_ -Force }
+```
+
+Also kill any orphaned `makemkvcon` processes this session started.
+
+- [ ] **Step 8: Open the PR**
+
+```bash
+git push -u origin claude/disc-backup-before-rip-4967ae
+```
+
+Then open the PR with `gh pr create`, and immediately post `@claude please review this PR` as a comment: the code-review workflow only fires on the `opened` event.
+
+---
+
+## Self-review notes
+
+Spec coverage checked section by section. Every spec section maps to a task: data model (4), components (1, 2, 3, 6), destination naming (5), reconciliation (9), failure handling (10), drive release and notifications (10), watchdog (7), WebSocket contract (8), import from backup (13, 14), frontend (17, 18, 19, 20), diagnostics (15), testing (every task, plus 16 and 21), open questions (23 step 6).
+
+Two deliberate deviations from the spec, both improvements found while planning:
+
+1. The spec's frontend section assumed a new UI state. Task 17 instead repurposes the orphaned `archiving_iso` / `isoProgress` scaffolding, which no backend code has ever emitted. Adding an eleventh state beside a dead tenth one would create exactly the drift `discState.ts` warns about.
+2. `next_state_after_identify` returns `RIPPING` when `backup_before_rip` is on but `backup_path` is empty, rather than entering `BACKING_UP` and immediately falling back. The `skipped:not_configured` path in `_run_backup` remains as the backstop for a root that is emptied mid-job, so both are covered.

--- a/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
+++ b/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
@@ -1125,6 +1125,23 @@ git commit -m "feat(backup): compute backup destinations and preflight free spac
 - Modify: `backend/app/core/extractor.py`
 - Test: `backend/tests/unit/test_backup_disc.py`
 
+> **Corrected during implementation and review.** Four things below are wrong as
+> written. (1) The `_parse_backup_progress` fixtures contradict the reference
+> implementation directly beneath them: in `PRGV:current,total,max`, `current` is
+> the per-title bar and `total` is the overall bar, pinned by a verbatim real rip
+> log in `tests/unit/test_rip_progress.py`, so `total/maximum` is right and the
+> fixtures had the fields swapped. Reading `current` would run the backup bar
+> backwards once per sub-operation. (2) `_run_backup_process` is an instance
+> method, not a staticmethod, so it can register its `Popen` in `self._processes`
+> and be cancelled; a staticmethod leaves a multi-hour backup uncancellable.
+> (3) The log file is `backup.log`, matching `scan.log` and `rip.log`, because
+> callers already pass a per-job log dir. (4) `_last_msg_text` parses the first
+> quoted field by regex rather than `split(",", 4)[4]`, because MakeMKV's MSG
+> format puts the format string at index 4 and a comma inside the message breaks
+> the naive split. Review then added a guarded `mkdir`, a clean-working-directory
+> rule for a retried backup (at most one stale `.partial` preserved), and a
+> `BackupResult.already_existed` flag. See commits `38598c54` and `8d4b1ce0`.
+
 - [ ] **Step 1: Write the failing tests**
 
 Create `backend/tests/unit/test_backup_disc.py`:

--- a/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
+++ b/docs/superpowers/plans/2026-09-05-disc-backup-before-rip.md
@@ -41,7 +41,7 @@
 
 | File | Change |
 | --- | --- |
-| `backend/app/models/disc_job.py` | `JobState.BACKING_UP`; `source_spec`, `backup_path`, `backup_status` columns. |
+| `backend/app/models/disc_job.py` | `JobState.BACKING_UP`; `source_spec`, `backup_path`, `backup_status`, `backup_status_reason` columns. |
 | `backend/app/models/app_config.py` | `backup_before_rip`, `backup_path`, `timeout_backing_up_seconds`. |
 | `backend/app/core/extractor.py` | `_to_source_spec`, `DiscSource`-aware locking, `backup_disc()`, `BackupResult`. |
 | `backend/app/core/import_scanner.py` | `DiscImageUnit` detection and short-circuit. |
@@ -740,16 +740,22 @@ Add to `DiscJob`, in the Paths block after `import_manifest_json`:
     # Where this job's backup landed. Kept for history and for re-import; Engram
     # never deletes it.
     backup_path: str | None = Field(default=None)
-    # "pending" | "completed" | "failed:<reason>" | "skipped:<reason>".
-    # None means no backup was attempted (the feature is off).
+    # "pending" | "completed" | "failed" | "skipped". None means no backup was
+    # attempted (the feature is off). Mirrors subtitle_status: a small closed set
+    # of literals here, with the free-text explanation in its own column, so no
+    # consumer has to parse a delimiter out of a status.
     backup_status: str | None = Field(default=None)
+    # Why the backup failed or was skipped, e.g. "insufficient_space",
+    # "not_configured", "no_disc_index", "unsupported_disc", or a MakeMKV error
+    # string. None when backup_status is pending or completed.
+    backup_status_reason: str | None = Field(default=None)
 ```
 
 In `backend/app/models/app_config.py`, add next to the other path fields (near line 43):
 
 ```python
     # Root for full decrypted disc backups. Empty means the feature cannot run,
-    # which the backup phase reports as skipped:not_configured rather than failing.
+    # which the backup phase reports as a "not_configured" skip rather than failing.
     backup_path: str = ""
 ```
 
@@ -815,6 +821,9 @@ def upgrade() -> None:
     op.add_column("disc_jobs", sa.Column("backup_path", sa.String(), nullable=True))
     op.add_column("disc_jobs", sa.Column("backup_status", sa.String(), nullable=True))
     op.add_column(
+        "disc_jobs", sa.Column("backup_status_reason", sa.String(), nullable=True)
+    )
+    op.add_column(
         "app_config",
         sa.Column("backup_path", sa.String(), nullable=False, server_default=sa.text("''")),
     )
@@ -843,6 +852,7 @@ def downgrade() -> None:
         batch_op.drop_column("backup_before_rip")
         batch_op.drop_column("backup_path")
     with op.batch_alter_table("disc_jobs", schema=None) as batch_op:
+        batch_op.drop_column("backup_status_reason")
         batch_op.drop_column("backup_status")
         batch_op.drop_column("backup_path")
         batch_op.drop_column("source_spec")
@@ -1022,7 +1032,7 @@ def backup_destination(job: DiscJob, backup_root: str) -> Path | None:
     """Compute where this job's backup should be written.
 
     Returns None when no root is configured, which the caller reports as
-    skipped:not_configured.
+    a "not_configured" skip.
     """
     if not backup_root:
         return None
@@ -1899,7 +1909,8 @@ class TestFallbacks:
         )), patch.object(job_manager, "_run_ripping", new=AsyncMock()):
             await job_manager._run_backup(job_id)
         job = await _reload(job_id)
-        assert job.backup_status == "skipped:not_configured"
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "not_configured"
         assert job.state == JobState.RIPPING
 
     @pytest.mark.asyncio
@@ -1911,7 +1922,8 @@ class TestFallbacks:
              patch.object(job_manager, "_run_ripping", new=AsyncMock()):
             await job_manager._run_backup(job_id)
         job = await _reload(job_id)
-        assert job.backup_status == "skipped:insufficient_space"
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "insufficient_space"
         assert job.state == JobState.RIPPING
 
     @pytest.mark.asyncio
@@ -1924,7 +1936,8 @@ class TestFallbacks:
              patch.object(job_manager, "_run_ripping", new=AsyncMock()):
             await job_manager._run_backup(job_id)
         job = await _reload(job_id)
-        assert job.backup_status == "skipped:no_disc_index"
+        assert job.backup_status == "skipped"
+        assert job.backup_status_reason == "no_disc_index"
         assert job.state == JobState.RIPPING
 
     @pytest.mark.asyncio
@@ -1939,8 +1952,8 @@ class TestFallbacks:
              )), patch.object(job_manager, "_run_ripping", new=AsyncMock()):
             await job_manager._run_backup(job_id)
         job = await _reload(job_id)
-        assert job.backup_status.startswith("failed:")
-        assert "read error" in job.backup_status
+        assert job.backup_status == "failed"
+        assert "read error" in job.backup_status_reason
         assert job.state == JobState.RIPPING
         # The drive was never released: extraction still needs the disc.
         assert job.source_spec is None
@@ -2053,12 +2066,19 @@ Add the method next to `_run_ripping`:
 
         safe_job = sanitize_log_value(job_id)
 
-        async def _record(status: str, *, path: str | None = None, spec: str | None = None):
+        async def _record(
+            status: str,
+            *,
+            reason: str | None = None,
+            path: str | None = None,
+            spec: str | None = None,
+        ):
             async with async_session() as session:
                 job = await session.get(DiscJob, job_id)
                 if not job:
                     return
                 job.backup_status = status
+                job.backup_status_reason = reason
                 if path is not None:
                     job.backup_path = path
                 if spec is not None:
@@ -2066,9 +2086,11 @@ Add the method next to `_run_ripping`:
                 job.updated_at = datetime.now(UTC)
                 await session.commit()
 
-        async def _fall_back(status: str) -> None:
-            logger.warning(f"Job {safe_job}: {status}; ripping directly from the drive")
-            await _record(status)
+        async def _fall_back(status: str, reason: str) -> None:
+            logger.warning(
+                f"Job {safe_job}: backup {status} ({reason}); ripping directly from the drive"
+            )
+            await _record(status, reason=reason)
             await self._enter_ripping(job_id)
 
         try:
@@ -2089,7 +2111,7 @@ Add the method next to `_run_ripping`:
             config = await get_config()
             dest = backup_destination(job, config.backup_path if config else "")
             if dest is None:
-                await _fall_back("skipped:not_configured")
+                await _fall_back("skipped", "not_configured")
                 return
 
             # Already backed up (a re-inserted disc, or a retried job). Reuse it
@@ -2103,12 +2125,12 @@ Add the method next to `_run_ripping`:
                 return
 
             if not has_room_for_backup(dest, total_bytes):
-                await _fall_back("skipped:insufficient_space")
+                await _fall_back("skipped", "insufficient_space")
                 return
 
             disc_spec = await resolve_disc_index(drive_id, str(self.extractor.makemkv_path))
             if disc_spec is None:
-                await _fall_back("skipped:no_disc_index")
+                await _fall_back("skipped", "no_disc_index")
                 return
 
             await _record("pending", path=str(dest))
@@ -2139,7 +2161,7 @@ Add the method next to `_run_ripping`:
             )
 
             if not result.success:
-                await _fall_back(f"failed:{result.error_message or 'unknown error'}")
+                await _fall_back("failed", result.error_message or "unknown error")
                 return
 
             await _record("completed", path=str(result.dest), spec=f"file:{result.dest}")
@@ -2154,7 +2176,7 @@ Add the method next to `_run_ripping`:
 
         except Exception as e:
             logger.error(f"Job {safe_job}: backup phase crashed: {e}", exc_info=True)
-            await _fall_back(f"failed:{e}")
+            await _fall_back("failed", str(e))
 
     async def _enter_ripping(self, job_id: int) -> None:
         """Transition into RIPPING and start the rip task."""
@@ -2878,7 +2900,7 @@ Expected: `KeyError: 'backup_status'`.
 
 - [ ] **Step 3: Write the implementation**
 
-In `build_job_detail`, add `backup_status`, `backup_path` and `source_spec` to the job dict alongside the other `DiscJob` scalars. The bundle's markdown summary and log collection need no change: `_run_backup` logs inside `with_job_log_context`, so its lines already carry the `job=<id>` tag the bundle greps, and `backup_disc` writes `backup_job<id>.log` into the same log dir the scan and rip logs use.
+In `build_job_detail`, add `backup_status`, `backup_status_reason`, `backup_path` and `source_spec` to the job dict alongside the other `DiscJob` scalars. The bundle's markdown summary and log collection need no change: `_run_backup` logs inside `with_job_log_context`, so its lines already carry the `job=<id>` tag the bundle greps, and `backup_disc` writes `backup_job<id>.log` into the same log dir the scan and rip logs use.
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -3288,7 +3310,7 @@ Expected: `Unable to find an element with the text: /disc backup/i`.
 
 In `ImportModal.tsx`, render `disc_image` and `iso` entries with a distinct icon and a "DISC BACKUP" / "ISO" tag, and add a preview line reading "N disc backup(s) will be scanned and extracted" so the user knows this path runs MakeMKV rather than filing existing MKVs. Include disc images in the selection and confirmation counts.
 
-In the History detail panel, render the backup path and status next to the other job paths. Render a warning row when `backup_status` starts with `skipped:` or `failed:`, mapping the suffix to plain text ("No backup folder configured", "Not enough free space", "MakeMKV could not enumerate the drive", "This disc type cannot be backed up", "Backup failed: <reason>").
+In the History detail panel, render the backup path and status next to the other job paths. Render a warning row when `backup_status` is `skipped` or `failed`, mapping `backup_status_reason` to plain text ("No backup folder configured", "Not enough free space", "MakeMKV could not enumerate the drive", "This disc type cannot be backed up", "Backup failed: <reason>").
 
 In `DiscMetadata.tsx`, show the same one-line note on the card for a live job.
 
@@ -3494,7 +3516,7 @@ curl -X POST localhost:8000/api/simulate/insert-disc -H "Content-Type: applicati
 Verify, and record the answers in the spec's Open Questions section:
 
 1. A Blu-ray with the setting on: the backup lands at the expected path, the tray opens when the backup finishes rather than when extraction finishes, and extraction reads from the backup.
-2. A DVD with the setting on: does `makemkvcon backup` accept it? If not, confirm the job records `skipped:unsupported_disc` and rips directly.
+2. A DVD with the setting on: does `makemkvcon backup` accept it? If not, confirm the job records `backup_status="skipped"` with `backup_status_reason="unsupported_disc"` and rips directly.
 3. Whether `makemkvcon backup` emits `PRGV` lines. If it does not, the progress bar will sit at zero, and `_run_backup` needs the filesystem-polling fallback that `_run_ripping` already demonstrates.
 4. An existing backup folder and an ISO imported through the modal.
 
@@ -3525,4 +3547,4 @@ Spec coverage checked section by section. Every spec section maps to a task: dat
 Two deliberate deviations from the spec, both improvements found while planning:
 
 1. The spec's frontend section assumed a new UI state. Task 17 instead repurposes the orphaned `archiving_iso` / `isoProgress` scaffolding, which no backend code has ever emitted. Adding an eleventh state beside a dead tenth one would create exactly the drift `discState.ts` warns about.
-2. `next_state_after_identify` returns `RIPPING` when `backup_before_rip` is on but `backup_path` is empty, rather than entering `BACKING_UP` and immediately falling back. The `skipped:not_configured` path in `_run_backup` remains as the backstop for a root that is emptied mid-job, so both are covered.
+2. `next_state_after_identify` returns `RIPPING` when `backup_before_rip` is on but `backup_path` is empty, rather than entering `BACKING_UP` and immediately falling back. The `skipped` / `not_configured` path in `_run_backup` remains as the backstop for a root that is emptied mid-job, so both are covered.

--- a/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
+++ b/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
@@ -450,6 +450,25 @@ Both were answered on real hardware (MakeMKV 1.18.3, Pioneer BDR-S13U,
    reading `total / max` is correct. Reading `current` would run the user's
    backup bar backwards once per sub-operation.
 
+### Blu-ray verification
+
+Re-run against a Blu-ray (`SOUTHPARK6_DISC2`), which exercises paths a DVD
+cannot: a DVD backup produces `VIDEO_TS`, a Blu-ray produces `BDMV/STREAM`,
+and two pieces of this feature key on the latter.
+
+- `is_disc_image_dir` detects a real MakeMKV `BDMV` tree, and `import_scanner`
+  emits it as one disc-image unit with zero MKV units. `total_files` came back
+  0, confirming the walk short-circuits at the image rather than pulling
+  thousands of stream files into the scanner's budget.
+- **An imported backup gets the same ContentHash as the disc it came from**,
+  which is what makes a TheDiscDB lookup work for an import. Verified rather
+  than assumed: of the stream files the interrupted backup had finished, 7 of 7
+  were byte-identical in size to the disc (the 8th was mid-write), and the hash
+  is an MD5 over those sizes in filename order, so a complete copy necessarily
+  hashes the same. `compute_content_hash("F:")` returned
+  `F1CBB868B97BA9965F3DF3FA0EB846A2`, matching an independent reimplementation
+  of the algorithm over the disc's own stream sizes.
+
 **A third thing surfaced that neither question anticipated, and it is the one
 with teeth.** MakeMKV refuses a destination directory that already exists,
 *even an empty one*: `MSG:5068 "Folder ... already contains a backup, please

--- a/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
+++ b/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
@@ -433,18 +433,35 @@ in the job-detail JSON via `build_job_detail`.
 - A DVD with the setting on: see the open question below.
 - An existing backup folder and an ISO imported through the modal.
 
-## Open questions
+## Open questions: resolved
 
-1. **Does `makemkvcon backup` accept DVDs on current MakeMKV builds?** MakeMKV's
-   backup path is historically Blu-ray-oriented. The design already degrades to
-   a direct rip on an unsupported disc, so a negative answer costs only the
-   wording of the `skipped:unsupported_disc` message and a documentation note.
-   Verify against a real DVD before finalizing that string.
-2. **Does `makemkvcon backup` emit `PRGV` progress lines in robot mode the same
-   way `mkv` does?** If it does not, backup progress falls back to polling the
-   destination directory's size against the estimated disc size, which the
-   filesystem-progress monitor in `_run_ripping` already demonstrates. Confirm
-   during implementation; either way the `backup_progress` contract is unchanged.
+Both were answered on real hardware (MakeMKV 1.18.3, Pioneer BDR-S13U,
+`ARRESTED_Development_S1D2`, a DVD) before merge.
+
+1. **Does `makemkvcon backup` accept DVDs?** **Yes.** The backup ran in
+   LibreDrive mode and copied 448 MB before being stopped deliberately. The
+   `skipped:unsupported_disc` path stays as defensive degradation rather than
+   the expected outcome for a DVD.
+2. **Does it emit `PRGV` progress lines in robot mode?** **Yes**, 5,872 of them
+   during the copy. The run also settles the field semantics directly: during
+   device scanning it emitted `PRGV:65536,0,65536`, where the two values
+   diverge completely (current operation 100 percent, overall 0 percent). So
+   `current` is the per-operation bar and `total` is the overall one, and
+   reading `total / max` is correct. Reading `current` would run the user's
+   backup bar backwards once per sub-operation.
+
+**A third thing surfaced that neither question anticipated, and it is the one
+with teeth.** MakeMKV refuses a destination directory that already exists,
+*even an empty one*: `MSG:5068 "Folder ... already contains a backup, please
+choose another folder"`, then `Backup failed`.
+
+That turns a decision made on weak grounds into a load-bearing one. The design
+already moved a stale `.partial` aside before launching, justified only as
+"MakeMKV's behaviour on a non-empty target is unspecified". It is in fact
+specified and fatal: without that move, every retry of a failed backup would
+die instantly on 5068, which this code would have reported as a generic
+non-zero exit. It also means `backup_disc` must never pre-create its own
+`.partial` target, only `dest.parent`. Both hold in the implementation.
 
 ## Consequences
 

--- a/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
+++ b/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
@@ -1,0 +1,445 @@
+# Disc backup before rip, and importing existing backups
+
+**Date:** 2026-09-05
+**Status:** Design approved, ready for implementation planning
+**Origin:** Discord feature request from Ironside7 (2026-09-02)
+
+## Problem
+
+Engram rips directly from the optical drive. Every title is a fresh read of the
+physical disc, so a scratched disc is stressed once per title and a read failure
+mid-library-build loses the whole disc. The requester's manual workflow avoids
+this: MakeMKV writes a full decrypted backup of the disc to local storage first,
+then extracts MKVs from that backup.
+
+That workflow solves three problems at once:
+
+1. **Preservation.** Some discs have no in-print replacement (the requester cites
+   *The Sweetest Thing*). A backup is the archival copy, kept and moved to a
+   separate server.
+2. **Disc safety.** The physical disc is read once, sequentially, instead of once
+   per title with seeks in between.
+3. **Speed and reliability.** Extraction from local storage is faster than from
+   an optical drive and does not fail on a marginal read.
+
+The request has a second half: once backups exist, the user wants to point
+Engram at one and have it run the normal pipeline. The requester explicitly does
+not want a monitored folder for this; a manual import action is the desired
+surface.
+
+## Goals
+
+- Optional backup phase between identification and extraction, writing a full
+  decrypted disc copy to a separate configurable root.
+- Extraction reads from that backup rather than from the drive.
+- The disc is released as soon as the backup completes, not after extraction.
+- Existing backups (folder or ISO) can be imported through the manual import
+  modal and run the full identify, rip, match, organize pipeline.
+- Enabling the feature can never make a disc less likely to finish than it is
+  today.
+
+## Non-goals
+
+- **Backup-only mode** (copy the disc and stop, producing no MKVs). A different
+  workflow from the request, and it would create a terminal path where COMPLETED
+  means no media was produced.
+- **Per-disc override in the UI.** A global setting only. Deferred until someone
+  asks for it.
+- **A monitored backups folder.** Explicitly out per the requester.
+- **Deleting backups automatically.** Backups are always kept. Engram never
+  removes 40 GB the user asked it to create.
+- **Concurrent disc handling.** Releasing the drive early makes it possible for
+  Engram to accept the next disc while the previous job extracts. This design
+  must not break that, but does not build it.
+
+## Approach
+
+### Why a source abstraction
+
+`Extractor` is drive-shaped: `_to_drive_spec()` maps `"E:"` to `dev:E:`, and both
+`scan_disc` and `rip_titles` take a `drive: str`. MakeMKV itself accepts three
+source forms: `dev:<letter or device>`, `disc:<index>`, and `file:<path>` for a
+backup folder or an ISO. Both halves of this feature reduce to the same change:
+a job's source may be a path rather than a drive.
+
+Three options were considered.
+
+- **A. A `source_spec` string column, parsed ad hoc.** Smallest diff, but the
+  question "is this source a physical drive?" gets asked in roughly six places
+  (eject, sentinel re-arm, drive lock, watchdog, `_release_drive`, progress
+  labelling) and each would answer it with its own string test.
+- **B. A `DiscSource` value object.** One home for that question, pure and
+  unit-testable, at the cost of a new module.
+- **C. A parallel backup-job pipeline.** Rejected: it duplicates the chain that
+  `IdentificationCoordinator`, `MatchingCoordinator` and
+  `FinalizationCoordinator` already own.
+
+**Chosen: B stored as A.** One nullable `source_spec` string column on `DiscJob`
+(the DB and wire form), parsed through `DiscSource.parse()` wherever behaviour
+depends on the source kind.
+
+### Pipeline ordering
+
+Backup runs **after** identification:
+
+```
+sentinel -> IDENTIFYING (scan dev:E:, content hash, TMDB/DiscDB lookup)
+         -> [REVIEW_NEEDED if identity is unresolved] --+
+         -> BACKING_UP  <---------------------------- --+
+              free-space preflight
+              resolve dev:E: -> disc:N
+              makemkvcon backup --decrypt disc:N <dest>.partial
+              rename .partial -> dest;  source_spec = file:<dest>
+              _release_drive(outcome="Backed up")     <- disc comes out here
+         -> RIPPING (re-scan file:<dest>, reconcile titles, extract to staging)
+         -> MATCHING -> ORGANIZING -> COMPLETED        (unchanged)
+```
+
+A scan costs about a minute, so the disc leaves the drive barely later than in a
+backup-first ordering, and in exchange Engram only spends 40 GB and 25 minutes of
+disc reads on a job it has already decided to run. Identity prompts still fire
+early, and content-hash and DiscDB lookup are untouched.
+
+Backing up and scanning concurrently was rejected: two `makemkvcon` processes on
+one drive is exactly what `Extractor`'s per-drive `asyncio.Lock` exists to
+prevent.
+
+### Why a distinct job state
+
+`BACKING_UP` becomes a real `JobState` rather than a sub-phase of `RIPPING`.
+Reusing `RIPPING` would be cheaper (215 `JobState.` references in the backend,
+about 41 frontend files carrying state literals) but every log line, history row
+and notification would say "ripping" during a copy that produces no MKV, and a
+single watchdog timeout would have to cover a 40 GB sequential copy and a
+per-title extraction. Folding it into `IDENTIFYING` is the wrong shape too:
+identification is minutes with no progress UI, a backup is tens of minutes with
+byte-level progress.
+
+## Data model
+
+### New config fields
+
+Adding a config field requires the three-way sync: `AppConfig`, `ConfigUpdate`,
+`ConfigResponse`, and `ConfigWizard`. Missing any one of them makes Pydantic drop
+the value silently.
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `backup_before_rip` | bool | `False`, `server_default "0"` | Opt-in, so a NULL on an upgraded DB must read as disabled. Mirrors `discord_notify_ripped`. |
+| `backup_path` | str | `""` | Empty means the feature cannot run. Validated like the library roots. |
+
+### New `DiscJob` columns
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `source_spec` | `str \| None` | MakeMKV source string. `None` on every existing row, meaning "legacy: derive from `drive_id`". |
+| `backup_path` | `str \| None` | Where this job's backup landed. Shown in history, used for re-import. |
+| `backup_status` | `str \| None` | `pending`, `completed`, `failed:<reason>`, `skipped:<reason>`. |
+
+`drive_id` keeps its current meaning (a physical drive, or the literal
+`"import"`). It stays the key for eject, sentinel re-arm and disc-side job
+lookup. `source_spec` is what MakeMKV is pointed at, and the two diverge exactly
+once: after a successful backup, when `drive_id` is still `E:` and `source_spec`
+has become `file:<backup>`.
+
+### New job state
+
+`JobState.BACKING_UP`, with these `VALID_TRANSITIONS` edits:
+
+- `IDENTIFYING -> BACKING_UP`
+- `BACKING_UP -> {RIPPING, REVIEW_NEEDED, FAILED}`
+- `REVIEW_NEEDED -> BACKING_UP` (a disc parked for a name prompt still needs its
+  backup once the user answers)
+
+`BACKING_UP` is non-terminal, so the job-visibility invariant exempts it from the
+dashboard's terminal-job cap automatically.
+
+## Components
+
+### `app/core/disc_source.py` (new)
+
+Pure module, no I/O except the drive-index resolver.
+
+- `DiscSource` value object: `kind` (`drive` | `backup` | `iso`), `value`, and
+  derived `spec` (the MakeMKV argument), `lock_key`, `is_physical`.
+- `DiscSource.parse(spec: str) -> DiscSource`, and
+  `DiscSource.from_job(job)` which falls back to `drive_id` when `source_spec`
+  is `None`.
+- `resolve_disc_index(drive: str) -> str | None`: runs `makemkvcon -r info
+  disc:9999` (the enumeration form) and maps a drive letter or device path to
+  `disc:N`. Required because `makemkvcon backup` accepts only `disc:N`, not
+  `dev:`. Engram has never needed this mapping before.
+
+`lock_key` is the important one. `Extractor._get_drive_lock` currently keys on
+`drive.replace("dev:", "").replace("disc:", "")`. A `file:` source must not
+contend for the physical drive lock, or extracting from a backup would block the
+next disc from being scanned. Backup and ISO sources key on their own resolved
+path instead.
+
+### `Extractor.backup_disc()` (new)
+
+Sibling of `rip_titles`, reusing the same robot-mode line parsing, stall
+watchdog, cancellation handling and `_save_makemkv_log` behaviour.
+
+```python
+async def backup_disc(
+    self,
+    source: DiscSource,
+    dest: Path,
+    progress_callback: BackupProgressCallback | None = None,
+    stall_timeout: float | None = None,
+    log_dir: Path | None = None,
+    *,
+    job_id: int = 0,
+) -> BackupResult
+```
+
+Writes to `<dest>.partial` and renames on success, so a killed or crashed backup
+never leaves something that looks complete. On failure the `.partial` is left in
+place rather than deleted: a partial backup of a dying disc has salvage value,
+and the user is the one who should decide to discard it.
+
+### `Extractor` source threading
+
+`_to_drive_spec` becomes `_to_source_spec`, passing through any known scheme.
+`scan_disc` and `rip_titles` take a `DiscSource` (or a string coerced through
+`parse`, for call-site compatibility during the migration).
+
+### `JobManager` backup phase
+
+A `_run_backup(job_id)` coroutine wrapped in `with_job_log_context` the same way
+`_run_ripping` is, so its lines carry the `job=<id>` tag the diagnostics bundle
+greps for. Structure mirrors `_run_ripping`: a short-lived setup session that is
+released before the long await, then post-backup transitions on fresh sessions.
+
+### `import_scanner` disc-image detection
+
+A directory containing `BDMV/` or `VIDEO_TS/` is a disc image and is emitted as a
+`DiscImageUnit` instead of being walked for MKVs. An `.iso` file is likewise a
+unit. Detection short-circuits the walk at that directory, so a backup's
+thousands of `.m2ts` files never count toward `_MAX_FILES`.
+
+A scan can return both kinds of unit. `ImportScan` gains `disc_images:
+list[DiscImageUnit]` alongside `units`.
+
+## Backup destination naming
+
+Computed after identification, mirroring the library layout so the backup shelf
+browses the same way the library does:
+
+- Movie: `<backup_path>/Movies/<Name> (<Year>)/`
+- TV: `<backup_path>/TV/<Show> (<Year>)/Season <NN>/<disc slug>/`
+- Unidentified: `<backup_path>/Unidentified/<sanitized volume label>/`
+
+The disc slug is `discdb_disc_slug` when known (for example `S01D01`), otherwise
+`Disc <disc_number>`. Naming reuses the Organizer's existing name-sanitization
+helpers rather than reimplementing them, so the two cannot drift. If the
+destination already exists and is non-empty, the job treats the backup as
+already done (`backup_status = "completed"`, `source_spec` pointed at it) rather
+than overwriting: re-inserting a disc that was backed up before should not cost
+another 40 GB copy.
+
+Backup destinations are derived from config plus sanitized identification data,
+never from client input.
+
+## Title reconciliation
+
+`DiscTitle` rows are created from the *disc* scan and carry `title_index`, which
+is what `_build_rip_commands` passes to MakeMKV. Extraction now runs against
+`file:<backup>`, so those indices must be re-validated rather than assumed.
+
+After the backup completes, re-scan the backup and reconcile:
+
+1. **Identical enumeration** (same title count, same durations in the same
+   order): reuse indices directly. Expected case, since a backup is a byte copy.
+2. **Reordered or shifted**: re-map by `source_filename` plus `segment_map`,
+   both already captured at scan time for TheDiscDB contributions, with duration
+   as a tiebreaker. Update `title_index` on the affected rows.
+3. **Ambiguous**: transition to `REVIEW_NEEDED` with an explicit reason. Do not
+   fall back to the disc, which may already be ejected. Nothing is lost: the
+   backup is on disk and the disc is safe, which is the point of the feature.
+
+## Failure handling
+
+Per the approved fallback policy, a backup problem degrades to today's behaviour
+rather than failing the job. Each case records `backup_status` and surfaces a
+note on the job card and in history.
+
+| Condition | `backup_status` | Behaviour |
+| --- | --- | --- |
+| `backup_path` empty or unwritable | `skipped:not_configured` | Direct rip from the drive |
+| Free space < needed | `skipped:insufficient_space` | Direct rip |
+| `disc:N` resolution fails | `skipped:no_disc_index` | Direct rip |
+| Disc type unsupported by `backup` | `skipped:unsupported_disc` | Direct rip |
+| `makemkvcon backup` non-zero or stalls out | `failed:<reason>` | `.partial` retained, direct rip |
+| Backup re-scan cannot be reconciled | `completed` | `REVIEW_NEEDED`, no drive fallback |
+
+Free-space preflight: sum the scanned titles' `file_size_bytes` as the disc-size
+estimate, multiply by 1.15 for margin and container overhead, and compare against
+`shutil.disk_usage(backup_path).free`. A conservative estimate is correct here;
+the cost of a false negative (one direct rip) is far below the cost of a false
+positive (a half-written 40 GB folder and a failed job).
+
+Cancellation during `BACKING_UP` terminates `makemkvcon`, leaves the `.partial`,
+and follows the existing cancel path.
+
+## Drive release and notifications
+
+`_release_drive` is the documented single chokepoint for "Engram is done with
+this disc", and it fires the Discord `RIPPED_EVENT` with a `rip_outcome`. Under
+backup-first, that moment moves from end-of-rip to end-of-backup. This is a
+faithful use of the event, not a stretch: CLAUDE.md defines `RIPPED_EVENT` as a
+hardware milestone meaning the disc is copied and out of the drive, deliberately
+outside the `JobState`-keyed `EVENTS` map. A backup satisfies that literally.
+
+`rip_outcome` gains the value `"Backed up"` alongside Complete, Stopped early and
+Re-rip.
+
+No new Discord event and no new toggle. `BACKING_UP` is a progress phase, not a
+notification-worthy milestone.
+
+## Watchdog
+
+`_phase_timeout` gains a `BACKING_UP` entry. The timeout is stall-based (no
+growth in the destination directory), not wall-clock: a scratched disc backs up
+slowly by design, and that is precisely the disc this feature exists for. The
+existing `_stall_watchdog` machinery in `Extractor` provides this; the config
+knob mirrors the ripping phase timeout.
+
+## WebSocket contract
+
+New server-to-client message:
+
+| Type | Data fields | Description |
+| --- | --- | --- |
+| `backup_progress` | `{"job_id": int, "current_bytes": int, "total_bytes": int, "speed": str, "eta": int}` | Backup copy progress |
+
+A distinct type rather than overloading `rip_progress`, because a client that
+renders "ripping" from a `rip_progress` message would be reporting a phase that
+produces no MKV. Parameter names must match exactly across `EventBroadcaster`,
+`ConnectionManager` and the message, per the documented WebSocket contract
+validation rule; integration tests assert the chain end to end.
+
+## Import from backup
+
+Surfaced through the existing manual-import modal with automatic detection, so
+there is one entry point and pointing at a backups root queues every disc under
+it.
+
+- `GET /api/import/browse` labels a directory containing `BDMV/` or `VIDEO_TS/`
+  as `type: "disc_image"`, and lists `.iso` files as `type: "iso"`, alongside
+  today's `dir` and `mkv` entries.
+- `POST /api/import/preview` returns disc-image units next to MKV units, with
+  total bytes.
+- `POST /api/import/start` creates one job per disc image, with
+  `drive_id="import"` and `source_spec` set to `file:<path>` or `iso:<path>`.
+
+Such a job enters `IDENTIFYING` (scan the image, compute the content hash, run
+TMDB and DiscDB lookup) and then goes straight to `RIPPING`. It never enters
+`BACKING_UP`: it already is a backup. Extraction writes to staging and the rest
+of the pipeline is unchanged.
+
+The content hash is the MD5 of the Int64 file sizes of `BDMV/STREAM/*.m2ts`
+sorted by filename, which is computable directly from a backup folder without
+MakeMKV, so DiscDB lookup works at least as well for an imported backup as for a
+physical disc.
+
+Import ownership rules are unchanged: `import_guard.classify_staging_path`
+treats the image path like any other staging path, so an in-flight job hard
+blocks and a completed one soft blocks with `force_keys` as the override.
+
+## Frontend
+
+- `ConfigWizard`: a "Back up disc before ripping" toggle and a `backup_path`
+  picker in the paths section, with the same validation treatment as the library
+  roots.
+- `StateIndicator` and `DiscCard`: a `BACKING_UP` phase labelled "Backing up",
+  reusing `CyberpunkProgressBar` driven by `backup_progress`, showing GB copied,
+  speed and ETA.
+- `DiscCard` and `HistoryPage` detail panel: a note when `backup_status` starts
+  with `skipped:` or `failed:`, naming the reason, and the backup path when the
+  backup succeeded.
+- `ImportModal`: disc-image and ISO entries with a distinct icon, and a
+  preview line that says these will be scanned and extracted rather than filed.
+
+## Diagnostics
+
+The backup `makemkvcon` log is written through `_save_makemkv_log` next to the
+scan and rip logs, and is picked up by the per-job diagnostics bundle
+(`GET /api/diagnostics/report/{job_id}/bundle`) with the same sanitization as
+the other MakeMKV logs. `backup_status`, `backup_path` and `source_spec` appear
+in the job-detail JSON via `build_job_detail`.
+
+## Testing
+
+**Unit**
+
+- `disc_source`: parse round-trips for all four spec forms, `lock_key`
+  separation between physical and file sources, `from_job` legacy fallback when
+  `source_spec` is `None`.
+- Backup destination naming: movie, TV with and without a DiscDB disc slug,
+  unidentified fallback, name sanitization, existing-non-empty-destination
+  short-circuit.
+- Free-space preflight: sufficient, insufficient, unreadable destination.
+- Title reconciliation: identical enumeration, reordered enumeration resolved by
+  `source_filename` and `segment_map`, ambiguous enumeration routing to
+  `REVIEW_NEEDED`.
+- `_build_backup_command` argv construction.
+- `import_scanner`: BDMV folder, VIDEO_TS folder, bare `.iso`, disc image nested
+  under a show folder, a tree mixing disc images and loose MKVs, and the
+  short-circuit that keeps `.m2ts` files out of the `_MAX_FILES` budget.
+
+**State machine**
+
+- The three new transitions are valid, and the ones deliberately absent (for
+  example `BACKING_UP -> MATCHING`) are rejected.
+
+**Integration**
+
+- `POST /api/simulate/insert-disc` gains `simulate_backup: true`, and
+  `SimulationService` fakes a `BACKING_UP` phase with synthetic progress so the
+  full flow is exercisable without 40 GB. Follows the existing pattern of
+  simulation living entirely in `SimulationService` and gated on DEBUG.
+- WebSocket contract test for `backup_progress` across `EventBroadcaster` and
+  `ConnectionManager`.
+- Import-from-backup job creation, including the guard's in-flight and
+  already-imported tiers.
+
+**E2E**
+
+- A simulated disc shows Backing up, then Ripping, on the card.
+- The import modal lists a fixture backup folder (empty `BDMV/STREAM/`
+  directories, no media needed) as a disc image and starts a job from it.
+
+**Manual verification, one backend only, real discs**
+
+- A Blu-ray with the setting on: backup lands in the right folder, disc ejects
+  after the backup, extraction reads from the backup.
+- A DVD with the setting on: see the open question below.
+- An existing backup folder and an ISO imported through the modal.
+
+## Open questions
+
+1. **Does `makemkvcon backup` accept DVDs on current MakeMKV builds?** MakeMKV's
+   backup path is historically Blu-ray-oriented. The design already degrades to
+   a direct rip on an unsupported disc, so a negative answer costs only the
+   wording of the `skipped:unsupported_disc` message and a documentation note.
+   Verify against a real DVD before finalizing that string.
+2. **Does `makemkvcon backup` emit `PRGV` progress lines in robot mode the same
+   way `mkv` does?** If it does not, backup progress falls back to polling the
+   destination directory's size against the estimated disc size, which the
+   filesystem-progress monitor in `_run_ripping` already demonstrates. Confirm
+   during implementation; either way the `backup_progress` contract is unchanged.
+
+## Consequences
+
+- The drive is free during extraction, which makes concurrent disc handling
+  possible for the first time. Not built here, but the design must not preclude
+  it: hence `lock_key` separation between physical and file sources.
+- Disk pressure moves. A user with backups enabled needs room for the backup plus
+  staging plus the library. The free-space preflight covers the backup itself;
+  the existing staging cleanup is untouched and never looks at `backup_path`.
+- `backup_path` is deliberately absent from `is_within_configured_roots`. That
+  guard exists for the review-playback media endpoints, which serve MKVs from
+  the DB. Backups are never served over HTTP, so widening the guard would grant
+  reach without a consumer.

--- a/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
+++ b/docs/superpowers/specs/2026-09-05-disc-backup-before-rip-design.md
@@ -227,13 +227,28 @@ list[DiscImageUnit]` alongside `units`.
 Computed after identification, mirroring the library layout so the backup shelf
 browses the same way the library does:
 
-- Movie: `<backup_path>/Movies/<Name> (<Year>)/`
-- TV: `<backup_path>/TV/<Show> (<Year>)/Season <NN>/<disc slug>/`
+- Movie: `<backup_path>/Movies/<movie folder>/`
+- TV: `<backup_path>/TV/<show folder>/<season folder>/<disc slug>/`
 - Unidentified: `<backup_path>/Unidentified/<sanitized volume label>/`
 
-The disc slug is `discdb_disc_slug` when known (for example `S01D01`), otherwise
-`Disc <disc_number>`. Naming reuses the Organizer's existing name-sanitization
-helpers rather than reimplementing them, so the two cannot drift. If the
+The folder names are not built here. Library naming is user-configurable
+(`naming_movie_format`, `naming_tv_show_format`, `naming_season_format`), so
+`backup_destination` delegates to the Organizer's own `format_movie_folder`,
+`format_tv_show_folder` and `format_season_folder`, passing `tmdb_id` through so
+a backup folder carries the same media-server disambiguation tag its library
+folder would. Reproducing the default shape locally would give any user with a
+customized format a backup tree that no longer mirrored their library, which is
+the one outcome this section exists to prevent. It follows that a TV backup
+folder carries no year under the shipped default `naming_tv_show_format`
+(`"{show}"`), exactly as the library folder does not.
+
+Only the disc level is built here, because the library has no per-disc level:
+`discdb_disc_slug` when known (for example `S01D01`), otherwise
+`Disc <disc_number>`, sanitized with the Organizer's `sanitize_filename`.
+
+A name that survives sanitization as an empty string falls back to `job-<id>`
+rather than a shared literal, so two unnameable discs cannot collide in one
+folder. If the
 destination already exists and is non-empty, the job treats the backup as
 already done (`backup_status = "completed"`, `source_spec` pointed at it) rather
 than overwriting: re-inserting a disc that was backed up before should not cost

--- a/frontend/e2e/disc-backup.spec.ts
+++ b/frontend/e2e/disc-backup.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resetAllJobs } from './fixtures/api-helpers';
+
+/**
+ * E2E for the optional disc-backup phase.
+ *
+ * With backup_before_rip on, a disc is copied whole to a separate folder after
+ * identification and extraction reads from that copy, so the disc leaves the
+ * drive at the end of BACKING_UP rather than at the end of RIPPING. The
+ * simulated backup parks in the phase instead of auto-advancing, which is what
+ * lets a test observe it at all: a real copy is tens of gigabytes.
+ *
+ * The second test covers the other half of the feature: an existing backup on
+ * disk is importable. The seeded tree only needs the BDMV marker directory,
+ * because detection keys on structure rather than on readable media.
+ */
+
+/** Seeded trees are torn down in afterAll so runs do not litter the OS temp dir. */
+const seededRoots: string[] = [];
+
+/** A minimal MakeMKV-shaped Blu-ray backup: the marker plus one tiny stream. */
+function seedDiscBackup(): string {
+    const root = mkdtempSync(join(tmpdir(), 'engram-backup-'));
+    seededRoots.push(root);
+    const stream = join(root, 'Inception (2010)', 'BDMV', 'STREAM');
+    mkdirSync(stream, { recursive: true });
+    writeFileSync(join(stream, '00001.m2ts'), Buffer.alloc(1024));
+    return root;
+}
+
+test.describe('Disc backup before rip', () => {
+    // backup_before_rip and import_watch_path live in the shared app_config
+    // table and outlive the process, so both are restored: otherwise a later
+    // spec inherits a backup setting it never asked for, or a watch path
+    // pointing at a directory afterAll just deleted.
+    let originalBackupBeforeRip = false;
+    let originalBackupPath = '';
+    let originalWatchPath = '';
+
+    test.beforeAll(async ({ request }) => {
+        const cfg = await (await request.get('/api/config')).json();
+        originalBackupBeforeRip = cfg.backup_before_rip ?? false;
+        originalBackupPath = cfg.backup_path ?? '';
+        originalWatchPath = cfg.import_watch_path ?? '';
+    });
+
+    test.afterAll(async ({ request }) => {
+        await request.put('/api/config', {
+            data: {
+                backup_before_rip: originalBackupBeforeRip,
+                backup_path: originalBackupPath,
+                import_watch_path: originalWatchPath,
+            },
+        });
+        for (const root of seededRoots) rmSync(root, { recursive: true, force: true });
+        seededRoots.length = 0;
+    });
+
+    test.beforeEach(async () => {
+        await resetAllJobs().catch(() => {});
+    });
+
+    test('a simulated disc shows BACKING UP, then RIPPING', async ({ page, request }) => {
+        await page.goto('/');
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 15000 });
+
+        const insert = await request.post('/api/simulate/insert-disc', {
+            data: {
+                volume_label: 'INCEPTION_2010',
+                content_type: 'movie',
+                simulate_backup: true,
+                simulate_ripping: false,
+            },
+        });
+        expect(insert.ok()).toBe(true);
+        const jobId = (await insert.json()).job_id;
+
+        // The phase is visible on the card, both as the state badge and as the
+        // copy-specific panel that replaced the orphaned ISO block.
+        await expect(page.locator('text=INCEPTION_2010').first()).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText('BACKING UP').first()).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText(/BACKING UP DISC/i).first()).toBeVisible({ timeout: 10000 });
+
+        // Advancing completes the copy and hands off to extraction. This is the
+        // transition the whole feature turns on, so assert the UI follows it
+        // rather than only the API.
+        await request.post(`/api/simulate/advance-job/${jobId}`);
+        await expect(page.getByText('RIPPING').first()).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText(/BACKING UP DISC/i)).toHaveCount(0);
+    });
+
+    test('an existing disc backup is importable', async ({ page, request }) => {
+        const root = seedDiscBackup();
+        await request.put('/api/config', { data: { import_watch_path: root } });
+
+        await page.goto('/');
+        await expect(page.locator('text=/LIVE/i')).toBeVisible({ timeout: 15000 });
+
+        await page.getByTestId('sv-import-btn').click();
+        await expect(page.getByText('IMPORT MEDIA')).toBeVisible();
+
+        // The backup folder is labelled as a disc backup rather than counted as
+        // a folder of media, which is the distinction that stops a user
+        // expecting a quick file move.
+        await expect(page.getByText(/disc backup/i).first()).toBeVisible({ timeout: 10000 });
+
+        await page.getByText('Inception (2010)', { exact: true }).first().click();
+        await expect(page.getByText(/scanned and extracted/i)).toBeVisible({ timeout: 10000 });
+
+        await page.getByTestId('import-start-btn').click();
+        await expect(page.getByTestId('import-start-btn')).toBeHidden({ timeout: 10000 });
+
+        // Assert on the API rather than a dashboard card: a fake backup has no
+        // readable media, so the job may reach a terminal state quickly and
+        // drop out of the default dashboard filter.
+        await expect
+            .poll(
+                async () => {
+                    const jobs = (await (await request.get('/api/jobs')).json()) as Array<{
+                        drive_id: string;
+                        source_spec: string | null;
+                    }>;
+                    return jobs.some(
+                        (j) =>
+                            j.drive_id === 'import' &&
+                            (j.source_spec || '').startsWith('file:'),
+                    );
+                },
+                { timeout: 20000 },
+            )
+            .toBe(true);
+    });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -318,10 +318,15 @@ export async function commitManualSubtitles(
 // Manual import
 // ---------------------------------------------------------------------------
 
+/**
+ * One row in the import picker. "disc_image" is a folder holding a BDMV or
+ * VIDEO_TS tree (a whole-disc backup) and "iso" is a disc image file; neither
+ * carries an mkv_count, because neither is a folder of finished media.
+ */
 export interface BrowseEntry {
   name: string;
   path: string;
-  type: "dir" | "mkv";
+  type: "dir" | "mkv" | "disc_image" | "iso";
   mkv_count?: number;
 }
 
@@ -339,10 +344,24 @@ export interface PreviewUnit {
   total_bytes: number;
 }
 
+/** A whole-disc backup folder or ISO found by the scan; each becomes one job. */
+export interface PreviewDiscImage {
+  name: string;
+  path: string;
+  /** "backup" for a BDMV/VIDEO_TS folder, "iso" for a disc image file. */
+  kind: string;
+  total_bytes: number;
+}
+
 export interface PreviewResult {
   root: string;
   units: PreviewUnit[];
   loose_files: string[];
+  /**
+   * Optional only for tolerance of an older backend: the current one always
+   * sends the key. Read it through `?? []`.
+   */
+  disc_images?: PreviewDiscImage[];
   total_jobs: number;
   total_files: number;
   total_bytes: number;

--- a/frontend/src/app/components/DashboardSideRail.tsx
+++ b/frontend/src/app/components/DashboardSideRail.tsx
@@ -16,7 +16,7 @@ interface Props {
   titlesMap: Record<number, DiscTitle[]>;
 }
 
-const ACTIVE_JOB_STATES: JobState[] = ["identifying", "ripping", "matching", "organizing"];
+const ACTIVE_JOB_STATES: JobState[] = ["identifying", "backing_up", "ripping", "matching", "organizing"];
 const TERMINAL_TITLE_STATES: TitleState[] = ["matched", "completed", "review", "failed"];
 
 /**

--- a/frontend/src/app/components/DiscCard.test.tsx
+++ b/frontend/src/app/components/DiscCard.test.tsx
@@ -458,3 +458,26 @@ describe('BACKING UP action affordances', () => {
     expect(screen.getByText(/BACKING UP DISC/)).toBeInTheDocument();
   });
 });
+
+describe('DiscCard: disc backup outcome', () => {
+  it('warns with the backend reason when the backup was skipped', () => {
+    render(<DiscCard disc={makeDisc({ backupStatus: 'skipped', backupStatusReason: 'no backup location is configured' })} />);
+    expect(screen.getByTestId('sv-backup-warning')).toHaveTextContent(
+      'Backup skipped: no backup location is configured',
+    );
+  });
+
+  it('warns when the backup failed', () => {
+    render(<DiscCard disc={makeDisc({ backupStatus: 'failed', backupStatusReason: 'not enough free space' })} />);
+    expect(screen.getByTestId('sv-backup-warning')).toHaveTextContent(
+      'Backup failed: not enough free space',
+    );
+  });
+
+  it('stays quiet for a pending or completed backup', () => {
+    const { rerender } = render(<DiscCard disc={makeDisc({ backupStatus: 'pending' })} />);
+    expect(screen.queryByTestId('sv-backup-warning')).not.toBeInTheDocument();
+    rerender(<DiscCard disc={makeDisc({ backupStatus: 'completed' })} />);
+    expect(screen.queryByTestId('sv-backup-warning')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/components/DiscCard.test.tsx
+++ b/frontend/src/app/components/DiscCard.test.tsx
@@ -366,13 +366,13 @@ describe('DiscCard — media-type badge vs job state (#552)', () => {
     expect(screen.getByTestId('sv-mediatype-unknown')).toHaveTextContent('ANALYZING');
   });
 
-  // archiving_iso is the state that distinguishes ACTIVE_PIPELINE_STATES from
-  // ActionButtons' deliberately narrower ACTIVE_STATES. Pin it so a future
-  // "consolidation" of those two lists can't silently change this badge.
-  it('still pulses "ANALYZING" while archiving to ISO', () => {
+  // backing_up is a mid-pipeline phase that is easy to omit from one list and
+  // not another. Pin it so a future "consolidation" of ACTIVE_PIPELINE_STATES
+  // and ActionButtons' narrower lists can't silently change this badge.
+  it('still pulses "ANALYZING" while backing up the disc', () => {
     render(
       <DiscCard
-        disc={makeDisc({ mediaType: 'unknown', state: 'archiving_iso', needsReview: false })}
+        disc={makeDisc({ mediaType: 'unknown', state: 'backing_up', needsReview: false })}
       />,
     );
 
@@ -430,5 +430,31 @@ describe('Eject button', () => {
     fireEvent.click(screen.getByTestId('eject-button'));
     fireEvent.click(screen.getByRole('button', { name: 'Keep ripping' }));
     expect(onEject).not.toHaveBeenCalled();
+  });
+});
+
+// A whole-disc backup can run for hours. If it fell off any of these lists the
+// user would be stuck watching it with no way to stop, skip or eject.
+describe('BACKING UP action affordances', () => {
+  const backingUp = () => makeDisc({ state: 'backing_up', needsReview: false });
+
+  it('offers Cancel', () => {
+    render(<DiscCard disc={backingUp()} onCancel={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Cancel job' })).toBeInTheDocument();
+  });
+
+  it('offers Eject, because the disc is still in the drive', () => {
+    render(<DiscCard disc={backingUp()} onEject={vi.fn()} />);
+    expect(screen.getByTestId('eject-button')).toBeInTheDocument();
+  });
+
+  it('offers Force-advance, because the job is actively processing', () => {
+    render(<DiscCard disc={backingUp()} onAdvance={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Force job to next step' })).toBeInTheDocument();
+  });
+
+  it('renders the backup progress panel when a percentage is present', () => {
+    render(<DiscCard disc={makeDisc({ state: 'backing_up', needsReview: false, backupProgress: 42 })} />);
+    expect(screen.getByText(/BACKING UP DISC/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -106,6 +106,11 @@ export interface DiscData {
    *  (key absent or rejected). Shown verbatim on active jobs; it also covers
    *  the configured-but-invalid-key case the global flag can't see (#243). */
   tmdbDegradedReason?: string;
+  /** Outcome of the optional whole-disc backup (pending / completed / failed /
+   *  skipped), straight from the job row. */
+  backupStatus?: string | null;
+  /** Backend prose explaining a skipped or failed backup; rendered verbatim. */
+  backupStatusReason?: string | null;
   /** True when at least one title on this disc has a rip-level failure (re-rippable). */
   hasDamagedTrack?: boolean;
   /** How this disc's identity was obtained, from the backend's
@@ -398,6 +403,8 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                   title={disc.title}
                   subtitle={disc.subtitle}
                   discLabel={disc.discLabel}
+                  backupStatus={disc.backupStatus}
+                  backupStatusReason={disc.backupStatusReason}
                 />
                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
                   {isManualIdentity && (

--- a/frontend/src/app/components/DiscCard.tsx
+++ b/frontend/src/app/components/DiscCard.tsx
@@ -15,7 +15,7 @@ import { sv, SvPanel, SvLabel, SvDiscInsert, SvProgressBar, type DiscInsertPhase
 import { formatEta } from "../../utils/formatting";
 
 export type MediaType = "movie" | "tv" | "unknown";
-export type DiscState = "idle" | "scanning" | "review_needed" | "archiving_iso" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
+export type DiscState = "idle" | "scanning" | "review_needed" | "backing_up" | "ripping" | "matching" | "organizing" | "processing" | "completed" | "error";
 export type TrackState = "pending" | "ripping" | "queued" | "matching" | "matched" | "review" | "failed" | "completed" | "skipped";
 
 export interface MatchCandidate {
@@ -69,7 +69,10 @@ export interface DiscData {
   mediaType: MediaType;
   state: DiscState;
   progress: number;
-  isoProgress?: number;
+  /** Percent complete (0-100) of the whole-disc backup that optionally runs
+   *  between identification and extraction. Only supplied while the job is in
+   *  the `backing_up` state; the backup panel is gated on it being defined. */
+  backupProgress?: number;
   tracks?: Track[];
   currentSpeed?: string;
   etaSeconds?: number;
@@ -672,8 +675,8 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                 );
               })()}
 
-              {/* ISO archiving */}
-              {disc.state === "archiving_iso" && disc.isoProgress !== undefined && (
+              {/* Whole-disc backup (runs before extraction when enabled) */}
+              {disc.state === "backing_up" && disc.backupProgress !== undefined && (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                   <div
                     style={{
@@ -688,9 +691,9 @@ const DiscCardComponent = React.forwardRef<HTMLDivElement, DiscCardProps>(
                     }}
                   >
                     <Database size={14} />
-                    <span>› ARCHIVING TO ISO…</span>
+                    <span>› BACKING UP DISC…</span>
                   </div>
-                  <SvProgressBar progress={disc.isoProgress} color="magenta" label="ISO ARCHIVE" />
+                  <SvProgressBar progress={disc.backupProgress} color="magenta" label="DISC BACKUP" />
                 </div>
               )}
 

--- a/frontend/src/app/components/DiscCard/ActionButtons.tsx
+++ b/frontend/src/app/components/DiscCard/ActionButtons.tsx
@@ -132,13 +132,18 @@ interface ActionButtonsProps {
 }
 
 // States where Force-advance makes sense (job is actively processing).
-const ACTIVE_STATES = ["scanning", "ripping", "matching", "organizing", "processing"];
+// backing_up qualifies: the whole-disc copy is real work the user may want to
+// step past.
+const ACTIVE_STATES = ["scanning", "backing_up", "ripping", "matching", "organizing", "processing"];
 // Cancel was historically shown only during rip-phase states; keep that scope so it
 // doesn't surface during organizing, where cancelling could leave files partially moved.
-const CANCELABLE_STATES = ["scanning", "ripping", "processing"];
+// backing_up belongs here: a full-disc copy can run for hours and aborting it only
+// abandons a scratch copy, never the library.
+const CANCELABLE_STATES = ["scanning", "backing_up", "ripping", "processing"];
 // Eject only makes sense while the drive physically holds the disc. Post-rip
 // states (matching, organizing) run after auto-eject has already fired.
-const EJECTABLE_STATES = ["scanning", "ripping"];
+// backing_up reads the disc directly, so it is still loaded.
+const EJECTABLE_STATES = ["scanning", "backing_up", "ripping"];
 
 interface Tone {
     fg: string;        // foreground / icon / text

--- a/frontend/src/app/components/DiscCard/DiscMetadata.tsx
+++ b/frontend/src/app/components/DiscCard/DiscMetadata.tsx
@@ -10,9 +10,27 @@ interface DiscMetadataProps {
     title: string;
     subtitle?: string;
     discLabel?: string;
+    /** Outcome of the optional whole-disc backup, straight from the job row. */
+    backupStatus?: string | null;
+    /** Backend prose for a skipped or failed backup, rendered verbatim. */
+    backupStatusReason?: string | null;
 }
 
-export function DiscMetadata({ title, subtitle, discLabel }: DiscMetadataProps) {
+export function DiscMetadata({
+    title,
+    subtitle,
+    discLabel,
+    backupStatus,
+    backupStatusReason,
+}: DiscMetadataProps) {
+    // Only the two outcomes that silently changed what happened are surfaced:
+    // "skipped" and "failed" both mean the disc was ripped from the drive with
+    // no copy kept. "pending" has its own BACKING UP phase rendering and
+    // "completed" is the happy path, so neither earns a warning line.
+    const backupWarning =
+        backupStatus === 'skipped' || backupStatus === 'failed'
+            ? backupStatusReason || 'the backup did not run; the disc was ripped directly'
+            : null;
     // Suppress the standalone disc-label caret line when the subtitle already
     // contains it (e.g. subtitle "TV · FOR_ALL_MANKIND_S1_D1" + discLabel
     // "FOR_ALL_MANKIND_S1_D1" → render only the subtitle).
@@ -69,6 +87,25 @@ export function DiscMetadata({ title, subtitle, discLabel }: DiscMetadataProps) 
                 >
                     <span style={{ color: sv.cyan }}>›</span> {discLabel}
                 </motion.p>
+            )}
+            {backupWarning && (
+                <p
+                    data-testid="sv-backup-warning"
+                    title={backupWarning}
+                    style={{
+                        fontFamily: sv.mono,
+                        fontSize: 10,
+                        letterSpacing: "0.08em",
+                        color: sv.amber,
+                        margin: "6px 0 0 0",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                    }}
+                >
+                    <span aria-hidden>⚠</span> Backup{" "}
+                    {backupStatus === "failed" ? "failed" : "skipped"}: {backupWarning}
+                </p>
             )}
         </div>
     );

--- a/frontend/src/app/components/discState.test.ts
+++ b/frontend/src/app/components/discState.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { DISC_STATE_CONFIG, discStateLabel } from './discState';
+import { DISC_STATE_CONFIG, discStateLabel, isActivePipelineState } from './discState';
 import { IcoMatching } from './icons';
 
 describe('disc state config', () => {
     it('gives ORGANIZING its own icon instead of reusing the matching glyph', () => {
         expect(DISC_STATE_CONFIG.organizing.icon).not.toBe(IcoMatching);
-        expect(DISC_STATE_CONFIG.organizing.icon).toBe(DISC_STATE_CONFIG.archiving_iso.icon);
+        expect(DISC_STATE_CONFIG.organizing.icon).toBe(DISC_STATE_CONFIG.backing_up.icon);
+    });
+
+    it('labels the whole-disc backup phase', () => {
+        expect(discStateLabel('backing_up')).toBe('BACKING UP');
+    });
+
+    it('counts backing_up as an active pipeline state', () => {
+        expect(isActivePipelineState('backing_up')).toBe(true);
     });
 
     it('formats labels from the shared config', () => {

--- a/frontend/src/app/components/discState.ts
+++ b/frontend/src/app/components/discState.ts
@@ -28,7 +28,7 @@ export const DISC_STATE_CONFIG: Record<DiscState, StateConfig> = {
   idle:           { label: "IDLE",          badgeState: "idle",     color: sv.inkDim,   glow: sv.inkDim,   icon: IcoIdle },
   scanning:       { label: "SCANNING",      badgeState: "scanning", color: sv.yellow,   glow: sv.yellow,   icon: IcoScan },
   review_needed:  { label: "REVIEW NEEDED", badgeState: "review",   color: sv.yellow,   glow: sv.yellow,   icon: IcoReview },
-  archiving_iso:  { label: "ARCHIVING",     badgeState: "matching", color: sv.purple,   glow: sv.purple,   icon: IcoLibrary },
+  backing_up:     { label: "BACKING UP",    badgeState: "matching", color: sv.purple,   glow: sv.purple,   icon: IcoLibrary },
   ripping:        { label: "RIPPING",       badgeState: "ripping",  color: sv.magenta,  glow: sv.magenta,  icon: IcoRipping },
   matching:       { label: "MATCHING",      badgeState: "matching", color: sv.amber,    glow: sv.amber,    icon: IcoMatching },
   organizing:     { label: "ORGANIZING",    badgeState: "matching", color: sv.purple,   glow: sv.purple,   icon: IcoLibrary },
@@ -48,12 +48,14 @@ export const DISC_STATE_CONFIG: Record<DiscState, StateConfig> = {
  * pulsed "ANALYZING" forever next to its own ERROR badge (#552).
  *
  * NOT the same as ActionButtons' ACTIVE_STATES / CANCELABLE_STATES. Those look
- * similar but answer a different question ("is this action safe here?") and are
- * deliberately narrower — force-advance and cancel both exclude archiving_iso.
+ * similar but answer a different question ("is this action safe here?") and
+ * stay narrower: organizing is active here but is not cancelable there, because
+ * aborting a move leaves files half-filed. backing_up is on every one of those
+ * lists (a copy is in flight, is safe to abort, and the disc is still loaded).
  */
 export const ACTIVE_PIPELINE_STATES: ReadonlySet<DiscState> = new Set<DiscState>([
   "scanning",
-  "archiving_iso",
+  "backing_up",
   "ripping",
   "matching",
   "organizing",

--- a/frontend/src/app/hooks/__tests__/useJobManagement.test.ts
+++ b/frontend/src/app/hooks/__tests__/useJobManagement.test.ts
@@ -9,6 +9,7 @@ import type {
   SubtitleEvent,
   WebSocketMessage,
   FingerprintDisclosureRequiredMessage,
+  BackupProgressMessage,
 } from "../../../types";
 
 // ---------------------------------------------------------------------------
@@ -51,7 +52,7 @@ vi.mock("../../../hooks/useWebSocket", () => ({
 }));
 
 // Imported after the mocks so the hook picks up the mocked useWebSocket.
-import { useJobManagement } from "../useJobManagement";
+import { useJobManagement, applyBackupProgress } from "../useJobManagement";
 
 /**
  * Tests for the job management logic extracted from useJobManagement.
@@ -740,5 +741,59 @@ describe("fingerprint_disclosure_required WS handling", () => {
     });
 
     expect(result.current.disclosure).toBeNull();
+  });
+});
+
+describe("applyBackupProgress", () => {
+  const msg = (over: Partial<BackupProgressMessage> = {}) => ({
+    job_id: 1,
+    current_bytes: 0,
+    total_bytes: 0,
+    speed: null,
+    eta: null,
+    ...over,
+  }) as Omit<BackupProgressMessage, "type">;
+
+  it("writes the percentage, speed and eta onto the matching job", () => {
+    const jobs = [makeJob(1), makeJob(2)];
+    const result = applyBackupProgress(
+      jobs,
+      msg({ current_bytes: 5_000, total_bytes: 20_000, speed: "12.0 MB/s", eta: 90 }),
+    );
+
+    expect(result[0].progress_percent).toBe(25);
+    expect(result[0].current_speed).toBe("12.0 MB/s");
+    expect(result[0].eta_seconds).toBe(90);
+    // Untouched jobs keep their identity, so their cards do not re-render.
+    expect(result[1]).toBe(jobs[1]);
+  });
+
+  it("returns the SAME array reference for an unknown job id", () => {
+    const jobs = [makeJob(1)];
+    const result = applyBackupProgress(jobs, msg({ job_id: 999, current_bytes: 1, total_bytes: 2 }));
+    expect(result).toBe(jobs);
+  });
+
+  it("yields 0 rather than dividing by zero when total_bytes is 0", () => {
+    const jobs = [makeJob(1, { progress_percent: 42 })];
+    const result = applyBackupProgress(jobs, msg({ current_bytes: 1_000, total_bytes: 0 }));
+    expect(result[0].progress_percent).toBe(0);
+  });
+
+  it("caps the percentage at 100 when the backup overshoots its estimate", () => {
+    const jobs = [makeJob(1)];
+    const result = applyBackupProgress(jobs, msg({ current_bytes: 30, total_bytes: 20 }));
+    expect(result[0].progress_percent).toBe(100);
+  });
+
+  it("leaves speed and eta intact when the message sends them as null", () => {
+    // MakeMKV's backup reports a percentage, not a byte rate, so null is the
+    // common case. It must not blank what the card is already showing.
+    const jobs = [makeJob(1, { current_speed: "8.0x", eta_seconds: 600 })];
+    const result = applyBackupProgress(jobs, msg({ current_bytes: 1, total_bytes: 4 }));
+
+    expect(result[0].progress_percent).toBe(25);
+    expect(result[0].current_speed).toBe("8.0x");
+    expect(result[0].eta_seconds).toBe(600);
   });
 });

--- a/frontend/src/app/hooks/useJobManagement.ts
+++ b/frontend/src/app/hooks/useJobManagement.ts
@@ -6,7 +6,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { apiFetch, apiFetchVoid } from '../../api/client';
-import type { Job, DiscTitle, WebSocketMessage, UpdateStatus, UpdateStatusMessage, ParkedDisc, ParkedDiscsMessage } from '../../types';
+import type { Job, DiscTitle, WebSocketMessage, UpdateStatus, UpdateStatusMessage, ParkedDisc, ParkedDiscsMessage, BackupProgressMessage } from '../../types';
 import type { ArmedIdentity } from '../components/ArmedDriveCard';
 
 // Trailing-debounce window for refetches triggered by a burst of unknown
@@ -51,6 +51,33 @@ function toUpdateStatus(raw: Omit<UpdateStatusMessage, 'type'>): UpdateStatus {
         last_update_success_version: raw.last_update_success_version ?? null,
         is_frozen: raw.is_frozen ?? false,
     };
+}
+
+/**
+ * Fold a `backup_progress` message into the job list. Returns the SAME array
+ * reference when no job matched, so React skips the re-render.
+ *
+ * `speed` and `eta` are coalesced rather than assigned: the backend always
+ * sends both keys, but MakeMKV's backup reports a percentage and not a byte
+ * rate, so they are usually null. A null must leave the card's existing
+ * readout alone instead of blanking it.
+ */
+export function applyBackupProgress(jobs: Job[], data: Omit<BackupProgressMessage, 'type'>): Job[] {
+    const idx = jobs.findIndex(j => j.id === data.job_id);
+    if (idx === -1) return jobs;
+
+    const pct = data.total_bytes > 0
+        ? Math.min(100, Math.round((data.current_bytes / data.total_bytes) * 100))
+        : 0;
+
+    const next = [...jobs];
+    next[idx] = {
+        ...next[idx],
+        progress_percent: pct,
+        current_speed: data.speed ?? next[idx].current_speed,
+        eta_seconds: data.eta ?? next[idx].eta_seconds,
+    };
+    return next;
 }
 
 export function useJobManagement(devMode: boolean = false) {
@@ -426,6 +453,10 @@ export function useJobManagement(devMode: boolean = false) {
                         });
                     }
                     fetchRef.current?.();
+                    break;
+
+                case 'backup_progress':
+                    setJobs(prev => applyBackupProgress(prev, message));
                     break;
 
                 case 'subtitle_event':

--- a/frontend/src/app/utils/mockData.ts
+++ b/frontend/src/app/utils/mockData.ts
@@ -18,7 +18,7 @@ export function generateMockDiscs(): DiscData[] {
       progress: 35,
       currentSpeed: "6.5x",
       etaSeconds: 1840,
-      isoProgress: 100,
+      backupProgress: 100,
       tracks: [
         {
           id: "t1",
@@ -83,7 +83,7 @@ export function generateMockDiscs(): DiscData[] {
       progress: 62,
       currentSpeed: "8.2x",
       etaSeconds: 920,
-      isoProgress: 100,
+      backupProgress: 100,
       tracks: [
         {
           id: "m1",
@@ -105,7 +105,7 @@ export function generateMockDiscs(): DiscData[] {
       mediaType: "tv",
       state: "scanning",
       progress: 0,
-      isoProgress: 0,
+      backupProgress: 0,
       tracks: [],
     },
 
@@ -119,7 +119,7 @@ export function generateMockDiscs(): DiscData[] {
       mediaType: "movie",
       state: "completed",
       progress: 100,
-      isoProgress: 100,
+      backupProgress: 100,
       tracks: [
         {
           id: "m2",

--- a/frontend/src/components/ConfigWizard.test.tsx
+++ b/frontend/src/components/ConfigWizard.test.tsx
@@ -557,3 +557,36 @@ describe('ConfigWizard: Discord finished-ripping notification', () => {
         expect(body.discord_template_ripped).toBe('{{title}} done');
     });
 });
+
+describe('ConfigWizard: disc backup before ripping', () => {
+    it('reveals the backup folder field only once the toggle is on', async () => {
+        render(<ConfigWizard {...noop} isOnboarding={false} initialSection="paths" />);
+
+        const toggle = await screen.findByLabelText(/back up disc before ripping/i);
+        expect(toggle).not.toBeChecked();
+        expect(screen.queryByLabelText('Disc Backup Folder')).not.toBeInTheDocument();
+
+        fireEvent.click(toggle);
+        expect(await screen.findByLabelText('Disc Backup Folder')).toBeInTheDocument();
+    });
+
+    it('sends both backup keys when saving', async () => {
+        render(<ConfigWizard {...noop} isOnboarding={false} initialSection="paths" />);
+
+        fireEvent.click(await screen.findByLabelText(/back up disc before ripping/i));
+        fireEvent.change(await screen.findByLabelText('Disc Backup Folder'), {
+            target: { value: '/mnt/backups' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() =>
+            expect((fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls.some((c) => c[1]?.method === 'PUT')).toBe(true),
+        );
+        const putCall = (fetch as unknown as { mock: { calls: [string, RequestInit?][] } }).mock.calls.find(
+            (c) => c[1]?.method === 'PUT',
+        );
+        const body = JSON.parse(putCall?.[1]?.body as string);
+        expect(body.backup_before_rip).toBe(true);
+        expect(body.backup_path).toBe('/mnt/backups');
+    });
+});

--- a/frontend/src/components/ConfigWizard.tsx
+++ b/frontend/src/components/ConfigWizard.tsx
@@ -162,6 +162,8 @@ interface ConfigData {
     stagingCleanupDays: number;
     extrasPolicy: string;
     alwaysReview: boolean;
+    backupBeforeRip: boolean;
+    backupPath: string;
     namingSeasonFormat: string;
     namingEpisodeFormat: string;
     namingMovieFormat: string;
@@ -254,6 +256,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
         stagingCleanupDays: 7,
         extrasPolicy: 'keep',
         alwaysReview: false,
+        backupBeforeRip: false,
+        backupPath: '',
         namingSeasonFormat: 'Season {season:02d}',
         namingEpisodeFormat: '{show} - S{season:02d}E{episode:02d}',
         namingMovieFormat: '{title} ({year})',
@@ -416,6 +420,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     stagingCleanupDays: data.staging_cleanup_days ?? 7,
                     extrasPolicy: data.extras_policy || 'keep',
                     alwaysReview: data.always_review ?? false,
+                    backupBeforeRip: data.backup_before_rip ?? false,
+                    backupPath: data.backup_path || '',
                     namingSeasonFormat: data.naming_season_format || 'Season {season:02d}',
                     namingEpisodeFormat: data.naming_episode_format || '{show} - S{season:02d}E{episode:02d}',
                     namingMovieFormat: data.naming_movie_format || '{title} ({year})',
@@ -640,6 +646,8 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                     staging_cleanup_days: config.stagingCleanupDays,
                     extras_policy: config.extrasPolicy,
                     always_review: config.alwaysReview,
+                    backup_before_rip: config.backupBeforeRip,
+                    backup_path: config.backupPath,
                     naming_season_format: config.namingSeasonFormat,
                     naming_episode_format: config.namingEpisodeFormat,
                     naming_movie_format: config.namingMovieFormat,
@@ -951,6 +959,44 @@ function ConfigWizard({ onClose, onComplete, isOnboarding = true, initialSection
                             />
                             <PathStatusHint path={config.libraryTvPath} label="TV library" />
                         </div>
+
+                        <div className="form-group checkbox-group">
+                            <label className="checkbox-label checkbox-plain">
+                                <input
+                                    type="checkbox"
+                                    checked={config.backupBeforeRip}
+                                    onChange={(e) => handleInputChange('backupBeforeRip', e.target.checked)}
+                                />
+                                <span className="checkbox-text">
+                                    <strong>Back up disc before ripping</strong>
+                                    <span className="checkbox-hint">
+                                        Writes a full copy of each disc to a separate folder and extracts
+                                        the titles from that copy, so the disc is read once instead of once
+                                        per title, and the copy is kept afterwards. The trade-off is real:
+                                        each disc takes longer, and the copies use tens of gigabytes apiece.
+                                    </span>
+                                </span>
+                            </label>
+                        </div>
+
+                        {config.backupBeforeRip && (
+                            <div className="form-group">
+                                <label htmlFor="backupPath">Disc Backup Folder</label>
+                                <input
+                                    id="backupPath"
+                                    type="text"
+                                    value={config.backupPath}
+                                    onChange={(e) => handleInputChange('backupPath', e.target.value)}
+                                    placeholder="e.g., D:\Media\Disc Backups or ~/engram-backups"
+                                />
+                                <span className="form-hint">
+                                    Where the whole-disc copies are written. Give it plenty of room: one
+                                    Blu-ray backup can be 40GB or more, and backups are not cleaned up
+                                    with staging.
+                                </span>
+                                <PathStatusHint path={config.backupPath} label="disc backup folder" />
+                            </div>
+                        )}
 
                     </div>
                 );

--- a/frontend/src/components/HistoryPage.tsx
+++ b/frontend/src/components/HistoryPage.tsx
@@ -110,6 +110,11 @@ interface JobDetail {
   subtitles_failed: number;
   staging_path: string | null;
   final_path: string | null;
+  // Optional whole-disc backup. backup_status decides whether the row warns;
+  // backup_status_reason is backend prose and is rendered verbatim.
+  backup_path?: string | null;
+  backup_status?: string | null;
+  backup_status_reason?: string | null;
   titles: JobDetailTitle[];
 }
 
@@ -245,6 +250,29 @@ function SvSelect({
       ))}
     </select>
   );
+}
+
+/**
+ * A backup that was skipped or failed changed what actually happened (the disc
+ * was ripped straight from the drive and no copy was kept), so those two get
+ * the warning colour. "pending" and "completed" are the in-progress and happy
+ * paths and read as plain rows.
+ */
+function backupWentWrong(status: string | null | undefined): boolean {
+  return status === "skipped" || status === "failed";
+}
+
+/**
+ * Status row text. The backend writes prose into backup_status_reason (e.g.
+ * "no backup location is configured"), so it is appended as given rather than
+ * mapped through a local dictionary of codes.
+ */
+function backupStatusText(detail: {
+  backup_status?: string | null;
+  backup_status_reason?: string | null;
+}): string {
+  const status = detail.backup_status ?? "";
+  return detail.backup_status_reason ? `${status}: ${detail.backup_status_reason}` : status;
 }
 
 /** Key/value row used inside Classification / Subtitles / Paths panels. */
@@ -799,7 +827,7 @@ function JobDetailPanel({
           </div>
 
           {/* Paths */}
-          {(detail.staging_path || detail.final_path) && (
+          {(detail.staging_path || detail.final_path || detail.backup_path || detail.backup_status) && (
             <div>
               <SvLabel>Paths</SvLabel>
               <div style={{ marginTop: 8 }}>
@@ -807,6 +835,17 @@ function JobDetailPanel({
                   <div style={{ display: "flex", flexDirection: "column", gap: 6, fontFamily: sv.mono, fontSize: 11 }}>
                     {detail.staging_path && <KvRow label="Staging" value={detail.staging_path} />}
                     {detail.final_path && <KvRow label="Library" value={detail.final_path} />}
+                    {detail.backup_path && (
+                      <KvRow label="Disc backup" value={detail.backup_path} alignTop />
+                    )}
+                    {detail.backup_status && (
+                      <KvRow
+                        label="Backup"
+                        value={backupStatusText(detail)}
+                        valueColor={backupWentWrong(detail.backup_status) ? sv.amber : undefined}
+                        alignTop
+                      />
+                    )}
                   </div>
                 </SvPanel>
               </div>

--- a/frontend/src/components/ImportModal.test.tsx
+++ b/frontend/src/components/ImportModal.test.tsx
@@ -314,3 +314,59 @@ describe("ImportModal", () => {
     expect(screen.getByText("/media/Unsorted Movie Folder")).toBeInTheDocument();
   });
 });
+
+describe("ImportModal: disc backups", () => {
+  beforeEach(() => {
+    vi.mocked(client.browseDir).mockResolvedValue({
+      cwd: "/media",
+      parent: "/",
+      roots: [],
+      entries: [
+        { name: "King of Queens", path: "/media/King of Queens", type: "dir", mkv_count: 3 },
+        // No mkv_count at all: a disc image is not a folder of media.
+        { name: "INCEPTION_2010", path: "/media/INCEPTION_2010", type: "disc_image" },
+        { name: "arrival.iso", path: "/media/arrival.iso", type: "iso" },
+      ],
+    });
+  });
+
+  it("tags disc backups and ISOs distinctly from folders of media", async () => {
+    const { container } = render(
+      <ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />,
+    );
+    await waitFor(() => expect(screen.getByText("INCEPTION_2010")).toBeInTheDocument());
+
+    expect(screen.getByText("disc backup")).toBeInTheDocument();
+    expect(screen.getByText("iso")).toBeInTheDocument();
+    // The disc mark, not the folder mark, and only on the two disc rows.
+    expect(container.querySelectorAll(".import-disc-icon")).toHaveLength(2);
+    // A plain folder keeps its mkv count; the disc rows have none to show.
+    expect(screen.getByText("3 mkv")).toBeInTheDocument();
+  });
+
+  it("summarises disc backups in the preview and counts them as jobs", async () => {
+    vi.mocked(client.previewImport).mockResolvedValue({
+      root: "/media/INCEPTION_2010",
+      units: [],
+      loose_files: [],
+      disc_images: [
+        { name: "INCEPTION_2010", path: "/media/INCEPTION_2010", kind: "backup", total_bytes: 40e9 },
+      ],
+      total_jobs: 1,
+      total_files: 0,
+      total_bytes: 40e9,
+      truncated: false,
+    });
+    render(<ImportModal onClose={() => {}} defaultPath="/media" defaultDestinationMode="library" />);
+    await waitFor(() => screen.getByText("INCEPTION_2010"));
+    fireEvent.click(screen.getByText("INCEPTION_2010"));
+
+    const panel = await screen.findByTestId("import-disc-images");
+    expect(panel).toHaveTextContent("BACKUP");
+    // The operation is a rip, not a file move; the modal must say so.
+    expect(panel).toHaveTextContent(/scanned and extracted/i);
+    // Counted as a job, so the start button is enabled and reports it.
+    expect(await screen.findByTestId("import-start-btn")).toHaveTextContent("1 JOBS");
+    expect(screen.getByText(/1 disc backup(?!s)/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ImportModal.tsx
+++ b/frontend/src/components/ImportModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { motion } from "motion/react";
-import { IcoLibrary, IcoFilter, IcoError } from "../app/components/icons";
+import { IcoLibrary, IcoFilter, IcoError, IcoDisc } from "../app/components/icons";
 import { SvPanel, sv } from "../app/components/synapse";
 import { formatBytesScaled as fmtBytes } from "../utils/formatting";
 import {
@@ -10,6 +10,7 @@ import {
   startImport,
   type BlockedUnit,
   type BrowseEntry,
+  type PreviewDiscImage,
   type ImportStartResult,
   type PreviewResult,
 } from "../api/client";
@@ -170,6 +171,10 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
       .map((b) => b.unit_key);
     if (keys.length > 0) void runImport(keys);
   }, [conflict, runImport]);
+
+  // Optional on the type only for tolerance of an older backend; the current
+  // one always sends the key.
+  const discImages: PreviewDiscImage[] = preview?.disc_images ?? [];
 
   const seasonsByShow = (p: PreviewResult) => {
     const map = new Map<string, typeof p.units>();
@@ -374,8 +379,67 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
                 )}
                 {preview && preview.total_jobs === 0 && (
                   <p style={{ fontFamily: sv.mono, fontSize: 11, color: sv.inkDim }}>
-                    No MKV files found here.
+                    No MKV files or disc backups found here.
                   </p>
+                )}
+                {discImages.length > 0 && (
+                  <div style={{ marginBottom: 12 }} data-testid="import-disc-images">
+                    <div
+                      style={{
+                        fontFamily: sv.mono,
+                        fontSize: 13,
+                        color: sv.magenta,
+                        marginBottom: 4,
+                      }}
+                    >
+                      Disc backups
+                    </div>
+                    {discImages.map((d) => (
+                      <div
+                        key={d.path}
+                        style={{
+                          display: "flex",
+                          gap: 8,
+                          alignItems: "center",
+                          fontFamily: sv.mono,
+                          fontSize: 11,
+                          color: sv.inkDim,
+                          padding: "3px 0",
+                        }}
+                      >
+                        <IcoDisc size={11} color={sv.magenta} />
+                        <span
+                          style={{
+                            flex: 1,
+                            minWidth: 0,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {d.name}
+                        </span>
+                        <span>{d.kind === "iso" ? "ISO" : "BACKUP"}</span>
+                        <span>{fmtBytes(d.total_bytes)}</span>
+                        <span style={{ color: sv.magenta }}>1 job</span>
+                      </div>
+                    ))}
+                    {/* An MKV import files what has already been ripped; a disc
+                        backup import starts a full extraction, which is a far
+                        longer operation. Say so before START is pressed. */}
+                    <p
+                      style={{
+                        fontFamily: sv.mono,
+                        fontSize: 10,
+                        lineHeight: 1.5,
+                        color: sv.inkFaint,
+                        margin: "6px 0 0 0",
+                      }}
+                    >
+                      Disc backups are scanned and extracted like a disc in the drive, not
+                      filed as-is. Expect a full rip per backup, not a quick move.
+                    </p>
+                  </div>
                 )}
                 {preview &&
                   seasonsByShow(preview).map(([show, units]) => (
@@ -479,7 +543,9 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
           >
             <span style={{ fontFamily: sv.mono, fontSize: 10, color: sv.inkFaint }}>
               {preview
-                ? `${preview.total_jobs} jobs · ${preview.total_files} files · ${fmtBytes(preview.total_bytes)}`
+                ? `${preview.total_jobs} jobs · ${preview.total_files} files${
+                    discImages.length > 0 ? ` · ${discImages.length} disc backup${discImages.length === 1 ? "" : "s"}` : ""
+                  } · ${fmtBytes(preview.total_bytes)}`
                 : ""}
             </span>
             <button
@@ -526,6 +592,14 @@ export default function ImportModal({ onClose, defaultPath, defaultDestinationMo
   );
 }
 
+/**
+ * A disc backup is not a folder of media, so it does not get the folder icon or
+ * an "N mkv" count (it has none). It gets the disc mark in magenta plus a short
+ * kind tag, so a shelf of backups is distinguishable at a glance from the
+ * season folders sitting next to it.
+ */
+const DISC_ROW_TAG: Record<string, string> = { disc_image: "disc backup", iso: "iso" };
+
 function Row({
   label,
   count,
@@ -536,7 +610,7 @@ function Row({
 }: {
   label: string;
   count?: number;
-  kind: "dir" | "mkv";
+  kind: BrowseEntry["type"];
   active?: boolean;
   scrollTo?: boolean;
   onClick: () => void;
@@ -567,10 +641,19 @@ function Row({
         cursor: "pointer",
       }}
     >
-      <IcoFilter size={12} color={kind === "mkv" ? sv.inkFaint : sv.cyan} />
+      {DISC_ROW_TAG[kind] ? (
+        <IcoDisc size={12} color={sv.magenta} className="import-disc-icon" />
+      ) : (
+        <IcoFilter size={12} color={kind === "mkv" ? sv.inkFaint : sv.cyan} />
+      )}
       <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
         {label}
       </span>
+      {DISC_ROW_TAG[kind] && (
+        <span style={{ fontSize: 9, color: sv.magenta, letterSpacing: "0.1em" }}>
+          {DISC_ROW_TAG[kind]}
+        </span>
+      )}
       {count != null && count > 0 && (
         <span style={{ fontSize: 9, color: sv.cyan }}>{count} mkv</span>
       )}

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -13,6 +13,7 @@ export function mapJobStateToDiscState(jobState: Job['state']): DiscState {
     'idle': 'idle',
     'identifying': 'scanning',
     'review_needed': 'review_needed',
+    'backing_up': 'backing_up',
     'ripping': 'ripping',
     'matching': 'matching',
     'organizing': 'organizing',
@@ -155,6 +156,10 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     mediaType: mediaType,
     state: mapJobStateToDiscState(job.state),
     progress: job.progress_percent || 0,
+    // The backup panel is gated on backupProgress being defined, so only feed it
+    // while the copy is actually running. progress_percent carries the backup
+    // percentage during that phase (see applyBackupProgress).
+    backupProgress: job.state === 'backing_up' ? (job.progress_percent || 0) : undefined,
     currentSpeed: job.current_speed,
     etaSeconds: job.eta_seconds,
     subtitleStatus: job.subtitle_status || undefined,

--- a/frontend/src/types/adapters.ts
+++ b/frontend/src/types/adapters.ts
@@ -168,6 +168,8 @@ export function transformJobToDiscData(job: Job, titles: DiscTitle[]): DiscData 
     reviewReason: job.review_reason || undefined,
     promptKind,
     tmdbDegradedReason: job.tmdb_degraded_reason || undefined,
+    backupStatus: job.backup_status ?? undefined,
+    backupStatusReason: job.backup_status_reason ?? undefined,
     identityReview,
     identitySource: job.classification_source,
     tmdbId: job.tmdb_id ?? null,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,6 +39,16 @@ export interface Job {
     review_reason?: string | null;
     conflict_status?: string | null;
     /**
+     * Outcome of the optional whole-disc backup that runs between identification
+     * and extraction. Absent/null when the feature never ran for this job.
+     * "skipped" and "failed" both mean the disc was ripped straight from the
+     * drive instead, which is worth telling the user about; "pending" and
+     * "completed" are the in-progress and happy paths and need no warning.
+     */
+    backup_status?: 'pending' | 'completed' | 'failed' | 'skipped' | null;
+    /** Backend-written prose explaining a skipped or failed backup. Rendered verbatim. */
+    backup_status_reason?: string | null;
+    /**
      * Human-readable cause set by the backend when classification ran WITHOUT
      * TMDB (key absent or rejected); null/absent when TMDB participated. The
      * DiscCard renders it verbatim in its degraded-mode alert (#243).

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,7 @@ export type JobState =
     | 'idle'
     | 'identifying'
     | 'review_needed'
+    | 'backing_up'
     | 'ripping'
     | 'matching'
     | 'organizing'
@@ -174,6 +175,21 @@ export interface SubtitleEvent {
     failed_count: number;
 }
 
+/**
+ * Progress of the optional whole-disc backup that runs between identification
+ * and extraction. `speed` and `eta` are always present but usually null:
+ * MakeMKV's backup reports a percentage, not a byte rate. A null must not
+ * erase what the card already shows.
+ */
+export interface BackupProgressMessage {
+    type: 'backup_progress';
+    job_id: number;
+    current_bytes: number;
+    total_bytes: number;
+    speed: string | null;
+    eta: number | null;
+}
+
 export interface TitlesDiscovered {
     type: 'titles_discovered';
     job_id: number;
@@ -265,6 +281,7 @@ export type WebSocketMessage =
     | JobUpdate
     | TitleUpdate
     | SubtitleEvent
+    | BackupProgressMessage
     | TitlesDiscovered
     | UpdateStatusMessage
     | FingerprintDisclosureRequiredMessage


### PR DESCRIPTION
Implements the Discord feature request from @Ironside7: back the disc up first, then extract from the backup.

## Why

> *some of my discs are super scratched and there aren't new releases of it (The Sweetest Thing is an example). Disc stays safe in my case and the backup is stored on a separate server for preservation. Extract is also significantly faster, and less prone to fail if it encounters an issue with the disc.*

Ripping reads the disc once per title. Copying it whole first means one sequential read, which is much gentler on a fragile disc, and extraction then runs off local storage.

## What this adds

**Back up before ripping** (`backup_before_rip` + `backup_path`, off by default). After identification the disc is copied whole to a separate folder, and extraction reads that copy. Three consequences:

- the disc is read **once, sequentially**, instead of once per title;
- the disc **leaves the drive when the copy finishes**, not when the rip does, so the next disc can go in within minutes;
- **you keep the copy.** Engram never deletes a completed backup.

Backups mirror the library layout and honour your own naming settings, so the shelf browses the way your library does.

**Import an existing backup.** The Import button now recognises a folder containing `BDMV`/`VIDEO_TS`, or an `.iso`, and runs it through the normal scan, identify, rip, match, organize pipeline. Point it at a shelf of backups and it queues one job per disc.

## The rule that governs it

**Every backup problem degrades to a direct rip.** No backup folder, not enough space, a disc MakeMKV cannot address, a copy that fails or stalls: the job rips from the drive as it does today and says why on the card. Turning this on cannot make a disc less likely to finish.

The one exception is a backup whose re-scan cannot be reconciled onto the stored title indices, which parks in review rather than guessing, because the disc has already been ejected by then.

## Notable design points

- **A job's MakeMKV source is now a value, not a drive** (`DiscSource`, `DiscJob.source_spec`). `None` means "legacy, derive from `drive_id`", so every existing job is unaffected. This is what lets one job read `dev:E:` and another read `file:<backup>`.
- **Title indices are re-validated against the backup.** A backup is a byte copy and almost always enumerates identically, but ripping the wrong index files an episode under another episode's name with no error anywhere. Ambiguity parks for review rather than guessing.
- **Nothing new runs when the feature is off.** `backup_before_rip` defaults false with `server_default 0`, so an upgraded row reads as disabled.

## Test plan

- [x] Backend unit: 3393 passed, 21 skipped
- [x] Backend pipeline + integration: 375 passed, 1 skipped
- [x] Frontend unit: 497 passed; `npm run build` and `npm run lint` clean
- [x] E2E: new `disc-backup.spec.ts` drives a simulated disc through BACKING UP into RIPPING and imports a seeded BDMV folder; existing `import-flow.spec.ts` still passes
- [x] Default-off path verified unchanged (pipeline tier exercises identification through ripping end to end)
- [x] **Real-disc verification (done).** Verified on MakeMKV 1.18.3 with a Pioneer BDR-S13U against a DVD. `makemkvcon backup` accepts DVDs (LibreDrive mode, 448 MB copied before the test was stopped deliberately), and robot mode emits `PRGV` throughout. The scanning phase emitted `PRGV:65536,0,65536`, where the fields diverge completely, confirming directly that `current` is the per-operation bar and `total` is the overall one, which is what the progress parser reads.

  The run also surfaced something neither question anticipated: **MakeMKV refuses a destination directory that already exists, even an empty one** (`MSG:5068 "Folder ... already contains a backup"`, then `Backup failed`). That makes the stale-`.partial`-moved-aside step a requirement rather than the tidiness it was documented as, since without it every retry of a failed backup would die instantly and be reported as a generic non-zero exit. The code was already correct; the comment and spec now say why it has to be.

- [x] **Blu-ray verification (done).** Re-run against a Blu-ray, which exercises what a DVD cannot: a DVD backup produces `VIDEO_TS`, a Blu-ray produces `BDMV/STREAM`, and both the import detector and the content hash key on the latter. `is_disc_image_dir` detects a real `BDMV` tree, the scanner emits it as one disc-image unit with zero MKV units, and `total_files` came back 0, confirming the walk short-circuits rather than pulling thousands of stream files into its budget.

  It also confirms **an imported backup hashes the same as its disc**, which is what makes TheDiscDB lookup work for an import. Verified rather than assumed: of the streams the interrupted copy had finished, 7 of 7 were byte-identical in size to the disc (the 8th was mid-write), and the hash is an MD5 over those sizes in filename order, so a complete copy necessarily hashes the same.

## Docs

`docs/getting-started/configuration.md` gains a Disc Backup section; `CLAUDE.md` gains the config field, the source-is-a-value pattern, and the `backup_progress` message. The spec and plan are in `docs/superpowers/`, including an execution record of two gaps the plan itself caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

