### PR TITLE
chore: release v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-09-07
+
+_Highlights: back up a disc before ripping it, and import backups you already have._
+
 ### Added
 
 - **Optionally back up a disc before ripping it.** Engram can write a full
@@ -17,12 +21,12 @@ All notable changes to Engram will be documented in this file.
   own naming settings. If anything prevents a backup, Engram rips directly from
   the drive as before and says why on the job card, so turning this on cannot
   make a disc less likely to finish. Off by default: enable it under Settings
-  and pick a backup folder. (#NNN)
+  and pick a backup folder. (#638)
 - **Import a disc backup you already have.** The Import button now recognises a
   folder containing `BDMV` or `VIDEO_TS`, or an `.iso` file, and runs it through
   the normal scan, identify, rip, match and organize pipeline instead of filing
   it as finished media. Point it at a shelf of backups and it queues one job per
-  disc. (#NNN)
+  disc. (#638)
 
 ### Fixed
 
@@ -38,7 +42,7 @@ All notable changes to Engram will be documented in this file.
   obvious rather than silent. Coverage that already succeeded no longer expires
   on a timer either, which is what used to trigger the oversized re-harvests
   that exhausted the quota in the first place. Run summaries also credit
-  OpenSubtitles correctly instead of reporting its downloads as cache hits.
+  OpenSubtitles correctly instead of reporting its downloads as cache hits. (#631)
 
 - **The same protection now covers the subtitle scrapers.** The fix above read
   only OpenSubtitles' health, so a build where OpenSubtitles was fine but both
@@ -46,7 +50,16 @@ All notable changes to Engram will be documented in this file.
   having no subtitles and stopped retrying them for 30 days. A scraper that
   goes down is now told apart from one that simply has nothing, so a season
   nobody could reach is left unmeasured and picked up on the next run, and the
-  run summary names the provider that never answered.
+  run summary names the provider that never answered. (#636)
+
+- **A non-ASCII show title no longer aborts a subtitle-cache harvest.** A
+  448-show run died partway through on a title spelled with a macron: Windows
+  opens both the console and a redirected pipe with the legacy ANSI codepage,
+  so rendering that one title's progress bar raised an encoding error and took
+  the whole multi-hour run down with it, discarding the completed work for
+  every show that had already succeeded. Output now forces UTF-8 up front, so
+  an unrepresentable character degrades to a placeholder instead of ending the
+  run. (#635)
 
 ## [0.34.0] - 2026-08-31
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,5 +2,5 @@
 
 Engram is built primarily by its maintainer, but these community contributors have shipped improvements — thank you!
 
-- [@raiju](https://github.com/raiju)
 - [@katelovescode](https://github.com/katelovescode) — first contribution: v0.15.0
+- [@raiju](https://github.com/raiju) — first contribution: v0.34.0

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.34.0"
+version = "0.35.0"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.34.0"
+version = "0.35.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.34.0",
+    "version": "0.35.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.34.0",
+            "version": "0.35.0",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.34.0",
+    "version": "0.35.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

Cuts release **v0.35.0**. On squash-merge, `tag-release.yml` will tag `v0.35.0` from `main` and dispatch the binary + Docker release workflows.

### Version bump (lockstep across all 5 files)
- `backend/pyproject.toml`
- `backend/app/__init__.py`
- `backend/uv.lock`
- `frontend/package.json`
- `frontend/package-lock.json` (both self-version fields)

### Changelog
Promoted `[Unreleased]` into `## [0.35.0] - 2026-09-07`:
- Filled in the `(#NNN)` placeholders on the disc-backup feature with the real PR (#638)
- Added PR references to the two subtitle-cache Fixed entries that were missing them (#631, #636)
- Added a missing entry for the non-ASCII show title harvest-crash fix (#635), which had no changelog coverage
- Verified `extract_changelog.py --version 0.35.0 --check` resolves the section cleanly

### Contributors
Regenerated `CONTRIBUTORS.md` via `contributors.py --roster` (picks up @raiju's "first contribution: v0.34.0" annotation that was missing from the committed file).

No external contributors landed in this release window (all commits since v0.34.0 are the maintainer's own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)