### PR TITLE
chore: release v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Engram will be documented in this file.
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-09-10
+
+_Highlights: a corrected disc identity now renames its backup too, and a stuck file move during organizing no longer leaves a stray copy._
+
 ### Fixed
 
 - When a misidentified disc was corrected during review, the disc backup kept the wrong show name and TMDB id even though the library output was correct. The backup folder is now moved to match the corrected identity once the job completes. (#643)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,4 @@
 # Keep in sync with pyproject.toml [project].version. Surfaced as the
 # User-Agent suffix on outbound API calls (OpenSubtitles, etc.), so a
 # stale value here misidentifies the app to upstream services.
-__version__ = "0.35.0"
+__version__ = "0.35.1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "engram-backend"
-version = "0.35.0"
+version = "0.35.1"
 description = "Engram - Disc ripping and media organization backend"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "engram-backend"
-version = "0.35.0"
+version = "0.35.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "engram-frontend",
-    "version": "0.35.0",
+    "version": "0.35.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "engram-frontend",
-            "version": "0.35.0",
+            "version": "0.35.1",
             "dependencies": {
                 "@popperjs/core": "2.11.8",
                 "@radix-ui/react-accordion": "1.2.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "engram-frontend",
     "private": true,
-    "version": "0.35.0",
+    "version": "0.35.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Summary

Patch release — fixes only, no new features.

- Bump version to `0.35.1` across `backend/pyproject.toml`, `backend/app/__init__.py`, `backend/uv.lock`, `frontend/package.json`, and `frontend/package-lock.json`
- Curate `CHANGELOG.md`: promote `[Unreleased]` into a new `## [0.35.1] - 2026-09-10` section with a highlights line
- `CONTRIBUTORS.md` unchanged — both fixes since v0.35.0 were authored by the maintainer, no external contributors to credit this release

## Changelog for this release

_Highlights: a corrected disc identity now renames its backup too, and a stuck file move during organizing no longer leaves a stray copy._

### Fixed

- When a misidentified disc was corrected during review, the disc backup kept the wrong show name and TMDB id even though the library output was correct. The backup folder is now moved to match the corrected identity once the job completes. (#643)
- Organizing a file that another process still had open could leave a copy in the library while reporting an error, so the next save attempt failed with "file already exists" and the episode had to be discarded. The move is now retried and rolled back cleanly. (#642)

## Verification

- `python3 backend/scripts/extract_changelog.py --version 0.35.1 --check` → `ok: CHANGELOG has a section for 0.35.1`
- `uv sync --locked` → lockfile consistent with the version bump
- `uv run ruff check .` → all checks passed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC1jNdVGHTPkT7JY2AfXp5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UC1jNdVGHTPkT7JY2AfXp5)_