### PR TITLE
fix: re-home a disc backup named before an identity correction (#643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- When a misidentified disc was corrected during review, the disc backup kept the wrong show name and TMDB id even though the library output was correct. The backup folder is now moved to match the corrected identity once the job completes. (#643)
+
 ## [0.35.0] - 2026-09-07
 
 _Highlights: back up a disc before ripping it, and import backups you already have._

--- a/backend/app/core/backup_paths.py
+++ b/backend/app/core/backup_paths.py
@@ -116,3 +116,66 @@ def has_room_for_backup(dest: Path, needed_bytes: int) -> bool:
         )
         return False
     return True
+
+
+def reconcile_backup_location(job: DiscJob, config: AppConfig) -> Path | None:
+    """Move a completed backup to the folder the CURRENT identity implies.
+
+    The backup folder is named at BACKING_UP time, before the user has seen
+    the identification. Correcting a misidentified disc updates the library
+    output but used to leave the preservation shelf under the wrong show and
+    TMDB id forever, which defeats the point of mirroring the library layout
+    (#643).
+
+    Returns the new path when the backup was moved, or None when there was
+    nothing to do. Never raises: this is cosmetic housekeeping on the job
+    completion path.
+    """
+    if not job.backup_path:
+        return None
+    current = Path(job.backup_path)
+    if not current.is_dir():
+        return None
+
+    desired = backup_destination(job, config)
+    if desired is None or desired == current:
+        return None
+    if desired.exists():
+        # Legitimately another disc of the same set. Merging blindly would
+        # be destructive, so leave both alone and say so.
+        logger.warning(f"Not moving backup {current} to {desired}: the destination already exists")
+        return None
+
+    try:
+        desired.parent.mkdir(parents=True, exist_ok=True)
+        # Same backup root means same volume, so this is a rename and not a
+        # multi-gigabyte copy.
+        current.rename(desired)
+    except OSError as e:
+        logger.warning(f"Could not move backup {current} to {desired}: {e}")
+        return None
+
+    logger.info(f"Moved backup to match the corrected identity: {desired}")
+    _prune_empty_parents(current.parent, Path(config.backup_path).expanduser())
+    return desired
+
+
+def _prune_empty_parents(start: Path, root: Path) -> None:
+    """Remove directories left empty by a rename, stopping at ``root``.
+
+    ``root`` itself is never removed: an empty backup root is a configured
+    location, not litter.
+    """
+    try:
+        root = root.resolve()
+        current = start.resolve()
+    except OSError:
+        return
+    while current != root and root in current.parents:
+        try:
+            if any(current.iterdir()):
+                return
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent

--- a/backend/app/core/backup_paths.py
+++ b/backend/app/core/backup_paths.py
@@ -143,6 +143,14 @@ def reconcile_backup_location(job: DiscJob, config: AppConfig) -> Path | None:
     if desired.exists():
         # Legitimately another disc of the same set. Merging blindly would
         # be destructive, so leave both alone and say so.
