### PR TITLE
refactor: normalize residual os.path usage to pathlib (#644)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3059,7 +3059,7 @@ async def import_browse(path: str = "") -> dict:
             # Probing 26 drive letters can each block for seconds on a stale
             # network/UNC mapping, so run it off the event loop thread.
             roots = await asyncio.to_thread(
-                lambda: [f"{d}:\\" for d in string.ascii_uppercase if os.path.exists(f"{d}:\\")]
+                lambda: [f"{d}:\\" for d in string.ascii_uppercase if Path(f"{d}:\\").exists()]
             )
         else:
             roots = ["/", str(Path.home())]

--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -95,10 +95,15 @@ def normalize_user_path(value: str | None) -> str:
         # describe_path names it instead.
         return cleaned
 
+    # Deliberately os.path and not pathlib on both lines below (#644).
+    # Path.expanduser() raises RuntimeError for a "~someone" whose home cannot
+    # be resolved; os.path.expanduser hands the string back unchanged. A
+    # settings screen asking "is this path ok?" must answer, not 500, on a typo.
     expanded = os.path.expanduser(cleaned)
     # normpath settles the separator style (a pasted "C:/Users/me" and a typed
     # "C:\Users\me" are one setting) and resolves any "..", without touching the
     # filesystem — this must stay usable for a path that does not exist yet.
+    # Path.resolve() is not a substitute: it stats and follows symlinks.
     expanded = os.path.normpath(expanded)
     # Trailing separators are noise except on a drive root ("C:\") — trimming
     # that would turn an absolute path into a relative one.

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -97,6 +97,11 @@ def executable_basename_allowed(path: str, allowed_basenames: Sequence[str]) -> 
     as a config path. Exact basename match (case-insensitive) — a substring
     check would let ``makemkv-exploit.sh`` through. Backslashes are normalised
     to ``/`` first so a Windows-style path is parsed correctly on any platform.
+
+    Stays on ``os.path.basename`` rather than ``PurePosixPath(...).name`` (#644):
+    basename of ``"makemkvcon/"`` is ``""`` and is denied, while ``.name`` is
+    ``"makemkvcon"`` and is allowed. A guard must not get more permissive in
+    order to look tidier.
     """
     name = os.path.basename(path.replace("\\", "/")).lower()
     return name in {allowed.lower() for allowed in allowed_basenames}

--- a/backend/app/core/sentinel.py
+++ b/backend/app/core/sentinel.py
@@ -13,6 +13,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 if sys.platform == "win32":
@@ -126,7 +127,7 @@ def _get_optical_drives_linux() -> list[str]:
     """Get optical drive device paths on Linux via /sys/block/sr*."""
     drives = []
     for block_dev in sorted(glob.glob("/sys/block/sr*")):
-        dev_name = os.path.basename(block_dev)
+        dev_name = Path(block_dev).name
         drives.append(f"/dev/{dev_name}")
     return drives
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import mimetypes
-import os
 import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -215,11 +215,13 @@ async def health_check():
 # In frozen builds, _MEIPASS is the bundle root and static files are at app/static/
 # In dev, __file__ is inside app/ so we just append "static"
 if getattr(sys, "_MEIPASS", None):
-    _static_dir = os.path.join(sys._MEIPASS, "app", "static")
+    _static_dir = Path(sys._MEIPASS) / "app" / "static"
 else:
-    _static_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
+    # .parent before .resolve(), matching dirname(abspath(...)): the directory
+    # this module lives in, not the directory a symlinked module points into.
+    _static_dir = Path(__file__).parent.resolve() / "static"
 
-if os.path.isdir(_static_dir):
+if _static_dir.is_dir():
     from fastapi.responses import FileResponse
     from fastapi.staticfiles import StaticFiles
 
@@ -241,9 +243,7 @@ if os.path.isdir(_static_dir):
             return resp
 
     # Mount static assets (JS, CSS, images)
-    app.mount(
-        "/assets", _ImmutableStatic(directory=os.path.join(_static_dir, "assets")), name="assets"
-    )
+    app.mount("/assets", _ImmutableStatic(directory=_static_dir / "assets"), name="assets")
 
     # Root-level static files emitted by the Vite build (favicon, SVGs, etc.).
     # Built once at server startup by listing the static dir — no manual
@@ -251,14 +251,14 @@ if os.path.isdir(_static_dir):
     # Maps URL path -> on-disk path; the catch-all uses the request path only
     # as a dict key, so user input is never interpolated into a filesystem path.
     _ROOT_STATIC_FILES = {
-        _name: os.path.join(_static_dir, _name)
-        for _name in os.listdir(_static_dir)
-        if _name != "index.html" and os.path.isfile(os.path.join(_static_dir, _name))
-        # isfile() intentionally excludes subdirectories — nested assets belong
+        _entry.name: _entry
+        for _entry in _static_dir.iterdir()
+        if _entry.name != "index.html" and _entry.is_file()
+        # is_file() intentionally excludes subdirectories — nested assets belong
         # under /assets (the StaticFiles mount above). A new root-level subdir
         # from the Vite build would need its own mount.
     }
-    _INDEX_HTML = os.path.join(_static_dir, "index.html")
+    _INDEX_HTML = _static_dir / "index.html"
 
     @app.get("/{full_path:path}")
     async def serve_spa(full_path: str):
@@ -268,9 +268,9 @@ if os.path.isdir(_static_dir):
         # filesystem path. Nested assets are served by the /assets mount
         # above; any other path is a client-side route -> index.html.
         static_file = _ROOT_STATIC_FILES.get(full_path)
-        # isfile() is a runtime safety net — a file present at startup could
+        # is_file() is a runtime safety net — a file present at startup could
         # have been removed since; fall through to index.html, never a 500.
-        if static_file is not None and os.path.isfile(static_file):
+        if static_file is not None and static_file.is_file():
             return FileResponse(static_file)
         # index.html keeps a stable name across builds, so without this header the
         # browser heuristically caches it and keeps loading the OLD hashed bundles

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -217,9 +217,11 @@ async def health_check():
 if getattr(sys, "_MEIPASS", None):
     _static_dir = Path(sys._MEIPASS) / "app" / "static"
 else:
-    # .parent before .resolve(), matching dirname(abspath(...)): the directory
-    # this module lives in, not the directory a symlinked module points into.
-    _static_dir = Path(__file__).parent.resolve() / "static"
+    # __file__ is already absolute for an imported module on 3.9+, so the
+    # abspath() this replaced was a no-op and no resolve() is wanted either:
+    # resolve() would canonicalize symlinked ancestors, which is the behaviour
+    # normalize_user_path deliberately keeps away from (see paths.py).
+    _static_dir = Path(__file__).parent / "static"
 
 if _static_dir.is_dir():
     from fastapi.responses import FileResponse


### PR DESCRIPTION
## Scope

The ~14 mechanical sites from #644, now that #642 and #643 have merged.

**Converted (11 sites):**

- `backend/app/main.py` — all 6 `os.path.join`, plus `isdir`, `isfile` ×2, `listdir`, `dirname`, `abspath`. `import os` is dropped entirely. `_ROOT_STATIC_FILES` now maps to `Path` values; `FileResponse` and `StaticFiles(directory=...)` both accept `os.PathLike`, so nothing downstream changed.
- `backend/app/api/routes.py:3062` — `os.path.exists` → `Path(...).exists()` in the Windows drive-letter probe.
- `backend/app/core/sentinel.py:129` — `os.path.basename` → `Path(...).name` for `/sys/block/sr*`.

`os.replace` (5) and `os.path.commonpath` (2) are untouched, per the issue.

## The three sites the issue flagged for individual review

All three turned out to be behavior changes rather than style changes, so they stay on `os.path`. Each now carries a comment saying why, so a future sweep does not redo the analysis:

- **`paths.normalize_user_path` — `expanduser`.** `Path.expanduser()` raises `RuntimeError` for a `~someone` whose home cannot be resolved; `os.path.expanduser` returns the string unchanged. `normalize_user_path` is called from `describe_path`, which is documented never to raise, so the swap would turn a Settings typo into a 500 on the path-check endpoint.
- **`paths.normalize_user_path` — `normpath`.** The existing comment already requires it to stay lexical and usable for a path that does not exist yet. `Path.resolve()` stats the filesystem and follows symlinks, so it is not a substitute.
- **`security.executable_basename_allowed` — `basename`.** `os.path.basename("makemkvcon/")` is `""` and is denied; `PurePosixPath("makemkvcon/").name` is `"makemkvcon"` and is allowed. This is the allowlist constraining which binaries the validation endpoints may execute — it must not get more permissive in order to look tidier. Same reasoning the issue applied to the `commonpath` sites in this module.

## No CHANGELOG entry

Zero user-facing behavior change, and `CHANGELOG.md` is the release-notes source (`extract_changelog.py` feeds the GitHub release body). There is no precedent in it for internal refactors.

## Verification

```
uv run ruff check .          # All checks passed!
uv run ruff format --check . # 429 files already formatted
uv run pytest tests/unit/ -q # 3413 passed, 21 skipped in 167.49s
```

The static-serving branch in `main.py` holds most of the diff and is inactive in dev (`app/static` only exists in a built bundle), so I exercised it directly against a temporary static tree:

- root-level static file served (`/favicon.svg` → 200)
- `/assets/<hashed>.js` → 200 with `Cache-Control: public, max-age=31536000, immutable`
- SPA catch-all `/history/12` → `index.html` with `Cache-Control: no-cache`
- a root-level **subdirectory** is still excluded from `_ROOT_STATIC_FILES` and falls through to `index.html`

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
