### PR TITLE
fix: roll back the library copy when organize cannot remove the source (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Organizing a file that another process still had open could leave a copy in the library while reporting an error, so the next save attempt failed with "file already exists" and the episode had to be discarded. The move is now retried and rolled back cleanly. (#642)
+
 ## [0.35.0] - 2026-09-07
 
 _Highlights: back up a disc before ripping it, and import backups you already have._

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -367,19 +367,40 @@ def move_media_file(src: Path, dest: Path, *, attempts: int = 3, delay: float = 
     except OSError:
         # A partial copy is worse than no copy: it looks like a real library
         # file to every later run.
-        with contextlib.suppress(OSError):
+        try:
             os.unlink(dest)
+        except FileNotFoundError:
+            pass  # nothing was created, so there is nothing to clean up
+        except OSError:
+            logger.error(
+                f"Could not remove the partial copy at {dest} after a failed "
+                "copy; it has to be deleted by hand before a retry can succeed."
+            )
         raise
 
     try:
         os.unlink(src)
     except OSError as e:
-        with contextlib.suppress(OSError):
+        # The rollback can itself fail: an antivirus or indexer briefly holding
+        # the copy we just made, or a delete-restricted ACL on the library. Say
+        # which case this is, because "retry me" and "there is an orphan in the
+        # library" need opposite responses from the caller, and claiming the
+        # first while the second is true recreates #642 with a reassuring
+        # message on top of it.
+        rolled_back = True
+        try:
             os.unlink(dest)
+        except OSError:
+            rolled_back = False
+        detail = (
+            "The copy was rolled back, so this is safe to retry."
+            if rolled_back
+            else f"The copy at {dest} could NOT be removed either, so it has to "
+            "be deleted by hand before a retry can succeed."
+        )
         raise OSError(
             f"Could not remove {src} after copying it to {dest}; the file is "
-            f"in use. The copy was rolled back, so this is safe to retry. "
-            f"Original error: {e}"
+            f"in use. {detail} Original error: {e}"
         ) from (last or e)
 
 

--- a/backend/app/core/organizer.py
+++ b/backend/app/core/organizer.py
@@ -6,9 +6,12 @@ Moves ripped files from staging to the library with proper naming conventions:
 """
 
 import contextlib
+import errno
 import logging
+import os
 import re
 import shutil
+import time
 import uuid
 from pathlib import Path
 
@@ -318,6 +321,68 @@ def resolve_conflict(dest_file: Path, conflict_resolution: str) -> tuple[Path | 
     }
 
 
+def move_media_file(src: Path, dest: Path, *, attempts: int = 3, delay: float = 0.5) -> None:
+    """Move ``src`` onto ``dest``, leaving nothing behind when it fails.
+
+    ``shutil.move`` catches a bare ``OSError`` around ``os.rename`` and then
+    silently degrades to copy-then-delete. On Windows an open handle on the
+    source (the transcript prewarmer's ffmpeg, or a review track opened in an
+    external player) fails the rename AND the post-copy unlink, so the copy is
+    left sitting in the library while the caller sees an exception. The next
+    retry then reports FILE_EXISTS against our own orphan, and discarding the
+    episode is the only way out (#642).
+
+    So: retry the atomic rename first, because these locks are transient, and
+    if the copy fallback cannot remove the source afterwards, roll the copy
+    back. A failed organize must leave the filesystem unchanged so that a
+    retry is clean.
+
+    Raises OSError when the move could not be completed.
+    """
+    last: OSError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            # os.replace, not os.rename: the caller has already run
+            # resolve_conflict, so an existing dest is intentional
+            # ("overwrite"), and replace is atomic where rename is not.
+            os.replace(src, dest)
+            return
+        except OSError as e:
+            last = e
+            # A cross-device move can never succeed via rename. Fall through
+            # to the copy path immediately instead of sleeping out the budget.
+            if e.errno == errno.EXDEV:
+                break
+            if attempt < attempts:
+                logger.warning(
+                    f"Rename attempt {attempt}/{attempts} failed for {src.name} "
+                    f"({e}); retrying in {delay}s"
+                )
+                time.sleep(delay)
+
+    # Rename is not going to work (cross-device, or the handle outlived our
+    # budget). Copy, then delete. Both halves clean up after themselves.
+    try:
+        shutil.copy2(str(src), str(dest))
+    except OSError:
+        # A partial copy is worse than no copy: it looks like a real library
+        # file to every later run.
+        with contextlib.suppress(OSError):
+            os.unlink(dest)
+        raise
+
+    try:
+        os.unlink(src)
+    except OSError as e:
+        with contextlib.suppress(OSError):
+            os.unlink(dest)
+        raise OSError(
+            f"Could not remove {src} after copying it to {dest}; the file is "
+            f"in use. The copy was rolled back, so this is safe to retry. "
+            f"Original error: {e}"
+        ) from (last or e)
+
+
 def check_library_writable(library_path: Path | str | None, *, create: bool = True) -> str | None:
     """Return a human-readable reason ``library_path`` is unusable, or None.
 
@@ -501,7 +566,7 @@ def organize_movie(
 
     try:
         # Move main movie
-        shutil.move(str(main_file), str(dest_file))
+        move_media_file(main_file, dest_file)
 
         moved_extras = []
         extras_mapping: dict[str, Path] = {}
@@ -517,7 +582,7 @@ def organize_movie(
                     extra_name = f"Extra {i}.mkv"
                     extra_dest = extras_dir / extra_name
                     logger.info(f"Moving extra: {extra.name} -> {extra_dest}")
-                    shutil.move(str(extra), str(extra_dest))
+                    move_media_file(extra, extra_dest)
                     moved_extras.append(extra_dest)
                     extras_mapping[extra.name] = extra_dest
 
@@ -704,7 +769,7 @@ def organize_tv_episode(
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         # Move the file
-        shutil.move(str(source_file), str(dest_file))
+        move_media_file(source_file, dest_file)
 
         logger.info(f"Successfully organized: {dest_file}")
 
@@ -791,7 +856,7 @@ def organize_tv_extras(
 
     try:
         dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(source_file), str(dest_file))
+        move_media_file(source_file, dest_file)
         logger.info(f"Successfully organized extra: {dest_file}")
         return {"success": True, "final_path": dest_file, "error": None}
     except Exception as e:

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2329,10 +2329,10 @@ class JobManager:
         edition: str | None = None,
     ) -> None:
         """Apply a user's review decision for a title."""
-        # Organization (shutil.move) starts now — stop background prewarming so
-        # ffmpeg/ffprobe don't hold the file open when the rename runs. The
-        # in-flight thread finishes its current chunk (~60s) before yielding.
-        self._prewarmer.cancel_for_job(job_id)
+        # Organization (shutil.move) starts now, so wait for ffmpeg/ffprobe to let
+        # go of the file before the rename runs (#642). Bounded: move_media_file
+        # retries past a lock that outlives the wait.
+        await self._prewarmer.cancel_and_wait(job_id)
         # Bind the job into the logging context: this runs straight off an API
         # handler, so without it every line the organize sweep emits (including
         # organizer.py's traceback) is tagged job=- and the diagnostics bundle's
@@ -2342,10 +2342,10 @@ class JobManager:
 
     async def apply_review_batch(self, job_id: int, decisions: list[dict]) -> None:
         """Apply several review decisions for a job in one atomic pass."""
-        # Organization (shutil.move) starts now — stop background prewarming so
-        # ffmpeg/ffprobe don't hold the file open when the rename runs. The
-        # in-flight thread finishes its current chunk (~60s) before yielding.
-        self._prewarmer.cancel_for_job(job_id)
+        # Organization (shutil.move) starts now, so wait for ffmpeg/ffprobe to let
+        # go of the file before the rename runs (#642). Bounded: move_media_file
+        # retries past a lock that outlives the wait.
+        await self._prewarmer.cancel_and_wait(job_id)
         with job_log_context(job_id):  # see apply_review (#563)
             await self._finalization.apply_review_batch(job_id, decisions)
 

--- a/backend/app/services/job_manager.py
+++ b/backend/app/services/job_manager.py
@@ -2329,24 +2329,25 @@ class JobManager:
         edition: str | None = None,
     ) -> None:
         """Apply a user's review decision for a title."""
-        # Organization (shutil.move) starts now, so wait for ffmpeg/ffprobe to let
-        # go of the file before the rename runs (#642). Bounded: move_media_file
-        # retries past a lock that outlives the wait.
-        await self._prewarmer.cancel_and_wait(job_id)
         # Bind the job into the logging context: this runs straight off an API
         # handler, so without it every line the organize sweep emits (including
         # organizer.py's traceback) is tagged job=- and the diagnostics bundle's
         # "| job=<id> |" grep drops it (#563).
         with job_log_context(job_id):
+            # Organization (shutil.move) starts now, so wait for ffmpeg/ffprobe
+            # to let go of the file before the rename runs (#642). Bounded:
+            # move_media_file retries past a lock that outlives the wait. Kept
+            # INSIDE the log context so the "did not stop in time" warning is
+            # job-tagged: it is the one line that explains why a later organize
+            # hit the retry path at all, so it must survive the bundle's grep.
+            await self._prewarmer.cancel_and_wait(job_id)
             await self._finalization.apply_review(job_id, title_id, episode_code, edition)
 
     async def apply_review_batch(self, job_id: int, decisions: list[dict]) -> None:
         """Apply several review decisions for a job in one atomic pass."""
-        # Organization (shutil.move) starts now, so wait for ffmpeg/ffprobe to let
-        # go of the file before the rename runs (#642). Bounded: move_media_file
-        # retries past a lock that outlives the wait.
-        await self._prewarmer.cancel_and_wait(job_id)
         with job_log_context(job_id):  # see apply_review (#563)
+            # Inside the context for the same reason as apply_review (#642).
+            await self._prewarmer.cancel_and_wait(job_id)
             await self._finalization.apply_review_batch(job_id, decisions)
 
     async def reassign_episode(

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -140,6 +140,34 @@ class TranscriptionPrewarmer:
                 f"Job {job_id}: transcript prewarm cancelled (in-flight thread finishes current chunk)"
             )
 
+    async def cancel_and_wait(self, job_id: int, timeout: float = 5.0) -> bool:
+        """Cancel ``job_id``'s prewarm task and wait for the thread to let go.
+
+        ``cancel_for_job`` is deliberately fire-and-forget, but organize needs
+        the file handle actually released, not merely asked for: an ffmpeg chunk
+        still holding the staging MKV is what makes the rename fail (#642).
+        ``asyncio.to_thread`` is not interruptible, so the in-flight chunk runs
+        to completion; we wait a short bounded time for that and let
+        ``move_media_file``'s retry cover the rest rather than blocking an API
+        handler for a full chunk.
+
+        Returns True when the task is done, False when the timeout won first.
+        """
+        task = self._tasks.pop(job_id, None)
+        if task is None or task.done():
+            return True
+        task.cancel()
+        # asyncio.wait, not await task: waiting on a cancelled task re-raises
+        # its CancelledError into this coroutine, which would abort the caller's
+        # organize. wait() reports completion without propagating.
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+        if not done:
+            logger.warning(
+                f"Job {job_id}: transcript prewarm did not stop within {timeout}s; "
+                "organize will retry past the lock"
+            )
+        return bool(done)
+
     async def on_job_terminal(self, job_id: int, _state) -> None:
         """JobStateMachine ``on_terminal_state`` hook: stop warming a finished job."""
         self.cancel_for_job(job_id)

--- a/backend/app/services/transcription_prewarm.py
+++ b/backend/app/services/transcription_prewarm.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from sqlmodel import select
 
 from app.core.log_context import with_job_log_context
+from app.core.security import sanitize_log_value
 from app.database import async_session
 from app.models import DiscJob
 from app.models.disc_job import DiscTitle, TitleState
@@ -163,8 +164,8 @@ class TranscriptionPrewarmer:
         done, _ = await asyncio.wait({task}, timeout=timeout)
         if not done:
             logger.warning(
-                f"Job {job_id}: transcript prewarm did not stop within {timeout}s; "
-                "organize will retry past the lock"
+                f"Job {sanitize_log_value(job_id)}: transcript prewarm did not stop "
+                f"within {timeout}s; organize will retry past the lock"
             )
         return bool(done)
 

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -533,3 +533,95 @@ class TestTVDisambiguation:
         assert str(r_ep["final_path"]).startswith(show_dir)
         assert str(r_ex["final_path"]).startswith(show_dir)
         assert "Extras" in str(r_ex["final_path"])
+
+
+class TestMoveMediaFileRollback:
+    """Rollback contract for move_media_file (#642).
+
+    shutil.move degrades to copy-then-delete on a failed rename, and if the
+    delete also fails (a held handle on Windows), the copy is left behind in
+    the library while the caller still sees an exception. These tests prove
+    move_media_file leaves the filesystem unchanged on failure instead.
+    """
+
+    def test_failed_unlink_leaves_no_destination(self, tmp_path, monkeypatch):
+        import app.core.organizer as organizer_mod
+
+        src = tmp_path / "src.mkv"
+        src.write_bytes(b"payload")
+        dest_dir = tmp_path / "dest_dir"
+        dest_dir.mkdir()
+        dest = dest_dir / "dest.mkv"
+
+        real_unlink = organizer_mod.os.unlink
+
+        def fake_replace(_src, _dst):
+            raise PermissionError(13, "in use")
+
+        def fake_unlink(path):
+            # Only the locked source file refuses to unlink; the rollback's
+            # own cleanup of the copy it just made must still go through, or
+            # this test could never distinguish "rolled back" from "gave up".
+            if str(path) == str(src):
+                raise PermissionError(13, "in use")
+            real_unlink(path)
+
+        monkeypatch.setattr(organizer_mod.os, "replace", fake_replace)
+        monkeypatch.setattr(organizer_mod.os, "unlink", fake_unlink)
+
+        with pytest.raises(OSError):
+            organizer_mod.move_media_file(src, dest, attempts=1, delay=0)
+
+        assert src.exists() is True
+        assert dest.exists() is False
+
+    def test_retries_then_succeeds(self, tmp_path, monkeypatch):
+        import app.core.organizer as organizer_mod
+
+        src = tmp_path / "src.mkv"
+        src.write_bytes(b"payload")
+        dest_dir = tmp_path / "dest_dir"
+        dest_dir.mkdir()
+        dest = dest_dir / "dest.mkv"
+
+        real_replace = organizer_mod.os.replace
+        calls = {"count": 0}
+
+        def flaky_replace(_src, _dst):
+            calls["count"] += 1
+            if calls["count"] <= 2:
+                raise PermissionError(13, "in use")
+            return real_replace(_src, _dst)
+
+        monkeypatch.setattr(organizer_mod.os, "replace", flaky_replace)
+
+        organizer_mod.move_media_file(src, dest, attempts=3, delay=0)
+
+        assert dest.exists() is True
+        assert src.exists() is False
+        assert calls["count"] == 3
+
+    def test_cross_device_falls_back_immediately(self, tmp_path, monkeypatch):
+        import errno
+
+        import app.core.organizer as organizer_mod
+
+        src = tmp_path / "src.mkv"
+        src.write_bytes(b"payload")
+        dest_dir = tmp_path / "dest_dir"
+        dest_dir.mkdir()
+        dest = dest_dir / "dest.mkv"
+
+        calls = {"count": 0}
+
+        def fake_replace(_src, _dst):
+            calls["count"] += 1
+            raise OSError(errno.EXDEV, "cross-device")
+
+        monkeypatch.setattr(organizer_mod.os, "replace", fake_replace)
+
+        organizer_mod.move_media_file(src, dest, attempts=3, delay=0)
+
+        assert calls["count"] == 1
+        assert dest.exists() is True
+        assert src.exists() is False

--- a/backend/tests/unit/test_organizer.py
+++ b/backend/tests/unit/test_organizer.py
@@ -3,12 +3,14 @@
 Tests movie/TV naming conventions, conflict resolution, and filename sanitization.
 """
 
+import os
 from unittest.mock import patch
 
 import pytest
 
 from app.core.organizer import (
     clean_movie_name,
+    move_media_file,
     organize_movie,
     organize_tv_episode,
     organize_tv_extras,
@@ -545,15 +547,13 @@ class TestMoveMediaFileRollback:
     """
 
     def test_failed_unlink_leaves_no_destination(self, tmp_path, monkeypatch):
-        import app.core.organizer as organizer_mod
-
         src = tmp_path / "src.mkv"
         src.write_bytes(b"payload")
         dest_dir = tmp_path / "dest_dir"
         dest_dir.mkdir()
         dest = dest_dir / "dest.mkv"
 
-        real_unlink = organizer_mod.os.unlink
+        real_unlink = os.unlink
 
         def fake_replace(_src, _dst):
             raise PermissionError(13, "in use")
@@ -566,25 +566,23 @@ class TestMoveMediaFileRollback:
                 raise PermissionError(13, "in use")
             real_unlink(path)
 
-        monkeypatch.setattr(organizer_mod.os, "replace", fake_replace)
-        monkeypatch.setattr(organizer_mod.os, "unlink", fake_unlink)
+        monkeypatch.setattr(os, "replace", fake_replace)
+        monkeypatch.setattr(os, "unlink", fake_unlink)
 
         with pytest.raises(OSError):
-            organizer_mod.move_media_file(src, dest, attempts=1, delay=0)
+            move_media_file(src, dest, attempts=1, delay=0)
 
         assert src.exists() is True
         assert dest.exists() is False
 
     def test_retries_then_succeeds(self, tmp_path, monkeypatch):
-        import app.core.organizer as organizer_mod
-
         src = tmp_path / "src.mkv"
         src.write_bytes(b"payload")
         dest_dir = tmp_path / "dest_dir"
         dest_dir.mkdir()
         dest = dest_dir / "dest.mkv"
 
-        real_replace = organizer_mod.os.replace
+        real_replace = os.replace
         calls = {"count": 0}
 
         def flaky_replace(_src, _dst):
@@ -593,9 +591,9 @@ class TestMoveMediaFileRollback:
                 raise PermissionError(13, "in use")
             return real_replace(_src, _dst)
 
-        monkeypatch.setattr(organizer_mod.os, "replace", flaky_replace)
+        monkeypatch.setattr(os, "replace", flaky_replace)
 
-        organizer_mod.move_media_file(src, dest, attempts=3, delay=0)
+        move_media_file(src, dest, attempts=3, delay=0)
 
         assert dest.exists() is True
         assert src.exists() is False
@@ -603,8 +601,6 @@ class TestMoveMediaFileRollback:
 
     def test_cross_device_falls_back_immediately(self, tmp_path, monkeypatch):
         import errno
-
-        import app.core.organizer as organizer_mod
 
         src = tmp_path / "src.mkv"
         src.write_bytes(b"payload")
@@ -618,10 +614,41 @@ class TestMoveMediaFileRollback:
             calls["count"] += 1
             raise OSError(errno.EXDEV, "cross-device")
 
-        monkeypatch.setattr(organizer_mod.os, "replace", fake_replace)
+        monkeypatch.setattr(os, "replace", fake_replace)
 
-        organizer_mod.move_media_file(src, dest, attempts=3, delay=0)
+        move_media_file(src, dest, attempts=3, delay=0)
 
         assert calls["count"] == 1
         assert dest.exists() is True
         assert src.exists() is False
+
+    def test_failed_rollback_says_so_instead_of_claiming_safe_to_retry(self, tmp_path, monkeypatch):
+        """Both unlinks failing is the one case we cannot clean up after.
+
+        The orphan copy survives, so the error must NOT tell the caller this is
+        safe to retry: a retry would hit FILE_EXISTS against that very copy,
+        which is #642 all over again with a reassuring message on top.
+        """
+        src = tmp_path / "src.mkv"
+        src.write_bytes(b"payload")
+        dest_dir = tmp_path / "dest_dir"
+        dest_dir.mkdir()
+        dest = dest_dir / "dest.mkv"
+
+        def fake_replace(_src, _dst):
+            raise PermissionError(13, "in use")
+
+        def fake_unlink(_path):
+            raise PermissionError(13, "in use")
+
+        monkeypatch.setattr(os, "replace", fake_replace)
+        monkeypatch.setattr(os, "unlink", fake_unlink)
+
+        with pytest.raises(OSError) as excinfo:
+            move_media_file(src, dest, attempts=1, delay=0)
+
+        message = str(excinfo.value)
+        assert "could NOT be removed" in message
+        assert "safe to retry" not in message
+        # The orphan really is still there: the message is telling the truth.
+        assert dest.exists() is True

--- a/backend/tests/unit/test_transcription_prewarm.py
+++ b/backend/tests/unit/test_transcription_prewarm.py
@@ -378,6 +378,28 @@ class TestCancellation:
         fake_task.cancel.assert_called_once()
         assert 5 not in p._tasks
 
+    async def test_cancel_and_wait_absent_job_returns_true(self):
+        result = await TranscriptionPrewarmer().cancel_and_wait(424242)
+        assert result is True
+
+    async def test_cancel_and_wait_cancels_and_waits_for_live_task(
+        self, tmp_path, config_flags, fake_matcher, model_loader, duration_stub
+    ):
+        sem = BlockingSemaphore()
+        p = TranscriptionPrewarmer(semaphore_provider=lambda: sem)
+        p._matcher = fake_matcher
+        job_id, _f = await _seed_review_job(tmp_path)
+
+        await p.start_for_job(job_id)
+        task = p._tasks[job_id]
+        await asyncio.wait_for(sem.blocked.wait(), timeout=5)
+
+        result = await p.cancel_and_wait(job_id)
+
+        assert result is True
+        assert task.done()
+        assert job_id not in p._tasks
+
     async def test_cancel_all_sweeps_every_task(self):
         p = TranscriptionPrewarmer()
         tasks = {}
@@ -517,21 +539,23 @@ class TestJobManagerWiring:
 
     async def test_apply_review_cancels_prewarm(self, monkeypatch):
         mock_prewarmer = MagicMock()
+        mock_prewarmer.cancel_and_wait = AsyncMock(return_value=True)
         monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
         monkeypatch.setattr(jm.job_manager._finalization, "apply_review", AsyncMock())
 
         await jm.job_manager.apply_review(14, 100, episode_code="S01E03")
 
-        mock_prewarmer.cancel_for_job.assert_called_once_with(14)
+        mock_prewarmer.cancel_and_wait.assert_called_once_with(14)
 
     async def test_apply_review_batch_cancels_prewarm(self, monkeypatch):
         mock_prewarmer = MagicMock()
+        mock_prewarmer.cancel_and_wait = AsyncMock(return_value=True)
         monkeypatch.setattr(jm.job_manager, "_prewarmer", mock_prewarmer)
         monkeypatch.setattr(jm.job_manager._finalization, "apply_review_batch", AsyncMock())
 
         await jm.job_manager.apply_review_batch(15, [{"title_id": 1, "episode_code": "S01E01"}])
 
-        mock_prewarmer.cancel_for_job.assert_called_once_with(15)
+        mock_prewarmer.cancel_and_wait.assert_called_once_with(15)
 
 
 class TestPrewarmerTempNamespace:


### PR DESCRIPTION
## Root cause

`shutil.move` wraps `os.rename` in a bare `except OSError` and, on failure, falls back to copy-then-delete. On Windows an open handle on the staging MKV (the transcript prewarmer's ffmpeg, or a review track opened in an external player) fails both `os.rename` AND the post-copy `os.unlink`. The copy is left sitting in the library while the caller still sees an exception, so the *next* save attempt hits `resolve_conflict` and reports `FILE_EXISTS` against our own orphan; discarding the episode was the only way out (#642).

## Changed behavior

- Added `move_media_file()` in `backend/app/core/organizer.py`: retries the atomic `os.replace` (a transient lock is the common case), falls back to `shutil.copy2` + `os.unlink` on a genuine failure (or immediately on `EXDEV`), and rolls the copy back if the source cannot be removed afterwards. A failed organize now leaves the filesystem unchanged so a retry is clean.
- Replaced all four `shutil.move` call sites in `organizer.py` (movie main file, movie extras, `organize_tv_episode`, `organize_tv_extras`) with `move_media_file`.
- Added `TranscriptionPrewarmer.cancel_and_wait()` in `backend/app/services/transcription_prewarm.py`: cancels the prewarm task and waits (bounded, 5s default) for the in-flight ffmpeg chunk to actually finish, instead of the fire-and-forget `cancel_for_job`.
- `job_manager.apply_review` and `apply_review_batch` now `await self._prewarmer.cancel_and_wait(job_id)` instead of calling `cancel_for_job` fire-and-forget, so the common case (prewarmer holding the handle) never even reaches the retry path.

## Out of scope

Layer 3 from issue #642 (treating an existing same-size destination as a recoverable orphan from a *previous* failed organize, rather than a genuine conflict) is deliberately not addressed here. This PR only prevents new orphans from being created going forward.

## Tests run

```
cd backend
uv run pytest tests/unit/test_organizer.py tests/unit/test_transcription_prewarm.py tests/unit/test_organize_failure_reporting.py tests/unit/test_defer_organization.py -q
# 98 passed in 4.19s

uv run ruff check .
# All checks passed!

uv run ruff format --check .
# 428 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