+        #
+        # This check is NOT atomic with the rename below: two jobs reconciling
+        # to the same destination could both pass it. What actually guarantees
+        # "never merge, never overwrite" is the rename itself, which refuses a
+        # non-empty directory (ENOTEMPTY on POSIX, FileExistsError on Windows)
+        # and lands in the except branch as a logged no-op. This check exists to
+        # make the common case explain itself in the log rather than to enforce
+        # the invariant, so do not "optimize" it away or rely on it alone.
         logger.warning(f"Not moving backup {current} to {desired}: the destination already exists")
         return None
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -1692,6 +1692,15 @@ class JobManager:
         Runs only on COMPLETED, where extraction is provably finished, because
         until then source_spec points AT the backup folder and renaming it would
         pull the floor out from under the rip (#643).
+
+        Terminal callbacks fire AFTER ``JobStateMachine.transition`` has already
+        committed and broadcast, so the ``backup_path``/``source_spec`` written
+        here reach no WebSocket client: there is no follow-up ``job_update``.
+        That is fine today because the only consumer, HistoryPage's detail
+        panel, re-fetches ``GET /api/jobs/{id}/detail`` when it opens rather
+        than reading the WS-cached job. A future consumer that reads either
+        field off the cached WS object would see the stale pre-correction value
+        until a hard refresh, and would need a broadcast added here.
         """
         if state != JobState.COMPLETED:
             return

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -325,6 +325,7 @@ class JobManager:
         # COMPLETES (FAILED jobs never contribute). Best-effort — a raised enqueue
         # is caught here and never crashes the terminal-state dispatch.
         state_machine.on_terminal_state(self._enqueue_disc_contribution_on_terminal)
+        state_machine.on_terminal_state(self._reconcile_backup_on_terminal)
         state_machine.on_terminal_state(self._notify_discord_on_terminal)
 
         # Reset the watchdog activity clock whenever a job changes phase.
@@ -1684,6 +1685,37 @@ class JobManager:
                 await session.commit()
         except Exception as e:
             logger.warning(f"Job {job_id}: disc contribution enqueue failed: {e}", exc_info=True)
+
+    async def _reconcile_backup_on_terminal(self, job_id: int, state: JobState) -> None:
+        """on_terminal_state hook: re-home a backup named before a correction.
+
+        Runs only on COMPLETED, where extraction is provably finished, because
+        until then source_spec points AT the backup folder and renaming it would
+        pull the floor out from under the rip (#643).
+        """
+        if state != JobState.COMPLETED:
+            return
+        try:
+            from app.core.backup_paths import reconcile_backup_location
+            from app.services.config_service import get_config
+
+            config = await get_config()
+            async with async_session() as session:
+                job = await session.get(DiscJob, job_id)
+                if job is None or job.backup_status != BACKUP_COMPLETED:
+                    return
+                moved = await asyncio.to_thread(reconcile_backup_location, job, config)
+                if moved is None:
+                    return
+                # backup_path and source_spec must move together: source_spec
+                # still carries "file:<old path>" from the backup handoff.
+                job.backup_path = str(moved)
+                if job.source_spec and job.source_spec.startswith("file:"):
+                    job.source_spec = f"file:{moved}"
+                session.add(job)
+                await session.commit()
+        except Exception as e:
+            logger.warning(f"Job {job_id}: backup reconciliation failed: {e}", exc_info=True)
 
     async def _notify_discord_on_terminal(self, job_id: int, state: JobState) -> None:
         """on_terminal_state hook: schedule a Discord notification and return immediately.

--- a/backend/tests/unit/test_backup_rename_on_terminal.py
+++ b/backend/tests/unit/test_backup_rename_on_terminal.py
@@ -131,6 +131,39 @@ class TestReconcileBackupLocation:
         assert root.exists()
         assert (root / "TV").exists()
 
+    def test_reshapes_when_content_type_changed(self, tmp_path):
+        """A TV disc corrected to a movie must move across the whole layout.
+
+        The most common correction is a wrong show name, but the classifier can
+        also be wrong about the KIND of disc, and then the backup does not just
+        get renamed: TV/Show/Season/Disc has to become Movies/Name (Year). This
+        works because backup_destination re-derives from the CURRENT
+        content_type rather than from whatever shape the stored path has.
+        """
+        root = tmp_path
+        old_dir = root / "TV" / "Wrong Show" / "Season 01" / "Disc 1"
+        old_dir.mkdir(parents=True)
+        (old_dir / "backup.mkv").write_text("data")
+
+        job = _job(
+            content_type=ContentType.MOVIE,
+            tmdb_name="Correct Movie",
+            tmdb_year=2001,
+            backup_path=str(old_dir),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        assert result is not None
+        # Assert the shape, not the exact folder string: the movie folder format
+        # is user-configurable, so hardcoding it here would couple this test to
+        # a default rather than to the behavior under test.
+        assert result.parent == root / "Movies"
+        assert (result / "backup.mkv").read_text() == "data"
+        assert not old_dir.exists()
+        assert not (root / "TV" / "Wrong Show").exists()
+
 
 class TestTerminalHookRegistration:
     """The helper is well covered; this guards the wiring that invokes it.

--- a/backend/tests/unit/test_backup_rename_on_terminal.py
+++ b/backend/tests/unit/test_backup_rename_on_terminal.py
@@ -130,3 +130,21 @@ class TestReconcileBackupLocation:
         assert not (root / "TV" / "Wrong Show").exists()
         assert root.exists()
         assert (root / "TV").exists()
+
+
+class TestTerminalHookRegistration:
+    """The helper is well covered; this guards the wiring that invokes it.
+
+    Without this, deleting the on_terminal_state registration in a refactor
+    leaves every other test green while the feature silently stops running.
+    """
+
+    def test_reconcile_hook_is_registered(self):
+        # Importing the module constructs the JobManager singleton, whose
+        # __init__ registers the terminal callbacks on the module-level
+        # state machine. Import the names directly: `import ... as mod` binds
+        # the job_manager SINGLETON rather than the module here.
+        from app.services.job_manager import state_machine
+
+        names = {getattr(cb, "__name__", "") for cb in state_machine._on_terminal_callbacks}
+        assert "_reconcile_backup_on_terminal" in names

--- a/backend/tests/unit/test_backup_rename_on_terminal.py
+++ b/backend/tests/unit/test_backup_rename_on_terminal.py
@@ -1,0 +1,132 @@
+"""Reconciling a disc backup's folder with a post-backup identity correction."""
+
+from app.core.backup_paths import reconcile_backup_location
+from app.models import AppConfig, ContentType, DiscJob
+
+
+def _job(**kw) -> DiscJob:
+    base = {"drive_id": "E:", "volume_label": "DISC_LABEL"}
+    base.update(kw)
+    return DiscJob(**base)
+
+
+def _config(**kw) -> AppConfig:
+    base = {"backup_path": "/b"}
+    base.update(kw)
+    return AppConfig(**base)
+
+
+class TestReconcileBackupLocation:
+    def test_renames_when_identity_changed(self, tmp_path):
+        root = tmp_path
+        old_dir = root / "TV" / "Wrong Show" / "Season 01" / "Disc 1"
+        old_dir.mkdir(parents=True)
+        dummy = old_dir / "backup.mkv"
+        dummy.write_text("data")
+
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Correct Show",
+            tmdb_year=2001,
+            detected_season=1,
+            disc_number=1,
+            backup_path=str(old_dir),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        expected = root / "TV" / "Correct Show" / "Season 01" / "Disc 1"
+        assert result == expected
+        assert expected.is_dir()
+        assert (expected / "backup.mkv").exists()
+        assert not old_dir.exists()
+
+    def test_noop_when_destination_matches(self, tmp_path):
+        root = tmp_path
+        dest_dir = root / "TV" / "Correct Show" / "Season 01" / "Disc 1"
+        dest_dir.mkdir(parents=True)
+        dummy = dest_dir / "backup.mkv"
+        dummy.write_text("data")
+
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Correct Show",
+            detected_season=1,
+            disc_number=1,
+            backup_path=str(dest_dir),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        assert result is None
+        assert dest_dir.is_dir()
+        assert (dest_dir / "backup.mkv").exists()
+
+    def test_noop_when_target_exists(self, tmp_path):
+        root = tmp_path
+        old_dir = root / "TV" / "Wrong Show" / "Season 01" / "Disc 1"
+        old_dir.mkdir(parents=True)
+        (old_dir / "backup.mkv").write_text("old data")
+
+        new_dir = root / "TV" / "Correct Show" / "Season 01" / "Disc 1"
+        new_dir.mkdir(parents=True)
+        (new_dir / "backup.mkv").write_text("existing data")
+
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Correct Show",
+            detected_season=1,
+            disc_number=1,
+            backup_path=str(old_dir),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        assert result is None
+        assert old_dir.is_dir()
+        assert (old_dir / "backup.mkv").read_text() == "old data"
+        assert new_dir.is_dir()
+        assert (new_dir / "backup.mkv").read_text() == "existing data"
+
+    def test_noop_when_stored_path_missing(self, tmp_path):
+        root = tmp_path
+        missing = root / "TV" / "Wrong Show" / "Season 01" / "Disc 1"
+
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Correct Show",
+            detected_season=1,
+            disc_number=1,
+            backup_path=str(missing),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        assert result is None
+
+    def test_prunes_emptied_parents_but_not_the_root(self, tmp_path):
+        root = tmp_path
+        old_dir = root / "TV" / "Wrong Show" / "Season 01" / "Disc 1"
+        old_dir.mkdir(parents=True)
+        (old_dir / "backup.mkv").write_text("data")
+
+        job = _job(
+            content_type=ContentType.TV,
+            tmdb_name="Correct Show",
+            detected_season=1,
+            disc_number=1,
+            backup_path=str(old_dir),
+        )
+        config = _config(backup_path=str(root))
+
+        result = reconcile_backup_location(job, config)
+
+        assert result is not None
+        assert not (root / "TV" / "Wrong Show" / "Season 01").exists()
+        assert not (root / "TV" / "Wrong Show").exists()
+        assert root.exists()
+        assert (root / "TV").exists()


### PR DESCRIPTION
## Root cause

`backup_destination` (in `backend/app/core/backup_paths.py`) computes the backup
folder from `job.tmdb_name` / `job.tmdb_id` / `job.detected_season` at
`BACKING_UP` time, which is before the user has ever seen the identification.
When the user later corrects a misidentified disc during review, the
finalization path recomputes the *library* path but nothing revisits the
*backup* folder, so the preservation shelf permanently disagrees with the
library (wrong show name and wrong TMDB id).

## Why the fix lands on the terminal hook, not at correction time

After a successful backup, `job.source_spec` is set to `file:<backup_path>`
(`job_manager.py` around line 2639): the backup IS the rip source for the rest
of the job. Renaming the backup folder while extraction is still reading from
it would pull the floor out from under the in-flight rip. `COMPLETED` is the
first point where extraction is provably finished and `source_spec` no longer
needs to point at the backup, so that is the safe seam to reconcile on.

## What changed

- `backend/app/core/backup_paths.py`: new pure helper
  `reconcile_backup_location(job, config)` that recomputes the desired backup
  path from the job's current identity and, if it differs from the stored
  `backup_path`, renames the folder to match. Guards:
  - no-op if `backup_path` is unset or the directory no longer exists
  - no-op if the recomputed destination equals the current path
  - no-op (never merges/overwrites) if the recomputed destination already
    exists on disk
  - prunes directories left empty by the rename, but never removes the
    configured backup root itself
  - never raises: all failures are logged and swallowed, since this is
    cosmetic housekeeping on the completion path
- `backend/app/services/job_manager.py`: new `on_terminal_state` hook
  `_reconcile_backup_on_terminal`, registered alongside the other terminal
  hooks. Runs only on `COMPLETED` and only when `job.backup_status ==
  BACKUP_COMPLETED`. Calls the pure helper via `asyncio.to_thread`, then
  updates `job.backup_path` and (if still `file:`-prefixed) `job.source_spec`
  to the new location.
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Tests

New file `backend/tests/unit/test_backup_rename_on_terminal.py` (5 tests, all
against the pure helper, no DB/event loop needed):

- renames when the identity changed
- no-op when the recomputed destination already matches the stored path
- no-op when the recomputed destination already exists (both directories and
  their contents survive untouched)
- no-op when the stored backup path is missing on disk
- prunes emptied parent directories but not the configured backup root

Ran:

    uv run pytest tests/unit/test_backup_rename_on_terminal.py tests/unit/test_backup_paths.py tests/unit/test_backup_disc.py tests/unit/test_backup_routing.py tests/unit/test_backup_reconciliation.py tests/unit/test_run_backup.py -q
    uv run ruff check .
    uv run ruff format --check .

All passing (109 passed; ruff clean).

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)
